### PR TITLE
Consolitate Piatra into Main

### DIFF
--- a/public/js/auth/discord.js
+++ b/public/js/auth/discord.js
@@ -3,11 +3,14 @@
 // Role-aware: stores role, player_id, character_ids from the server response.
 
 const DISCORD_CLIENT_ID = '1488404820917223484';
-// All OAuth callbacks land on /admin (registered in Discord app settings)
-const REDIRECT_URI = location.origin + '/admin';
+// All OAuth callbacks land on /admin (registered in Discord app settings).
+// Guarded so this module imports cleanly under Node (vitest); these
+// constants are only read inside browser-only login/fetch flows.
+const _LOC = typeof location === 'undefined' ? null : location;
+const REDIRECT_URI = _LOC ? _LOC.origin + '/admin' : '';
 const SCOPES = 'identify';
 
-const API_BASE = location.hostname === 'localhost'
+const API_BASE = _LOC && _LOC.hostname === 'localhost'
   ? 'http://localhost:3000'
   : '';
 

--- a/public/js/editor/rule_engine/safe-word-evaluator.js
+++ b/public/js/editor/rule_engine/safe-word-evaluator.js
@@ -105,10 +105,14 @@ function _removeStaleSwMerit(c) {
 /**
  * Effective partner merit rating: sums all active dot sources.
  * Excludes free_sw to prevent circular reference (one-hop only).
+ * Mirrors meritEffectiveRating() in public/js/editor/domain.js minus
+ * free_sw — adding a new free_* channel there must update both.
  */
 function _effectivePartnerRating(m) {
-  // inherent-intentional: effective partner rating sums all purchased + free dot sources; mirrors legacy mci.js line 79-81
-  return (m.cp || 0) + (m.free_bloodline || 0) + (m.free_pet || 0) + (m.free_mci || 0) + // inherent-intentional: continuation
+  // inherent-intentional: effective partner rating sums all purchased + free dot sources except free_sw (cycle guard)
+  return (m.cp || 0) + (m.xp || 0) + (m.free || 0) +
+    (m.free_bloodline || 0) + (m.free_pet || 0) + (m.free_mci || 0) +
     (m.free_vm || 0) + (m.free_lk || 0) + (m.free_ohm || 0) + (m.free_inv || 0) +
-    (m.free_pt || 0) + (m.free_mdb || 0) + (m.xp || 0); // inherent-intentional: continuation
+    (m.free_pt || 0) + (m.free_mdb || 0) +
+    (m.free_fwb || 0) + (m.free_attache || 0); // inherent-intentional: continuation
 }


### PR DESCRIPTION
## Summary
  Final consolidation of the `piatra` developer branch into `main` ahead of branch retirement. Two real changes plus the sync merge:
  - **`chore(auth)` (c32b1a9)** — Guard `location` access in `public/js/auth/discord.js` so the module imports cleanly under Node / vitest. Pure
   testability fix; no runtime behaviour change in the browser.
  - **`fix(merits)` (5c334da)** — `_effectivePartnerRating` in `safe-word-evaluator.js` now includes the generic `free` channel plus `free_fwb`
  (Friend With Benefits) and `free_attache` (Attaché). Without these, partner ratings underread for any merit using FWB or Attaché free dots.
  Brings the sum into line with `meritFreeSum()` (introduced in f9d8297) minus `free_sw` which stays excluded as the one-hop cycle guard.
  ## Closes
  _None — these are out-of-band fixes, not issue-tracked._
  ## Test plan
  - [ ] CI green
  - [ ] Manual: load admin sheet for any character with a Friend-With-Benefits or Attaché-bearing merit; confirm partner-rating display matches
  the sum of all dot channels (including free_fwb / free_attache)
  - [ ] Manual: import `public/js/auth/discord.js` from a Node REPL — should not throw
  ## Branch flow
  - From: `piatra`
  - Into: `main`
  - **PRODUCTION MERGE** — auto-deploys to Netlify and Render on merge.
  ## Post-merge
  - `dev` will be fast-forwarded to `main` (currently behind by both this PR and PR #15).
  - `piatra` branch will be deleted from origin and local. Future side branches come off `dev` named `issue-N-slug`.