### PR TITLE
chore(migration): territory FK slug → _id (issue #3c, ADR-002 step 3)

### DIFF
--- a/server/scripts/migrate-territory-fk.js
+++ b/server/scripts/migrate-territory-fk.js
@@ -42,8 +42,15 @@
  *   2  safety abort (data shape divergence from audit)
  *
  * Run history:
- *   - <yet to run> — first --apply in production. Update with date + commit
- *     SHA + per-mutation counts after SM executes the apply step.
+ *   - 2026-05-05 — first --apply in production from script commit 2f6ebf1.
+ *     Backup: server/scripts/_backups/territory-fk-migration-
+ *     2026-05-05T05-36-59-765Z.json. Mutations: 5 territory $rename id→slug,
+ *     5 confirmed_ambience rekeys + 5 discipline_profile rekeys on Downtime 2,
+ *     4 territory_residency $rename territory→territory_id with name resolution,
+ *     0 regent_confirmations (empty across all live cycles), 0 territory_pulse.
+ *     Total 19 in-place mutations. Post-state: all three "expected 0" checks
+ *     at 0. Idempotency confirmed (second --apply returned already-migrated:
+ *     true). Affected server suites 56/56 PASS post-apply.
  */
 import 'dotenv/config';
 import { MongoClient } from 'mongodb';

--- a/server/scripts/migrate-territory-fk.js
+++ b/server/scripts/migrate-territory-fk.js
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+/**
+ * One-off migration: rewrite slug-keyed FKs across tm_suite to use territory
+ * _id strings, and rename the legacy `id` field on territory documents to
+ * `slug`. Implements ADR-002 step 3 (specs/architecture/adr-002-territory-fk.md).
+ *
+ * ADR decisions honoured:
+ *   - Q1 retain-as-slug:  $rename territories.id → territories.slug
+ *   - Q2 strict cutover:  post-apply, no slug FKs anywhere on disk in scope
+ *   - Q5 migrate residency: $rename territory_residency.territory → territory_id
+ *                           (resolved via territories.name → _id)
+ *   - Q4 leave submissions: feeding_territories keys NOT touched
+ *
+ * Targets:
+ *   - territories:                                 $rename id → slug
+ *   - downtime_cycles.regent_confirmations[].territory_id:  slug → _idstr
+ *   - downtime_cycles.confirmed_ambience:          rekey slug → _idstr
+ *   - downtime_cycles.discipline_profile:          rekey slug → _idstr
+ *   - downtime_cycles.territory_pulse:             rekey slug → _idstr
+ *   - territory_residency:                         $rename territory → territory_id
+ *                                                  (value: name → _idstr via name match)
+ *
+ * Usage:
+ *   cd server && node scripts/migrate-territory-fk.js          # dry-run (default)
+ *   cd server && node scripts/migrate-territory-fk.js --apply  # actual mutation
+ *
+ * Behaviour:
+ *   - Always writes a backup BEFORE applying mutations. Sequential await chain
+ *     means a backup-write throw aborts the script before any DB write fires.
+ *   - Idempotent re-run: detects already-migrated state by checking that no
+ *     territory has a legacy `id` field, no cycle's object maps have non-OID-
+ *     shaped keys, and no residency doc still has a `territory` field. Exits
+ *     0 with `already-migrated: true` and no backup file.
+ *   - Safety guard: any slug-shaped key in a cycle that doesn't resolve via
+ *     the slug→_id map aborts with exit 2 BEFORE any write.
+ *   - Safety guard: any residency doc whose `territory` value doesn't match
+ *     a territory's `name` aborts with exit 2.
+ *
+ * Exit codes:
+ *   0  success / dry-run / already-migrated
+ *   1  config error (MONGODB_URI missing)
+ *   2  safety abort (data shape divergence from audit)
+ *
+ * Run history:
+ *   - <yet to run> — first --apply in production. Update with date + commit
+ *     SHA + per-mutation counts after SM executes the apply step.
+ */
+import 'dotenv/config';
+import { MongoClient } from 'mongodb';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const APPLY = process.argv.includes('--apply');
+const HELP  = process.argv.includes('--help') || process.argv.includes('-h');
+
+if (HELP) {
+  console.log('Usage: node scripts/migrate-territory-fk.js [--apply]');
+  console.log('  Default is DRY-RUN. --apply writes a backup then mutates.');
+  process.exit(0);
+}
+
+const URI = process.env.MONGODB_URI;
+if (!URI) {
+  console.error('MONGODB_URI missing — populate server/.env before running.');
+  process.exit(1);
+}
+
+const HEX24 = /^[0-9a-f]{24}$/i;
+const isOidShaped = s => typeof s === 'string' && HEX24.test(s);
+
+const client = new MongoClient(URI);
+await client.connect();
+const db = client.db('tm_suite');
+
+// ── Step 1: build slug → _idstr map from territories ────────────────────────
+const territories = await db.collection('territories').find().toArray();
+const slugToOid = new Map();
+for (const t of territories) {
+  // Read `id ?? slug` so the script tolerates partial-state docs (some renamed,
+  // some not) during a re-run or interrupted previous attempt.
+  const slug = t.id ?? t.slug;
+  if (slug) slugToOid.set(slug, String(t._id));
+}
+
+console.log('slug → _id map:');
+for (const [s, o] of slugToOid) console.log(`  '${s}' → ${o}`);
+
+// ── Step 2: audit pass (count expected mutations) ───────────────────────────
+const cycles = await db.collection('downtime_cycles').find().toArray();
+const residency = await db.collection('territory_residency').find().toArray();
+
+const plan = {
+  territories: { rename: 0 },
+  cycles: [],
+  residency: { rename: 0, total: residency.length },
+  alreadyMigrated: true,
+};
+
+// Territory rename count
+plan.territories.rename = territories.filter(t => t.id !== undefined).length;
+if (plan.territories.rename > 0) plan.alreadyMigrated = false;
+
+// Cycle audit (with safety abort on unresolvable slugs)
+for (const cycle of cycles) {
+  const cyclePlan = {
+    _id: String(cycle._id),
+    label: cycle.label,
+    confirmations: 0,
+    ambience: 0,
+    profile: 0,
+    pulse: 0,
+  };
+
+  for (const c of (cycle.regent_confirmations || [])) {
+    if (slugToOid.has(c.territory_id)) cyclePlan.confirmations++;
+    else if (!isOidShaped(c.territory_id)) {
+      console.error(`SAFETY ABORT: cycle ${cycle._id} regent_confirmations has unresolved territory_id="${c.territory_id}"`);
+      await client.close();
+      process.exit(2);
+    }
+  }
+
+  for (const [field, label] of [['confirmed_ambience','ambience'], ['discipline_profile','profile'], ['territory_pulse','pulse']]) {
+    if (!cycle[field]) continue;
+    for (const k of Object.keys(cycle[field])) {
+      if (slugToOid.has(k)) cyclePlan[label]++;
+      else if (!isOidShaped(k)) {
+        console.error(`SAFETY ABORT: cycle ${cycle._id} ${field} has unresolved key="${k}"`);
+        await client.close();
+        process.exit(2);
+      }
+    }
+  }
+
+  if (cyclePlan.confirmations + cyclePlan.ambience + cyclePlan.profile + cyclePlan.pulse > 0) {
+    plan.cycles.push(cyclePlan);
+    plan.alreadyMigrated = false;
+  }
+}
+
+// Residency audit (with safety abort on unresolvable names)
+for (const doc of residency) {
+  if (doc.territory_id !== undefined) continue; // already migrated
+  if (doc.territory === undefined) continue;     // shape unknown; nothing to do
+  // Resolve name → territory _id via territories.name match.
+  const terr = territories.find(t => t.name === doc.territory);
+  if (!terr) {
+    console.error(`SAFETY ABORT: residency doc ${doc._id} territory='${doc.territory}' has no matching territory by name`);
+    await client.close();
+    process.exit(2);
+  }
+  plan.residency.rename++;
+}
+if (plan.residency.rename > 0) plan.alreadyMigrated = false;
+
+console.log('\n--- Audit ---');
+console.log(JSON.stringify(plan, null, 2));
+
+if (plan.alreadyMigrated) {
+  console.log('\nalready-migrated: true   nothing to do.');
+  await client.close();
+  process.exit(0);
+}
+
+if (!APPLY) {
+  console.log('\nDRY-RUN — re-run with --apply to execute.');
+  await client.close();
+  process.exit(0);
+}
+
+// ── Step 3: backup BEFORE any mutation ──────────────────────────────────────
+const here = dirname(fileURLToPath(import.meta.url));
+const backupDir = join(here, '_backups');
+mkdirSync(backupDir, { recursive: true });
+const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+const backupPath = join(backupDir, `territory-fk-migration-${stamp}.json`);
+writeFileSync(backupPath, JSON.stringify({
+  capturedAt: stamp,
+  territories,
+  cycles,
+  residency,
+}, null, 2));
+console.log(`\nBackup → ${backupPath}`);
+
+// ── Step 4: apply mutations ─────────────────────────────────────────────────
+const counts = { confirmations: 0, ambience: 0, profile: 0, pulse: 0, terrRename: 0, residencyRename: 0 };
+
+// 4a: cycle rewrites
+for (const cycle of cycles) {
+  const updates = {};
+  let dirty = false;
+
+  // regent_confirmations[].territory_id
+  if (cycle.regent_confirmations?.length) {
+    let changed = false;
+    const newConfirms = cycle.regent_confirmations.map(c => {
+      const oid = slugToOid.get(c.territory_id);
+      if (oid && !isOidShaped(c.territory_id)) {
+        counts.confirmations++;
+        changed = true;
+        return { ...c, territory_id: oid };
+      }
+      return c;
+    });
+    if (changed) {
+      updates.regent_confirmations = newConfirms;
+      dirty = true;
+    }
+  }
+
+  // Object rekeys
+  for (const [field, label] of [['confirmed_ambience','ambience'], ['discipline_profile','profile'], ['territory_pulse','pulse']]) {
+    if (!cycle[field]) continue;
+    const old = cycle[field];
+    const next = {};
+    let changed = false;
+    for (const [k, v] of Object.entries(old)) {
+      const oid = slugToOid.get(k);
+      if (oid && !isOidShaped(k)) {
+        next[oid] = v;
+        counts[label]++;
+        changed = true;
+      } else {
+        next[k] = v;
+      }
+    }
+    if (changed) {
+      updates[field] = next;
+      dirty = true;
+    }
+  }
+
+  if (dirty) {
+    await db.collection('downtime_cycles').updateOne({ _id: cycle._id }, { $set: updates });
+  }
+}
+
+// 4b: territory $rename id → slug
+if (plan.territories.rename > 0) {
+  const r = await db.collection('territories').updateMany(
+    { id: { $exists: true } },
+    { $rename: { id: 'slug' } }
+  );
+  counts.terrRename = r.modifiedCount;
+}
+
+// 4c: residency $rename + name resolution
+for (const doc of residency) {
+  if (doc.territory_id !== undefined) continue;
+  if (doc.territory === undefined) continue;
+  const terr = territories.find(t => t.name === doc.territory);
+  // Map was confirmed in audit pass; safety abort handled there. Re-check
+  // defensively in case territories drifted between audit and apply (paranoia).
+  if (!terr) {
+    console.error(`POST-AUDIT SAFETY ABORT: residency doc ${doc._id} territory='${doc.territory}' lost its match`);
+    await client.close();
+    process.exit(2);
+  }
+  await db.collection('territory_residency').updateOne(
+    { _id: doc._id },
+    { $set: { territory_id: String(terr._id) }, $unset: { territory: '' } }
+  );
+  counts.residencyRename++;
+}
+
+console.log('\n--- Apply counts ---');
+console.log(JSON.stringify(counts, null, 2));
+
+// ── Step 5: re-audit ────────────────────────────────────────────────────────
+const postT = await db.collection('territories').find({ id: { $exists: true } }).toArray();
+console.log(`\nPost-state: territories with legacy 'id' field = ${postT.length} (expected 0)`);
+
+const postCyc = await db.collection('downtime_cycles').find().toArray();
+let postSlugKeys = 0;
+for (const cycle of postCyc) {
+  for (const field of ['confirmed_ambience','discipline_profile','territory_pulse']) {
+    if (!cycle[field]) continue;
+    for (const k of Object.keys(cycle[field])) {
+      if (!isOidShaped(k)) postSlugKeys++;
+    }
+  }
+  for (const c of (cycle.regent_confirmations || [])) {
+    if (!isOidShaped(c.territory_id)) postSlugKeys++;
+  }
+}
+console.log(`Post-state: cycle map keys + confirmation territory_ids that are still slug-shaped = ${postSlugKeys} (expected 0)`);
+
+const postRes = await db.collection('territory_residency').find({ territory: { $exists: true } }).toArray();
+console.log(`Post-state: residency docs with legacy 'territory' field = ${postRes.length} (expected 0)`);
+
+await client.close();

--- a/specs/stories/3c-migration-script.story.md
+++ b/specs/stories/3c-migration-script.story.md
@@ -1,0 +1,496 @@
+---
+id: issue-3c
+issue: 3
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/3
+branch: issue-3c-migration-script
+status: ready-for-review
+priority: high
+depends_on: ['issue-3-territory-fk-adr', 'issue-3b']
+parent: issue-3
+---
+
+# Story #3c: Migration script — slug → `_id` across `tm_suite`
+
+As an ST whose production data still holds slug-keyed cross-document FKs that the new server contract no longer recognises,
+I should run a one-shot migration script that rewrites every slug FK to its corresponding territory `_id` and renames the legacy `id` field to `slug`,
+So that on-disk data matches the schema/route contract that #3b shipped to `dev`, before #3d's client refactor goes live.
+
+This story implements **migration step 3** from ADR-002. Same shape as `cleanup-rfr-territory-residue.js` (PR #20): dry-run by default, `--apply` for the actual op, backup-before-write, safety guard, idempotent re-runs.
+
+---
+
+## Context
+
+#3b landed on `dev` at commit `e773e2b`. The server now speaks `_id`-as-FK; the slug-keyed contract is gone from the API. But the **on-disk data is still in the old shape**:
+
+- `tm_suite.territories` — 5 docs, each carries an `id` field (the slug). Schema has been renamed `id → slug` but the on-disk field name is still `id`. Data needs `$rename: { id: 'slug' }`.
+- `tm_suite.downtime_cycles.regent_confirmations` — empty across all live cycles per ADR-002 audit. Migration touches near-zero data here.
+- `tm_suite.downtime_cycles.confirmed_ambience` / `discipline_profile` / `territory_pulse` — slug-keyed objects in some closed cycles. Keys need rekeying from slug → `String(territory._id)`.
+- `tm_suite.territory_residency` — 0 docs. Schema-only effectively, but the script should still inspect for any unexpected docs and rename `territory` → `territory_id` if found.
+- `tm_suite.downtime_submissions.responses.feeding_territories` — out of scope per Q4. The slug-variant pattern stays as a legacy reader (`TERRITORY_SLUG_MAP`).
+
+### What this script does
+
+1. **Connect** to `tm_suite`.
+2. **Build slug → `_id` map** from current territories collection. Each doc currently has both `id` (slug) and `_id` (ObjectId); read `id || slug` for robustness against partial state. The map is `{ secondcity: '<oidstr>', northshore: '<oidstr>', ... }`.
+3. **Audit pass (read-only)** — count expected mutations across all four document types. Print summary.
+4. **Apply (only with `--apply`)**:
+   a. **Backup**: write `_backups/territory-fk-migration-<ISO>.json` with snapshots of `territories` and all `downtime_cycles` and any `territory_residency` documents.
+   b. **Rewrite cycles** — for each cycle:
+      - `regent_confirmations[i].territory_id`: if slug, replace with `_id`-string from map.
+      - Rekey `confirmed_ambience`, `discipline_profile`, `territory_pulse` — for each key that's a slug, replace with `_id`-string. Keys already `_id`-shaped (24 hex chars) are left alone (idempotency).
+   c. **Rewrite residency** (if any docs): `$rename` `territory` → `territory_id`; resolve the old `territory` value (a name string) against territories collection, replace with `_id`-string.
+   d. **Rename territory field**: for each territory doc, `$rename: { id: 'slug' }`.
+5. **Re-audit** — confirm no slug-shaped keys remain in any of the rekeyed objects. Print final state.
+6. **Idempotent**: a second `--apply` run detects nothing to migrate (all keys already `_id`-shaped, no `id` field on territories) and exits 0 with `already-migrated: true`.
+
+### Files in scope
+
+- `server/scripts/migrate-territory-fk.js` (new) — the migration script.
+- The story file (Dev Agent Record + dry-run output captured before user authorises apply).
+
+### Files NOT in scope
+
+- **Any code change beyond the script.** No client touched (#3d). No reference data alignment (#3e). No removal of the `territory.slug || territory.id` fallback at `routes/territories.js:122` (that stays — `id` field is gone after this script applies, but removing the fallback ships in #3e per ADR-002 Step 6).
+- **`downtime_submissions.responses.feeding_territories`** — leave as user-typed slug-variants per Q4.
+- **`server/utils/territory-slugs.js`** — demoted to legacy reader in #3e.
+- **Dead client block** in `downtime-form.js:73, 1311-1317` — out of scope per user's Q5; file as a separate cleanup issue post-migration.
+
+---
+
+## Acceptance Criteria
+
+**Given** the script is invoked without `--apply`
+**When** it runs against the live MongoDB
+**Then** it prints the slug→`_id` map, an audit table of expected mutations (per cycle, per object map, plus the territory-rename count), and **does not modify anything**. Exit 0.
+
+**Given** the script is invoked with `--apply`
+**When** it runs against the live MongoDB
+**Then** it writes a backup file, applies all four mutation types, prints per-mutation counts, and re-audits to confirm the post-state. Exit 0 on success, non-zero on any safety abort.
+
+**Given** the safety guard finds a slug-keyed value in a cycle that doesn't resolve to any territory in the slug→`_id` map
+**When** the script runs in either mode
+**Then** it aborts with a clear error citing the unresolved slug + the cycle `_id` + the field path. No partial mutations. Exit code distinct from "success" and "config error".
+
+**Given** the script is run twice with `--apply`
+**When** the second run executes
+**Then** it detects nothing to migrate (`territories` have no `id` field; cycles' object maps have no slug-shaped keys), reports `already-migrated: true`, and exits 0 without writing a backup file.
+
+**Given** the apply completes successfully
+**When** an audit query checks the post-state
+**Then**:
+- Every territory doc has `slug` (renamed from `id`); no doc has `id` field.
+- Every `regent_confirmations[i].territory_id` value is a 24-character hex string (no slug strings).
+- Every `confirmed_ambience` / `discipline_profile` / `territory_pulse` key is a 24-character hex string (no slug keys).
+- Any `territory_residency` doc has `territory_id` (renamed from `territory`), value is a 24-character hex string.
+
+**Given** the apply completes successfully
+**When** the running server (`dev` contract) reads territories and cycles
+**Then** all routes (POST, PATCH, confirm-feeding) work correctly with the new on-disk shape. Server tests on dev still pass.
+
+**Given** the script is committed to the repo
+**When** a future operator wants to read the audit trail
+**Then** the script is at `server/scripts/migrate-territory-fk.js` with a docstring covering the scope, the Q1/Q2/Q5 ADR decisions, and the actual production run-history (date, source commit SHA, mutations applied — added by SM after running `--apply`).
+
+---
+
+## Implementation Notes
+
+### Script shape (sketch)
+
+Modelled directly on `cleanup-rfr-territory-residue.js`. Pattern:
+
+```js
+#!/usr/bin/env node
+/**
+ * One-off migration: rewrite slug-keyed FKs across tm_suite to use territory _id strings.
+ * Implements ADR-002 step 3 (specs/architecture/adr-002-territory-fk.md).
+ *
+ * Decisions honoured:
+ *   - Q1 retain-as-slug: $rename territories.id → territories.slug (keep field as label).
+ *   - Q2 strict cutover: post-apply, no slug FKs anywhere on disk in scope.
+ *   - Q5 migrate residency: rename territory_residency.territory → territory_id.
+ *   - Q4 leave submissions: feeding_territories keys NOT touched.
+ *
+ * Targets:
+ *   - territories: $rename id → slug
+ *   - downtime_cycles.regent_confirmations[].territory_id: slug → _idstr
+ *   - downtime_cycles.confirmed_ambience: rekey slug → _idstr
+ *   - downtime_cycles.discipline_profile: rekey slug → _idstr
+ *   - downtime_cycles.territory_pulse: rekey slug → _idstr
+ *   - territory_residency: $rename territory → territory_id, resolve name → _idstr
+ *
+ * Usage:
+ *   cd server && node scripts/migrate-territory-fk.js          # dry-run
+ *   cd server && node scripts/migrate-territory-fk.js --apply  # actual mutation
+ *
+ * Always writes a backup before applying. Idempotent re-runs return 0.
+ *
+ * Run history:
+ *   - <yet to run>
+ */
+import 'dotenv/config';
+import { MongoClient, ObjectId } from 'mongodb';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const APPLY = process.argv.includes('--apply');
+const URI = process.env.MONGODB_URI;
+if (!URI) { console.error('MONGODB_URI missing'); process.exit(1); }
+
+const HEX24 = /^[0-9a-f]{24}$/i;
+const isOidShaped = s => typeof s === 'string' && HEX24.test(s);
+
+const client = new MongoClient(URI);
+await client.connect();
+const db = client.db('tm_suite');
+
+// Step 1: build slug → _idstr map from territories
+const territories = await db.collection('territories').find().toArray();
+const slugToOid = new Map();
+for (const t of territories) {
+  const slug = t.id ?? t.slug;
+  if (slug) slugToOid.set(slug, String(t._id));
+}
+console.log('slug → _id map:');
+for (const [s, o] of slugToOid) console.log(`  '${s}' → ${o}`);
+
+// Step 2: audit pass
+let plan = { cycles: [], terrRename: 0, residencyRename: 0, alreadyMigrated: true };
+
+const cycles = await db.collection('downtime_cycles').find().toArray();
+for (const cycle of cycles) {
+  const cyclePlan = { _id: String(cycle._id), confirmations: 0, ambience: 0, profile: 0, pulse: 0 };
+
+  for (const c of (cycle.regent_confirmations || [])) {
+    if (slugToOid.has(c.territory_id)) cyclePlan.confirmations++;
+    else if (!isOidShaped(c.territory_id)) {
+      console.error(`SAFETY: cycle ${cycle._id} regent_confirmations has unresolved territory_id="${c.territory_id}"`);
+      process.exit(2);
+    }
+  }
+  for (const obj of [['confirmed_ambience','ambience'], ['discipline_profile','profile'], ['territory_pulse','pulse']]) {
+    const [field, label] = obj;
+    if (!cycle[field]) continue;
+    for (const k of Object.keys(cycle[field])) {
+      if (slugToOid.has(k)) cyclePlan[label]++;
+      else if (!isOidShaped(k)) {
+        console.error(`SAFETY: cycle ${cycle._id} ${field} has unresolved key="${k}"`);
+        process.exit(2);
+      }
+    }
+  }
+
+  if (cyclePlan.confirmations + cyclePlan.ambience + cyclePlan.profile + cyclePlan.pulse > 0) {
+    plan.cycles.push(cyclePlan);
+    plan.alreadyMigrated = false;
+  }
+}
+
+plan.terrRename = territories.filter(t => t.id !== undefined).length;
+if (plan.terrRename > 0) plan.alreadyMigrated = false;
+
+const residency = await db.collection('territory_residency').find().toArray();
+plan.residencyRename = residency.filter(r => r.territory !== undefined && r.territory_id === undefined).length;
+if (plan.residencyRename > 0) plan.alreadyMigrated = false;
+
+console.log('\n--- Audit ---');
+console.log(JSON.stringify(plan, null, 2));
+
+if (plan.alreadyMigrated) {
+  console.log('\nalready-migrated: true');
+  await client.close();
+  process.exit(0);
+}
+
+if (!APPLY) {
+  console.log('\nDRY-RUN — re-run with --apply to execute.');
+  await client.close();
+  process.exit(0);
+}
+
+// Step 3: backup
+const here = dirname(fileURLToPath(import.meta.url));
+const backupDir = join(here, '_backups');
+mkdirSync(backupDir, { recursive: true });
+const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+const backupPath = join(backupDir, `territory-fk-migration-${stamp}.json`);
+writeFileSync(backupPath, JSON.stringify({
+  territories,
+  cycles,
+  residency,
+  capturedAt: stamp,
+}, null, 2));
+console.log(`\nBackup → ${backupPath}`);
+
+// Step 4: apply mutations
+let counts = { confirmations: 0, ambience: 0, profile: 0, pulse: 0, terrRename: 0, residencyRename: 0 };
+
+for (const cycle of cycles) {
+  const updates = {};
+  let dirty = false;
+
+  // regent_confirmations
+  if (cycle.regent_confirmations?.length) {
+    const newConfirms = cycle.regent_confirmations.map(c => {
+      const oid = slugToOid.get(c.territory_id);
+      if (oid && !isOidShaped(c.territory_id)) {
+        counts.confirmations++;
+        return { ...c, territory_id: oid };
+      }
+      return c;
+    });
+    if (newConfirms.some((c, i) => c.territory_id !== cycle.regent_confirmations[i].territory_id)) {
+      updates.regent_confirmations = newConfirms;
+      dirty = true;
+    }
+  }
+
+  // object rekeys
+  for (const [field, label] of [['confirmed_ambience','ambience'], ['discipline_profile','profile'], ['territory_pulse','pulse']]) {
+    if (!cycle[field]) continue;
+    const old = cycle[field];
+    const next = {};
+    let changed = false;
+    for (const [k, v] of Object.entries(old)) {
+      const oid = slugToOid.get(k);
+      if (oid && !isOidShaped(k)) {
+        next[oid] = v;
+        counts[label]++;
+        changed = true;
+      } else {
+        next[k] = v;
+      }
+    }
+    if (changed) {
+      updates[field] = next;
+      dirty = true;
+    }
+  }
+
+  if (dirty) {
+    await db.collection('downtime_cycles').updateOne({ _id: cycle._id }, { $set: updates });
+  }
+}
+
+// Territory $rename id → slug
+if (plan.terrRename > 0) {
+  const r = await db.collection('territories').updateMany({ id: { $exists: true } }, { $rename: { id: 'slug' } });
+  counts.terrRename = r.modifiedCount;
+}
+
+// Residency rename territory → territory_id (resolving name → _id)
+for (const doc of residency) {
+  if (doc.territory_id !== undefined) continue;
+  // doc.territory is a NAME string ("The North Shore" etc.). Resolve via territories.find().
+  const terr = territories.find(t => t.name === doc.territory);
+  if (!terr) {
+    console.error(`SAFETY: residency doc ${doc._id} territory='${doc.territory}' has no matching territory by name`);
+    process.exit(2);
+  }
+  await db.collection('territory_residency').updateOne(
+    { _id: doc._id },
+    { $set: { territory_id: String(terr._id) }, $unset: { territory: '' } }
+  );
+  counts.residencyRename++;
+}
+
+console.log('\n--- Apply counts ---');
+console.log(JSON.stringify(counts, null, 2));
+
+// Step 5: re-audit
+const postT = await db.collection('territories').find({ id: { $exists: true } }).toArray();
+console.log(`\nPost-state: territories with legacy id field = ${postT.length} (expected 0)`);
+
+await client.close();
+```
+
+### Critical safety properties
+
+1. **Map is built before any writes.** The slug→`_id` map is captured up-front from `territories` (reading `id || slug` for tolerance). All subsequent rewrites consult the map; no second read of territories.
+2. **Backup before any write.** `mkdirSync` → `writeFileSync` → mutations. Sequential await chain — any throw aborts before mutations.
+3. **Safety abort on unknown slugs.** If a cycle has `confirmed_ambience['mystery_slug']` and `mystery_slug` isn't in the map, the script aborts with exit 2. No partial writes.
+4. **Idempotency by key shape.** The script detects already-migrated state by checking for legacy `id` field on territories AND any non-OID-shaped keys in cycle object maps. If neither exists, exits with `already-migrated: true`.
+5. **No data loss.** All operations are `$set` / `$rename` / `$unset`. The backup retains the pre-state regardless.
+
+### What this story does NOT remove
+
+- The `territory.slug || territory.id` fallback at `server/routes/territories.js:122` — Ma'at's #3b QA flagged this as transitional code that becomes dead after this migration runs. **Removal is deferred to #3e** per ADR-002 Step 6 (legacy compatibility removal). Adding it to #3c risks the deploy-window discipline: between this PR's merge and the user running `--apply`, the fallback is still load-bearing.
+
+---
+
+## Test Plan
+
+This is destructive prod-data work, layered like β:
+
+1. **Static review (Ma'at)** — read the script. Confirm: slug→`_id` map building, safety abort on unknown slugs, backup-before-write sequence, idempotency check, exit codes, scope discipline (no other code touched).
+
+2. **Dry-run (Ptah, then Ma'at, then SM)** — `node scripts/migrate-territory-fk.js`. Each reviewer confirms the plan looks reasonable: which cycles touched, how many slugs to rekey, the slug→`_id` map. **Capture Ptah's dry-run verbatim into the Dev Agent Record.**
+
+3. **User authorisation step** — explicit go-ahead in chat before `--apply`.
+
+4. **Apply (SM)** — `node scripts/migrate-territory-fk.js --apply`. Verify: backup file written, per-mutation counts match dry-run plan, post-state audit shows zero legacy slugs.
+
+5. **Post-apply audit (Ma'at)** — independent audit query confirming:
+   - All 5 territories have `slug`, none have `id`.
+   - All cycle object maps' keys are 24-char hex strings.
+   - Server tests still pass against the post-migration data (run `cd server && npm test` and confirm no regression).
+
+6. **Idempotency check** — re-run `--apply`. Confirm `already-migrated: true`, exit 0.
+
+7. **Server smoke** — bring up `cd server && npm run dev` against the migrated data. Exercise a few routes (GET territories, POST update by `_id`, PATCH feeding-rights). Confirm functional.
+
+---
+
+## Definition of Done
+
+- [x] Script lives at `server/scripts/migrate-territory-fk.js`, exec bit set, docstring complete with run-history placeholder
+- [x] Dry-run output reviewed by Ptah *(captured in Dev Agent Record below; awaits Maat + SM)*
+- [ ] User explicitly authorises `--apply` *(SM gate)*
+- [ ] `--apply` executed; backup file present; per-mutation counts captured *(SM step)*
+- [ ] Post-apply audit (Ma'at) confirms zero legacy slugs across territories + cycles
+- [ ] Idempotency check confirmed (`already-migrated: true` on re-run)
+- [ ] Server tests pass against the post-migration data
+- [ ] Run history docstring updated post-apply with date + commit SHA + counts
+- [ ] PR opened by `tm-gh-pr-for-branch` into `dev`, body cross-references parent issue #3 + ADR-002
+
+---
+
+## Note for Ptah
+
+This is a slightly more complex shape than `cleanup-rfr-territory-residue.js` because:
+
+1. The migration involves **building a map and consulting it across multiple collection reads/writes** rather than just deleting a known set of `_id`s.
+2. There are **four distinct mutation types** (regent_confirmations array entry, three object-rekey operations, plus the territory rename).
+3. The audit has to count expected mutations per type so the user can see what will happen before authorising.
+
+Take it in steps:
+
+1. Probe the live data first (read-only) to verify the ADR-002 audit's claims still hold (all 5 territories present, regent_confirmations empty, etc.). Build the actual slug→`_id` map.
+2. Implement the dry-run path. Run it. Capture output.
+3. Implement the apply path. **Do not run it.** That's SM's step after user authorisation.
+4. Run the dry-run again at the end to confirm no regressions in the audit logic from your apply-path implementation.
+
+**Hard rule (same as β):** **do NOT run with `--apply`.** Backup → mutate → re-audit only happens via SM after the user's explicit go-ahead.
+
+If anything in the audit is unexpected (a cycle with unresolved keys, an unknown collection field, a residency doc that exists), surface it in your reply rather than fixing it in the script. The user/SM will decide how to handle.
+
+## Note for Ma'at
+
+This is the highest-risk migration in the territory FK refactor — it transforms shape across two collections plus rekeys nested objects. Static review priorities:
+
+1. **Map building** — read `id ?? slug` for tolerance during partial states. The map is an authoritative slug→`_id` resolver; any divergence corrupts.
+2. **Safety abort** — unknown slug in a cycle MUST abort, not silently skip. Verify exit codes are non-zero.
+3. **Backup completeness** — territories + cycles + residency, all three. If a recovery is needed, the backup is the only ground truth.
+4. **Idempotency** — the second `--apply` should detect already-migrated state by checking for both legacy `id` field on territories AND non-OID-shaped keys in cycle object maps. Both checks needed; either alone is incomplete.
+5. **Order of operations on disk** — the territory rename can happen at any point because it's independent of the cross-doc rewrites (the script reads from territories before any mutation). But verify the script reads the slug map BEFORE the territory rename, otherwise the second-call lookup would miss.
+
+After Ptah's reply, run your own dry-run and compare output. Append your QA Results commit before the apply gate.
+
+---
+
+## Dev Agent Record
+
+**Agent Model Used:** claude-opus-4-7 (James / DEV / Ptah)
+
+**Files Changed (1):**
+- `server/scripts/migrate-territory-fk.js` (new, exec bit set, +218) — modelled directly on `cleanup-rfr-territory-residue.js` (PR #20). Dry-run default, `--apply` for actual op, `--help` flag, backup-before-write, safety guards, idempotent re-run, distinct exit codes (0 success / dry-run / already-migrated; 1 config; 2 safety abort).
+
+**Live data probe (read-only, executed first per Note for Ptah §1):**
+A throwaway probe script `server/scripts/_probe-tm-territory-fk.mjs` was written, executed, and deleted before commit. It surfaced one **important deviation from the ADR-002 audit**:
+
+> ADR-002 §Live-data baseline reported `territory_residency.count = 0`. **Live state on 2026-05-05 shows 4 documents** with residents lists of 3, 7, 4, 6.
+
+This means the dead-client-block analysis from ADR-002 Q5 is **only partially correct**: the consumer at `public/js/tabs/downtime-form.js:1311-1317` populates `residencyByTerritory` with documents that *something* has been writing to the collection between the ADR audit and now. Either:
+1. There is a write path I missed in the ADR audit, or
+2. Someone manually populated these documents in the gap between the ADR and #3b shipping, or
+3. The dead client block is actually being read somewhere I missed.
+
+Either way, **the migration script handles all 4 docs correctly**: it resolves the legacy `territory` field (a name string like "The Academy") to the territory's `_id` via `territories.find(t => t.name === doc.territory)`, all 4 names resolve cleanly to 4 of the 5 known territories (only "The Dockyards" has no residency doc).
+
+I did **not** investigate the writer. Per the user's Q5 decision the dead-client question is for a follow-on cleanup story, and the migration script handles the docs as-is regardless of who's writing them.
+
+**slug → _id map (5 entries, all unique):**
+```
+'secondcity' → 69d9e54c00815d471503bea8
+'northshore' → 69d9e54b00815d471503bea6
+'dockyards'  → 69d9e54c00815d471503bea9
+'academy'    → 69d9e54b00815d471503bea7
+'harbour'    → 69d5dc6a00815d47150397c6
+```
+
+**Dry-run output (verbatim, executed locally with no `--apply`):**
+
+```
+slug → _id map:
+  'secondcity' → 69d9e54c00815d471503bea8
+  'northshore' → 69d9e54b00815d471503bea6
+  'dockyards' → 69d9e54c00815d471503bea9
+  'academy' → 69d9e54b00815d471503bea7
+  'harbour' → 69d5dc6a00815d47150397c6
+
+--- Audit ---
+{
+  "territories": {
+    "rename": 5
+  },
+  "cycles": [
+    {
+      "_id": "69d0a3c5052b57f6be774e69",
+      "label": "Downtime 2",
+      "confirmations": 0,
+      "ambience": 5,
+      "profile": 5,
+      "pulse": 0
+    }
+  ],
+  "residency": {
+    "rename": 4,
+    "total": 4
+  },
+  "alreadyMigrated": false
+}
+
+DRY-RUN — re-run with --apply to execute.
+```
+
+**Expected mutations on `--apply`: 19 total**
+- 5 territory documents `$rename id → slug`
+- Downtime 2 cycle: 5 `confirmed_ambience` keys rekeyed (slug → _id) + 5 `discipline_profile` keys rekeyed = 10 in-place rewrites
+- 4 territory_residency documents `$rename territory → territory_id` (with name-to-_id resolution)
+- 0 `regent_confirmations` rewrites (none are slug-shaped; matches ADR audit)
+- 0 `territory_pulse` rewrites (no cycles populate this field)
+
+**Safety guards exercised in dry-run:**
+- All cycle keys resolve via the map (no SAFETY ABORT exit 2 triggered).
+- All 4 residency `territory` values resolve to a territory `name` (no SAFETY ABORT triggered).
+- Idempotency detection: `alreadyMigrated: false` correctly triggered by 5 territories with legacy `id` field + 1 cycle with non-OID-shaped object keys + 4 residency docs with legacy `territory` field. A second `--apply` post-run would return `alreadyMigrated: true` if all three conditions cleared.
+
+**Implementation notes (anything surprising):**
+
+1. **Residency count was 4, not 0.** Filed as the most important note — see live-data probe section above. The migration handles them correctly via name resolution, but the Q5 decision rationale changes: the residency collection is *not* dormant after all. **Recommend the SM/user file an issue post-migration to investigate which writer populated these docs**, given the dead-code analysis flagged the only known consumer as "set, never read".
+
+2. **`territory.slug || territory.id` fallback at routes/territories.js:122 NOT removed** per Khepri's instruction. Once `--apply` runs and the on-disk `id` field becomes `slug`, the `|| territory.id` clause becomes load-bearing-zero (always falsy). Removal is deferred to #3e per ADR-002 Step 6, as flagged in Maat's #3b QA review.
+
+3. **Map building reads `id ?? slug`** for tolerance against partial state (e.g. an interrupted previous attempt). Currently all 5 territories have `id` and no `slug`, but the script tolerates either.
+
+4. **Idempotency check is three-pronged**: (a) territories.id absent, (b) all cycle map keys are 24-char hex, (c) all residency docs have territory_id, none have territory. All three must hold for `alreadyMigrated: true`.
+
+5. **Backup-before-write enforced by sequential await** — `mkdirSync` → `writeFileSync` → first DB mutation. If the write throws, the chain aborts before touching the DB. No try/catch (would obscure the safety property).
+
+6. **POST-AUDIT SAFETY ABORT** in the residency loop is paranoid defensive-programming. The audit pass already validates name resolution; the apply pass re-checks in case territories drift between audit and apply (which they shouldn't in a single process run, but the cost is one comparison and the value is "never half-write a residency doc").
+
+7. **Two pre-existing test failures on dev** (rule_engine_grep contract, api-relationships-player-create NPC directory) are unrelated to this story — already known from #3b.
+
+**Resisted scope creep:**
+- Did NOT remove the `territory.slug || territory.id` fallback (deferred to #3e per ADR-002 Step 6).
+- Did NOT investigate the residency-docs surprise (Q5 follow-up; user's call).
+- Did NOT touch `server/utils/territory-slugs.js` (Q4; #3e).
+- Did NOT modify any client file in `public/`.
+- Did NOT execute `--apply` (HARD RULE).
+
+**Probe artefact**: `server/scripts/_probe-tm-territory-fk.mjs` was created, run, and deleted before commit. Not in the repo.
+
+**Change Log:**
+- 2026-05-05 — Implemented per Story #3c on `issue-3c-migration-script`. Single commit (script + this Dev Agent Record together). Dry-run executed; `--apply` deferred to SM after user authorisation.

--- a/specs/stories/3c-migration-script.story.md
+++ b/specs/stories/3c-migration-script.story.md
@@ -494,3 +494,112 @@ DRY-RUN — re-run with --apply to execute.
 
 **Change Log:**
 - 2026-05-05 — Implemented per Story #3c on `issue-3c-migration-script`. Single commit (script + this Dev Agent Record together). Dry-run executed; `--apply` deferred to SM after user authorisation.
+
+---
+
+## QA Results
+
+**Reviewer:** Quinn (Ma'at / QA), claude-opus-4-7
+**Date:** 2026-05-05
+**Commit reviewed:** 2f6ebf1
+**Method:** Static review of the script line-by-line; independent dry-run from this terminal; live-data probe to validate the residency surprise; six-mode failure walkthrough.
+
+### Gate decision: **PASS** — recommend AUTHORISE-APPLY (subject to user explicit go-ahead per the standing rule).
+
+### Static review (Khepri's checklist) — all PASS
+
+| Item | Verdict | Evidence |
+|---|---|---|
+| Map building reads `id ?? slug` for partial-state tolerance | PASS | `script:82`. Handles a re-run after a partial $rename. |
+| Safety abort on unresolved slug (exit 2, not silent skip) | PASS | `script:117-120` (regent_confirmations), `:128-131` (object map keys), `:148-151` (residency name). All print before `await client.close()` + `process.exit(2)` and are reached during the audit pass — before any apply branch. |
+| Backup BEFORE mutate (sequential await chain) | PASS | `:172-184` mkdirSync → writeFileSync are synchronous; throws abort the chain before line 186 mutations. `recursive: true` makes mkdir idempotent. |
+| Idempotency three-pronged | PASS | All three required to flip `plan.alreadyMigrated` to false: `:101-102` (territory `id` field absent), `:136-138` (any cycle map keys not OID-shaped), `:153-155` (residency `territory` field present). Default true; only flipped if any pre-state is detected. |
+| Order of operations safe | PASS | `slugToOid` map captured at `:77-84` before any write at `:235`. Territory $rename at `:240` comes after cycle rewrites; cycle rewrites use the in-memory map (not a live read), so the rename order is irrelevant. Residency rewrite at `:249-265` uses the in-memory `territories` array (`t.name === doc.territory` at `:252`) which is unchanged by the on-disk rename, so name resolution still works. |
+| Distinct exit codes 0/1/2 | PASS | 0 = success/dry-run/already-migrated (`:60, 163, 169` and end-of-file). 1 = config (`:66`). 2 = safety abort (`:120, 131, 151, 258`). |
+| `id ?? slug` map tolerance | PASS | A failed-mid-apply state where some territories have `slug` and some still have `id` is recoverable on re-run: `:82` reads either; map is built correctly; cycle audit treats already-OID keys as skip; residency audit treats already-migrated docs as skip. |
+
+### Independent dry-run — reproducible **YES**
+
+```
+slug → _id map:
+  'secondcity' → 69d9e54c00815d471503bea8
+  'northshore' → 69d9e54b00815d471503bea6
+  'dockyards' → 69d9e54c00815d471503bea9
+  'academy' → 69d9e54b00815d471503bea7
+  'harbour' → 69d5dc6a00815d47150397c6
+
+--- Audit ---
+{
+  "territories": { "rename": 5 },
+  "cycles": [{
+    "_id": "69d0a3c5052b57f6be774e69",
+    "label": "Downtime 2",
+    "confirmations": 0, "ambience": 5, "profile": 5, "pulse": 0
+  }],
+  "residency": { "rename": 4, "total": 4 },
+  "alreadyMigrated": false
+}
+DRY-RUN — re-run with --apply to execute.
+```
+
+Reproduces Ptah's output verbatim: 5 territory renames, 1 cycle (Downtime 2) with 5 ambience + 5 profile rekeys, 4 residency renames, 0 confirmations / 0 pulse.
+
+### Surprise validation — residency count
+
+**Confirmed: residency.count = 4, not 0** as ADR-002 §Live-data baseline reported.
+
+Independent probe of the live `tm_suite.territory_residency`:
+
+| Doc `_id` | `territory` (legacy field) | `territory_id` | residents | `updated_at` |
+|---|---|---|---|---|
+| `69d0a08800815d4715035832` | The Academy | (missing) | 3 | 2026-04-04T05:24:24.023Z |
+| `69d1dacd00815d4715035fcb` | The Harbour | (missing) | 7 | (similar) |
+| `69d37ee400815d4715037e56` | The Second City | (missing) | 4 | (similar) |
+| `69cd7fbd78fd76a2d6ba60c4` | The North Shore | (missing) | 6 | (similar) |
+
+All four resolve cleanly via `name` match against the territories collection. `Field presence` shows: every doc has `territory`, none has `territory_id` — consistent legacy shape, no half-migrated state.
+
+The 2026-04-04 `updated_at` timestamps tell us the docs predate the ADR audit on 2026-05-05, not "something is writing post-ADR". So the ADR's "0 documents" reading was simply wrong on the day — likely a connection-string misread or a stale local probe — rather than evidence of a recent writer. The Q5 user decision (MIGRATE) absorbs the discrepancy at zero cost: the script handles all 4 correctly via name → `_id` resolution.
+
+**Writer-investigation (Q7 follow-up) timing — file post-migration.** Reasoning:
+- `#3b` already changed the route contract; no NEW writes can land in `territory`-name shape via the API.
+- The 4 existing docs are pre-existing data, last touched 2026-04-04 — likely a one-shot import or manual write at that date, not an ongoing writer.
+- After `#3c` migrates the 4 docs to `territory_id`, the data is in the new shape. Any post-migration appearance of a `territory`-name-shape doc would be unambiguous evidence of a residual writer.
+- That post-migration view is the cheapest detection surface — investigating now would have to disprove a writer; investigating after migration only has to detect one if it exists.
+
+### Failure-mode walkthrough — all six PASS
+
+| Scenario | Outcome | Verdict |
+|---|---|---|
+| Mongo connect fails | `await client.connect()` line 73 throws; process exits before any read or write. | PASS |
+| Backup `mkdir` / `writeFile` fails | Synchronous throw at `:175` or `:178` aborts before the apply loop at `:186`. `recursive: true` handles existing dir idempotently. | PASS |
+| Cycle has unresolved slug | Audit-pass safety abort at `:117-120` (confirmations) or `:128-131` (object keys) — `slugToOid.has(k)` false AND `!isOidShaped(k)` true → exit 2. Apply branch never reached. | PASS |
+| Residency doc has unresolvable name | `territories.find(t => t.name === doc.territory)` returns `undefined` at `:147`; safety abort at `:148-151` exits 2. | PASS |
+| Re-run after apply | Three-pronged idempotency check (territories sans `id`, all keys OID-shaped, residency on `territory_id`) flips `alreadyMigrated` true; lines `:160-164` print `already-migrated: true`, exit 0, no backup file. | PASS by code path; cannot exercise pre-apply. |
+| Map-building on partial state | `:82` reads `id ?? slug` → both legacy and renamed docs feed the map. Cycle audit treats already-OID keys as skip. Residency audit treats already-migrated docs as skip. Re-run completes the remainder. | PASS |
+
+### Per-AC verdict
+
+| # | AC | Verdict | Notes |
+|---|---|---|---|
+| 1 | Dry-run prints map + audit, no mutation | PASS | Verified independently. Exit 0. |
+| 2 | `--apply` writes backup, applies, prints counts, re-audits | PASS-by-static | Cannot exercise pre-authorisation. Apply path at `:172-290` matches spec. |
+| 3 | Safety abort on unresolved slug | PASS | Exit 2 at `:120, 131, 151`. Apply branch never reached on abort. |
+| 4 | Idempotent re-run: `already-migrated: true`, exit 0, no backup | PASS-by-static | Three-pronged check verified. Cannot exercise pre-apply. |
+| 5 | Post-apply state: territories have `slug`; confirm/ambience/profile/pulse keys OID-shaped; residency has `territory_id` | PASS-by-static | Re-audit at `:271-290` prints exactly these three checks with `(expected 0)` annotations. |
+| 6 | Server tests pass with new on-disk shape | DEFERRED | Post-apply verification. Strict cutover already validated against `_id`-shaped data in #3b suite. |
+| 7 | Script committed with docstring covering scope + Q1/Q2/Q5 decisions + run-history placeholder | PASS | `script:1-47` covers all three. Run-history line is `<yet to run>` placeholder for SM to update post-apply. |
+
+### Notes for SM (post-apply checklist)
+
+After `--apply`:
+1. Update the `Run history` line at `migrate-territory-fk.js:45` with date + apply-commit SHA + per-mutation counts (`Apply counts` JSON from script output).
+2. Backup file lands at `server/scripts/_backups/territory-fk-migration-<ISO>.json`. Retain locally until #3d/#3e land.
+3. Re-run the script in apply mode immediately to verify idempotency (`already-migrated: true`).
+4. Run the affected server suites (`api-territories*`, `api-downtime-regent-gate`, `api-players-sessions-residency`) — should remain 56/56.
+5. File a Q7 follow-up issue: "audit territory_residency writer (4 pre-existing docs from 2026-04-04)". Low priority — purely diagnostic.
+6. Future-clean note: tag removal of `territory.slug || territory.id` at `routes/territories.js:122` — once this script applies, the `|| territory.id` clause becomes dead code. Per ADR Step 6, removed in #3e.
+
+### Recommendation
+
+**AUTHORISE-APPLY.** Standing by for SM to capture the user's explicit go-ahead and run `--apply`. Will re-verify the post-state on your reply: (a) `Apply counts` matches the dry-run audit exactly (5 / 5+5 / 4 / 0 / 0 / 5); (b) re-audit prints all three "expected 0" checks at zero; (c) backup file present; (d) server suites still 56/56.

--- a/specs/stories/3c-migration-script.story.md
+++ b/specs/stories/3c-migration-script.story.md
@@ -603,3 +603,37 @@ After `--apply`:
 ### Recommendation
 
 **AUTHORISE-APPLY.** Standing by for SM to capture the user's explicit go-ahead and run `--apply`. Will re-verify the post-state on your reply: (a) `Apply counts` matches the dry-run audit exactly (5 / 5+5 / 4 / 0 / 0 / 5); (b) re-audit prints all three "expected 0" checks at zero; (c) backup file present; (d) server suites still 56/56.
+
+### Post-apply re-verify (after dc85738)
+
+Independent audit from this terminal against the live `tm_suite`:
+
+```
+territories: total=5  with id=0 (expect 0)  with slug=5 (expect 5)
+  _id=69d9e54c00815d471503bea8  slug='secondcity'  name='The Second City'
+  _id=69d9e54b00815d471503bea6  slug='northshore'  name='The North Shore'
+  _id=69d9e54c00815d471503bea9  slug='dockyards'   name='The Dockyards'
+  _id=69d9e54b00815d471503bea7  slug='academy'     name='The Academy'
+  _id=69d5dc6a00815d47150397c6  slug='harbour'     name='The Harbour'
+
+cycles (Downtime 2):
+  confirmed_ambience: 5 keys, ALL OID-shaped ✓
+  discipline_profile: 5 keys, ALL OID-shaped ✓
+  non-OID map keys = 0 (expect 0)
+  non-OID regent_confirmations.territory_id = 0 (expect 0)
+
+residency: total=4  with territory=0 (expect 0)  with valid territory_id=4 (expect 4)
+  Academy   → 69d9e54b00815d471503bea7  residents=3
+  Harbour   → 69d5dc6a00815d47150397c6  residents=7
+  Second C. → 69d9e54c00815d471503bea8  residents=4
+  North Sh. → 69d9e54b00815d471503bea6  residents=6
+  unresolved territory_id = 0 (expect 0)
+```
+
+- **AC #5** (post-state shape) — PASS. All three "expected 0" checks at zero, independently verified. All five territories carry `slug` only; both DT2 object maps are fully OID-keyed; all four residency docs migrated cleanly with cross-resolved `territory_id` values matching the slug→_id map from dry-run; resident counts preserved (3/7/4/6).
+- **AC #4** (idempotency) — PASS. SM's second `--apply` returned `already-migrated: true   nothing to do.`, no backup written.
+- **AC #6** (server tests against new on-disk shape) — PASS. SM reports 56/56 in the four affected suites post-apply.
+- **Docstring update at dc85738** — PASS. Date `2026-05-05`, source commit `2f6ebf1`, all per-mutation counts (5 / 5+5 / 4 / 0 / 0 = 19 total), backup path, post-state, idempotency, and server-suite confirmation all recorded.
+- **Backup file** present locally at `server/scripts/_backups/territory-fk-migration-2026-05-05T05-36-59-765Z.json`.
+
+**Final gate: PASS.** All 7 ACs closed. Branch ready for PR into `dev`.


### PR DESCRIPTION
## Summary

Migration script for ADR-002 step 3. Rewrites slug-keyed territory FKs to `_id` strings across `tm_suite`. Modelled on `cleanup-rfr-territory-residue.js` (PR #20): dry-run by default, `--apply` for the real op, backup-before-write, three-pronged idempotency, distinct exit codes 0/1/2.

**Applied to production on 2026-05-05.** 19 mutations:
- 5 territory `$rename id → slug`
- 5 confirmed_ambience + 5 discipline_profile rekeys on Downtime 2
- 4 territory_residency `$rename territory → territory_id` with name → `_id` resolution
- 0 regent_confirmations (empty across all live cycles per ADR-002 audit)
- 0 territory_pulse (no cycles use this field)

Post-state: all three "expected 0" checks at zero. Idempotency confirmed (second `--apply` returns `already-migrated: true`). Affected server suites 56/56 PASS post-apply.

## Closes

_None — issue #3 stays OPEN through #3d–#3e._

## Story / ADR

- `specs/stories/3c-migration-script.story.md` (status: ready-for-review; full Dev Agent Record + dry-run output + QA Results + post-apply re-verify all committed in-branch)
- `specs/architecture/adr-002-territory-fk.md` step 3

## Commits

- `2f6ebf1` chore(scripts): add territory FK migration script (dry-run default) — Ptah
- `212e064` docs(story-3c): append QA Results from Ma'at — gate PASS pre-apply — Ma'at
- `dc85738` docs(scripts): record migrate-territory-fk run history (apply 2026-05-05) — Khepri
- `269593b` docs(story-3c): post-apply re-verify — gate PASS — Ma'at

## Discoveries

- **`territory_residency` had 4 docs**, not 0 as ADR-002 reported. Sample doc `updated_at: 2026-04-04T05:24:24Z` — pre-existing data the ADR audit missed (not a residual writer). Q5 user decision MIGRATE was correct; the docs (Academy 3, Harbour 7, Second City 4, North Shore 6 residents) are preserved and rekeyed cleanly.

## Pre-merge sign-off

- DEV: Ptah — commit `2f6ebf1`, dry-run captured, slug→`_id` map building + safety guards verified
- QA pre-apply: Ma'at — gate PASS at `212e064`, independent dry-run reproduced, 6 failure modes walked, AUTHORISE-APPLY recommendation
- USER: Angelus/Peter — explicit "apply" authorisation in chat
- APPLY: Khepri — executed `--apply` 2026-05-05, 19 mutations applied, idempotency + server suites verified, run-history committed at `dc85738`
- QA post-apply: Ma'at — independent live-DB audit at `269593b`, all 3 "expected 0" checks at zero, all 7 ACs closed

## Notes for follow-up

- **Q7 follow-up issue to file post-merge:** "audit `territory_residency` writer" — the 4 docs pre-date the ADR audit, but knowing the write path is good hygiene for future-proofing
- **Tag for #3e:** removal of `territory.slug || territory.id` fallback at `routes/territories.js:122` — now confirmed dead code (no doc has `id` field on disk anymore), removed in #3e per ADR-002 Step 6
- **Backup file** `server/scripts/_backups/territory-fk-migration-2026-05-05T05-36-59-765Z.json` retained locally; keep until #3d/#3e land

## Branch flow

- From: `issue-3c-migration-script`
- Into: `dev`