### PR TITLE
hotfix: smart quotes break downtime-form.js parse (regression from PR #28)

### DIFF
--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -3743,36 +3743,36 @@ function getRowCost(row) {
 // and describe the interaction; no registered relationship required.
 
 function renderPersonalStorySection(saved) {
-  const section = DOWNTIME_SECTIONS.find(s => s.key === ‘personal_story’);
-  if (!section) return ‘’;
+  const section = DOWNTIME_SECTIONS.find(s => s.key === 'personal_story');
+  if (!section) return '';
 
-  const savedName = saved[‘personal_story_npc_name’] || ‘’;
-  const savedNote = saved[‘personal_story_note’]
-                  || saved[‘story_moment_note’]
-                  || saved[‘osl_moment’]
-                  || saved[‘correspondence’]
-                  || ‘’;
+  const savedName = saved['personal_story_npc_name'] || '';
+  const savedNote = saved['personal_story_note']
+                  || saved['story_moment_note']
+                  || saved['osl_moment']
+                  || saved['correspondence']
+                  || '';
 
-  let h = ‘<div class="qf-section collapsed" data-section-key="personal_story">’;
+  let h = '<div class="qf-section collapsed" data-section-key="personal_story">';
   h += `<h4 class="qf-section-title">${esc(section.title)}<span class="qf-section-tick">✔</span></h4>`;
-  h += ‘<div class="qf-section-body">’;
-  h += ‘<p class="qf-section-intro">Name someone your character spends time with this cycle, and describe the kind of moment you\’re hoping for.</p>’;
+  h += '<div class="qf-section-body">';
+  h += '<p class="qf-section-intro">Name someone your character spends time with this cycle, and describe the kind of moment you\'re hoping for.</p>';
 
   // Hidden sync fields consumed by collectResponses() at submit time.
-  h += `<input type="hidden" id="dt-personal_story_npc_id" value="${esc(savedName ? ‘__new__’ : ‘’)}">`;
+  h += `<input type="hidden" id="dt-personal_story_npc_id" value="${esc(savedName ? '__new__' : '')}">`;
   h += `<input type="hidden" id="dt-personal_story_npc_name" value="${esc(savedName)}">`;
 
-  h += ‘<div class="qf-field">’;
-  h += ‘<label class="qf-label">Who is this moment about?</label>’;
+  h += '<div class="qf-field">';
+  h += '<label class="qf-label">Who is this moment about?</label>';
   h += `<input type="text" class="qf-input" id="dt-personal_story_npc_name_free" value="${esc(savedName)}" placeholder="Name an NPC — anyone your character knows or has heard of…">`;
-  h += ‘</div>’;
+  h += '</div>';
 
-  h += ‘<div class="qf-field" style="margin-top:12px;">’;
-  h += ‘<label class="qf-label">How do you want to interact with them?</label>’;
-  h += `<textarea id="dt-personal_story_note" class="qf-textarea" rows="4" placeholder="Describe the kind of moment you’re hoping for — a conversation, a letter, an unexpected encounter…">${esc(savedNote)}</textarea>`;
-  h += ‘</div>’;
+  h += '<div class="qf-field" style="margin-top:12px;">';
+  h += '<label class="qf-label">How do you want to interact with them?</label>';
+  h += `<textarea id="dt-personal_story_note" class="qf-textarea" rows="4" placeholder="Describe the kind of moment you're hoping for — a conversation, a letter, an unexpected encounter…">${esc(savedNote)}</textarea>`;
+  h += '</div>';
 
-  h += ‘</div></div>’;
+  h += '</div></div>';
   return h;
 }
 


### PR DESCRIPTION
## Production hotfix

`public/js/tabs/downtime-form.js:3746` was throwing `Uncaught SyntaxError: Invalid or unexpected token` on every page load that imports the module — i.e. every player session that opens the downtime form.

Root cause: smart quotes (U+2018 `'` and U+2019 `'`) instead of straight apostrophes throughout `renderPersonalStorySection` (lines 3745-3777). Came in via PR #28 (issue #24 — story free-text NPC fields). Likely an editor auto-conversion that wasn't caught before merge.

## Fix

Replaced 23 occurrences of curly quotes with straight apostrophes. One escaped apostrophe in body text (`\'re`) preserved as a literal inside a single-quoted string.

Verified: `node --input-type=module --check < public/js/tabs/downtime-form.js` parses clean.

Smart quotes elsewhere in the codebase (`game/rules.js`, `dev-fixtures.js`) are inside string content, not syntax — left untouched.

## Why straight to main

Production is unusable for the player downtime form right now. Hotfix is permitted under the architectural-reset freeze (cycle-blocker, strict definition). User confirmed the regression in chat and authorised the fix path.

## Test plan

- [x] `node --input-type=module --check` parses clean
- [x] Diff is contained to one function (lines 3745-3777, 20 lines added / 20 removed)
- [ ] CI green
- [ ] Manual: hard-reload the player suite; downtime form opens without console errors; the new "Personal Story" section renders the NPC name + interaction note fields

## Branch flow

- From: `hotfix/downtime-form-smart-quotes`
- Into: `main`
- **PRODUCTION HOTFIX** — auto-deploys to Netlify on merge

## Follow-up

Worth a lint-style guard against U+2018 / U+2019 (and U+201C / U+201D) in `*.js` files to prevent a recurrence. Could be a pre-commit hook or a CI check. Out of scope for this hotfix.