### PR TITLE
Deploy: DT submission form MVP redesign epic + 18 stories

### DIFF
--- a/specs/stories/dt-form.16-character-picker.story.md
+++ b/specs/stories/dt-form.16-character-picker.story.md
@@ -1,0 +1,149 @@
+---
+id: dt-form.16
+task: 16
+epic: epic-dt-form-mvp-redesign
+status: Draft
+priority: high
+depends_on: []
+adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q6, §Q10)
+---
+
+# Story dt-form.16 — Universal character picker component
+
+As an author of any DT form section that needs to select a character (or set of characters),
+I should have a single component to consume — `charPicker({...})` — with two scope variants and one render shape,
+So that the five existing divergent picker shapes collapse to one and future sections don't reinvent the same UX.
+
+This is **foundation story #1 of 2** (the other is #17). Must merge before any per-section story.
+
+---
+
+## Context
+
+ADR-003 §Q6 locks the universal character picker decision: one component, two scoped variants, one render shape. The five existing picker sites (`dt-flex-char-sel` single-select at `:4817`, `dt-chip` button grid at `:5000`, project-cast checkbox grid at `:508`/`:2367`, last-game-attendees subset at `:1332`, regency tab `<select id="reg-slot-N">` at `regency-tab.js:192-199`) all replace their local pickers with calls to the new component.
+
+Component location: `public/js/components/character-picker.js` (new). Form-local consumption only in this epic; broader adoption deferred to a future ADR per ADR-003 §Out-of-scope.
+
+ADR-003 §Q10 locks the keyboard model: WAI-ARIA combobox (`role="combobox"`, `aria-expanded`, `aria-activedescendant`) with standard tab/arrow/enter/escape semantics.
+
+ADR-003 §Q6 also locks the `excludeIds` parameter as v1 (not deferred) so ALLY-attach pickers can exclude self without revisiting consumers later.
+
+### Files in scope
+
+- `public/js/components/character-picker.js` (new)
+- `public/js/tabs/downtime-form.js` — replace 5 picker sites listed above
+- `public/js/tabs/regency-tab.js` — replace `<select id="reg-slot-N">` at `:192-199`
+- CSS: existing `dt-chip` and `qf-select` styling adapted or new `char-picker-*` rules added — implementer's choice; stay form-local
+
+### Files NOT in scope
+
+- Any picker outside the DT form context (admin character editor, etc.) — broader adoption is a future ADR
+- The reference data sources (`allCharNames`, `lastGameAttendees`) themselves — already module-scoped in `downtime-form.js`; the component reads them but doesn't reshape them
+
+---
+
+## Acceptance Criteria
+
+**Given** the component is imported and called as `charPicker({ scope: 'all', cardinality: 'single', initial: charId, onChange: fn, placeholder: 'pick a character', excludeIds: [] })`
+**When** the component renders
+**Then** a single text input with a fuzzy-matching dropdown appears; mouse + keyboard navigable; current selection rendered as a confirmed pill.
+
+**Given** `cardinality: 'multi'`
+**When** the user selects multiple characters
+**Then** each selection renders as a removable chip; the dropdown stays open after each pick; clicking the chip's × removes that selection and updates `onChange` with the new array.
+
+**Given** `scope: 'all'`
+**When** the dropdown filters
+**Then** the source list is `allCharNames` (already module-scoped in `downtime-form.js:43`).
+
+**Given** `scope: 'attendees'`
+**When** the dropdown filters
+**Then** the source list is `lastGameAttendees` (already module-scoped at `:67`).
+
+**Given** `excludeIds: ['someCharId']`
+**When** the dropdown renders
+**Then** the listed character ids are filtered out of the dropdown options. The selection input behaves correctly even if `excludeIds` changes between renders.
+
+**Given** the picker is keyboard-focused
+**When** the user types
+**Then** the dropdown narrows progressively (fuzzy match, case-insensitive). Tab navigates focus, arrow-keys move within the dropdown, Enter selects, Escape cancels.
+
+**Given** WAI-ARIA combobox semantics are required
+**When** assistive tech inspects the picker
+**Then** `role="combobox"` is on the input, `aria-expanded` reflects dropdown state, `aria-activedescendant` points at the focused option. Tab/arrow/Enter/Escape are wired per the standard combobox pattern.
+
+**Given** the 5 existing picker sites listed in ADR-003 §Audit-baseline
+**When** they are migrated in this story
+**Then** each site's HTML is replaced by a `charPicker(...)` call configured with the appropriate `scope` and `cardinality` (single for sites #1, #2, #5; multi for site #3; attendees-scope for site #4).
+
+**Given** the migration is reviewed
+**When** a developer greps the codebase
+**Then** zero remaining instances of the 5 audit-baseline locator patterns exist (`dt-flex-char-sel`, `dt-chip data-project-target-char` direct render — though the `dt-chip` class may persist on the new component's chip rendering — and the regency `<select id="reg-slot-N">` direct render).
+
+**Given** the component is form-local only
+**When** the diff is reviewed for scope discipline
+**Then** the component file is at `public/js/components/character-picker.js` and is imported only by `downtime-form.js` (and `regency-tab.js` if the regency picker is also migrated). No imports from admin-app or other suite surfaces.
+
+---
+
+## Implementation Notes
+
+### Component signature (lock)
+
+```js
+export function charPicker({
+  scope: 'all' | 'attendees',     // source list
+  cardinality: 'single' | 'multi', // selection mode
+  initial: string[] | string,      // initial value
+  onChange: (next) => void,        // change handler
+  placeholder: string,             // for empty state
+  excludeIds?: string[],           // hide these (e.g. self)
+})
+```
+
+### Fuzzy-match shape
+
+ADR-003 names "fuzzy-matching text input with progressively-narrowing dropdown list". Implementer's choice on the matcher (substring match, prefix-weighted, etc.) — keep it simple; the source lists are 30-ish characters, not 30,000.
+
+### Migration order within this PR
+
+1. Build the component in `public/js/components/character-picker.js` with all 6 parameters wired.
+2. Replace site #1 (`dt-flex-char-sel` single-select). Smoke-test the section.
+3. Replace site #2 (`dt-chip` project-target-char single-select). Smoke-test.
+4. Replace site #3 (project-cast multi-select checkbox grid). Smoke-test.
+5. Replace site #4 (last-game-attendees subset, `attendees` scope). Smoke-test.
+6. Replace site #5 (regency tab `<select id="reg-slot-N">`). Smoke-test.
+
+If any site reveals a missing capability (e.g. needs `disabled` per-option, needs to render the empty-list state differently), surface in DAR before extending the component signature.
+
+---
+
+## Test Plan
+
+1. **Static review** (Ma'at) — component signature matches ADR-003 §Q6; ARIA roles match §Q10.
+2. **Server tests** — no new server impact; existing suites should remain green.
+3. **Browser smoke** (DEFERRED to user/SM if Ptah can't run from terminal):
+   - Each of the 5 migrated sites renders correctly
+   - Keyboard navigation works at each
+   - Multi-select chips render and remove cleanly
+   - `excludeIds` exclusion works (e.g. ALLY picker excludes self)
+   - Existing form draft data round-trips correctly through the new picker
+
+---
+
+## Definition of Done
+
+- [ ] `public/js/components/character-picker.js` exists with the locked signature
+- [ ] All 5 audit-baseline picker sites migrated to `charPicker(...)`
+- [ ] Component is form-local (only `downtime-form.js` and optionally `regency-tab.js` import it)
+- [ ] WAI-ARIA combobox semantics present and verified
+- [ ] `excludeIds` parameter wired and used by at least one consumer (likely ALLY-attach in personal actions, post-#24)
+- [ ] Browser smoke confirms each migrated site behaves equivalently or better than before
+- [ ] PR opened by `tm-gh-pr-for-branch` into `dev`, body links to ADR-003 §Q6 + §Q10
+
+---
+
+## Dependencies
+
+- **None upstream.** This is the first story to land.
+- Downstream: blocks #18, #20, #22, #23, #24, #28 (every per-section story that consumes a picker).

--- a/specs/stories/dt-form.17-minimal-advanced-lifecycle.story.md
+++ b/specs/stories/dt-form.17-minimal-advanced-lifecycle.story.md
@@ -1,0 +1,227 @@
+---
+id: dt-form.17
+task: 17
+epic: epic-dt-form-mvp-redesign
+status: Draft
+priority: high
+depends_on: ['dt-form.16']
+adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q1, §Q2, §Q3, §Q4, §Q8, §Q11)
+---
+
+# Story dt-form.17 — Minimal/Advanced mode + soft-submit lifecycle + auto-XP mirror
+
+As a player using the DT form,
+I should see a Minimal mode by default that surfaces only what I need to submit, with my downtime-XP credit auto-awarded the moment my form is minimum-complete and auto-revoked if I drop below — visibly, with a banner and XP-Available annotation explaining the state,
+So that the form is honest about its state and the manual "Submit Downtime" workflow is retired.
+
+This is **foundation story #2 of 2**. Lands after #16. **All other per-section stories depend on this.**
+
+---
+
+## Context
+
+ADR-003 locks five intertwined decisions in this single story:
+- **§Q1 mode persistence**: `responses._mode = 'minimal' | 'advanced'`, default minimal, mode-switch preserves entered data.
+- **§Q2 MINIMAL set composition**: court + personal_story (reduced) + feeding (simplified) + 1 project + regency-if-regent. Sections outside this set are not rendered in MINIMAL.
+- **§Q3 derived-bool lifecycle (HARD MIRROR, rev 2)**: `responses._has_minimum: boolean` derived from `isMinimalComplete(responses)`. On every save: if changed, PATCH submission status + PATCH attendance.downtime to mirror.
+- **§Q4 auto-XP timing**: `attendance.downtime` flips both ways with `_has_minimum`, immediately. Cycle close is the only true seal.
+- **§Q8 location**: `isMinimalComplete()` in `public/js/data/dt-completeness.js` (separate module).
+- **§Q11 cycle-close server gate**: `PATCH /api/downtime_submissions/:id` returns 423 Locked when `cycle.status === 'closed'`.
+
+The ADR is explicit (§Q3 / §Q4) that hard mirror requires three UI affordances or "feels broken to players":
+1. **Persistent banner** when `_has_minimum` is false
+2. **XP-Available delta annotation** ("(downtime credit on hold)")
+3. **Negative-`xpLeft()` red treatment** in the player view
+
+These three affordances are **non-negotiable acceptance criteria for this story**. They ship together with the lifecycle wiring or this story does not ship.
+
+### Files in scope
+
+- `public/js/data/dt-completeness.js` (new) — exports `isMinimalComplete(responses)`. ESM module, importable client + server.
+- `public/js/tabs/downtime-form.js` — mode selector at top of form; rendering gate per `_mode`; lifecycle hook in `scheduleSave()` / `saveDraft()`; the three UI affordances (banner, annotation, negative-XP-Left).
+- `public/js/tabs/downtime-data.js` — `DOWNTIME_SECTIONS` annotated with which sections render in MINIMAL.
+- `public/js/data/game-xp.js` — consumers must respect the new auto-derived `attendance[i].downtime` flow (no manual ST-flip dependency for the auto-flipped path).
+- `server/routes/downtime.js` — new middleware: cycle-close 423 gate on `PATCH /api/downtime_submissions/:id`.
+- `server/schemas/downtime_submission.schema.js` — document new fields under `properties`: `_mode`, `_has_minimum`, `_final_submitted_at` (last for compat with §Q5 / story #31).
+- Player XP panel render path (suite — likely `public/js/suite/xp.js` or similar) — negative-`xpLeft()` red treatment + tooltip.
+
+### Files NOT in scope
+
+- The Submit Final modal itself — that's story #31. This story sets up the lifecycle the modal depends on.
+- Per-section MINIMAL UI changes — those are stories #18, #20, #22, #23, #24. This story sets up the rendering gate; per-section authors respect it.
+- Server-side validation of `_has_minimum` — Q7 deferred (server trusts the client PATCH).
+- `game_session.schema.js` — **no schema delta** per ADR-003 rev 2 hard-mirror decision.
+
+---
+
+## Acceptance Criteria
+
+### Mode selector (Q1, Q2)
+
+**Given** a player opens a fresh DT submission
+**When** the form renders
+**Then** the mode selector at the top of the form defaults to MINIMAL. `responses._mode` is `'minimal'` on the persisted document.
+
+**Given** a player switches MINIMAL → ADVANCED
+**When** the form re-renders
+**Then** all 11 sections from `DOWNTIME_SECTIONS` render. Previously-entered MINIMAL fields are preserved unchanged.
+
+**Given** a player switches ADVANCED → MINIMAL
+**When** the form re-renders
+**Then** only the MINIMAL sections render (court + personal_story + feeding + 1 project + regency-if-regent). Previously-entered ADVANCED fields are NOT cleared from the persisted document — they remain in `responses` even though their UI is hidden. Switching back to ADVANCED reveals them unchanged.
+
+**Given** a regent character (auto-detected from territory ownership per `downtime-form.js:1337`)
+**When** the form is in MINIMAL mode
+**Then** the regency section renders.
+
+**Given** a non-regent character
+**When** the form is in MINIMAL mode
+**Then** the regency section does not render.
+
+### Soft-submit lifecycle (Q3)
+
+**Given** the form auto-saves (every keystroke + 2s debounce per existing `scheduleSave()`)
+**When** the save fires
+**Then** `isMinimalComplete(responses)` runs; if its result differs from the previous `responses._has_minimum`, the new value is written AND a PATCH fires to update `submission.status` (`'submitted'` ↔ `'draft'`) AND a PATCH fires to update `attendance[i].downtime` for the player's character on the active cycle's `game_session`.
+
+**Given** the player flips from below-minimum to above-minimum
+**When** the lifecycle PATCHes fire
+**Then** `submission.status === 'submitted'`, `attendance[i].downtime === true`, the banner disappears, the XP-Available annotation disappears, and `xpGame()` recomputes to include the +1 downtime credit.
+
+**Given** the player flips from above-minimum to below-minimum
+**When** the lifecycle PATCHes fire
+**Then** `submission.status === 'draft'`, `attendance[i].downtime === false`, the banner reappears, the XP-Available annotation reappears, and `xpGame()` recomputes to drop the +1 downtime credit.
+
+**Given** the cycle is closed (`cycle.status === 'closed'`)
+**When** the player attempts to PATCH the submission
+**Then** the server middleware returns 423 Locked. The client surfaces a "Cycle closed; submission locked" message and does not retry.
+
+### `isMinimalComplete()` (Q8)
+
+**Given** the function lives at `public/js/data/dt-completeness.js`
+**When** a developer reads it
+**Then** it exports a single `isMinimalComplete(responses)` function returning a boolean. The function encodes the MINIMAL-completeness rules from §Q2:
+- Court section has been touched (recount text non-empty)
+- Personal Story has the binary Touchstone-or-Correspondence + text input filled
+- Feeding has territory + method + blood type + violence-mode set
+- Project slot 1 has at least an action selected (further per-action validation TBD per §future-work)
+- For regents: regency confirmation is positive
+
+**Given** the same function
+**When** imported from a server-side context (potential Q7 future-work)
+**Then** the import succeeds without browser-only globals. The module has no `document` / `window` / DOM dependencies.
+
+### The three UI affordances (Q3 hard mirror is honest)
+
+**Given** `_has_minimum === false`
+**When** the form renders
+**Then** a persistent banner displays at the top of the form (or below the mode selector — implementer's call) with text approximately:
+> *"Your form is below minimum-complete. Your downtime XP credit is on hold. Add the missing pieces to restore it: [list]."*
+
+The list of missing pieces is derived from inverting `isMinimalComplete()`'s logic — each rule that fails contributes a one-line "[section]: [what's missing]" item.
+
+**Given** `_has_minimum === false`
+**When** the player's XP-Available number renders (anywhere it surfaces — sheet, suite, player tabs)
+**Then** a small "(downtime credit on hold)" annotation appears immediately after the number. When `_has_minimum === true`, the annotation disappears.
+
+**Given** the player has spent XP that subsequently flipped back below minimum (so `xpLeft()` returns negative)
+**When** the player view renders XP-Left
+**Then** the value is shown in red with a hover tooltip explaining the temporary deficit and how to resolve it ("restore the form to minimum-complete, or reverse the spend").
+
+### Cycle-close server gate (Q11)
+
+**Given** middleware on `PATCH /api/downtime_submissions/:id`
+**When** the request fires
+**Then** the middleware looks up the submission's `cycle_id`, fetches the cycle, and if `cycle.status === 'closed'` returns 423 Locked with `{ error: 'CYCLE_CLOSED', message: 'Cycle is closed; submissions are locked' }`. Otherwise, the request proceeds normally.
+
+**Given** the middleware is implemented
+**When** server tests run
+**Then** all existing suites pass + at least one new test covers the 423 path.
+
+---
+
+## Implementation Notes
+
+### Sequencing within this PR
+
+1. Land `public/js/data/dt-completeness.js` first. Pure module, no DOM. Easy to test in isolation.
+2. Land the rendering gate in `downtime-form.js`. `_mode` is read; sections in MINIMAL render; sections outside MINIMAL render only when `_mode === 'advanced'`.
+3. Land the lifecycle wiring in `scheduleSave()` / `saveDraft()`. Compute `_has_minimum`; if changed from previous, PATCH the two artefacts.
+4. Land the three UI affordances (banner, annotation, negative-XP-Left treatment). These are the user-facing signals that make hard mirror legible.
+5. Land the server middleware (`server/routes/downtime.js`). One small `requireOpenCycle` middleware applied to the PATCH route.
+
+### Banner copy (lock)
+
+The exact wording is in §Q3:
+> *"Your form is below minimum-complete. Your downtime XP credit is on hold. Add the missing pieces to restore it."*
+
+Plus a list of missing pieces below. Implementer's call on visual treatment (yellow banner, blue info banner, etc.) — it should match existing form-banner styling if any (search `dt-banner-*` or similar).
+
+### XP-Available annotation copy (lock)
+
+The exact wording is in §Q3:
+> *"(downtime credit on hold)"*
+
+In parentheses, immediately after the XP-Available number. Smaller font / muted colour to not crowd the number.
+
+### `attendance[i].downtime` PATCH endpoint
+
+ADR-003 §Q3 sketches:
+```
+PATCH /api/game_sessions/.../attendance/:char_id { downtime: has_minimum }
+```
+
+If this endpoint doesn't exist yet, surface in DAR — may need a new route. Most likely it does (the ST attendance UI flips this flag manually; the same path applies).
+
+### MINIMAL set per-section behaviour table (lock)
+
+| Section | MINIMAL renders? | MINIMAL state |
+|---|---|---|
+| court | Yes | Full section as today |
+| personal_story | Yes | Reduced binary (Touchstone-or-Correspondence + 1 text input) per #18 |
+| feeding | Yes | Simplified per #20 |
+| projects | Yes — 1 slot only | First slot rendered; ADVANCED renders all 4 |
+| regency | Yes — only if regent | Confirmation UI per #23 |
+| blood_sorcery | No | Hidden |
+| territory | No | Hidden |
+| acquisitions | No | Hidden |
+| equipment | No | Hidden (also #30 hides for ADVANCED in this cycle) |
+| vamping | No | Hidden |
+| admin | No | Removed entirely (#31 replaces with submit-final modal) |
+
+---
+
+## Test Plan
+
+1. **Server tests** — territory + downtime suites should remain green; new test for the 423 cycle-close path.
+2. **Static review (Ma'at)** — three UI affordances are present in the diff; lifecycle PATCH calls are idempotent; mode-switch preserves data.
+3. **Browser smoke (DEFERRED to user/SM)**:
+   - Open a fresh submission → MINIMAL by default → only MINIMAL sections visible
+   - Fill enough fields to flip `_has_minimum` true → banner disappears, annotation disappears, XP-Available updates
+   - Empty a field to flip back to false → banner reappears, annotation reappears, XP-Available drops
+   - Spend XP while above minimum, then drop below → red XP-Left + tooltip appears
+   - Switch MINIMAL → ADVANCED → MINIMAL → no data lost
+   - ST closes cycle → player attempts edit → 423 + locked message
+   - Regent character: regency section appears in MINIMAL; non-regent: it does not
+
+---
+
+## Definition of Done
+
+- [ ] `public/js/data/dt-completeness.js` ships with `isMinimalComplete(responses)` exported
+- [ ] Mode selector renders at top of form; persistence in `responses._mode` works; default MINIMAL; switch preserves data
+- [ ] Lifecycle wiring in `scheduleSave()`/`saveDraft()` PATCHes both submission status + attendance.downtime on transition
+- [ ] All three UI affordances ship: banner, XP-Available annotation, negative-XP-Left red treatment
+- [ ] Cycle-close server gate returns 423 Locked
+- [ ] Schema documents new fields (`_mode`, `_has_minimum`, `_final_submitted_at`) under `downtime_submission.schema.js properties`
+- [ ] No `game_session.schema.js` delta (per ADR rev 2)
+- [ ] Server tests green; new 423 test added
+- [ ] Browser smoke completes the 7-step plan in §Test Plan §3
+- [ ] PR opened by `tm-gh-pr-for-branch` into `dev`, body links ADR-003 §Q1/Q2/Q3/Q4/Q8/Q11
+
+---
+
+## Dependencies
+
+- **Upstream**: #16 (universal character picker — used by feeding section's territory/method UI in the simplified MINIMAL variant if it consumes a picker; #17 doesn't directly call it but per-section MINIMAL stories depend on both)
+- **Downstream**: blocks every per-section story (#18, #19, #20, #21, #22, #23, #24, #25, #26, #27, #28, #29, #30, #31). The mode/lifecycle gate is the rendering contract those stories respect.

--- a/specs/stories/dt-form.18-personal-story-reduce.story.md
+++ b/specs/stories/dt-form.18-personal-story-reduce.story.md
@@ -1,0 +1,76 @@
+---
+id: dt-form.18
+task: 18
+epic: epic-dt-form-mvp-redesign
+status: Draft
+priority: high
+depends_on: ['dt-form.17']
+adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q2)
+---
+
+# Story dt-form.18 — Personal Story reduced to Touchstone-or-Correspondence binary
+
+As a player on MINIMAL mode,
+I should see Personal Story as a tight binary choice (Touchstone OR Correspondence) with one text input,
+So that the section captures the minimum narrative the cycle needs without the maximalist current shape.
+
+## Context
+
+ADR-003 §Q2 calls Personal Story for reduction in MINIMAL mode: "Reduced to binary Touchstone-or-Correspondence with one text input." This story implements that reduction; ADVANCED mode still renders the full Personal Story section as it exists today.
+
+The current Personal Story section (introduced via PR #28 / issue #24) renders an NPC-name + interaction-note pair. The reduced MINIMAL variant collapses to a single radio choice (Touchstone | Correspondence) plus one text input scoped to the chosen option.
+
+### Files in scope
+
+- `public/js/tabs/downtime-form.js` — the `personal_story` section render path (currently around `:1741+`, `renderPersonalStorySection(saved)`)
+- `public/js/data/dt-completeness.js` — `isMinimalComplete()` updated to consume the new MINIMAL Personal Story shape
+
+### Files NOT in scope
+
+- The ADVANCED Personal Story section (unchanged)
+- Submission schema (the new fields fit under existing `responses` keys; no schema delta)
+- Issue #24's underlying free-text NPC fields — those remain available in ADVANCED
+
+## Acceptance Criteria
+
+**Given** a player on MINIMAL mode
+**When** the Personal Story section renders
+**Then** they see one radio group (Touchstone | Correspondence) and one text input scoped to the chosen radio (placeholder text adapts: "Describe the touchstone moment..." vs "Describe the correspondence...").
+
+**Given** the player picks Touchstone and fills the text input
+**When** `isMinimalComplete()` is evaluated
+**Then** Personal Story passes its rule (chosen radio + non-empty text).
+
+**Given** ADVANCED mode is active
+**When** the Personal Story section renders
+**Then** the full existing Personal Story UI renders unchanged (free-text NPC fields per issue #24 remain available).
+
+**Given** a player switches MINIMAL → ADVANCED → MINIMAL
+**When** the form re-renders
+**Then** the MINIMAL radio + text values are preserved (per ADR-003 §Q1 mode-switch-preserves-data).
+
+## Implementation Notes
+
+The current `renderPersonalStorySection(saved)` already lives at `:1741+`. Wrap with a `_mode === 'minimal'` branch:
+- MINIMAL → render the binary (radio + text, persisted in `responses.personal_story_kind` and `responses.personal_story_text`)
+- ADVANCED → render the existing free-text NPC field shape
+
+`isMinimalComplete()` (in `dt-completeness.js`, owned by #17) reads `personal_story_kind` and `personal_story_text` to decide; the rule passes when both are set.
+
+## Test Plan
+
+- Static review: branch on `_mode` is the only structural change; existing ADVANCED path untouched
+- Browser smoke (DEFERRED): MINIMAL renders binary; switch to ADVANCED; switch back; values preserved
+
+## Definition of Done
+
+- [ ] MINIMAL Personal Story renders binary (radio + text)
+- [ ] ADVANCED Personal Story renders unchanged
+- [ ] `isMinimalComplete()` consults new fields
+- [ ] Browser smoke: round-trip mode switching preserves data
+- [ ] PR opened into `dev`
+
+## Dependencies
+
+- **Upstream**: #17 (lifecycle + `_mode` rendering gate)
+- **Downstream**: none direct

--- a/specs/stories/dt-form.19-influence-breakdown-tooltip.story.md
+++ b/specs/stories/dt-form.19-influence-breakdown-tooltip.story.md
@@ -1,0 +1,66 @@
+---
+id: dt-form.19
+task: 19
+epic: epic-dt-form-mvp-redesign
+status: Draft
+priority: medium
+depends_on: ['dt-form.17']
+adr: specs/architecture/adr-003-dt-form-cross-cutting.md (Implementation Plan)
+---
+
+# Story dt-form.19 — City Influence breakdown tooltip
+
+As a player or ST seeing the City Influence label (e.g. `8/10 Influence`),
+I should be able to hover and see how that figure is derived (which merits, which adjustments, which territory bonuses contribute),
+So that the figure is auditable inline without leaving the form.
+
+## Context
+
+The `8/10 Influence` label in the City section (territory + influence subsection) is currently a flat number. ADR-003 lists task #19 as independent feature work; per Piatra (2026-05-06): mirror an existing tooltip pattern from elsewhere in the codebase rather than invent a new one.
+
+`influenceBreakdown(c)` in `public/js/editor/domain.js` already exists as the source-of-truth for the breakdown — reuse it.
+
+### Files in scope
+
+- `public/js/tabs/downtime-form.js` — the territory section's influence label render
+- CSS — adopt the existing tooltip styling pattern (search for existing `tooltip` or `title=` patterns; the Attaché derived-note at `sheet.js:830` is a precedent for inline-explanatory copy)
+
+### Files NOT in scope
+
+- `influenceBreakdown(c)` itself — already correct; just consume it
+- Other influence-display sites (admin, suite) — out of scope; this story is form-only per ADR-003 §Out-of-scope on broader adoption
+
+## Acceptance Criteria
+
+**Given** the City section renders the `N/M Influence` label
+**When** the player hovers
+**Then** a tooltip appears showing the breakdown by source: merit contributions, attaché bonuses, regency bonus (if any), and any other contributors per `influenceBreakdown(c)`.
+
+**Given** the tooltip is keyboard-accessible
+**When** the label receives focus
+**Then** the tooltip surfaces (or an `aria-describedby` association exposes the breakdown to assistive tech).
+
+**Given** an existing tooltip pattern exists elsewhere in the codebase
+**When** this tooltip ships
+**Then** it visually matches that pattern (no novel styling).
+
+## Implementation Notes
+
+`influenceBreakdown(c)` returns a structured object — render its contents as a small dt/dd list inside the tooltip body. Examples to mirror: any `title=` pattern in the form, or the Attaché derived-note inline-explanatory copy.
+
+## Test Plan
+
+- Static review: tooltip wired to the existing breakdown helper
+- Browser smoke: hover on `N/M Influence` label, verify tooltip; tab to label, verify keyboard accessibility
+
+## Definition of Done
+
+- [ ] Tooltip on `N/M Influence` shows breakdown
+- [ ] Visual treatment matches existing tooltip pattern
+- [ ] Keyboard-accessible
+- [ ] PR opened into `dev`
+
+## Dependencies
+
+- **Upstream**: #17 (rendering gate; the territory section is ADVANCED-only)
+- **Downstream**: none

--- a/specs/stories/dt-form.20-feeding-simplified.story.md
+++ b/specs/stories/dt-form.20-feeding-simplified.story.md
@@ -1,0 +1,76 @@
+---
+id: dt-form.20
+task: 20
+epic: epic-dt-form-mvp-redesign
+status: Draft
+priority: high
+depends_on: ['dt-form.17']
+adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q2)
+---
+
+# Story dt-form.20 — Feeding simplified MINIMAL variant
+
+As a player on MINIMAL mode,
+I should see a Simplified Feeding Form (territory + method + blood type + violence + description, with auto-pick best dice pool),
+So that the feeding decision is captured without exposing the dice-pool selector chrome.
+
+## Context
+
+ADR-003 §Q2 lists the MINIMAL feeding state: "Simplified Feeding Form variant; auto-pick best dice pool; territory + method + blood type + violence + description." The full feeding section with manual dice-pool / ROTE-as-secondary chrome remains the ADVANCED variant.
+
+"Auto-pick best dice pool" means the form derives the highest-quality dice pool the character can use given their feeding rights, method choice, and territory ambience — no UI for the player to hand-pick.
+
+### Files in scope
+
+- `public/js/tabs/downtime-form.js` — the `feeding` section render path (currently around `:3500-4200` for `renderFeedingSection`)
+- `public/js/data/dt-completeness.js` — `isMinimalComplete()` updated to consume the simplified feeding fields
+
+### Files NOT in scope
+
+- ROTE hunt logic itself — that's #22
+- Feeding territory tinting — that's #21 (separate visual change)
+- Feeding rights data model (`territories.feeding_rights[]` is canonical post-fix.39)
+- The full ADVANCED feeding form (unchanged in this story)
+
+## Acceptance Criteria
+
+**Given** a player on MINIMAL mode
+**When** the Feeding section renders
+**Then** they see: territory selector (uses #16 picker if applicable, otherwise existing chip set per #21 tinting), method selector, blood type selector, violence-mode selector, description text input.
+
+**Given** territory + method + blood-type + violence are all set
+**When** the form computes dice pool
+**Then** the highest-quality pool the character can use under those choices is auto-selected. The player sees the resulting pool but not a UI to pick from alternatives.
+
+**Given** all five MINIMAL feeding fields are filled
+**When** `isMinimalComplete()` is evaluated
+**Then** Feeding passes its rule.
+
+**Given** a player on ADVANCED mode
+**When** the Feeding section renders
+**Then** the full existing feeding form renders unchanged (manual dice-pool selector, ROTE-as-secondary chrome, etc.).
+
+## Implementation Notes
+
+Auto-pick best dice pool: derive from existing helpers (search for `feedDicePool`, `bestFeedingPool`, or similar) or compute inline against the character's feeding-rights territories crossed with method/blood-type/violence affinities. Surface the resulting pool number near the description input as read-only ("Pool: 7" or similar).
+
+`isMinimalComplete()` rule for Feeding (per ADR §Q2 + this story): all five fields present.
+
+## Test Plan
+
+- Static review: MINIMAL branch renders only the 5 fields; auto-pool computes; ADVANCED path untouched
+- Browser smoke (DEFERRED): MINIMAL fills cleanly, mode-switch preserves data, dice pool auto-derives sensibly
+
+## Definition of Done
+
+- [ ] MINIMAL feeding renders the 5-field simplified form
+- [ ] Auto-pick best dice pool surfaces a read-only pool number
+- [ ] ADVANCED feeding form unchanged
+- [ ] `isMinimalComplete()` consults the simplified fields
+- [ ] PR opened into `dev`
+
+## Dependencies
+
+- **Upstream**: #17 (lifecycle + `_mode`); #16 (picker, if territory selector adopts it)
+- **Soft co-ordination**: #21 (territory tinting) ships independently but the same territory chip surface is used; coordinate visual style on overlap
+- **Downstream**: none

--- a/specs/stories/dt-form.21-feeding-territory-tint.story.md
+++ b/specs/stories/dt-form.21-feeding-territory-tint.story.md
@@ -1,0 +1,85 @@
+---
+id: dt-form.21
+task: 21
+epic: epic-dt-form-mvp-redesign
+status: Draft
+priority: medium
+depends_on: ['dt-form.17']
+adr: specs/architecture/adr-003-dt-form-cross-cutting.md (Implementation Plan)
+---
+
+# Story dt-form.21 — Feeding territory tinting (green/red regardless of selection)
+
+As a player choosing a feeding territory,
+I should see green tinting on territories where I have feeding rights / regency / lieutenancy and red tinting on barrens / no-rights territories — visible regardless of whether the territory is currently selected,
+So that I can make an informed selection at a glance without selecting each chip to discover its status.
+
+## Context
+
+Currently the residency badge in the feeding territory selector only tints when the territory is selected. Per Piatra (2026-05-06), this should change: green-tint background if the character has feeding rights / regent / lieutenant in that territory; red-tint if barrens or no rights. Tint visible in both selected and unselected states.
+
+Feeding-rights data is canonical at `territories.feeding_rights[]` (post-fix.39). Regent and lieutenant relationships are implicit per RFR.1 — the rights check must include all three:
+
+```
+hasFeedingRights(c, t) = t.feeding_rights.includes(String(c._id))
+                      || String(t.regent_id) === String(c._id)
+                      || String(t.lieutenant_id) === String(c._id)
+```
+
+### Files in scope
+
+- `public/js/tabs/downtime-form.js` — the feeding territory chip render path
+- CSS — green / red tint variants. Match existing tint patterns if any (search `dt-chip-*` for precedents); otherwise add `dt-chip-territory-rights` / `dt-chip-territory-barrens` classes
+
+### Files NOT in scope
+
+- The feeding-rights data model (already canonical via `territories.feeding_rights[]`)
+- Territory editor / regent-management UI (separate flow)
+- The simplified MINIMAL feeding shape (#20 — separate concern; both stories operate on the same chip surface)
+
+## Acceptance Criteria
+
+**Given** a character has feeding rights, regency, or lieutenancy on a territory
+**When** the feeding territory chip set renders
+**Then** that chip has the green-tint background applied. Visible in both selected and unselected states.
+
+**Given** a territory is barrens (or the character has no rights / regency / lieutenancy)
+**When** the chip renders
+**Then** that chip has the red-tint background applied. Visible in both states.
+
+**Given** the chip is currently selected
+**When** the visual treatment renders
+**Then** the selection state is layered on top of the tint (e.g. selection ring + tint background). Both signals are simultaneously legible.
+
+**Given** the rights check
+**When** evaluated for a character
+**Then** it returns true for any of: `feeding_rights.includes(String(c._id))`, `String(regent_id) === String(c._id)`, `String(lieutenant_id) === String(c._id)`.
+
+**Given** the chip set re-renders mid-session (e.g. after a regent change)
+**When** the same character's feeding chip set is re-rendered
+**Then** the tint reflects the updated state without needing a full reload (couples cleanly with #13b's drop-the-cache pattern that just shipped).
+
+## Implementation Notes
+
+The check function should be a small helper, ideally co-located with where the chip renders. Recommend exporting from `public/js/data/helpers.js` if other surfaces want it later, but keeping form-local for this story's scope (per ADR-003's cross-suite-helper gate).
+
+Visual treatment: green = success / OK colour from existing CSS palette; red = warning / unavailable colour. Stay subtle — the tint is informational, not blocking.
+
+## Test Plan
+
+- Static review: rights check correctly checks all three fields; tint applied regardless of selection state
+- Browser smoke (DEFERRED): walk through a character's feeding chips; confirm green/red tints match their feeding-rights status; select/deselect a chip and confirm tint persists
+
+## Definition of Done
+
+- [ ] Feeding territory chips green-tint on rights/regency/lieutenancy
+- [ ] Red-tint on barrens / no-rights
+- [ ] Tint visible regardless of selection state
+- [ ] Rights check includes all three fields (feeding_rights, regent_id, lieutenant_id)
+- [ ] PR opened into `dev`
+
+## Dependencies
+
+- **Upstream**: #17 (rendering gate; this surface lives within the feeding section which renders in MINIMAL)
+- **Soft co-ordination**: #20 (simplified feeding) — same chip surface; #21 is purely visual; merge order doesn't matter but conflicts in the same render path likely
+- **Downstream**: none

--- a/specs/stories/dt-form.22-rote-hunt.story.md
+++ b/specs/stories/dt-form.22-rote-hunt.story.md
@@ -1,0 +1,70 @@
+---
+id: dt-form.22
+task: 22
+epic: epic-dt-form-mvp-redesign
+status: Draft
+priority: medium
+depends_on: ['dt-form.17', 'dt-form.20']
+adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q2)
+---
+
+# Story dt-form.22 — ROTE hunt redesign (secondary feeding)
+
+As a player who wants to use ROTE-hunt as a secondary feeding option,
+I should see a clear secondary-feeding UI within the feeding section that explicitly distinguishes ROTE from primary feeding,
+So that ROTE choices are not buried in primary-feeding chrome and the section's MINIMAL/ADVANCED gating handles ROTE correctly.
+
+## Context
+
+ADR-003 §Audit-baseline notes ROTE hunt as "secondary feeding" within the existing `feeding` section. ADR §Q2 calls feeding for simplification in MINIMAL but does not specifically reduce ROTE chrome — that's this story's redesign.
+
+ROTE hunt is the "this is where you usually feed" lighter option that contrasts with primary feeding's per-cycle hunt. Players who do ROTE this cycle still need a way to declare it; the redesign gives ROTE a clear surface inside the feeding section.
+
+### Files in scope
+
+- `public/js/tabs/downtime-form.js` — the feeding section's ROTE-secondary render
+- `public/js/data/dt-completeness.js` — `isMinimalComplete()` rule for feeding may need to consider ROTE-only as a valid completion (or not — this story decides)
+
+### Files NOT in scope
+
+- Primary feeding logic (covered by #20)
+- Feeding territory tinting (#21)
+- The `MAINTENANCE_MERITS` ROTE-related interaction (separate concern)
+
+## Acceptance Criteria
+
+**Given** a player on MINIMAL or ADVANCED with feeding section visible
+**When** the ROTE option is selected
+**Then** the form shows a secondary-feeding UI clearly distinguished from primary feeding (separate sub-block, label, optional collapse/expand affordance).
+
+**Given** ROTE-only is a valid feeding choice for the cycle
+**When** `isMinimalComplete()` is evaluated against a submission that has filled ROTE but not primary feeding
+**Then** the rule passes (ROTE counts as feeding for MINIMAL completeness — confirm with rules; if ROTE does NOT count, story decides MINIMAL requires primary feeding and ROTE is ADVANCED-only).
+
+**Given** ROTE is selected
+**When** the player provides whatever ROTE-specific fields are needed (territory, RP description, etc.)
+**Then** those values persist on `responses.feeding_rote_*` keys (or follow the existing convention if these fields already exist).
+
+## Implementation Notes
+
+The ROTE-vs-primary distinction in current code is fuzzy. Implementer should first **survey current ROTE behaviour** (grep for `rote`, `ROTE`, `_feeding_rote`, etc. in `downtime-form.js`); document findings in DAR; then redesign.
+
+If the survey shows ROTE has no current implementation at all (just a placeholder in the section list), this story should ship a minimum-viable ROTE block (territory + description) and mark deeper game-rules questions for a follow-up story.
+
+## Test Plan
+
+- DAR captures the survey of current ROTE state
+- Browser smoke: ROTE selection surfaces clearly; persists; mode-switch preserves ROTE values
+
+## Definition of Done
+
+- [ ] ROTE secondary-feeding block clearly distinguished in the feeding section
+- [ ] Persistence keys documented in DAR
+- [ ] `isMinimalComplete()` rule for ROTE-only confirmed (counts vs ADVANCED-only)
+- [ ] PR opened into `dev`
+
+## Dependencies
+
+- **Upstream**: #17 (rendering gate); #20 (simplified feeding)
+- **Downstream**: none
+- **Open question**: surface "is ROTE-only sufficient for MINIMAL completeness?" to Piatra during pickup — likely a quick chat answer

--- a/specs/stories/dt-form.22-rote-hunt.story.md
+++ b/specs/stories/dt-form.22-rote-hunt.story.md
@@ -37,9 +37,13 @@ ROTE hunt is the "this is where you usually feed" lighter option that contrasts 
 **When** the ROTE option is selected
 **Then** the form shows a secondary-feeding UI clearly distinguished from primary feeding (separate sub-block, label, optional collapse/expand affordance).
 
-**Given** ROTE-only is a valid feeding choice for the cycle
-**When** `isMinimalComplete()` is evaluated against a submission that has filled ROTE but not primary feeding
-**Then** the rule passes (ROTE counts as feeding for MINIMAL completeness — confirm with rules; if ROTE does NOT count, story decides MINIMAL requires primary feeding and ROTE is ADVANCED-only).
+**Given** ROTE feeding is selected on a MINIMAL submission
+**When** `isMinimalComplete()` is evaluated
+**Then** the rule passes — **ROTE counts as feeding for MINIMAL completeness** (confirmed by Piatra 2026-05-06). ROTE is a valid path through the MINIMAL gate.
+
+**Given** ROTE is selected on a MINIMAL submission
+**When** the form auto-saves
+**Then** the corresponding downtime action is auto-populated with the ROTE feeding action — the player does not need to declare a Personal Action separately to record their ROTE hunt; the form derives it from the ROTE selection. (Per Piatra: "ROTE feeding is available in MINIMAL and would auto-populate the DOWNTIME action with the feeding action.")
 
 **Given** ROTE is selected
 **When** the player provides whatever ROTE-specific fields are needed (territory, RP description, etc.)

--- a/specs/stories/dt-form.23-regency-confirm.story.md
+++ b/specs/stories/dt-form.23-regency-confirm.story.md
@@ -1,0 +1,77 @@
+---
+id: dt-form.23
+task: 23
+epic: epic-dt-form-mvp-redesign
+status: Draft
+priority: high
+depends_on: ['dt-form.17']
+adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q2)
+---
+
+# Story dt-form.23 — Regency confirmation UI
+
+As a regent character (auto-detected from territory ownership),
+I should see a confirmation UI in the regency section of the DT form,
+So that my regency status for the cycle is positively affirmed (or declined) and counts toward MINIMAL completeness for regents.
+
+## Context
+
+ADR-003 §Q2: regency renders only if `is_regent === 'yes'` (already auto-detected at `downtime-form.js:1337`). For regents, MINIMAL completeness includes a positive regency confirmation. This story redesigns the regency confirmation interaction.
+
+The current regency tab UI may have its own affordances; this story scopes the DT-form-context regency confirmation only.
+
+### Files in scope
+
+- `public/js/tabs/downtime-form.js` — the `regency` section render path (currently around `:1337+`)
+- `public/js/data/dt-completeness.js` — `isMinimalComplete()` rule for regency
+
+### Files NOT in scope
+
+- The regency tab itself (`public/js/tabs/regency-tab.js`) — that's a separate surface
+- Territory feeding-rights data (canonical at `territories.feeding_rights[]`)
+- Lieutenant entitlement (decided NO in #13b — no story here on extending bonus to lieutenants)
+
+## Acceptance Criteria
+
+**Given** a regent character (`is_regent === 'yes'` per existing detection)
+**When** the form renders in MINIMAL mode
+**Then** the regency section appears with a confirmation UI: "I am acting as regent of [Territory] for this cycle" with a positive affirmation control (button or checkbox).
+
+**Given** the regent confirms
+**When** the form auto-saves
+**Then** `responses.regency_confirmed === true` (or equivalent persisted value); `isMinimalComplete()` for regents passes its regency rule.
+
+**Given** the regent declines
+**When** the form auto-saves
+**Then** `responses.regency_confirmed === false`; `isMinimalComplete()` for regents fails its regency rule until they affirm or stop being a regent.
+
+**Given** a non-regent character
+**When** the form renders
+**Then** the regency section is not rendered; `isMinimalComplete()` does not have a regency rule for them.
+
+**Given** the regent has multiple territories (rare)
+**When** the regency section renders
+**Then** the section enumerates each (one confirmation per territory), or surfaces them as a single "regent of N territories" block — implementer's call based on how the live data shapes (audit during pickup).
+
+## Implementation Notes
+
+`is_regent` detection at `:1337` is already in place. The new UI is the confirmation interaction layered on that detection. Persistence under `responses.regency_*` keys.
+
+Visual treatment: keep light. A regent section that's a wall of legalese will feel heavy in MINIMAL. The confirmation is a single sentence + button.
+
+## Test Plan
+
+- Static review: regent gate is intact; confirmation persists
+- Browser smoke (DEFERRED): regent character sees the section; non-regent does not; confirmation flow round-trips
+
+## Definition of Done
+
+- [ ] Regency confirmation UI lives in the `regency` section
+- [ ] `isMinimalComplete()` consults regency confirmation for regents
+- [ ] Non-regents see no section (existing gate preserved)
+- [ ] PR opened into `dev`
+
+## Dependencies
+
+- **Upstream**: #17 (lifecycle + `_mode`)
+- **Downstream**: none

--- a/specs/stories/dt-form.24-personal-actions-chrome.story.md
+++ b/specs/stories/dt-form.24-personal-actions-chrome.story.md
@@ -1,0 +1,74 @@
+---
+id: dt-form.24
+task: 24
+epic: epic-dt-form-mvp-redesign
+status: Draft
+priority: high
+depends_on: ['dt-form.16', 'dt-form.17']
+adr: specs/architecture/adr-003-dt-form-cross-cutting.md (Implementation Plan)
+---
+
+# Story dt-form.24 — Personal Actions chrome strip + adopt charPicker for ALLY
+
+As a player filling Personal Action slots,
+I should not see MODE / SUPPORT / single-vs-dual roll selectors that no rule consumes,
+And ALLY-attach pickers should use the universal `charPicker()` (with `excludeIds: [self]`),
+So that the action chrome is decluttered and ALLY selection is consistent with the rest of the form.
+
+## Context
+
+ADR-003 §Audit-baseline names redundant chrome the rules don't consume on Personal Action slots: MODE, SUPPORT, and single-vs-dual roll choice. The Implementation Plan locks task #24 to strip this chrome and adopt `charPicker()` for any ALLY-attach selectors.
+
+MINIMAL mode renders only 1 project slot per ADR §Q2 (Q1's MINIMAL composition). ADVANCED renders all 4. This story applies to both.
+
+### Files in scope
+
+- `public/js/tabs/downtime-form.js` — the project-slot render path (`:5000+`-ish, `renderProjectSlot(...)` and the Personal Actions section rendering)
+- `public/js/tabs/downtime-data.js` — if MODE/SUPPORT enums need cleanup (likely they do)
+
+### Files NOT in scope
+
+- The action-type list itself (action types like `ambience_increase`, `attack`, `xp_spend`, etc. — those are scoped per-action by other stories)
+- Single-slot vs four-slot rendering — covered by #17's MINIMAL gate
+- Joint authoring / project invitation — that's removed in #32
+
+## Acceptance Criteria
+
+**Given** a Personal Action slot renders
+**When** the slot is in any state
+**Then** there is no MODE selector visible. There is no SUPPORT selector visible. There is no single-vs-dual roll selector visible. Any backing fields in `responses` for these have been removed (or migrated to inert under-the-hood derivations).
+
+**Given** an ALLY-attach selector exists within an action slot
+**When** it renders
+**Then** it uses `charPicker({ scope: 'all', cardinality: 'single', excludeIds: [String(currentChar._id)], onChange: fn })`.
+
+**Given** the player previously had a MODE/SUPPORT value persisted
+**When** the form loads against pre-existing data
+**Then** the legacy fields are tolerated (not an error) but not surfaced. Optional: the form auto-cleans them on next save (drop the keys); recommend yes for hygiene.
+
+**Given** the chrome is stripped
+**When** the action slot is filled and saved
+**Then** the surviving fields (action type, target, dice pool if applicable, cast, merits) round-trip cleanly.
+
+## Implementation Notes
+
+Survey current chrome before stripping: grep for `_mode`, `_support`, `_single_dual` (or the actual literal field names) in `downtime-form.js` to find every render and persist site. Strip them all.
+
+ALLY-attach is the principal `excludeIds` consumer per ADR §Q6 — confirms the v1 parameter shipping.
+
+## Test Plan
+
+- Static review: chrome fields gone from renders + persists; ALLY-attach uses `charPicker`
+- Browser smoke: action slot fills cleanly; legacy data with MODE/SUPPORT loads without error; ALLY picker excludes self
+
+## Definition of Done
+
+- [ ] MODE / SUPPORT / single-vs-dual chrome removed from action-slot render
+- [ ] ALLY-attach uses `charPicker` with `excludeIds: [self]`
+- [ ] Legacy data tolerated (or auto-cleaned)
+- [ ] PR opened into `dev`
+
+## Dependencies
+
+- **Upstream**: #16 (charPicker), #17 (lifecycle/mode)
+- **Downstream**: #25 (ambience action redesign — operates on individual action types within slots; #24's chrome strip is the surface they share), #26 (XP spend), #28 (Mentor/Staff)

--- a/specs/stories/dt-form.25-ambience-action-redesign.story.md
+++ b/specs/stories/dt-form.25-ambience-action-redesign.story.md
@@ -11,17 +11,17 @@ adr: specs/architecture/adr-003-dt-form-cross-cutting.md (Implementation Plan)
 # Story dt-form.25 — Ambience Increase/Decrease action redesign (territory-row table)
 
 As a player declaring an Ambience Increase or Decrease action,
-I should see a territory-row table where each row has a RED DOWN arrow and a GREEN UP arrow (mutually exclusive per row, with toggle-off to reveal both again),
+I should see a territory-row table where each row has a RED DOWN arrow and a GREEN UP arrow, each independently toggleable,
 So that the choice surface is direct (territory + direction) rather than a generic target/Increase/Decrease form.
 
 ## Context
 
-The current `ambience_increase` and `ambience_decrease` action types within Personal Actions slots use generic target/direction inputs. Per Piatra (2026-05-06), redesign as a table:
+The current `ambience_increase` and `ambience_decrease` action types within Personal Actions slots use generic target/direction inputs. Per Piatra (2026-05-06, clarified 2026-05-06 follow-up):
 - One row per territory
-- RED DOWN arrow (selectable) — encodes "Decrease ambience here"
-- GREEN UP arrow (mutually exclusive per row) — encodes "Increase ambience here"
-- Selecting one collapses the other for that row
-- Clicking the selection toggles it off and reveals both arrows again
+- Each row has both a RED DOWN arrow and a GREEN UP arrow as toggleable selectors
+- Each direction is **independently toggleable**: click to select that direction; click again to deselect
+- Both selectors stay visible at all times (do not collapse on selection)
+- The original brief's "mutually exclusive per row" language was relaxed to "independently toggleable" in the follow-up clarification
 
 Rules summary text: *"Success is +/-2 influence change to territory, +/-4 on exceptional success."*
 
@@ -40,19 +40,23 @@ Rules summary text: *"Success is +/-2 influence change to territory, +/-4 on exc
 
 **Given** a player selects `ambience_increase` or `ambience_decrease` action type
 **When** the action slot renders
-**Then** a territory-row table renders. Each row has the territory name, a RED DOWN arrow chip, and a GREEN UP arrow chip.
+**Then** a territory-row table renders. Each row has the territory name, a RED DOWN arrow chip, and a GREEN UP arrow chip. Both chips are visible at all times.
 
 **Given** the player clicks the GREEN UP arrow on a row
 **When** the chip toggles
-**Then** the GREEN UP is selected for that row; the RED DOWN for that row is hidden / collapsed; other rows are unaffected.
+**Then** the GREEN UP is selected (highlighted) for that row. The RED DOWN remains visible. Other rows are unaffected.
 
 **Given** the GREEN UP arrow is selected for a row
 **When** the player clicks the GREEN UP arrow again on the same row
-**Then** the selection toggles off; both arrows reappear for that row.
+**Then** the selection toggles off. The arrow returns to its unselected state.
 
-**Given** a player has selected one direction on one row
+**Given** the player clicks the RED DOWN arrow on the same row that already has GREEN UP selected
+**When** the chip toggles
+**Then** RED DOWN becomes selected. **GREEN UP and RED DOWN are independently toggleable per Piatra's 2026-05-06 follow-up clarification** — both directions may be selected simultaneously on the same row if the player chooses. The form does not enforce mutual exclusivity at the UI level.
+
+**Given** a player has selected directions on multiple rows
 **When** they click an arrow on a different row
-**Then** both rows can hold selections — the table allows multi-row selection (one direction per row). (If per-action rules limit this to one row total, surface to Piatra during pickup; default assumption is multi-row allowed.)
+**Then** all rows can hold independent selections — the table allows multi-row selection.
 
 **Given** the form persists
 **When** the slot is saved

--- a/specs/stories/dt-form.25-ambience-action-redesign.story.md
+++ b/specs/stories/dt-form.25-ambience-action-redesign.story.md
@@ -1,0 +1,87 @@
+---
+id: dt-form.25
+task: 25
+epic: epic-dt-form-mvp-redesign
+status: Draft
+priority: medium
+depends_on: ['dt-form.17', 'dt-form.24']
+adr: specs/architecture/adr-003-dt-form-cross-cutting.md (Implementation Plan)
+---
+
+# Story dt-form.25 — Ambience Increase/Decrease action redesign (territory-row table)
+
+As a player declaring an Ambience Increase or Decrease action,
+I should see a territory-row table where each row has a RED DOWN arrow and a GREEN UP arrow (mutually exclusive per row, with toggle-off to reveal both again),
+So that the choice surface is direct (territory + direction) rather than a generic target/Increase/Decrease form.
+
+## Context
+
+The current `ambience_increase` and `ambience_decrease` action types within Personal Actions slots use generic target/direction inputs. Per Piatra (2026-05-06), redesign as a table:
+- One row per territory
+- RED DOWN arrow (selectable) — encodes "Decrease ambience here"
+- GREEN UP arrow (mutually exclusive per row) — encodes "Increase ambience here"
+- Selecting one collapses the other for that row
+- Clicking the selection toggles it off and reveals both arrows again
+
+Rules summary text: *"Success is +/-2 influence change to territory, +/-4 on exceptional success."*
+
+### Files in scope
+
+- `public/js/tabs/downtime-form.js` — the `ambience_increase` / `ambience_decrease` action render within project slots
+- CSS — arrow-chip styling. Match existing chip patterns (`dt-chip` family) where possible.
+
+### Files NOT in scope
+
+- The underlying `projectActionEnum` — these actions remain in the list; only their UI shape changes
+- Other project-slot action types (attack, feed, hide-protect, etc.) — out of scope
+- The territory data source (live MongoDB territories collection, post-#3c)
+
+## Acceptance Criteria
+
+**Given** a player selects `ambience_increase` or `ambience_decrease` action type
+**When** the action slot renders
+**Then** a territory-row table renders. Each row has the territory name, a RED DOWN arrow chip, and a GREEN UP arrow chip.
+
+**Given** the player clicks the GREEN UP arrow on a row
+**When** the chip toggles
+**Then** the GREEN UP is selected for that row; the RED DOWN for that row is hidden / collapsed; other rows are unaffected.
+
+**Given** the GREEN UP arrow is selected for a row
+**When** the player clicks the GREEN UP arrow again on the same row
+**Then** the selection toggles off; both arrows reappear for that row.
+
+**Given** a player has selected one direction on one row
+**When** they click an arrow on a different row
+**Then** both rows can hold selections — the table allows multi-row selection (one direction per row). (If per-action rules limit this to one row total, surface to Piatra during pickup; default assumption is multi-row allowed.)
+
+**Given** the form persists
+**When** the slot is saved
+**Then** the selections persist as a per-territory direction map (e.g. `responses.project_N_ambience_targets = { '<terr_id>': 'up' | 'down' }`).
+
+**Given** the rules summary needs to surface
+**When** the action UI renders
+**Then** the text "Success is +/-2 influence change to territory, +/-4 on exceptional success." appears near the table (above or below — implementer's call).
+
+## Implementation Notes
+
+Both action types (`ambience_increase` and `ambience_decrease`) collapse to the same UI shape. The action-type field is retained in `responses` for historical reasons but the UI doesn't ask the player to pick "increase or decrease" before the table — they just pick directions per row.
+
+If the per-action-type distinction (increase vs decrease) is no longer meaningful post-redesign, surface to Piatra during pickup as a simplification candidate (collapse to one action type called `ambience` with directions per territory).
+
+## Test Plan
+
+- Static review: arrow chips mutually exclusive per row; toggle-off works; persistence map shape sensible
+- Browser smoke: pick a direction on a row; toggle off; pick on another row; reload; values persist
+
+## Definition of Done
+
+- [ ] Territory-row table renders for ambience actions
+- [ ] RED DOWN / GREEN UP arrows mutually exclusive per row, toggle-off reveals both
+- [ ] Rules summary text present
+- [ ] Persistence shape documented in DAR
+- [ ] PR opened into `dev`
+
+## Dependencies
+
+- **Upstream**: #17 (lifecycle); #24 (Personal Actions chrome strip — same render path for action slots; coordinate merge order)
+- **Downstream**: none

--- a/specs/stories/dt-form.26-xp-spend-action.story.md
+++ b/specs/stories/dt-form.26-xp-spend-action.story.md
@@ -1,0 +1,89 @@
+---
+id: dt-form.26
+task: 26
+epic: epic-dt-form-mvp-redesign
+status: Draft
+priority: high
+depends_on: ['dt-form.17', 'dt-form.24', 'dt-form.31']
+hotfix_predecessor: 'GitHub issue #44'
+adr: specs/architecture/adr-003-dt-form-cross-cutting.md (Implementation Plan)
+---
+
+# Story dt-form.26 — XP Spend action overhaul + remove Admin XP section
+
+As a player wanting to spend any amount of XP in a downtime,
+I should do all my XP-spend declaration inside a single Personal Action slot of type `xp_spend` (with a merit selector that shows all merit categories, including Carthian Law / Invictus Oaths under their covenant gating),
+So that the form has one canonical XP-spend surface instead of a duplicate UI in the Admin section.
+
+This story **PRESERVES the merit-selector category fix** from hotfix #44 — the redesign replaces the surrounding UI but the underlying merit-eligibility logic from #44 remains the source of truth.
+
+## Context
+
+ADR-003 + Piatra (2026-05-06) lock the redesign:
+- XP Spend personal action allows any XP amount in a single action.
+- Move the entire XP spend UI from the Admin section (`admin.xp_spend` per `DOWNTIME_SECTIONS`) into this personal action.
+- Merit selector dropdown must include all merit categories: general, influence, domain, standing, manoeuvre, plus Carthian Law / Invictus Oaths under their covenant gating.
+
+Cross-cutting note from Piatra: hotfix issue #44 (Merit selector dropdown missing Carthian Law / Invictus Oath / standing-merit categories) lands BEFORE this story via the hotfix lane. **Story #26 must preserve the #44 fix's merit-eligibility logic.**
+
+This story also depends on #31 (Submit Final modal / Admin section removal) for the Admin XP section's actual removal — both stories touch the Admin section's lifecycle.
+
+### Files in scope
+
+- `public/js/tabs/downtime-form.js` — the `xp_spend` action render within project slots; also the Admin section's xp_spend sub-section (for removal — coordinate with #31)
+- `public/js/tabs/downtime-data.js` — Admin section sub-keys (likely a `DOWNTIME_SECTIONS` entry change to remove `admin.xp_spend`)
+- Reference data: `public/js/data/merits.js` `MERITS_DB` if the merit-eligibility logic from #44 needs adjustment (most likely it doesn't — preserve it)
+
+### Files NOT in scope
+
+- The merit-eligibility logic itself (locked by #44 hotfix)
+- The XP cost rate constants (`CLAUDE.md` documents these — 4 XP/dot for attributes, 2 XP/dot for skills, etc.)
+- The full Admin section removal (covered by #31)
+- The Submit Final modal (covered by #31)
+
+## Acceptance Criteria
+
+**Given** a player creates a Personal Action slot of type `xp_spend`
+**When** the slot renders
+**Then** the full XP spend UI is in-slot: amount input, target type (attribute / skill / discipline / merit / etc.), target selector (filtered per type), cost computation visible, save persists to `responses.project_N_xp_*` keys.
+
+**Given** the merit-target selector renders
+**When** the dropdown opens
+**Then** all merit categories are present (general, influence, domain, standing, manoeuvre, Carthian Law, Invictus Oaths). Covenant gating is correct (Carthian Law gated to Carthian Movement covenant; Invictus Oaths gated to Invictus). The eligibility logic from hotfix #44 is the canonical source — this story must not override or duplicate it.
+
+**Given** the Admin section's xp_spend sub-section exists pre-redesign
+**When** this story (and #31) ship
+**Then** the Admin section's xp_spend UI is gone. `DOWNTIME_SECTIONS` entry for `admin.xp_spend` is removed.
+
+**Given** legacy submission data has XP-spend entries on the old `admin.xp_*` keys
+**When** the form loads against pre-existing data
+**Then** the legacy entries are tolerated (not errors). Implementer's call: surface a one-time migration banner or silently leave them. Recommendation: silent leave; the data is in `responses` and ignored.
+
+**Given** XP cost computation
+**When** the slot is filled
+**Then** the cost is shown to the player in the slot UI (read-only annotation), so they see the cost before saving.
+
+## Implementation Notes
+
+Coordinate merge with #31. Both touch Admin section. Recommended: #31 lands first (removes Admin section structure entirely, replaces with submit-final modal); #26 lands second (puts XP spend functionality in the project slot). If both ship in the same PR, coordinate.
+
+Survey current Admin xp_spend UI before move — its persistence keys, its computation helpers, its dropdown sources — so the redesigned in-slot UI doesn't lose features.
+
+## Test Plan
+
+- Static review: hotfix #44 logic untouched; admin xp_spend removed; in-slot xp_spend has full feature parity with admin's
+- Browser smoke (DEFERRED): XP spend in-slot for an attribute, skill, discipline, merit, including a Carthian Law and an Invictus Oath; persistence; cost shown; legacy admin xp_* data tolerated
+
+## Definition of Done
+
+- [ ] In-slot `xp_spend` action has full XP-spend UI (amount, target type, target selector, cost)
+- [ ] Merit selector category-filter logic (#44 hotfix) preserved as source of truth
+- [ ] Admin section's xp_spend sub-section removed from `DOWNTIME_SECTIONS`
+- [ ] Coordination with #31 documented
+- [ ] PR opened into `dev`
+
+## Dependencies
+
+- **Upstream**: #17 (lifecycle); #24 (chrome strip — same render path); **#31** (Admin section removal — coordinate); **hotfix #44** (merit-selector category-filter — must land first via hotfix lane)
+- **Downstream**: none
+- **Cross-reference**: GitHub issue #44 carries the merit-eligibility hotfix; this story's #44 dependency is hard (#26 cannot land before #44).

--- a/specs/stories/dt-form.27-blood-sorcery-reorder.story.md
+++ b/specs/stories/dt-form.27-blood-sorcery-reorder.story.md
@@ -1,0 +1,68 @@
+---
+id: dt-form.27
+task: 27
+epic: epic-dt-form-mvp-redesign
+status: Draft
+priority: medium
+depends_on: ['dt-form.17']
+adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Audit-baseline)
+---
+
+# Story dt-form.27 — Blood Sorcery section reorder (Crúac / Theban)
+
+As a player using Blood Sorcery (Crúac or Theban) in downtime,
+I should see the rituals reordered into a logical reading order (e.g. Crúac vs Theban grouped, or by tier, or by frequency-of-use),
+So that finding the ritual I want to declare is faster than scrolling the current order.
+
+## Context
+
+ADR-003 §Audit-baseline lists `blood_sorcery` as the section with reordering as task #27: *"Crúac/Theban; conditional on rituals owned. Remediation reorders (task #27)."* The exact target order isn't specified in the ADR — implementer should propose during pickup.
+
+This is ADVANCED-only per ADR §Q2 (blood_sorcery is not in the MINIMAL set). Players who use ritual sorcery declare it via the ADVANCED variant.
+
+### Files in scope
+
+- `public/js/tabs/downtime-form.js` — the `blood_sorcery` section render path
+- Possibly `public/js/data/rituals.js` (or wherever ritual reference data lives) if a sort key is needed; otherwise just a render-side reorder
+
+### Files NOT in scope
+
+- The ritual reference data itself (Crúac and Theban canon — not changing)
+- The conditional-on-rituals-owned gating (already in place; preserve it)
+- The MINIMAL gate (this section stays ADVANCED)
+
+## Acceptance Criteria
+
+**Given** a player owns ritual sorcery
+**When** the Blood Sorcery section renders in ADVANCED mode
+**Then** the rituals are presented in a logical order. The chosen order is documented in DAR (e.g. "Crúac first, alphabetical within; Theban second, alphabetical within"). Implementer proposes; surface to Piatra during pickup if uncertain.
+
+**Given** a player does not own any ritual sorcery
+**When** the Blood Sorcery section is evaluated
+**Then** the section does not render (existing conditional preserved).
+
+**Given** the reordering ships
+**When** an existing player opens their cycle's submission
+**Then** their already-selected rituals load correctly (no data loss; persistence keys unchanged).
+
+## Implementation Notes
+
+Survey the current order; document; pick a target order; surface to Piatra for sign-off if non-obvious. Recommend: Crúac before Theban (alphabetical within each), since that's the order Disciplines are usually inventoried. Or: by tier-level (lowest first) within each style.
+
+## Test Plan
+
+- DAR captures current vs target order rationale
+- Browser smoke: rituals appear in target order; persistence preserved
+
+## Definition of Done
+
+- [ ] Target order chosen and documented in DAR
+- [ ] Rituals render in that order
+- [ ] Conditional-on-rituals-owned gate preserved
+- [ ] Persistence keys unchanged (no data loss)
+- [ ] PR opened into `dev`
+
+## Dependencies
+
+- **Upstream**: #17 (rendering gate; ADVANCED-only)
+- **Downstream**: none

--- a/specs/stories/dt-form.27-blood-sorcery-reorder.story.md
+++ b/specs/stories/dt-form.27-blood-sorcery-reorder.story.md
@@ -35,7 +35,7 @@ This is ADVANCED-only per ADR §Q2 (blood_sorcery is not in the MINIMAL set). Pl
 
 **Given** a player owns ritual sorcery
 **When** the Blood Sorcery section renders in ADVANCED mode
-**Then** the rituals are presented in a logical order. The chosen order is documented in DAR (e.g. "Crúac first, alphabetical within; Theban second, alphabetical within"). Implementer proposes; surface to Piatra during pickup if uncertain.
+**Then** the rituals are presented in this order: **Crúac first, then Theban** (per Piatra clarification 2026-05-06). Within each style, alphabetical-by-name unless the implementer surfaces a better-justified alternative during pickup.
 
 **Given** a player does not own any ritual sorcery
 **When** the Blood Sorcery section is evaluated
@@ -47,7 +47,7 @@ This is ADVANCED-only per ADR §Q2 (blood_sorcery is not in the MINIMAL set). Pl
 
 ## Implementation Notes
 
-Survey the current order; document; pick a target order; surface to Piatra for sign-off if non-obvious. Recommend: Crúac before Theban (alphabetical within each), since that's the order Disciplines are usually inventoried. Or: by tier-level (lowest first) within each style.
+Target order locked by Piatra 2026-05-06: **Crúac first, Theban second.** Within each style, alphabetical-by-name is the implementer's default; if pickup-time analysis suggests a better order (e.g. tier-level grouping, frequency-of-use), surface for Piatra's sign-off rather than diverging silently.
 
 ## Test Plan
 

--- a/specs/stories/dt-form.28-mentor-staff-actions.story.md
+++ b/specs/stories/dt-form.28-mentor-staff-actions.story.md
@@ -1,0 +1,86 @@
+---
+id: dt-form.28
+task: 28
+epic: epic-dt-form-mvp-redesign
+status: Draft
+priority: medium
+depends_on: ['dt-form.16', 'dt-form.17']
+hotfix_predecessor: 'GitHub issue #46'
+adr: specs/architecture/adr-003-dt-form-cross-cutting.md (Implementation Plan)
+---
+
+# Story dt-form.28 — Mentor + Staff actions
+
+As a player who holds Mentor or Staff merits,
+I should see one Mentor action per Mentor merit owned (like Retainer's existing pattern) and one Staff action per dot of Staff (like Contacts' existing pattern),
+So that these merits surface their downtime actions cleanly alongside Retainer / Contacts.
+
+This story's merit detection follows the **established walk pattern from hotfix #46** (Charlie Ballsack Retainer-via-Attaché missing-action fix).
+
+## Context
+
+Per Piatra (2026-05-06):
+- **Mentor**: one action per Mentor merit owned, mirrors Retainer's pattern
+- **Staff**: one action per dot of Staff, mirrors Contacts' pattern
+- Both surface alongside Retainer / Contacts in the form
+- Use the universal character picker (#16) for any character selection within these actions
+
+Cross-cutting note from Piatra: hotfix issue #46 (granted-merit detection walk) lands BEFORE this story. **Story #28's merit detection follows the same walk pattern from #46.**
+
+### Files in scope
+
+- `public/js/tabs/downtime-form.js` — wherever Retainer / Contacts merit-action detection currently happens; add Mentor + Staff to the same surface
+- Per Piatra: detection should walk `benefit_grants` / `granted_by` per the pattern issue #46 establishes
+
+### Files NOT in scope
+
+- `MERITS_DB` (Mentor and Staff are already in the data; this story consumes them)
+- Other merit-driven actions (Retainer, Contacts — preserved unchanged; they're the template)
+- The granted-merit detection logic itself (locked by #46 hotfix)
+
+## Acceptance Criteria
+
+**Given** a character holds N Mentor merits
+**When** the Personal Actions area renders
+**Then** N "Mentor" actions are surfaced, one per merit. Each Mentor action carries the standard action UI (target picker, dice pool if applicable, description).
+
+**Given** a character holds Staff with M dots
+**When** the Personal Actions area renders
+**Then** M "Staff" actions are surfaced, one per dot. Each Staff action carries the standard simple-action UI (similar to Contacts per-sphere actions).
+
+**Given** any character-selection within a Mentor or Staff action
+**When** the picker renders
+**Then** it uses `charPicker({ scope: 'all', cardinality: 'single', excludeIds: [...] })` from #16.
+
+**Given** a character holds Mentor or Staff via a granted source (e.g. via Attaché)
+**When** the merit-detection walk fires
+**Then** the granted Mentor/Staff is detected per the walk pattern from hotfix #46. Story #28's detection logic must use the same walk (no duplicating, no diverging).
+
+**Given** Mentor or Staff merit-action surfacing exists
+**When** persistence fires
+**Then** Mentor/Staff selections persist on `responses.mentor_action_*` / `responses.staff_action_*` keys (or follow the existing convention in the surrounding Retainer/Contacts pattern).
+
+## Implementation Notes
+
+Survey: where do Retainer and Contacts actions currently surface? That's the template. Read the surrounding render code — likely a "for each [merit]" loop over the character's merit set, gated on merit name. Add Mentor (per-merit) and Staff (per-dot) to the same loop.
+
+Detection walk: hotfix #46 establishes that granted merits should be detected by walking `c.merits[i].benefit_grants` and `c.merits[i].granted_by`. Ensure this story's Mentor/Staff detection uses the same walk so a granted Mentor (e.g. via Patron) is surfaced too.
+
+## Test Plan
+
+- Static review: Mentor surfaces N actions per N merits; Staff surfaces M actions per M dots; #16 picker used; #46 walk pattern applied
+- Browser smoke (DEFERRED): a character with Mentor + Staff sees both action sets; selections persist
+
+## Definition of Done
+
+- [ ] Mentor action: one per Mentor merit (like Retainer)
+- [ ] Staff action: one per dot of Staff (like Contacts)
+- [ ] Character pickers use `charPicker` (#16)
+- [ ] Merit detection follows hotfix #46 walk
+- [ ] PR opened into `dev`
+
+## Dependencies
+
+- **Upstream**: #16 (picker); #17 (lifecycle); **hotfix #46** (granted-merit detection walk — must land first via hotfix lane)
+- **Downstream**: none
+- **Cross-reference**: GitHub issue #46 establishes the merit-detection walk; #28's detection follows that pattern.

--- a/specs/stories/dt-form.29-acquisitions-redesign.story.md
+++ b/specs/stories/dt-form.29-acquisitions-redesign.story.md
@@ -1,0 +1,77 @@
+---
+id: dt-form.29
+task: 29
+epic: epic-dt-form-mvp-redesign
+status: Draft
+priority: medium
+depends_on: ['dt-form.17']
+hotfix_predecessor: 'GitHub issue #42'
+adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Audit-baseline)
+---
+
+# Story dt-form.29 — Acquisitions section redesign (Resources + Skills)
+
+As a player buying resources or learning skills in downtime,
+I should have a clean Acquisitions section that handles both resource buys and skill buys,
+With the skill-acquisition pool fix (issue #42 — pool is SKILL only, not ATTR + SKILL) preserved as the source of truth.
+
+This is **ADVANCED-only** per ADR §Q2 — Acquisitions is not in the MINIMAL set.
+
+## Context
+
+ADR-003 §Audit-baseline notes the Acquisitions section has the skill-acquisition pool bug (ATTR + SKILL where rules say SKILL only) which is hotfix issue #42. Story #29 redesigns the section's UI but **preserves** the #42 fix as the underlying logic.
+
+Per Piatra: the redesign is about clean UI surfacing of both resource buys and skill buys, not re-deriving the rules.
+
+### Files in scope
+
+- `public/js/tabs/downtime-form.js` — the `acquisitions` section render path
+- `public/js/data/dt-completeness.js` — no MINIMAL impact (Acquisitions is ADVANCED-only); but if any helpers are introduced for the redesign, they may live here
+
+### Files NOT in scope
+
+- The skill-acquisition pool computation (locked by #42 hotfix; preserve)
+- Resource cost logic (existing; preserve)
+- The MINIMAL set (Acquisitions stays ADVANCED-only per ADR §Q2)
+
+## Acceptance Criteria
+
+**Given** a player on ADVANCED with Acquisitions visible
+**When** the section renders
+**Then** there are clearly distinguished sub-blocks for Resource buys and Skill buys (or a unified UI that doesn't conflate the two — implementer's call).
+
+**Given** the skill-acquisition pool computes
+**When** it renders for a skill buy
+**Then** it uses SKILL only (per #42 hotfix), not ATTR + SKILL. The #42 logic is the source of truth — story #29 must not duplicate or override it.
+
+**Given** legacy submission data
+**When** the form loads against pre-existing Acquisitions data
+**Then** the redesign loads it cleanly. Persistence keys preserved or migrated cleanly (document in DAR).
+
+**Given** the redesign ships
+**When** a developer greps for the skill-pool computation
+**Then** there is one canonical helper (from #42); the new UI consumes it.
+
+## Implementation Notes
+
+Survey current Acquisitions UI before redesign — its persistence keys, cost computations, dropdown sources. Document in DAR. Then redesign with the survey as the contract.
+
+If the redesign is large, surface to Piatra during pickup; consider scoping down (e.g. ship the visual reorganisation only this story; defer deeper UX changes).
+
+## Test Plan
+
+- DAR captures pre/post UI state
+- Browser smoke: resource buy and skill buy both work; skill pool uses SKILL only; legacy data loads
+
+## Definition of Done
+
+- [ ] Acquisitions section redesigned (Resources + Skills clearly distinguished)
+- [ ] #42 skill-pool fix preserved as source of truth
+- [ ] Legacy data loads cleanly
+- [ ] PR opened into `dev`
+
+## Dependencies
+
+- **Upstream**: #17 (rendering gate; ADVANCED-only); **hotfix #42** (skill-pool fix — must land first)
+- **Downstream**: none
+- **Cross-reference**: GitHub issue #42 carries the skill-pool fix.

--- a/specs/stories/dt-form.30-equipment-hide.story.md
+++ b/specs/stories/dt-form.30-equipment-hide.story.md
@@ -1,0 +1,68 @@
+---
+id: dt-form.30
+task: 30
+epic: epic-dt-form-mvp-redesign
+status: Draft
+priority: low
+depends_on: ['dt-form.17']
+adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Audit-baseline)
+---
+
+# Story dt-form.30 — Equipment section hidden for this DT cycle
+
+As an ST shipping the redesigned DT form,
+I should not see the Equipment section in the form for this cycle (neither MINIMAL nor ADVANCED),
+So that players are not asked questions about equipment that the cycle's mechanics don't yet consume.
+
+## Context
+
+ADR-003 §Audit-baseline marks Equipment as: *"Hidden for this DT cycle per task #30."*
+
+This is a hide, not a remove. The section's render path is gated off; data already in `responses.equipment_*` keys is preserved and ignored. If a future cycle wants Equipment back, the gate is flipped.
+
+### Files in scope
+
+- `public/js/tabs/downtime-form.js` — Equipment section render path; gate it off
+- `public/js/tabs/downtime-data.js` — `DOWNTIME_SECTIONS` Equipment entry annotated as hidden (or removed; either works)
+
+### Files NOT in scope
+
+- Existing Equipment data (preserved as-is in `responses`; ignored by the form)
+- Equipment-related helpers elsewhere in the codebase (no audit of those; the form just stops surfacing)
+
+## Acceptance Criteria
+
+**Given** a player opens the DT form (any mode)
+**When** the form renders
+**Then** the Equipment section is not visible. No header, no fields, no chrome.
+
+**Given** legacy submission data has `equipment_*` fields populated
+**When** the form loads
+**Then** no error. The data is in `responses` but not surfaced. Persistence on next save is unchanged (legacy fields stay; form-level is hidden).
+
+**Given** the gate is implemented as a configurable flag (recommended)
+**When** a future cycle wants Equipment back
+**Then** flipping the flag re-enables the section without code archaeology.
+
+## Implementation Notes
+
+Simplest implementation: a top-of-file `EQUIPMENT_HIDDEN = true` const that the section render path checks. Or a per-section `hidden` flag in `DOWNTIME_SECTIONS` and the render loop respects it.
+
+Recommend the per-section flag — generalises to any future "hide this section temporarily" need.
+
+## Test Plan
+
+- Static review: section gate is in place; data preservation confirmed
+- Browser smoke: form renders without Equipment; legacy data loads without error
+
+## Definition of Done
+
+- [ ] Equipment section not rendered in MINIMAL or ADVANCED
+- [ ] Legacy `equipment_*` data preserved on save
+- [ ] Gate is configurable (flag-flip restores)
+- [ ] PR opened into `dev`
+
+## Dependencies
+
+- **Upstream**: #17 (rendering gate); independent otherwise
+- **Downstream**: none

--- a/specs/stories/dt-form.31-submit-final-modal.story.md
+++ b/specs/stories/dt-form.31-submit-final-modal.story.md
@@ -1,0 +1,119 @@
+---
+id: dt-form.31
+task: 31
+epic: epic-dt-form-mvp-redesign
+status: Draft
+priority: high
+depends_on: ['dt-form.17']
+adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q5)
+---
+
+# Story dt-form.31 — Submit Final modal (ADVANCED) + Admin section removal
+
+As an ADVANCED-mode player who wants to declare "I'm done editing,"
+I should see a Submit Final modal (dismissable, action-spent summary, optional rate-the-form widget) when I click a "Submit Final" button,
+So that the form has a clear "I am done" affordance — replacing the manual submit button and the removed Admin section's form-rating widget.
+
+For MINIMAL-mode players, the form auto-submits silently with a persistent toast confirmation. No modal.
+
+## Context
+
+ADR-003 §Q5 locks the Submit Final modal:
+- ADVANCED-only
+- Triggered by a "Submit Final" button (visible only in ADVANCED)
+- Modal contents:
+  - Action-spent summary ("4/4 Personal Actions, 2/3 Contact actions, 1/1 Sphere actions, 0/2 Acquisition slots used.")
+  - Optional rate-the-form widget (Likert 1-5, free-text feedback) — optional, not blocking
+  - "Submit Final" button which sets `responses._final_submitted_at` (timestamp marking player's stated intent)
+- Per §Q9: an ADVANCED player who only filled MINIMAL still sees the modal (with zeros in most slots)
+- Cycle close still seals (Q11)
+
+This story also handles the **Admin section removal** since the Admin section's form-rating widget moves to this modal.
+
+Note: `_final_submitted_at` is **not** a status flip — the form is already in `submitted` state from the auto-flip per §Q3. It's a player-stated "I am done editing" hint for the ST.
+
+For MINIMAL: the form auto-submits silently. A persistent toast confirms ("Submitted — keep editing until the deadline").
+
+### Files in scope
+
+- `public/js/tabs/downtime-form.js` — Submit Final button (ADVANCED-only); modal trigger; modal render; MINIMAL toast
+- `public/js/tabs/downtime-data.js` — remove the `admin` section entry from `DOWNTIME_SECTIONS` (the section is gone)
+- `server/schemas/downtime_submission.schema.js` — document `_final_submitted_at` under `properties` (per ADR §Implementation-plan)
+- `public/css/...` — modal styling (mirror existing modal patterns if any)
+
+### Files NOT in scope
+
+- The `_has_minimum` lifecycle (covered by #17)
+- The XP-spend UI move into a personal action (covered by #26 — coordinate)
+- The `submitted` workflow flip (already auto via #17)
+- Server-side validation of the modal's contents (Q7 deferred)
+
+## Acceptance Criteria
+
+**Given** an ADVANCED-mode player
+**When** the form renders
+**Then** a "Submit Final" button is visible (location: top-right or bottom — implementer's call; mirror existing button positions).
+
+**Given** the player clicks "Submit Final"
+**When** the modal opens
+**Then** the modal shows:
+- Action-spent summary (e.g. "4/4 Personal Actions, 2/3 Contact actions, 1/1 Sphere actions, 0/2 Acquisition slots used.")
+- An optional rate-the-form widget (Likert 1-5 + free-text feedback) — optional, not blocking
+- A "Submit Final" button inside the modal that confirms the action
+
+**Given** the player clicks the modal's "Submit Final" button
+**When** the action fires
+**Then** `responses._final_submitted_at = <ISO timestamp>` is set; the form auto-saves; the modal dismisses; a toast confirms ("Final submission recorded; keep editing until the deadline").
+
+**Given** the player dismisses the modal without confirming
+**When** they close it
+**Then** no `_final_submitted_at` is set; the form continues as draft (auto-submit per #17 is unaffected).
+
+**Given** a MINIMAL-mode player
+**When** their form flips `_has_minimum` to true
+**Then** a persistent toast appears: "Submitted — keep editing until the deadline." No modal.
+
+**Given** an ADVANCED-mode player who has only filled MINIMAL fields
+**When** they click "Submit Final"
+**Then** the modal still opens, with zeros in most slots (per ADR §Q9). The player sees their actual usage even if it's all zeros.
+
+**Given** the Admin section is removed
+**When** the form renders (any mode)
+**Then** the Admin section header and content are gone. The form-rating widget that used to live there now lives in the Submit Final modal.
+
+**Given** the schema documents the new field
+**When** a developer reads `downtime_submission.schema.js`
+**Then** `_final_submitted_at: { type: 'string', format: 'date-time' }` is under `properties`.
+
+## Implementation Notes
+
+The action-spent summary is data-driven. Compute counts from `responses` by walking each section's slot counts. Helper recommended (e.g. `actionSpentSummary(responses)` returning a small structured object the modal renders).
+
+The rate-the-form widget is the existing widget from the Admin section, just in a modal now. Lift the existing render code rather than re-implementing.
+
+Coordinate merge with #26 (XP Spend overhaul + Admin section removal). Both touch Admin section. Recommend #31 land first to remove the Admin section structure entirely; #26 follows to put XP Spend in a project slot.
+
+## Test Plan
+
+- Static review: ADVANCED-only button + modal; MINIMAL toast; Admin section removed; schema documents new field
+- Browser smoke (DEFERRED):
+  1. ADVANCED player → click Submit Final → modal shows summary + rating → confirm → toast appears
+  2. ADVANCED player → click Submit Final → dismiss → no `_final_submitted_at` set
+  3. MINIMAL player → fill enough to flip `_has_minimum` true → toast appears, no modal
+  4. ADVANCED player who filled only MINIMAL → click Submit Final → modal shows with zeros
+  5. Admin section absent in all modes
+
+## Definition of Done
+
+- [ ] ADVANCED-only "Submit Final" button + modal with summary + optional rating widget
+- [ ] MINIMAL toast on auto-submit
+- [ ] Admin section removed from `DOWNTIME_SECTIONS`
+- [ ] `_final_submitted_at` schema field documented
+- [ ] Coordination with #26 in place
+- [ ] PR opened into `dev`
+
+## Dependencies
+
+- **Upstream**: #17 (lifecycle — modal is a layer atop the auto-submit; Q5 explicit)
+- **Cross-coordination**: #26 (XP Spend; both touch Admin section — recommend #31 lands first)
+- **Downstream**: none

--- a/specs/stories/dt-form.32-joint-authoring-remove.story.md
+++ b/specs/stories/dt-form.32-joint-authoring-remove.story.md
@@ -1,0 +1,69 @@
+---
+id: dt-form.32
+task: 32
+epic: epic-dt-form-mvp-redesign
+status: Draft
+priority: low
+depends_on: []
+adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Out-of-scope)
+---
+
+# Story dt-form.32 — Remove joint authoring / project invitation from MVP
+
+As an ST shipping the MVP DT form,
+I should not see joint-authoring / project-invitation UI surfaces in the form,
+So that the MVP scope matches ADR-003 and joint authoring is preserved as a future scoping decision rather than a half-functional feature.
+
+## Context
+
+ADR-003 §Out-of-scope: *"Joint authoring / project invitation. Task #32 removes from MVP. Re-enabling is a future scoping decision."*
+
+This story removes the joint-authoring affordances from the form. Data already in submissions that referenced joint authors is preserved (no destructive migration); the surface that lets players create new joint-author relationships is removed.
+
+### Files in scope
+
+- `public/js/tabs/downtime-form.js` — joint-authoring UI render paths (likely "Add co-author" buttons, invitation lists, etc. — survey for exact locations)
+- Possibly `public/js/tabs/downtime-data.js` — joint-author related field defaults
+
+### Files NOT in scope
+
+- Existing submission data (preserved as-is in `responses`)
+- Server-side joint-authoring routes if any (out of scope for this story; may re-enable at the route level when joint authoring returns)
+- Admin views of joint authorship (separate concern; scope this story to the player form)
+
+## Acceptance Criteria
+
+**Given** the player opens the DT form (any mode)
+**When** the form renders
+**Then** there is no joint-authoring UI surface: no "Invite co-author" button, no joint-author list, no per-slot joint-author toggles.
+
+**Given** legacy data has joint-author references in `responses`
+**When** the form loads
+**Then** no error. Joint-author fields are not surfaced but are preserved in `responses` for historical record.
+
+**Given** a future story revives joint authoring
+**When** that work picks up
+**Then** the removed UI can be reintroduced cleanly. This story should aim to delete joint-authoring chrome via removal (not feature-flag), keeping the diff legible.
+
+## Implementation Notes
+
+Survey first. Joint authoring may be a thin surface (a single button + dropdown) or a deeper invitation flow. DAR captures the survey + the specific UI sites removed.
+
+If the survey reveals joint authoring is significantly entangled with project-slot structure (e.g. project slot data shape includes joint-author fields), surface to Piatra; this story may need to expand scope to include data-shape simplification.
+
+## Test Plan
+
+- DAR captures pre-removal joint-authoring surface
+- Browser smoke: form renders without joint-author UI; legacy data loads cleanly
+
+## Definition of Done
+
+- [ ] Joint-authoring UI surfaces removed from `downtime-form.js`
+- [ ] Legacy data preserved on save
+- [ ] Survey + removal sites documented in DAR
+- [ ] PR opened into `dev`
+
+## Dependencies
+
+- **Upstream**: none direct (removal is independent of #16 / #17)
+- **Downstream**: none

--- a/specs/stories/dt-form.33-npc-selectors-remove.story.md
+++ b/specs/stories/dt-form.33-npc-selectors-remove.story.md
@@ -1,0 +1,71 @@
+---
+id: dt-form.33
+task: 33
+epic: epic-dt-form-mvp-redesign
+status: Draft
+priority: low
+depends_on: []
+adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Out-of-scope)
+---
+
+# Story dt-form.33 — Remove NPC selectors from the DT form
+
+As an ST shipping the MVP DT form,
+I should not see NPC-selection UI surfaces in the form (per ADR-003 §Out-of-scope),
+So that NPC selectors don't drag the form back into the registered-NPC complexity that issue #24 already partly retired.
+
+## Context
+
+ADR-003 §Out-of-scope: *"NPC selector replacement. Task #33 removes NPC selectors entirely; if NPCs come back to the form later, they will need their own picker variant. Not addressed here."*
+
+Issue #24 (Story Personal Story free-text NPC fields, PR #28) already moved Personal Story away from the registered-NPC picker to free-text NPC names. This story removes any remaining NPC-selector chrome from other sections of the form.
+
+### Files in scope
+
+- `public/js/tabs/downtime-form.js` — any remaining NPC-selector dropdowns or pickers across sections
+- Possibly survey other section-helper files if any
+
+### Files NOT in scope
+
+- The free-text NPC-name fields introduced by issue #24 (those stay)
+- The NPC data model (registered NPCs, `npcs` collection — out of scope; the form just stops surfacing them)
+- The character picker (#16) — this story removes NPC selectors specifically; the character picker is for character-list selection (registered characters, not NPCs)
+- Issue #23 (NPC sidebar removal in admin app) — already shipped; separate surface
+
+## Acceptance Criteria
+
+**Given** the player opens the DT form (any mode)
+**When** any section that previously surfaced an NPC selector renders
+**Then** the NPC selector is gone. If a free-text NPC-name field was the issue-#24 replacement, it remains; if the section needs NPC reference at all post-removal, free-text is the path.
+
+**Given** legacy data has NPC IDs in `responses`
+**When** the form loads
+**Then** no error. The IDs are preserved in `responses` but not surfaced. (Future stories that revive NPC selection will need to migrate them.)
+
+**Given** the survey
+**When** Ptah greps for NPC-selector patterns
+**Then** every site is identified and removed. Document the inventory in DAR.
+
+## Implementation Notes
+
+Survey: grep for `npc`, `npcId`, `selectedNpc`, `_npc_*` field patterns in `downtime-form.js` and helper files. Some legitimate NPC mentions (free-text fields per issue #24) stay; selectors / dropdowns / typeaheads against the registered-NPC list go.
+
+If the survey reveals an NPC selector that has rules-bound behaviour (e.g. an NPC pick affects dice pool), surface to Piatra — that's a "needs replacement, not just removal" case.
+
+## Test Plan
+
+- DAR captures the inventory of removed sites
+- Browser smoke: form renders cleanly; no NPC-selector chrome anywhere; legacy data loads
+
+## Definition of Done
+
+- [ ] NPC selector UI surfaces removed from `downtime-form.js`
+- [ ] Free-text NPC fields (issue #24) preserved
+- [ ] Survey + removal sites documented in DAR
+- [ ] Legacy data preserved on save
+- [ ] PR opened into `dev`
+
+## Dependencies
+
+- **Upstream**: none direct (removal is independent of cross-cutting foundation)
+- **Downstream**: none

--- a/specs/stories/epic-dt-form-mvp-redesign.md
+++ b/specs/stories/epic-dt-form-mvp-redesign.md
@@ -1,0 +1,172 @@
+---
+type: epic
+id: epic-dt-form-mvp-redesign
+title: 'DT submission form — MVP redesign'
+status: ready-for-dev
+date: 2026-05-06
+owner: Piatra (Peter)
+sm: Khepri
+adr: specs/architecture/adr-003-dt-form-cross-cutting.md
+audit: specs/audits/maintenance-action-audit.md
+---
+
+# Epic — DT submission form MVP redesign
+
+This is the epic README for the cross-cutting remediation of `public/js/tabs/downtime-form.js`. It indexes the per-section story files below; **the epic itself does not carry acceptance criteria** — the stories do. Read top-to-bottom as a navigation surface.
+
+## Why this epic exists
+
+The DT submission form has accumulated chrome that obscures the minimum a player must supply, while asking architectural choices the rules don't consume. ADR-003 (*DT submission form cross-cutting decisions*, status `approved`, rev 3 / 2026-05-06) locked the three load-bearing decisions:
+
+1. **Minimal/Advanced mode selector** — gates how much of the form a player sees.
+2. **Hard-mirror soft-submit lifecycle** — `_has_minimum` derived bool replaces the manual `submitted` workflow string; auto-XP credit mirrors both directions; cycle close is the only true seal.
+3. **Universal character picker** — single component, two scope variants (`all` / `attendees`), one render shape; replaces the five existing picker shapes.
+
+ADR-003 also resolves Q1-Q12 (resolutions table at the bottom of the ADR). All decisions in stories below pull through that resolutions table by reference; do not re-litigate them in story bodies.
+
+## Context: architectural-reset freeze
+
+The freeze (ratified 2026-04-something, see `specs/architectural-reset-charter.md`) was lifted on 2026-05-06. The DT submission form is the surface that prompted the lift. ADR-003 was authored after the lift as the contested-architecture-mechanism artefact the charter describes; this epic is its implementation layer.
+
+Diagnostic content in the charter remains useful reference. The freeze's gate-2 rule (cross-suite helpers) is explicitly retained per ADR-003 §Q6 — the universal character picker stays form-local in this epic; broader adoption is a future ADR.
+
+## Stories under this epic
+
+Naming convention: `dt-form.NN-<slug>.story.md`, where `NN` matches the in-session task ID for traceability. All stories ship at status `Draft` initially and are picked up via `tm-gh-issue-pickup`-style flow once #15 (this decomposition) is merged.
+
+### Foundation (must merge before per-section stories)
+
+| Task | Story | Title |
+|---|---|---|
+| #16 | `dt-form.16-character-picker.story.md` | Universal character picker component |
+| #17 | `dt-form.17-minimal-advanced-lifecycle.story.md` | Minimal/Advanced mode + soft-submit lifecycle + auto-XP mirror |
+
+**Sequencing rule:** #16 lands first (other stories consume `charPicker()`). #17 lands second (sets the rendering gate every per-section story respects). Per-section stories may then run in parallel.
+
+### Per-section MINIMAL wiring
+
+| Task | Story | Title |
+|---|---|---|
+| #18 | `dt-form.18-personal-story-reduce.story.md` | Personal Story — reduce to Touchstone-or-Correspondence binary |
+| #20 | `dt-form.20-feeding-simplified.story.md` | Feeding — simplified MINIMAL variant |
+| #22 | `dt-form.22-rote-hunt.story.md` | ROTE hunt redesign (secondary feeding) |
+| #23 | `dt-form.23-regency-confirm.story.md` | Regency confirmation UI |
+
+### Personal Actions chrome strip
+
+| Task | Story | Title |
+|---|---|---|
+| #24 | `dt-form.24-personal-actions-chrome.story.md` | Personal Actions — strip MODE/SUPPORT/single-vs-dual; adopt `charPicker()` for ALLY |
+
+### Per-section feature work
+
+The ADR's Implementation Plan table calls these out as "Independent; can land in any order after #17". Titles for #19, #21, #25, #26, #28 supplied by Piatra 2026-05-06 in response to a clarification request from SM.
+
+| Task | Story | Title |
+|---|---|---|
+| #19 | `dt-form.19-influence-breakdown-tooltip.story.md` | City Influence breakdown tooltip |
+| #21 | `dt-form.21-feeding-territory-tint.story.md` | Feeding territory tinting (green/red, regardless of selection) |
+| #25 | `dt-form.25-ambience-action-redesign.story.md` | Ambience Increase/Decrease — territory-row table with up/down arrow chips |
+| #26 | `dt-form.26-xp-spend-action.story.md` | XP Spend action overhaul + remove Admin XP section |
+| #27 | `dt-form.27-blood-sorcery-reorder.story.md` | Blood Sorcery — reorder rituals (Crúac/Theban) |
+| #28 | `dt-form.28-mentor-staff-actions.story.md` | Mentor + Staff actions (per-merit / per-dot surfacing) |
+| #29 | `dt-form.29-acquisitions-redesign.story.md` | Acquisitions — Resources + Skills redesign (subsumes hotfix #42 skill-acquisition fix once that lands) |
+| #30 | `dt-form.30-equipment-hide.story.md` | Equipment — hide section for this DT cycle |
+
+### Submission summary modal
+
+| Task | Story | Title |
+|---|---|---|
+| #31 | `dt-form.31-submit-final-modal.story.md` | Submit Final modal (ADVANCED only) — replaces Admin section + form-rating widget |
+
+### Removals
+
+| Task | Story | Title |
+|---|---|---|
+| #32 | `dt-form.32-joint-authoring-remove.story.md` | Remove joint authoring / project invitation |
+| #33 | `dt-form.33-npc-selectors-remove.story.md` | Remove NPC selectors |
+
+## Cross-cutting notes (hotfix ↔ epic-story dependencies)
+
+Two epic stories carry hotfix dependencies that change their landing order:
+
+- **Issue #44 ↔ task #26.** The Merit selector category-filter fix (cycle-blocker hotfix #44) lands BEFORE story #26 (XP Spend redesign). Story #26 preserves that fix; #26 replaces the surrounding UI but the underlying merit-eligibility logic from the #44 hotfix remains the source of truth.
+- **Issue #46 ↔ task #28.** The granted-merit detection walk (cycle-blocker hotfix #46, Charlie Ballsack Retainer-via-Attaché) lands BEFORE story #28 (Mentor + Staff actions). Story #28's merit detection follows the established walk pattern from the #46 hotfix.
+
+Both are flagged in the affected stories' Dependencies blocks and again in the Cross-references section of each.
+
+## Cross-cutting hotfix references (NOT in scope of this epic)
+
+The 9 hotfix bugs labelled `cycle-blocker` and `audit-finding` ship via the `tm-gh-issue-pickup` lane, not as stories under this epic. They are listed here only so the context the epic operates in is captured. Order is by issue number, not priority.
+
+| Issue | Title |
+|---|---|
+| #42 | DT form: Skill acquisition pool incorrectly uses ATTR + SKILL (rules say SKILL only) |
+| #43 | DT form: Feeding Grounds (5) merit doubles dice bonus to +10 instead of +5 |
+| #44 | DT form: Merit selector dropdown missing Carthian Law / Invictus Oath / standing-merit categories |
+| #45 | DT form: Charlie Ballsack does not see Retainer action despite holding Retainer via Attaché grant |
+| #46 | DT form: Status / Allies sections bleed — status section starts showing ally-only options |
+| #47 | DT form: Save Draft button does nothing visible (status indicator not surfacing) |
+| #48 | Calculated merits: Keeper's Quick Draw shows 2 hollow dots in render |
+| #49 | DT form: Yusuf's Contacts list pulls stale post-edit data — offers actions for contacts he no longer owns |
+| #50 | DT form: Maintenance Action toggle inversion — PT is greyed (needs maintenance), MCI is clickable (already maintained) |
+
+Note that issue #50 has a dedicated audit at `specs/audits/maintenance-action-audit.md` — its fix work feeds the per-section Maintenance redesign within #24 (Personal Actions chrome) implicitly. The audit's *recommended fix scope* section is the implementation contract for the hotfix lane; the per-section redesign in this epic does not re-derive it.
+
+## Foundational acceptance criteria (lifted from ADR-003)
+
+These are non-negotiable and re-stated in the bodies of #16 and #17 directly:
+
+### #16 (character picker)
+
+- WAI-ARIA combobox keyboard model per Q10 (`role="combobox"`, `aria-expanded`, `aria-activedescendant`, tab/arrow/enter/escape semantics)
+- `excludeIds` parameter present from v1 per Q6 (so ALLY-attach pickers can exclude self without revisiting consumers later)
+- Two scope variants: `all` (reads from `allCharNames`), `attendees` (filters to `lastGameAttendees`)
+- Replaces the 5 existing picker shapes inventoried in ADR-003 §Audit-baseline:
+  - `<select class="qf-select dt-flex-char-sel">` at `downtime-form.js:4817`
+  - `<button class="dt-chip" data-project-target-char>` at `downtime-form.js:5000`
+  - Project-cast checkbox grid at `downtime-form.js:508, 2367`
+  - Last-game-attendees subset at `downtime-form.js:1332`
+  - Regency tab `<select id="reg-slot-N">` at `regency-tab.js:192-199`
+
+### #17 (Minimal/Advanced + lifecycle)
+
+- Per Q3 / Q4 hard mirror: `attendance.downtime` flips both ways with `_has_minimum`, immediately, with cycle close as the final seal
+- The three UI affordances **MUST ship together with the lifecycle wiring** or hard mirror feels broken:
+  1. Persistent banner when `_has_minimum` is false ("Your form is below minimum-complete. Your downtime XP credit is on hold."), listing missing pieces
+  2. Visible XP-Available delta annotation ("(downtime credit on hold)") when bool is false; disappears when true
+  3. Negative-`xpLeft()` treatment in the player view (red XP-Left + hover tooltip) when player has spent XP that subsequently flipped back below minimum
+- `responses._mode` field per Q1 — default `'minimal'`; switching MINIMAL → ADVANCED → MINIMAL preserves entered data (does not clear unrendered-section fields)
+- `isMinimalComplete()` lives in `public/js/data/dt-completeness.js` per Q8 — single function, one source of truth, importable from server later if Q7 promotes
+- Cycle-close server gate (Q11) returns 423 Locked from `PATCH /api/downtime_submissions/:id` when `cycle.status === 'closed'`
+
+## Branching and merge posture
+
+- Branch: `docs/dt-form-epic-decomposition`
+- Push to origin; **do not merge** — Piatra reviews and merges per the request
+- Once merged, individual stories are picked up by `tm-gh-issue-pickup`-style flow against new feature branches (`dev` base)
+
+## Story dependency block (read this before scheduling)
+
+```
+#16  ─┐
+      ├─→ #18, #20, #22, #23, #24  (per-section MINIMAL wiring)
+#17 ──┤    │
+      │    └→ #19, #21, #25, #26, #27, #28  (independent feature work, post-#17)
+      ├─→ #29  (acquisitions; subsumes hotfix #42 once that ships)
+      ├─→ #30  (equipment hidden — trivial, can ship anytime after #17)
+      ├─→ #31  (submit final modal — depends on #17's lifecycle being live)
+      └─→ #32, #33  (removals — independent of cross-cutting; can ship anytime)
+```
+
+## References
+
+- `specs/architecture/adr-003-dt-form-cross-cutting.md` — the locked design contract
+- `specs/audits/maintenance-action-audit.md` — feeds Maintenance redesign within #24
+- `specs/architectural-reset-charter.md` — context for why this epic exists; freeze lift status header at top
+- GitHub issues #42-#50 — hotfix lane, not in scope of this epic
+- `public/js/tabs/downtime-form.js` — primary remediation surface
+- `public/js/tabs/downtime-data.js` — `DOWNTIME_SECTIONS` source of truth (`:171`)
+- `public/js/data/game-xp.js` — Game-XP attendance linkage; lifecycle wiring (#17) amends consumers here
+- `server/schemas/downtime_submission.schema.js` — submission contract; new fields `_mode`, `_has_minimum`, `_final_submitted_at` documented under `properties`
+- `server/schemas/game_session.schema.js` — attendance contract; **no schema delta** per ADR-003 rev 2 hard-mirror decision

--- a/specs/stories/epic-dt-form-mvp-redesign.md
+++ b/specs/stories/epic-dt-form-mvp-redesign.md
@@ -95,6 +95,20 @@ Two epic stories carry hotfix dependencies that change their landing order:
 
 Both are flagged in the affected stories' Dependencies blocks and again in the Cross-references section of each.
 
+## Story-pair sequencing notes (intra-epic, confirmed by Piatra)
+
+- **#26 ↔ #31 (Admin section removal).** Both touch the Admin section. Confirmed sequencing 2026-05-06: **#31 lands first** (removes the Admin section structure and replaces it with the Submit Final modal), **#26 follows** (puts XP Spend functionality in a project slot). Documented in #26's Dependencies block.
+
+## Open-questions resolutions (Piatra 2026-05-06 follow-up)
+
+Three open questions surfaced during decomposition were resolved by Piatra in the same review pass that confirmed merge-readiness:
+
+| Story | Question | Resolution |
+|---|---|---|
+| #22 ROTE hunt | Does ROTE-only count toward MINIMAL completeness? | **Yes.** ROTE feeding is available in MINIMAL and auto-populates the downtime feeding action. Story #22 carries this in its ACs. |
+| #25 Ambience action | Mutual exclusivity per row? | **No — relaxed to independently toggleable.** Both UP and DOWN may be selected simultaneously on the same row. Story #25 ACs updated. |
+| #27 Blood Sorcery order | Crúac vs Theban order? | **Crúac first, Theban second.** Within each, alphabetical-by-name unless pickup-time analysis surfaces a better order. Story #27 AC updated. |
+
 ## Cross-cutting hotfix references (NOT in scope of this epic)
 
 The 9 hotfix bugs labelled `cycle-blocker` and `audit-finding` ship via the `tm-gh-issue-pickup` lane, not as stories under this epic. They are listed here only so the context the epic operates in is captured. Order is by issue number, not priority.


### PR DESCRIPTION
## Summary

Production deploy of the DT submission form MVP redesign decomposition (epic + 18 stories, doc-only). No code change ships in this PR; the stories themselves are individual implementation work picked up afterward.

## What ships

- `specs/stories/epic-dt-form-mvp-redesign.md` — epic README
- 18 per-section story files `dt-form.16-character-picker.story.md` through `dt-form.33-npc-selectors-remove.story.md`

All at status `Draft`; nothing executes on merge.

## Pre-deploy verification

- Branch reviewed by Piatra in chat with all open questions resolved (#22 ROTE, #25 Ambience, #26↔#31 sequencing, #27 Blood Sorcery order)
- All four clarifications applied to relevant stories before this deploy
- Doc-only PR — no Netlify/Render code-deploy implications

## Branch flow

- From: `dev`
- Into: `main`
- **PRODUCTION DEPLOY** — auto-syncs to Netlify + Render but contents are docs only