### PR TITLE
docs(epic): apply Piatra 2026-05-06 afternoon corrections — ROTE + Ambience

### DIFF
--- a/specs/stories/dt-form.17-minimal-advanced-lifecycle.story.md
+++ b/specs/stories/dt-form.17-minimal-advanced-lifecycle.story.md
@@ -103,8 +103,8 @@ These three affordances are **non-negotiable acceptance criteria for this story*
 **Then** it exports a single `isMinimalComplete(responses)` function returning a boolean. The function encodes the MINIMAL-completeness rules from §Q2:
 - Court section has been touched (recount text non-empty)
 - Personal Story has the binary Touchstone-or-Correspondence + text input filled
-- Feeding has territory + method + blood type + violence-mode set
-- Project slot 1 has at least an action selected (further per-action validation TBD per §future-work)
+- Feeding (PRIMARY hunt) has territory + method + blood type + violence-mode set. **ROTE in a project slot does NOT satisfy this rule** (per Piatra clarification 2026-05-06: ROTE is a personal-project-action variant, not a feeding-section action; primary feeding must be filled independently).
+- Project slot 1 has at least an action selected (any action type, including ROTE if the player chooses; further per-action validation TBD per §future-work)
 - For regents: regency confirmation is positive
 
 **Given** the same function

--- a/specs/stories/dt-form.20-feeding-simplified.story.md
+++ b/specs/stories/dt-form.20-feeding-simplified.story.md
@@ -27,7 +27,7 @@ ADR-003 §Q2 lists the MINIMAL feeding state: "Simplified Feeding Form variant; 
 
 ### Files NOT in scope
 
-- ROTE hunt logic itself — that's #22
+- ROTE hunt logic itself — that's #22, **and per Piatra clarification 2026-05-06 ROTE is a personal-project-action variant, NOT a feeding-section sub-block.** ROTE never renders inside this story's feeding section.
 - Feeding territory tinting — that's #21 (separate visual change)
 - Feeding rights data model (`territories.feeding_rights[]` is canonical post-fix.39)
 - The full ADVANCED feeding form (unchanged in this story)
@@ -54,7 +54,9 @@ ADR-003 §Q2 lists the MINIMAL feeding state: "Simplified Feeding Form variant; 
 
 Auto-pick best dice pool: derive from existing helpers (search for `feedDicePool`, `bestFeedingPool`, or similar) or compute inline against the character's feeding-rights territories crossed with method/blood-type/violence affinities. Surface the resulting pool number near the description input as read-only ("Pool: 7" or similar).
 
-`isMinimalComplete()` rule for Feeding (per ADR §Q2 + this story): all five fields present.
+**Pool helper export**: the auto-pick computation should be exported from this section so #22 (ROTE) can import and reuse it for the inherited-pool display. Suggest a small named export from the section module (or inline helper in `dt-completeness.js` if more natural).
+
+`isMinimalComplete()` rule for Feeding (per ADR §Q2 + this story): all five PRIMARY feeding fields present. ROTE in a project slot does NOT satisfy this rule — that's the project-slot rule, separately gated.
 
 ## Test Plan
 

--- a/specs/stories/dt-form.22-rote-hunt.story.md
+++ b/specs/stories/dt-form.22-rote-hunt.story.md
@@ -4,71 +4,110 @@ task: 22
 epic: epic-dt-form-mvp-redesign
 status: Draft
 priority: medium
-depends_on: ['dt-form.17', 'dt-form.20']
+depends_on: ['dt-form.17', 'dt-form.20', 'dt-form.24']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q2)
 ---
 
-# Story dt-form.22 — ROTE hunt redesign (secondary feeding)
+# Story dt-form.22 — ROTE hunt as a personal-project-action variant
 
-As a player who wants to use ROTE-hunt as a secondary feeding option,
-I should see a clear secondary-feeding UI within the feeding section that explicitly distinguishes ROTE from primary feeding,
-So that ROTE choices are not buried in primary-feeding chrome and the section's MINIMAL/ADVANCED gating handles ROTE correctly.
+As a player who wants to use ROTE hunt to feed a second time in a downtime cycle,
+I should declare ROTE as a personal-project-action (consuming one of my project slots) where the dice pool is reused from my primary feeding and only the territory is selectable,
+So that ROTE has a clean home in the project-actions area rather than a parallel sub-block in the feeding section.
 
 ## Context
 
-ADR-003 §Audit-baseline notes ROTE hunt as "secondary feeding" within the existing `feeding` section. ADR §Q2 calls feeding for simplification in MINIMAL but does not specifically reduce ROTE chrome — that's this story's redesign.
+**Architectural correction 2026-05-06 (Piatra Q1 follow-up):** ROTE is **not a feeding-section sub-action**. It is a **personal-action variant** that consumes one of the player's project slots. The pool is reused from the primary hunt; only the territory (potentially a new one) is selectable.
 
-ROTE hunt is the "this is where you usually feed" lighter option that contrasts with primary feeding's per-cycle hunt. Players who do ROTE this cycle still need a way to declare it; the redesign gives ROTE a clear surface inside the feeding section.
+This corrects the earlier draft which positioned ROTE as a feeding-section secondary block. The corrected design:
+
+- ROTE lives as one of the action types available in a Personal Action slot (alongside `attack`, `feed`, `xp_spend`, etc.)
+- ROTE uses the same dice pool as the primary hunt (reads it from the feeding section's auto-derived pool per #20)
+- Player picks the ROTE territory (potentially different from primary)
+- The existing schema already supports this: `project_N_feed_method2` field in `downtime_submission.schema.js`
+- ROTE alone does **NOT** satisfy MINIMAL completeness — primary feeding is still required separately
+
+A player who wants to use ROTE for their MINIMAL "1 project slot" allocation can do so: ROTE-in-the-project-slot is a valid project-slot action. But primary feeding must also be filled in the feeding section.
 
 ### Files in scope
 
-- `public/js/tabs/downtime-form.js` — the feeding section's ROTE-secondary render
-- `public/js/data/dt-completeness.js` — `isMinimalComplete()` rule for feeding may need to consider ROTE-only as a valid completion (or not — this story decides)
+- `public/js/tabs/downtime-form.js` — the project-action render path; add ROTE as a recognised action type that surfaces a territory-only picker (pool is read-only and inherited from primary feeding)
+- `public/js/data/dt-completeness.js` — confirm primary feeding is the gate; ROTE selection in the project slot is NOT what unlocks MINIMAL feeding's rule
+- `server/schemas/downtime_submission.schema.js` — confirm `project_N_feed_method2` already exists (and any sibling fields like `project_N_feed_territory2`); document under `properties` if missing
 
 ### Files NOT in scope
 
-- Primary feeding logic (covered by #20)
+- Primary feeding logic (covered by #20 — primary stays in the feeding section)
+- The personal-actions chrome strip (covered by #24; ROTE follows whatever the post-#24 action UI looks like)
 - Feeding territory tinting (#21)
-- The `MAINTENANCE_MERITS` ROTE-related interaction (separate concern)
 
 ## Acceptance Criteria
 
-**Given** a player on MINIMAL or ADVANCED with feeding section visible
-**When** the ROTE option is selected
-**Then** the form shows a secondary-feeding UI clearly distinguished from primary feeding (separate sub-block, label, optional collapse/expand affordance).
+**Given** a player selects ROTE as a project-slot action type
+**When** the slot renders
+**Then** the slot shows a territory selector (using `charPicker`-style or chip-style territory picker, consistent with the feeding section's territory UX) and a read-only pool annotation displaying the inherited primary-feeding pool ("Pool: 7 (inherited from primary hunt)" or similar).
 
-**Given** ROTE feeding is selected on a MINIMAL submission
+**Given** the player has not filled primary feeding
+**When** they select ROTE as a project action
+**Then** the read-only pool annotation surfaces a clear note: "Pool will be derived from primary feeding once you fill it." The ROTE selection persists; the pool annotation updates once primary feeding is filled.
+
+**Given** the player selects a ROTE territory
+**When** the form persists
+**Then** the territory is saved to `responses.project_N_feed_territory2` (or the existing schema field; confirm during pickup survey). The pool is NOT separately persisted; it is derived from primary feeding at render and execute time.
+
+**Given** a MINIMAL-mode submission has ROTE in the project slot but no primary feeding filled
 **When** `isMinimalComplete()` is evaluated
-**Then** the rule passes — **ROTE counts as feeding for MINIMAL completeness** (confirmed by Piatra 2026-05-06). ROTE is a valid path through the MINIMAL gate.
+**Then** the rule **fails** (primary feeding is missing). The banner from #17 surfaces "Primary feeding is required" as the missing piece.
 
-**Given** ROTE is selected on a MINIMAL submission
-**When** the form auto-saves
-**Then** the corresponding downtime action is auto-populated with the ROTE feeding action — the player does not need to declare a Personal Action separately to record their ROTE hunt; the form derives it from the ROTE selection. (Per Piatra: "ROTE feeding is available in MINIMAL and would auto-populate the DOWNTIME action with the feeding action.")
+**Given** a MINIMAL-mode submission has primary feeding filled AND ROTE in the project slot
+**When** `isMinimalComplete()` is evaluated
+**Then** the rule **passes** (primary feeding satisfies feeding; the project-slot rule is satisfied because ROTE is a valid project action; mode set is complete).
 
-**Given** ROTE is selected
-**When** the player provides whatever ROTE-specific fields are needed (territory, RP description, etc.)
-**Then** those values persist on `responses.feeding_rote_*` keys (or follow the existing convention if these fields already exist).
+**Given** the implementer's current-state survey
+**When** they grep for `_feed_method2`, `_feed_territory2`, `rote`, `ROTE`
+**Then** they confirm the existing schema field set and document survey findings in DAR. If a field is missing, surface to Piatra rather than inventing a new shape.
 
 ## Implementation Notes
 
-The ROTE-vs-primary distinction in current code is fuzzy. Implementer should first **survey current ROTE behaviour** (grep for `rote`, `ROTE`, `_feeding_rote`, etc. in `downtime-form.js`); document findings in DAR; then redesign.
+### Survey first
 
-If the survey shows ROTE has no current implementation at all (just a placeholder in the section list), this story should ship a minimum-viable ROTE block (territory + description) and mark deeper game-rules questions for a follow-up story.
+`project_N_feed_method2` is the existing schema field per Piatra's note. Confirm via:
+```bash
+grep -n "feed_method2\|feed_territory2\|_rote" public/js/tabs/downtime-form.js server/schemas/downtime_submission.schema.js
+```
+
+The expected pattern: a project slot of type `feed` already has a method/territory pair; ROTE adds a second method/territory pair (`_method2`/`_territory2`) for the ROTE variant. If that's the existing shape, ROTE is a UI surface over an already-supported data shape.
+
+### Pool inheritance
+
+The primary feeding pool is auto-derived per #20. ROTE reads the same value at render-time via the same helper. Implementation: import the primary-pool computation helper from #20, call it from the ROTE render path. Read-only display.
+
+### MINIMAL gate
+
+`isMinimalComplete()` (owned by #17) has a `feeding` rule. That rule reads the **primary** feeding fields (`responses._feed_*`), not the ROTE fields. ROTE in a project slot is captured under the `1 project slot` MINIMAL rule (any action type counts), not the feeding rule.
 
 ## Test Plan
 
-- DAR captures the survey of current ROTE state
-- Browser smoke: ROTE selection surfaces clearly; persists; mode-switch preserves ROTE values
+- DAR: survey output for the schema field set
+- Static review: ROTE is a project-action variant; primary feeding is independent; MINIMAL rules confirmed against both fields
+- Browser smoke (DEFERRED):
+  1. Pick ROTE in project slot → territory picker appears; pool annotation shows inherited pool (or "fill primary feeding first" note)
+  2. Fill primary feeding → ROTE pool annotation updates with the derived pool
+  3. MINIMAL submission with ROTE only (no primary) → banner shows "Primary feeding required" from #17
+  4. MINIMAL submission with primary + ROTE in project slot → passes MINIMAL gate
 
 ## Definition of Done
 
-- [ ] ROTE secondary-feeding block clearly distinguished in the feeding section
-- [ ] Persistence keys documented in DAR
-- [ ] `isMinimalComplete()` rule for ROTE-only confirmed (counts vs ADVANCED-only)
+- [ ] ROTE renders as a project-action variant (territory picker + read-only inherited pool)
+- [ ] No ROTE block in the feeding section
+- [ ] `project_N_feed_method2` / `project_N_feed_territory2` schema fields confirmed (or surfaced for clarification)
+- [ ] `isMinimalComplete()` does NOT count ROTE-only as feeding-complete
 - [ ] PR opened into `dev`
 
 ## Dependencies
 
-- **Upstream**: #17 (rendering gate); #20 (simplified feeding)
+- **Upstream**: #17 (lifecycle + `isMinimalComplete()`); #20 (simplified primary feeding — pool helper to inherit); #24 (personal-actions chrome strip — ROTE renders inside the post-#24 action slot UI)
 - **Downstream**: none
-- **Open question**: surface "is ROTE-only sufficient for MINIMAL completeness?" to Piatra during pickup — likely a quick chat answer
+
+## Note on the architectural correction
+
+This story was originally drafted as a feeding-section secondary block with ROTE-only-counts-as-MINIMAL semantics. The correction (Piatra 2026-05-06 follow-up) repositions ROTE as a personal-project-action variant and requires primary feeding for MINIMAL. All ACs above reflect the corrected design.

--- a/specs/stories/dt-form.25-ambience-action-redesign.story.md
+++ b/specs/stories/dt-form.25-ambience-action-redesign.story.md
@@ -8,20 +8,21 @@ depends_on: ['dt-form.17', 'dt-form.24']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (Implementation Plan)
 ---
 
-# Story dt-form.25 — Ambience Increase/Decrease action redesign (territory-row table)
+# Story dt-form.25 — Ambience Increase/Decrease action redesign (territory-row table, single selection)
 
 As a player declaring an Ambience Increase or Decrease action,
-I should see a territory-row table where each row has a RED DOWN arrow and a GREEN UP arrow, each independently toggleable,
-So that the choice surface is direct (territory + direction) rather than a generic target/Increase/Decrease form.
+I should see a territory-row table where each row has a RED DOWN arrow and a GREEN UP arrow, with **one direction on one row** selectable per action slot,
+So that the choice surface is direct (territory + direction) and one Ambience action targets exactly one territory in exactly one direction.
 
 ## Context
 
-The current `ambience_increase` and `ambience_decrease` action types within Personal Actions slots use generic target/direction inputs. Per Piatra (2026-05-06, clarified 2026-05-06 follow-up):
-- One row per territory
-- Each row has both a RED DOWN arrow and a GREEN UP arrow as toggleable selectors
-- Each direction is **independently toggleable**: click to select that direction; click again to deselect
-- Both selectors stay visible at all times (do not collapse on selection)
-- The original brief's "mutually exclusive per row" language was relaxed to "independently toggleable" in the follow-up clarification
+The current `ambience_increase` and `ambience_decrease` action types within Personal Actions slots use generic target/direction inputs. Per Piatra (2026-05-06, FINAL clarification via Q2 follow-up 2026-05-06):
+
+- **One territory affected per single Ambience action.**
+- Multi-row table UX is fine for display (player sees all territories), but **only one row's UP/DOWN can be selected at a time per action slot**.
+- If the player wants two ambience changes, they spend two project slots.
+
+This supersedes the earlier "independently toggleable, multi-row allowed" interpretation. The action is single-target; the table is a display affordance, not a multi-selection surface.
 
 Rules summary text: *"Success is +/-2 influence change to territory, +/-4 on exceptional success."*
 
@@ -42,21 +43,29 @@ Rules summary text: *"Success is +/-2 influence change to territory, +/-4 on exc
 **When** the action slot renders
 **Then** a territory-row table renders. Each row has the territory name, a RED DOWN arrow chip, and a GREEN UP arrow chip. Both chips are visible at all times.
 
-**Given** the player clicks the GREEN UP arrow on a row
-**When** the chip toggles
-**Then** the GREEN UP is selected (highlighted) for that row. The RED DOWN remains visible. Other rows are unaffected.
+**Given** no row currently has a selection
+**When** the player clicks any direction arrow on any row
+**Then** that arrow becomes selected (highlighted) for that row. The clicked direction (UP or DOWN) is the action's chosen direction; the row's territory is the action's chosen target.
 
-**Given** the GREEN UP arrow is selected for a row
-**When** the player clicks the GREEN UP arrow again on the same row
-**Then** the selection toggles off. The arrow returns to its unselected state.
+**Given** a row already has a direction selected
+**When** the player clicks the same arrow again on the same row
+**Then** the selection toggles off. The action slot is back to no-selection state.
 
-**Given** the player clicks the RED DOWN arrow on the same row that already has GREEN UP selected
-**When** the chip toggles
-**Then** RED DOWN becomes selected. **GREEN UP and RED DOWN are independently toggleable per Piatra's 2026-05-06 follow-up clarification** — both directions may be selected simultaneously on the same row if the player chooses. The form does not enforce mutual exclusivity at the UI level.
+**Given** a row already has a direction selected
+**When** the player clicks the OPPOSITE direction on the same row
+**Then** the selection switches to the new direction on the same row (UP becomes DOWN, or vice versa). The action retains the same territory; only direction changes.
 
-**Given** a player has selected directions on multiple rows
-**When** they click an arrow on a different row
-**Then** all rows can hold independent selections — the table allows multi-row selection.
+**Given** a row already has a direction selected
+**When** the player clicks any direction on a DIFFERENT row
+**Then** the previous row's selection is cleared and the new row's clicked direction becomes the active selection. **At most one row can hold a selection at any time.**
+
+**Given** the player wants to record two ambience changes
+**When** they need a second target
+**Then** they fill a separate project slot with another `ambience_*` action. Two ambience changes consume two project slots — the action is single-target by design.
+
+**Given** the persistence
+**When** the slot is saved
+**Then** the selection is stored as a single (territory, direction) pair (e.g. `responses.project_N_ambience_target` and `responses.project_N_ambience_direction`).
 
 **Given** the form persists
 **When** the slot is saved
@@ -68,9 +77,13 @@ Rules summary text: *"Success is +/-2 influence change to territory, +/-4 on exc
 
 ## Implementation Notes
 
-Both action types (`ambience_increase` and `ambience_decrease`) collapse to the same UI shape. The action-type field is retained in `responses` for historical reasons but the UI doesn't ask the player to pick "increase or decrease" before the table — they just pick directions per row.
+Both action types (`ambience_increase` and `ambience_decrease`) collapse to the same UI shape. The action-type field is retained in `responses` for historical reasons but the UI doesn't ask the player to pick "increase or decrease" before the table — they just pick the direction on the row whose territory they want to target.
 
-If the per-action-type distinction (increase vs decrease) is no longer meaningful post-redesign, surface to Piatra during pickup as a simplification candidate (collapse to one action type called `ambience` with directions per territory).
+If the per-action-type distinction (increase vs decrease) is no longer meaningful post-redesign, surface to Piatra during pickup as a simplification candidate (collapse to one action type called `ambience` with a single direction-per-target).
+
+**Persistence shape (lock):** single (territory, direction) pair per action slot. Suggested fields:
+- `responses.project_N_ambience_target` — territory `_id` string
+- `responses.project_N_ambience_direction` — `'up' | 'down'`
 
 ## Test Plan
 
@@ -80,9 +93,12 @@ If the per-action-type distinction (increase vs decrease) is no longer meaningfu
 ## Definition of Done
 
 - [ ] Territory-row table renders for ambience actions
-- [ ] RED DOWN / GREEN UP arrows mutually exclusive per row, toggle-off reveals both
+- [ ] At most one row holds a selection at any time per action slot (single-target design)
+- [ ] Clicking a different row clears the previous selection
+- [ ] Clicking the opposite direction on the same row switches direction (does NOT add a second selection)
+- [ ] Clicking the same arrow again toggles off
 - [ ] Rules summary text present
-- [ ] Persistence shape documented in DAR
+- [ ] Persistence shape: single (territory, direction) pair per slot
 - [ ] PR opened into `dev`
 
 ## Dependencies

--- a/specs/stories/epic-dt-form-mvp-redesign.md
+++ b/specs/stories/epic-dt-form-mvp-redesign.md
@@ -99,15 +99,23 @@ Both are flagged in the affected stories' Dependencies blocks and again in the C
 
 - **#26 ↔ #31 (Admin section removal).** Both touch the Admin section. Confirmed sequencing 2026-05-06: **#31 lands first** (removes the Admin section structure and replaces it with the Submit Final modal), **#26 follows** (puts XP Spend functionality in a project slot). Documented in #26's Dependencies block.
 
-## Open-questions resolutions (Piatra 2026-05-06 follow-up)
+## Open-questions resolutions (Piatra 2026-05-06, two passes)
 
-Three open questions surfaced during decomposition were resolved by Piatra in the same review pass that confirmed merge-readiness:
+Two waves of resolutions during decomposition. The first wave was applied 2026-05-06 morning; the second wave (Q1, Q2 architectural corrections) was applied 2026-05-06 afternoon following Piatra's review. The second wave **inverts/constrains** the first wave on Q1 and Q2 — current state is the second-wave resolutions in the table below.
 
-| Story | Question | Resolution |
+| Story | Question | Final resolution (Piatra 2026-05-06 afternoon) |
 |---|---|---|
-| #22 ROTE hunt | Does ROTE-only count toward MINIMAL completeness? | **Yes.** ROTE feeding is available in MINIMAL and auto-populates the downtime feeding action. Story #22 carries this in its ACs. |
-| #25 Ambience action | Mutual exclusivity per row? | **No — relaxed to independently toggleable.** Both UP and DOWN may be selected simultaneously on the same row. Story #25 ACs updated. |
-| #27 Blood Sorcery order | Crúac vs Theban order? | **Crúac first, Theban second.** Within each, alphabetical-by-name unless pickup-time analysis surfaces a better order. Story #27 AC updated. |
+| #22 ROTE hunt | Where does ROTE live; does ROTE-only count toward MINIMAL? | **ROTE is a personal-project-action variant, NOT a feeding-section block.** Reuses primary feeding's pool; only territory selectable. Existing schema field `project_N_feed_method2` already supports this. **ROTE-only does NOT satisfy MINIMAL completeness; primary feeding is independently required.** A player can put ROTE in their MINIMAL "1 project slot" allocation but must also fill primary feeding in the feeding section. |
+| #25 Ambience action | UP/DOWN exclusivity? Multi-row? | **Single target per action.** One row's UP or DOWN selectable at a time per action slot. Switching to a different row clears the previous selection. Two changes = two project slots. The earlier "independently toggleable, multi-row" interpretation is superseded. |
+| #27 Blood Sorcery order | Crúac vs Theban order? | **Crúac first, Theban second.** Within each, alphabetical-by-name unless pickup-time analysis surfaces a better order. (No change from morning resolution.) |
+| #26 ↔ #31 sequencing | Admin section removal order? | **#31 first (Admin section structure removed); #26 follows (XP Spend relocated to project slot).** Confirmed. |
+
+### Earlier (morning, 2026-05-06) resolutions superseded by the afternoon pass
+
+For audit trail. The first-pass resolutions are recorded in commit `8279207d` and are corrected by this commit:
+
+- *(superseded)* #22 ROTE-only counts toward MINIMAL completeness
+- *(superseded)* #25 Ambience UP/DOWN are independently toggleable; both may be selected simultaneously per row; multi-row allowed
 
 ## Cross-cutting hotfix references (NOT in scope of this epic)
 


### PR DESCRIPTION
## Summary

Follow-up corrections to the DT submission form epic (PR #51 / #52). Applies Piatra's afternoon clarifications on ROTE positioning and Ambience cardinality. Doc-only.

## Corrections

### Q1 — ROTE & MINIMAL (Stories #17, #20, #22)

ROTE repositioned as a **personal-project-action variant**, NOT a feeding-section sub-block. Pool inherited from primary feeding; only territory is selectable. ROTE alone does NOT satisfy MINIMAL completeness — primary feeding is independently required.

- #22 rewritten as a project-action variant
- #20 NOT-in-scope list explicitly excludes ROTE from the feeding section; pool helper export added for #22 to import
- #17 `isMinimalComplete()` rule clarified

### Q2 — Ambience cardinality (Story #25)

Single target per action. One row's UP or DOWN selectable at a time per action slot. Switching rows clears the previous selection. Two ambience changes = two project slots. Persistence: single (territory, direction) pair per slot.

### Q3 — Admin removal sequencing

#31 first, #26 follows (already documented in #26 Dependencies; re-confirmed in epic).

## Audit trail

Epic README's resolutions table now records both waves: the morning resolutions are listed under a "superseded" block; the afternoon corrections are the current state.

## Branch flow

- From: `docs/dt-form-epic-corrections`
- Into: `dev`
- (Then `dev → main` per same-message authorisation)