### PR TITLE
feat(dt-form): minimal/advanced mode + soft-submit lifecycle (story dt-form.17)

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -5002,6 +5002,106 @@ html:not([data-theme="dark"]) .influence-title,
 html:not([data-theme="dark"]) .char-picker__pill { font-weight: 600; }
 
 /* ════════════════════════════════════════════════════════════════════
+   .dt-mode-selector — Minimal/Advanced toggle (ADR-003 §Q1, story dt-form.17)
+   ════════════════════════════════════════════════════════════════════ */
+.dt-mode-selector {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  margin: 0 0 12px;
+  padding: 8px 10px;
+  background: var(--surf2);
+  border: 1px solid var(--bdr2);
+  border-radius: 4px;
+}
+
+.dt-mode-pill {
+  appearance: none;
+  border: 1px solid var(--bdr2);
+  background: var(--surf);
+  color: var(--txt);
+  padding: 4px 12px;
+  border-radius: 999px;
+  font-family: var(--fl);
+  font-size: 0.9em;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.dt-mode-pill:hover {
+  border-color: var(--gold);
+}
+
+.dt-mode-pill--active {
+  background: var(--gold-a15);
+  border-color: var(--gold);
+  color: var(--gold2);
+}
+
+.dt-mode-desc {
+  flex: 1 1 200px;
+  font-family: var(--fl);
+  font-size: 0.85em;
+  color: var(--txt3);
+}
+
+/* ════════════════════════════════════════════════════════════════════
+   .dt-min-banner — below-minimum-complete banner (ADR-003 §Q3, dt-form.17)
+   ════════════════════════════════════════════════════════════════════ */
+.dt-min-banner {
+  margin: 0 0 14px;
+  padding: 10px 14px;
+  background: var(--crim-a15, var(--gold-a15));
+  border: 1px solid var(--crim2, var(--gold));
+  border-left: 4px solid var(--crim, var(--gold));
+  border-radius: 4px;
+  color: var(--txt);
+}
+
+.dt-min-banner__lead {
+  margin: 0 0 6px;
+  font-family: var(--fl);
+  font-size: 0.95em;
+}
+
+.dt-min-banner__list {
+  margin: 0;
+  padding-left: 20px;
+  font-family: var(--fl);
+  font-size: 0.9em;
+  color: var(--txt2);
+}
+
+.dt-min-banner__list li {
+  margin: 2px 0;
+}
+
+/* ════════════════════════════════════════════════════════════════════
+   .dt-xp-on-hold — XP-Available annotation (ADR-003 §Q3, dt-form.17)
+   ════════════════════════════════════════════════════════════════════ */
+.dt-xp-on-hold {
+  margin-left: 6px;
+  font-family: var(--fl);
+  font-size: 0.78em;
+  font-style: italic;
+  color: var(--crim, var(--txt3));
+  white-space: nowrap;
+}
+
+/* dt-form.17: negative xpLeft treatment in player-facing XP panels. */
+.dt-xp-deficit {
+  color: var(--crim, #b00020);
+  font-weight: 700;
+}
+
+.dt-xp-deficit[title] {
+  cursor: help;
+  text-decoration: underline dotted var(--crim, #b00020);
+  text-underline-offset: 2px;
+}
+
+/* ════════════════════════════════════════════════════════════════════
    .char-picker — universal character picker (ADR-003 §Q6, story dt-form.16)
    Form-local consumption: downtime-form.js + regency-tab.js
    ════════════════════════════════════════════════════════════════════ */

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -89,6 +89,7 @@ import {
 import { loadCharsFromApi, sanitiseChar, loadRulesFromApi, getRulesByCategory } from './data/loader.js';
 import { apiGet, apiPost, apiPut } from './data/api.js';
 import { loadGameXP } from './data/game-xp.js';
+import { loadDowntimeHoldFlag } from './data/dt-hold-flag.js';
 import { applyDerivedMerits } from './editor/mci.js';
 import { preloadRules } from './editor/rule_engine/load-rules.js';
 import { loadPool, chgPool, chgMod, updPool, setAgain, togMod, togSpec, doRoll, clrHist, effPool } from './suite/roll.js';
@@ -506,6 +507,8 @@ async function loadAllData() {
 
   // 1b. Load game session XP (attendance-based) — same as admin/player portal
   await loadGameXP(editorState.chars, getRole() === 'st').catch(() => {});
+  // dt-form.17: cache downtime-credit-on-hold flag so XP-Available renders the annotation.
+  await loadDowntimeHoldFlag(editorState.chars, { isST: getRole() === 'st' }).catch(() => {});
 
   // 1c. Compute derived bonus fields (PT/MCI/OHM grants, 9-Again, etc.)
   editorState.chars.forEach(c => applyDerivedMerits(c));

--- a/public/js/data/dt-completeness.js
+++ b/public/js/data/dt-completeness.js
@@ -1,0 +1,143 @@
+/**
+ * DT submission MINIMAL-completeness check (ADR-003 §Q3, §Q8).
+ *
+ * Single source of truth for "is this player above the minimum-complete bar
+ * this cycle?". Lives in its own module so it can be imported client-side
+ * (downtime-form lifecycle) and, in a future Q7 server-side validation pass,
+ * by the API without dragging form code along.
+ *
+ * Pure ESM. No DOM. No `document` / `window` / `localStorage` / `fetch`.
+ *
+ * MINIMAL set per ADR §Q2:
+ *   court + personal_story (reduced) + feeding (simplified)
+ *   + 1 project + regency-if-regent
+ *
+ * Each rule below mirrors the §Q8 spec and is inverted to drive the
+ * banner's missing-pieces list (story #17 UI affordance #1).
+ */
+
+const FEEDING_POOL_KEYS = ['_feed_disc', '_feed_custom_attr', '_feed_custom_skill', '_feed_custom_disc'];
+
+function isNonEmptyString(v) {
+  return typeof v === 'string' && v.trim().length > 0;
+}
+
+function _hasAnyGameRecount(responses) {
+  // Any of game_recount_1..5 non-empty, or the legacy joined `game_recount`.
+  for (let n = 1; n <= 5; n++) {
+    if (isNonEmptyString(responses[`game_recount_${n}`])) return true;
+  }
+  return isNonEmptyString(responses.game_recount);
+}
+
+function _hasPersonalStory(responses) {
+  // Per ADR §Q2 / story #18 simplification: a target ("who") + a note ("what
+  // moment"). The current renderer (renderPersonalStorySection) persists
+  // personal_story_npc_name + personal_story_note. Legacy fallbacks accept
+  // `correspondence` as the moment text.
+  const hasWho = isNonEmptyString(responses.personal_story_npc_name)
+              || isNonEmptyString(responses.personal_story_npc_id);
+  const hasWhat = isNonEmptyString(responses.personal_story_note)
+               || isNonEmptyString(responses.story_moment_note)
+               || isNonEmptyString(responses.osl_moment)
+               || isNonEmptyString(responses.correspondence);
+  return hasWho && hasWhat;
+}
+
+function _hasFeedingTerritory(responses) {
+  // feeding_territories is a JSON-stringified map of slug → state. Any slug
+  // not 'none' counts as a chosen feeding territory.
+  let grid;
+  try { grid = JSON.parse(responses.feeding_territories || '{}'); } catch { return false; }
+  if (!grid || typeof grid !== 'object') return false;
+  return Object.values(grid).some(state => isNonEmptyString(state) && state !== 'none');
+}
+
+function _hasFeedingMethod(responses) {
+  return FEEDING_POOL_KEYS.some(k => isNonEmptyString(responses[k]));
+}
+
+function _hasFeedingBloodType(responses) {
+  let arr;
+  try { arr = JSON.parse(responses._feed_blood_types || '[]'); } catch { return false; }
+  return Array.isArray(arr) && arr.length > 0;
+}
+
+function _hasFeedingViolence(responses) {
+  return isNonEmptyString(responses.feed_violence);
+}
+
+function _hasFeedingComplete(responses) {
+  return _hasFeedingTerritory(responses)
+      && _hasFeedingMethod(responses)
+      && _hasFeedingBloodType(responses)
+      && _hasFeedingViolence(responses);
+}
+
+function _hasFirstProject(responses) {
+  return isNonEmptyString(responses.project_1_action);
+}
+
+/**
+ * @param {object} responses           — submission.responses bag
+ * @param {object} [ctx]               — optional caller-side context
+ * @param {boolean} [ctx.isRegent]      — true if the character owns a regent territory
+ * @param {boolean} [ctx.regencyConfirmed] — true if the regent has confirmed feeding rights this cycle
+ * @returns {boolean}
+ */
+export function isMinimalComplete(responses, ctx = {}) {
+  if (!responses || typeof responses !== 'object') return false;
+  const { isRegent = false, regencyConfirmed = false } = ctx;
+
+  if (!_hasAnyGameRecount(responses)) return false;
+  if (!_hasPersonalStory(responses)) return false;
+  if (!_hasFeedingComplete(responses)) return false;
+  if (!_hasFirstProject(responses)) return false;
+  if (isRegent && !regencyConfirmed) return false;
+  return true;
+}
+
+/**
+ * Inverts isMinimalComplete to drive the banner's missing-pieces list.
+ *
+ * @param {object} responses
+ * @param {object} [ctx]
+ * @returns {{section: string, label: string}[]}
+ */
+export function missingMinimumPieces(responses, ctx = {}) {
+  const out = [];
+  if (!responses || typeof responses !== 'object') {
+    out.push({ section: 'court', label: 'Fill in your game recount' });
+    out.push({ section: 'personal_story', label: 'Name a Personal Story moment' });
+    out.push({ section: 'feeding', label: 'Pick a feeding territory, method, blood type, and Kiss/Violent toggle' });
+    out.push({ section: 'projects', label: 'Pick an action for Project 1' });
+    return out;
+  }
+  const { isRegent = false, regencyConfirmed = false } = ctx;
+
+  if (!_hasAnyGameRecount(responses)) {
+    out.push({ section: 'court', label: 'Game Recount: add at least one highlight from last session' });
+  }
+  if (!_hasPersonalStory(responses)) {
+    out.push({ section: 'personal_story', label: 'Personal Story: name an NPC and describe the moment you want' });
+  }
+  if (!_hasFeedingTerritory(responses)) {
+    out.push({ section: 'feeding', label: 'Feeding: pick a territory to hunt in' });
+  }
+  if (!_hasFeedingMethod(responses)) {
+    out.push({ section: 'feeding', label: 'Feeding: pick a method (build the hunt pool)' });
+  }
+  if (!_hasFeedingBloodType(responses)) {
+    out.push({ section: 'feeding', label: 'Feeding: pick at least one blood type' });
+  }
+  if (!_hasFeedingViolence(responses)) {
+    out.push({ section: 'feeding', label: 'Feeding: choose Kiss or Violent' });
+  }
+  if (!_hasFirstProject(responses)) {
+    out.push({ section: 'projects', label: 'Project 1: pick an action' });
+  }
+  if (isRegent && !regencyConfirmed) {
+    out.push({ section: 'regency', label: 'Regency: confirm this cycle’s feeding rights' });
+  }
+  return out;
+}

--- a/public/js/data/dt-hold-flag.js
+++ b/public/js/data/dt-hold-flag.js
@@ -1,0 +1,55 @@
+/**
+ * Cache the "downtime credit on hold" flag on each character (ADR-003 §Q3,
+ * story dt-form.17 UI affordance #2).
+ *
+ * The flag mirrors the player's most-recent submission's `_has_minimum`
+ * derived bool for the currently-active cycle. When false, the player's
+ * downtime XP credit is "on hold" — XP-Available renders a "(downtime
+ * credit on hold)" annotation and `attendance.downtime` for that game
+ * session is being held at false until the form clears the minimum bar.
+ *
+ * Browser-only. The pure rule encoder is in `dt-completeness.js`.
+ */
+
+import { apiGet } from './api.js';
+
+export async function loadDowntimeHoldFlag(chars, { isST = false } = {}) {
+  if (!Array.isArray(chars) || chars.length === 0) return;
+
+  // Default flag to false (not on hold) before any async work, so renderers
+  // don't show a stale `true` while the fetch is in flight.
+  for (const c of chars) {
+    if (c._dtHoldFlag === undefined) c._dtHoldFlag = false;
+  }
+
+  let activeCycle = null;
+  try {
+    const cycles = await apiGet('/api/downtime_cycles');
+    activeCycle = (cycles || []).find(c => c.status === 'active') || null;
+  } catch { /* fall through — flag stays false */ }
+  if (!activeCycle?._id) return;
+
+  for (const c of chars) {
+    try {
+      const subs = await apiGet(
+        `/api/downtime_submissions?cycle_id=${encodeURIComponent(activeCycle._id)}&character_id=${encodeURIComponent(c._id)}`
+      );
+      const sub = Array.isArray(subs) ? subs[0] : null;
+      if (!sub) {
+        // No submission yet for this cycle ⇒ definitely below-minimum.
+        c._dtHoldFlag = true;
+        continue;
+      }
+      const r = sub.responses || {};
+      // Trust the persisted derived bool when present; otherwise fall back
+      // to the submission's coarse status (mirrored by the lifecycle hook).
+      if (typeof r._has_minimum === 'boolean') {
+        c._dtHoldFlag = !r._has_minimum;
+      } else {
+        c._dtHoldFlag = sub.status !== 'submitted';
+      }
+    } catch {
+      // Best-effort — if a single fetch fails, leave the prior flag value.
+    }
+  }
+}

--- a/public/js/player.js
+++ b/public/js/player.js
@@ -2,6 +2,7 @@
 
 import { apiGet, apiPut } from './data/api.js';
 import { loadGameXP } from './data/game-xp.js';
+import { loadDowntimeHoldFlag } from './data/dt-hold-flag.js';
 import { esc, displayName, dropdownName, sortName, discordAvatarUrl, findRegentTerritory } from './data/helpers.js';
 import { setStatusTerritories } from './data/accessors.js';
 import { handleCallback, isLoggedIn, validateToken, login, logout, getUser, getPlayerInfo, getRole, isSTRole } from './auth/discord.js';
@@ -170,6 +171,8 @@ async function loadCharacters() {
     // Sanitise: strip zero-dot disciplines (treated as absent)
     chars.forEach(c => { if (c.disciplines) for (const [k, v] of Object.entries(c.disciplines)) { if ((v?.dots ?? v) === 0) delete c.disciplines[k]; } });
     await loadGameXP(chars, isSTRole());
+    // dt-form.17: cache "downtime credit on hold" flag for XP-Available annotation
+    await loadDowntimeHoldFlag(chars, { isST: isSTRole() }).catch(() => {});
   } catch (err) {
     document.getElementById('sh-content').innerHTML =
       `<p class="placeholder-msg">Failed to load characters: ${esc(err.message)}</p>`;

--- a/public/js/suite/sheet.js
+++ b/public/js/suite/sheet.js
@@ -149,11 +149,18 @@ export function renderSheet() {
   infoHtml += `<div class="sh-char-hdr">`;
 
   // Name row
+  // dt-form.17: red-flag the xpLeft portion if negative; annotate when the
+  // active cycle's downtime credit is on hold.
+  const _xpL = xpLeft(c);
+  const _xpDef = _xpL < 0
+    ? ' dt-xp-deficit" title="Spent XP exceeds available \u2014 restore the form to minimum-complete, or reverse the spend."'
+    : '"';
+  const _xpHoldFlag = !!c._dtHoldFlag;
   infoHtml += `<div class="sh-namerow">
     <div class="sh-char-name">${displayName(c)}</div>
     <div class="sh-player-row">
       <span class="sh-char-player">${redactPlayer(c.player || '')}${c.pronouns ? ' \u00B7 ' + c.pronouns : ''}</span>
-      <span class="sh-xp-badge">XP ${xpLeft(c)}/${xpEarned(c)}</span>
+      <span class="sh-xp-badge">XP <span class="sh-xp-badge-left${_xpDef}>${_xpL}</span>/${xpEarned(c)}${_xpHoldFlag ? ' <span class="dt-xp-on-hold">(downtime credit on hold)</span>' : ''}</span>
     </div>
     ${c.concept ? `<div class="sh-char-concept" style="margin-top:4px">${c.concept}</div>` : ''}
   </div>`;

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -24,6 +24,7 @@ import { getRole, isSTRole } from '../auth/discord.js';
 import { FAMILIES, kindByCode } from '../data/relationship-kinds.js';
 import { promptForKind } from '../data/kind-prompts.js';
 import { charPicker, setCharPickerSources } from '../components/character-picker.js';
+import { isMinimalComplete, missingMinimumPieces } from '../data/dt-completeness.js';
 
 // Influence merit names that generate monthly influence
 const INFLUENCE_MERIT_NAMES = ['Allies', 'Retainer', 'Mentor', 'Resources', 'Staff', 'Contacts', 'Status'];
@@ -67,6 +68,9 @@ let detectedMerits = { spheres: [], contacts: [], retainers: [], status: [] };
 
 // Characters who attended last game (for shoutout picks)
 let lastGameAttendees = [];
+// dt-form.17: game_session id matching the active cycle, for the soft-submit
+// lifecycle PATCH on attendance.downtime.
+let _activeGameSessionId = null;
 // All active characters (for cast picker modal)
 let allCharacters = [];
 
@@ -258,7 +262,19 @@ function effectiveDomainDots(c, name) {
 
 /** Get the feeding cap for the regent's territory based on its ambience. */
 function collectResponses() {
-  const responses = {};
+  // dt-form.17 (ADR-003 §Q1 Resolutions): preserve previously-entered fields
+  // for sections hidden by the current mode. Spread the prior responses as a
+  // base, then specific section blocks below either overwrite (when their UI
+  // is rendered) or are skipped (when hidden by MINIMAL).
+  const _prior = responseDoc?.responses || {};
+  const responses = { ..._prior };
+  // Carry the existing mode flag forward; the toggle handler updates it
+  // explicitly before triggering a save/render.
+  if (_prior._mode === 'minimal' || _prior._mode === 'advanced') {
+    responses._mode = _prior._mode;
+  }
+  const _mode = _formMode(_prior);
+  const _isMinimal = _mode === 'minimal';
 
   // Persist auto-detected gates
   responses['_gate_attended'] = gateValues.attended || '';
@@ -277,6 +293,9 @@ function collectResponses() {
   // Collect static section responses
   for (const section of DOWNTIME_SECTIONS) {
     if (section.gate && gateValues[section.gate] !== 'yes') continue;
+    // dt-form.17: skip hidden sections in MINIMAL so we don't clobber prior
+    // values with empty strings when the DOM isn't rendered.
+    if (_isMinimal && !MINIMAL_SECTIONS.has(section.key)) continue;
 
     for (const q of section.questions) {
       if (q.type === 'shoutout_picks') {
@@ -402,12 +421,14 @@ function collectResponses() {
   responses['story_moment_relationship_id'] = relIdEl ? relIdEl.value : '';
   responses['story_moment_note']            = noteEl  ? noteEl.value  : '';
 
-  // Aspiration structured slots
-  for (let n = 1; n <= 3; n++) {
-    const typeEl = document.getElementById(`dt-aspiration_${n}_type`);
-    const textEl = document.getElementById(`dt-aspiration_${n}_text`);
-    responses[`aspiration_${n}_type`] = typeEl ? typeEl.value : '';
-    responses[`aspiration_${n}_text`] = textEl ? textEl.value : '';
+  // Aspiration structured slots — admin section, ADVANCED only.
+  if (!_isMinimal) {
+    for (let n = 1; n <= 3; n++) {
+      const typeEl = document.getElementById(`dt-aspiration_${n}_type`);
+      const textEl = document.getElementById(`dt-aspiration_${n}_text`);
+      responses[`aspiration_${n}_type`] = typeEl ? typeEl.value : '';
+      responses[`aspiration_${n}_text`] = textEl ? textEl.value : '';
+    }
   }
 
   // DTR.1: Game recount structured highlight slots (game_recount_1…5).
@@ -429,8 +450,10 @@ function collectResponses() {
   }
 
   // Collect project slots
+  // dt-form.17: in MINIMAL only the first slot is rendered; iterate just slot
+  // 1 so slots 2-4 retain their prior values from the spread base.
   const projectSection = DOWNTIME_SECTIONS.find(s => s.key === 'projects');
-  const projectSlotCount = projectSection?.projectSlots || 4;
+  const projectSlotCount = _isMinimal ? 1 : (projectSection?.projectSlots || 4);
   for (let n = 1; n <= projectSlotCount; n++) {
     const actionEl = document.getElementById(`dt-project_${n}_action`);
     responses[`project_${n}_action`] = actionEl ? actionEl.value : '';
@@ -549,6 +572,11 @@ function collectResponses() {
       if (prior !== undefined) responses[`project_${n}_joint_sphere_chips`] = prior;
     }
   }
+
+  // dt-form.17: collection of ADVANCED-only sections (sorcery, spheres,
+  // status, contacts, retainers, acquisitions, equipment, skill acq) is
+  // skipped in MINIMAL mode. Their prior values stay intact via the spread.
+  if (!_isMinimal) {
 
   // Collect sorcery slots (dynamic count)
   const sorceryCountEl = document.getElementById('dt-sorcery-slot-count');
@@ -780,6 +808,8 @@ function collectResponses() {
     responses[`equipment_${n}_notes`] = notesEl ? notesEl.value : '';
   }
 
+  } // end if (!_isMinimal) — ADVANCED-only collection
+
   return responses;
 }
 
@@ -795,17 +825,31 @@ async function saveDraft() {
   }
   const responses = collectResponses();
 
+  // dt-form.17 (ADR-003 §Q3, §Q4): hard-mirror lifecycle. Compute the
+  // derived bool, persist on responses, and on transition mirror to
+  // submission.status + attendance.downtime.
+  const completenessCtx = _completenessCtx();
+  const hasMinimum = isMinimalComplete(responses, completenessCtx);
+  responses._has_minimum = hasMinimum;
+  const priorHasMinimum = !!responseDoc?.responses?._has_minimum;
+  const flipped = priorHasMinimum !== hasMinimum;
+  const nextStatus = hasMinimum ? 'submitted' : 'draft';
+
   try {
     if (!responseDoc) {
       responseDoc = await apiPost('/api/downtime_submissions', {
         character_id: currentChar._id,
         character_name: currentChar.name,
         cycle_id: currentCycle._id,
-        status: 'draft',
+        status: nextStatus,
         responses,
       });
     } else {
-      responseDoc = await apiPut(`/api/downtime_submissions/${responseDoc._id}`, { responses });
+      // Include status in the body so a status flip and the responses write
+      // land in the same PUT — saves a round-trip and keeps the two fields
+      // consistent on retry.
+      const body = flipped ? { responses, status: nextStatus } : { responses };
+      responseDoc = await apiPut(`/api/downtime_submissions/${responseDoc._id}`, body);
     }
     // Residency is now saved in the Regency tab
     if (statusEl) statusEl.textContent = 'Saved';
@@ -813,11 +857,36 @@ async function saveDraft() {
     // DTU-2: server now has the truth, drop the local mirror.
     _clearLocalSnapshot();
 
+    // dt-form.17: mirror to attendance.downtime on transition. Idempotent —
+    // we still send the PATCH on flip, even if the bool is the same as last
+    // time (e.g. on a fresh form load with no prior state).
+    if (flipped && _activeGameSessionId && currentChar?._id) {
+      try {
+        await apiPatch(
+          `/api/attendance/${encodeURIComponent(_activeGameSessionId)}/${encodeURIComponent(String(currentChar._id))}`,
+          { downtime: hasMinimum }
+        );
+        // Local cache for XP-Available annotation; also flips the player
+        // sheet's _gameXP on the next loadGameXP call.
+        currentChar._dtHoldFlag = !hasMinimum;
+      } catch {
+        // Non-fatal — the bool can be reconciled at cycle-close. The 423
+        // gate handler logs to status if cycle is closed.
+      }
+    } else if (currentChar) {
+      currentChar._dtHoldFlag = !hasMinimum;
+    }
+
     // JDT-2: After the submission save lands, fan out joint creations for any
     // slot that authored a joint and doesn't yet have a backing joint document.
     await createPendingJoints(responses);
   } catch (err) {
-    if (statusEl) statusEl.textContent = 'Save failed: ' + err.message;
+    // dt-form.17 §Q11: surface the cycle-close 423 with a stable message.
+    if (err && /CYCLE_CLOSED|423|Cycle is closed/i.test(err.message || '')) {
+      if (statusEl) statusEl.textContent = 'Cycle closed; submission locked';
+    } else if (statusEl) {
+      statusEl.textContent = 'Save failed: ' + err.message;
+    }
   }
 }
 
@@ -1314,12 +1383,14 @@ export async function renderDowntimeTab(targetEl, char, territories, options = {
 
   // Auto-detect attendance from the game session matching this downtime cycle
   lastGameAttendees = [];
+  _activeGameSessionId = null;
   try {
     let attUrl = '/api/attendance?character_id=' + encodeURIComponent(String(currentChar._id));
     if (currentCycle?.game_number) attUrl += '&game_number=' + currentCycle.game_number;
     const att = await apiGet(attUrl);
     gateValues.attended = att.attended ? 'yes' : 'no';
     lastGameAttendees = att.attendees || [];
+    _activeGameSessionId = att.session_id || null;
   } catch { /* fall back — leave gateValues.attended unset */ }
 
   // Load all character names for cast picker
@@ -1618,11 +1689,49 @@ function _remountShoutoutPicker(trimmed) {
   cur.replaceWith(fresh);
 }
 
+// dt-form.17 (ADR-003 §Q1, §Q2): MINIMAL vs ADVANCED mode gate.
+// Sections in MINIMAL_SECTIONS render in both modes; everything else is
+// hidden in MINIMAL (per ADR §Q2 lock — "not rendered, not just display:none").
+const MINIMAL_SECTIONS = new Set(['court', 'personal_story', 'feeding', 'projects', 'regency']);
+
+function _formMode(saved) {
+  return saved?._mode === 'advanced' ? 'advanced' : 'minimal';
+}
+
+function _isSectionVisibleInMode(sectionKey, mode) {
+  if (mode === 'advanced') return true;
+  return MINIMAL_SECTIONS.has(sectionKey);
+}
+
+function _completenessCtx() {
+  return {
+    isRegent: gateValues.is_regent === 'yes',
+    regencyConfirmed: _isRegencyConfirmedThisCycle(),
+  };
+}
+
+function _isRegencyConfirmedThisCycle() {
+  if (!currentCycle?.regent_confirmations) return false;
+  const ri = findRegentTerritory(_territories, currentChar);
+  if (!ri?.territoryId) return false;
+  return (currentCycle.regent_confirmations || []).some(
+    c => String(c.territory_id) === String(ri.territoryId)
+  );
+}
+
 function renderForm(container) {
   const saved = responseDoc?.responses || {};
   const status = responseDoc?.status || 'new';
   const isST = isSTRole();
   const isSubmitted = status === 'submitted';
+
+  // dt-form.17: derive _mode + _has_minimum on every render so the gate and
+  // banner reflect the latest state. The persistent fields are written by
+  // the lifecycle hook in scheduleSave; this is read-only here.
+  const mode = _formMode(saved);
+  const ctx = _completenessCtx();
+  const hasMinimum = isMinimalComplete(saved, ctx);
+  const missing = hasMinimum ? [] : missingMinimumPieces(saved, ctx);
 
   // Re-publish picker sources every render — guards against another module
   // (regency-tab) overwriting them between navigations.
@@ -1649,6 +1758,32 @@ function renderForm(container) {
     h += '<div class="qf-results-pending"><p class="qf-results-pending-msg">Your downtime is submitted. You can keep editing until the deadline — changes auto-save and update your submission.</p></div>';
   } else if (!published && priorPublishedLabel) {
     h += `<div class="qf-results-banner">&#x2713; Your <strong>${esc(priorPublishedLabel)}</strong> results are published &mdash; see the <strong>Story</strong> tab.</div>`;
+  }
+
+  // dt-form.17 (ADR-003 §Q1): mode selector at top of form.
+  h += '<div class="dt-mode-selector" role="group" aria-label="Form mode">';
+  h += `<button type="button" class="dt-mode-pill${mode === 'minimal' ? ' dt-mode-pill--active' : ''}" data-dt-mode="minimal" aria-pressed="${mode === 'minimal'}">Minimal</button>`;
+  h += `<button type="button" class="dt-mode-pill${mode === 'advanced' ? ' dt-mode-pill--active' : ''}" data-dt-mode="advanced" aria-pressed="${mode === 'advanced'}">Advanced</button>`;
+  h += '<span class="dt-mode-desc">';
+  h += mode === 'minimal'
+    ? 'Just the essentials. Switch to Advanced for the full form — your data is preserved either way.'
+    : 'All sections shown. Switch back to Minimal at any time without losing what you have entered.';
+  h += '</span>';
+  h += '</div>';
+
+  // dt-form.17 (ADR-003 §Q3): persistent below-minimum banner with the
+  // missing-pieces list. Locked copy per story §Banner copy.
+  if (!hasMinimum) {
+    h += '<div class="dt-min-banner" role="status" aria-live="polite">';
+    h += '<p class="dt-min-banner__lead"><strong>Your form is below minimum-complete.</strong> Your downtime XP credit is on hold. Add the missing pieces to restore it:</p>';
+    if (missing.length) {
+      h += '<ul class="dt-min-banner__list">';
+      for (const item of missing) {
+        h += `<li>${esc(item.label)}</li>`;
+      }
+      h += '</ul>';
+    }
+    h += '</div>';
   }
 
   // Header
@@ -1711,6 +1846,9 @@ function renderForm(container) {
     if (section.key === 'feeding') continue;
     if (section.key === 'regency') continue;
     if (section.key === 'personal_story') continue; // rendered explicitly below
+    // dt-form.17: hide non-minimal sections when in MINIMAL mode (court is in
+    // MINIMAL so it falls through; trust/harm/aspirations live in admin).
+    if (!_isSectionVisibleInMode(section.key, mode)) continue;
 
     const isGated = section.gate && gateValues[section.gate] !== 'yes';
     const sectionClass = isGated ? 'qf-section dt-gated-hidden' : 'qf-section collapsed';
@@ -1732,12 +1870,13 @@ function renderForm(container) {
   h += renderPersonalStorySection(saved);
 
   // ── Blood Sorcery before Territory/Feeding — rites can affect hunt pool ──
-  if (gateValues.has_sorcery === 'yes') {
+  if (gateValues.has_sorcery === 'yes' && _isSectionVisibleInMode('blood_sorcery', mode)) {
     h += renderSorcerySection(saved);
   }
 
   // ── Territory then Feeding — players see ambience/cap before choosing hunt method ──
   for (const key of ['territory', 'feeding']) {
+    if (!_isSectionVisibleInMode(key, mode)) continue;
     const section = DOWNTIME_SECTIONS.find(s => s.key === key);
     if (!section) continue;
     h += `<div class="qf-section collapsed" data-gate-section="" data-section-key="${key}">`;
@@ -1753,18 +1892,23 @@ function renderForm(container) {
   }
 
   // ── Projects section with dynamic slots ──
-  h += renderProjectSlots(saved);
+  // dt-form.17: in MINIMAL only the first project slot renders.
+  h += renderProjectSlots(saved, mode);
 
-  // ── Dynamic merit sections ──
-  h += renderMeritToggles(saved);
+  // dt-form.17: ADVANCED-only sections below the projects.
+  if (mode === 'advanced') {
+    // ── Dynamic merit sections ──
+    h += renderMeritToggles(saved);
 
-  // ── Acquisitions (custom render) ──
-  h += renderAcquisitionsSection(saved);
+    // ── Acquisitions (custom render) ──
+    h += renderAcquisitionsSection(saved);
 
-  // ── Equipment (dynamic rows) ──
-  h += renderEquipmentSection(saved);
+    // ── Equipment (dynamic rows) ──
+    h += renderEquipmentSection(saved);
+  }
 
   for (const key of ['vamping', 'admin']) {
+    if (!_isSectionVisibleInMode(key, mode)) continue;
     const section = DOWNTIME_SECTIONS.find(s => s.key === key);
     if (!section) continue;
     const isGated = section.gate && gateValues[section.gate] !== 'yes';
@@ -1838,6 +1982,20 @@ function renderForm(container) {
 
   // Section collapse/expand toggle
   container.addEventListener('click', (e) => {
+    // dt-form.17: Mode pill toggle. Persist on responses._mode and re-render.
+    // Switching preserves entered data (per ADR §Q1 Resolutions): non-MINIMAL
+    // fields stay in responses; only their UI is hidden.
+    const modePill = e.target.closest('[data-dt-mode]');
+    if (modePill) {
+      const next = modePill.dataset.dtMode === 'advanced' ? 'advanced' : 'minimal';
+      const cur = collectResponses();
+      cur._mode = next;
+      if (responseDoc) responseDoc.responses = cur;
+      else responseDoc = { responses: cur };
+      renderForm(container);
+      scheduleSave();
+      return;
+    }
     // DTOSL.2 choice chip handler — removed in NPCR.12 (replaced by the
     // single relationships picker in renderPersonalStorySection).
 
@@ -3027,9 +3185,10 @@ function renderMaintenanceWarnings(char, cycle) {
   return out.join('');
 }
 
-function renderProjectSlots(saved) {
+function renderProjectSlots(saved, mode = 'advanced') {
   const section = DOWNTIME_SECTIONS.find(s => s.key === 'projects');
-  const slotCount = section?.projectSlots || 4;
+  // dt-form.17 (ADR-003 §Q2): MINIMAL renders one project slot only.
+  const slotCount = mode === 'minimal' ? 1 : (section?.projectSlots || 4);
 
   // Build attribute/skill/discipline option lists from character data
   const attrs = ALL_ATTRS.filter(a => getAttrTotal(currentChar, a) > 0);

--- a/public/js/tabs/xp-log-tab.js
+++ b/public/js/tabs/xp-log-tab.js
@@ -27,10 +27,19 @@ export function renderXpLogTab(el, char) {
   let h = '<div class="xpl-log">';
 
   // Balance
+  // dt-form.17: annotate when downtime credit is on hold (cycle's submission
+  // below minimum-complete) and render xpLeft red with a tooltip when negative.
+  const onHold = !!char._dtHoldFlag;
+  const deficitTip = overBudget
+    ? 'Spent XP exceeds available — restore the form to minimum-complete, or reverse the spend.'
+    : '';
   h += `<div class="xpl-panel ${overBudget ? 'xpl-over' : 'xpl-ok'}">`;
   h += '<div class="xpl-balance">';
   h += '<span class="xpl-bal-lbl">XP Available</span>';
-  h += `<span class="xpl-bal-val">${left}</span>`;
+  h += `<span class="xpl-bal-val${overBudget ? ' dt-xp-deficit' : ''}"${deficitTip ? ` title="${esc(deficitTip)}"` : ''}>${left}</span>`;
+  if (onHold) {
+    h += '<span class="dt-xp-on-hold">(downtime credit on hold)</span>';
+  }
   h += '</div>';
   if (overBudget) {
     h += `<p class="xpl-over-warn">Over budget by ${Math.abs(left)} XP</p>`;

--- a/server/routes/attendance.js
+++ b/server/routes/attendance.js
@@ -87,7 +87,65 @@ router.get('/', async (req, res) => {
     })
     .sort((a, b) => a.name.localeCompare(b.name));
 
-  res.json({ attended, attendees });
+  // dt-form.17: surface session_id so the player client can address the
+  // soft-submit lifecycle PATCH at /api/attendance/:session_id/:character_id.
+  res.json({ attended, attendees, session_id: latest?._id ? String(latest._id) : null });
+});
+
+// dt-form.17 (ADR-003 §Q3): PATCH attendance.downtime for a single character
+// on a single game session. Mirrors the player's submission `_has_minimum`
+// derived bool both ways. Idempotent: writing the same value is a no-op
+// success. Players may flip their own character; ST may flip any.
+//
+// Mounted under /api/attendance (player-accessible) rather than
+// /api/game_sessions (ST/coordinator-only) so players can run their own
+// soft-submit lifecycle. ST attendance edits still go through the existing
+// PUT /api/game_sessions/:id (whole-document overwrite) for compat.
+//
+// Path: PATCH /api/attendance/:session_id/:character_id
+// Body: { downtime: true | false }
+// Returns: 200 + the updated attendance entry, or 404 if no match.
+router.patch('/:session_id/:character_id', async (req, res) => {
+  const sessionId = req.params.session_id;
+  const charId = String(req.params.character_id || '');
+  const downtime = req.body?.downtime;
+  if (typeof downtime !== 'boolean') {
+    return res.status(400).json({
+      error: 'VALIDATION_ERROR',
+      message: 'Body field `downtime` must be boolean',
+    });
+  }
+
+  let sessOid;
+  try { sessOid = new ObjectId(sessionId); }
+  catch { return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid session ID format' }); }
+
+  // Player auth: only flip their own character.
+  if (req.user.role === 'player') {
+    const owned = (req.user.character_ids || []).map(id => String(id));
+    if (!owned.includes(charId)) {
+      return res.status(403).json({ error: 'FORBIDDEN', message: 'Not your character' });
+    }
+  }
+
+  const result = await col().findOneAndUpdate(
+    { _id: sessOid, 'attendance.character_id': charId },
+    {
+      $set: {
+        'attendance.$.downtime': downtime,
+        updated_at: new Date().toISOString(),
+      },
+    },
+    { returnDocument: 'after', projection: { attendance: 1 } }
+  );
+  if (!result) {
+    return res.status(404).json({
+      error: 'NOT_FOUND',
+      message: 'No attendance entry for that character on that session',
+    });
+  }
+  const entry = (result.attendance || []).find(a => String(a.character_id) === charId);
+  res.json({ ok: true, entry });
 });
 
 export default router;

--- a/server/routes/downtime.js
+++ b/server/routes/downtime.js
@@ -29,6 +29,37 @@ function parseId(id) {
   }
 }
 
+// dt-form.17 (ADR-003 §Q11): hard server gate on submission edits when the
+// cycle is closed. Hard mirror's contract is that cycle-close seals the state
+// in both directions; players and ST alike cannot mutate a submission whose
+// cycle is closed. Returns 423 Locked with a stable error code so the client
+// can surface a clear message and stop retrying.
+async function requireOpenCycle(req, res, next) {
+  const oid = parseId(req.params.id);
+  if (!oid) return next(); // existing handler returns 400 for the format error
+  const sub = await getCollection('downtime_submissions').findOne(
+    { _id: oid },
+    { projection: { cycle_id: 1 } }
+  );
+  if (!sub) return next(); // existing handler returns 404
+  if (!sub.cycle_id) return next();
+  const cycleOid = sub.cycle_id instanceof ObjectId
+    ? sub.cycle_id
+    : parseId(String(sub.cycle_id));
+  if (!cycleOid) return next();
+  const cycle = await getCollection('downtime_cycles').findOne(
+    { _id: cycleOid },
+    { projection: { status: 1 } }
+  );
+  if (cycle?.status === 'closed') {
+    return res.status(423).json({
+      error: 'CYCLE_CLOSED',
+      message: 'Cycle is closed; submissions are locked',
+    });
+  }
+  return next();
+}
+
 // --- Cycles: /api/downtime_cycles ---
 
 export const cyclesRouter = Router();
@@ -569,7 +600,8 @@ submissionsRouter.get('/', async (req, res) => {
 });
 
 // PUT /api/downtime_submissions/:id — ST can update any, player can update own (before deadline)
-submissionsRouter.put('/:id', async (req, res) => {
+// dt-form.17: cycle-close gate (ADR-003 §Q11) returns 423 before the handler runs.
+submissionsRouter.put('/:id', requireOpenCycle, async (req, res) => {
   const oid = parseId(req.params.id);
   if (!oid) return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid submission ID format' });
 

--- a/server/schemas/downtime_submission.schema.js
+++ b/server/schemas/downtime_submission.schema.js
@@ -168,6 +168,20 @@ export const downtimeSubmissionSchema = {
         _gate_has_acquisitions: yesNoGate,  // Legacy — acquisitions always shown now
         regent_territory:       { type: 'string' },
 
+        // ── dt-form.17 (ADR-003 §Q1, §Q3, §Q5) lifecycle metadata ────
+        // _mode: rendering tier the form is in. Default 'minimal'; switching
+        // ADVANCED preserves any previously-entered fields rather than clearing.
+        _mode: { type: 'string', enum: ['minimal', 'advanced', ''] },
+        // _has_minimum: derived bool from isMinimalComplete(responses, ctx).
+        // Hard-mirrored both ways onto submission.status + attendance.downtime
+        // until cycle close. Written on every save; not authoritative — the
+        // function in public/js/data/dt-completeness.js is.
+        _has_minimum: { type: 'boolean' },
+        // _final_submitted_at: ADVANCED-mode "I'm done editing" hint set by the
+        // Submit Final modal (story #31). Not a status flip — submission.status
+        // already mirrors _has_minimum from the soft-submit lifecycle.
+        _final_submitted_at: { type: 'string' },  // ISO timestamp
+
         // ── Merit toggle states (legacy, preserved for contacts/retainers) ──
         // Dynamic keys: _merit_<merit_key> = "yes" | "no"
         // merit_key format: "name_rating_area".toLowerCase().replace(/[^a-z0-9]+/g, '_')

--- a/server/tests/api-downtime.test.js
+++ b/server/tests/api-downtime.test.js
@@ -268,4 +268,48 @@ describe('PUT /api/downtime_submissions/:id', () => {
       .send({ status: 'submitted' });
     expect(res.status).toBe(400);
   });
+
+  // dt-form.17 (ADR-003 §Q11): cycle-close gate
+  it('returns 423 CYCLE_CLOSED when the submission’s cycle is closed', async () => {
+    const cycleCol = getCollection('downtime_cycles');
+    const cycleRes = await cycleCol.insertOne({
+      game_number: 9001,
+      label: 'Closed Test Cycle',
+      status: 'closed',
+      created_at: new Date().toISOString(),
+    });
+    try {
+      const sub = await insertSub(testChars[0].id, { cycle_id: cycleRes.insertedId });
+      const res = await request(app)
+        .put(`/api/downtime_submissions/${sub._id}`)
+        .set('X-Test-User', playerUser([testChars[0].id]))
+        .send({ responses: { travel: 'Trying to edit a closed cycle' } });
+      expect(res.status).toBe(423);
+      expect(res.body.error).toBe('CYCLE_CLOSED');
+      expect(res.body.message).toMatch(/locked/i);
+    } finally {
+      await cycleCol.deleteOne({ _id: cycleRes.insertedId });
+    }
+  });
+
+  it('allows edits when the cycle is active (gate passes)', async () => {
+    const cycleCol = getCollection('downtime_cycles');
+    const cycleRes = await cycleCol.insertOne({
+      game_number: 9002,
+      label: 'Active Test Cycle',
+      status: 'active',
+      created_at: new Date().toISOString(),
+    });
+    try {
+      const sub = await insertSub(testChars[0].id, { cycle_id: cycleRes.insertedId });
+      const res = await request(app)
+        .put(`/api/downtime_submissions/${sub._id}`)
+        .set('X-Test-User', playerUser([testChars[0].id]))
+        .send({ responses: { travel: 'Edit on active cycle' } });
+      expect(res.status).toBe(200);
+      expect(res.body.responses.travel).toBe('Edit on active cycle');
+    } finally {
+      await cycleCol.deleteOne({ _id: cycleRes.insertedId });
+    }
+  });
 });

--- a/server/tests/api-game-sessions.test.js
+++ b/server/tests/api-game-sessions.test.js
@@ -198,3 +198,101 @@ describe('GET /api/game_sessions/next', () => {
     expect(res.status).toBe(401);
   });
 });
+
+// dt-form.17 (ADR-003 §Q3): PATCH attendance.downtime per-character.
+// Mounted under /api/attendance (player-accessible) — see attendance.js.
+describe('PATCH /api/attendance/:session_id/:character_id', () => {
+  it('flips downtime true for a matching attendance entry (ST)', async () => {
+    const charId = '69d73ea49162ece35897a47e'; // sample valid 24-char hex
+    const sessRes = await getCollection('game_sessions').insertOne({
+      session_date: '2026-05-06',
+      title: 'PATCH-Attendance Test',
+      attendance: [{
+        character_id: charId,
+        character_name: 'Test PC',
+        attended: true,
+        costuming: false,
+        downtime: false,
+        extra: 0,
+        paid: false,
+      }],
+    });
+    cleanupIds.game_sessions.push(sessRes.insertedId);
+
+    const res = await request(app)
+      .patch(`/api/attendance/${sessRes.insertedId}/${charId}`)
+      .set('X-Test-User', stUser())
+      .send({ downtime: true });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.entry.downtime).toBe(true);
+  });
+
+  it('flips downtime back to false (idempotent both ways)', async () => {
+    const charId = '69d73ea49162ece35897a48d';
+    const sessRes = await getCollection('game_sessions').insertOne({
+      session_date: '2026-05-06',
+      title: 'PATCH-Attendance Flipback',
+      attendance: [{ character_id: charId, character_name: 'Test PC', downtime: true }],
+    });
+    cleanupIds.game_sessions.push(sessRes.insertedId);
+
+    const res = await request(app)
+      .patch(`/api/attendance/${sessRes.insertedId}/${charId}`)
+      .set('X-Test-User', stUser())
+      .send({ downtime: false });
+    expect(res.status).toBe(200);
+    expect(res.body.entry.downtime).toBe(false);
+  });
+
+  it('returns 404 when no attendance entry matches', async () => {
+    const sessRes = await getCollection('game_sessions').insertOne({
+      session_date: '2026-05-06',
+      attendance: [],
+    });
+    cleanupIds.game_sessions.push(sessRes.insertedId);
+    const res = await request(app)
+      .patch(`/api/attendance/${sessRes.insertedId}/000000000000000000000000`)
+      .set('X-Test-User', stUser())
+      .send({ downtime: true });
+    expect(res.status).toBe(404);
+  });
+
+  it('rejects non-boolean downtime body', async () => {
+    const sessRes = await getCollection('game_sessions').insertOne({
+      session_date: '2026-05-06',
+      attendance: [{ character_id: '69d73ea49162ece35897a47f', downtime: false }],
+    });
+    cleanupIds.game_sessions.push(sessRes.insertedId);
+    const res = await request(app)
+      .patch(`/api/attendance/${sessRes.insertedId}/69d73ea49162ece35897a47f`)
+      .set('X-Test-User', stUser())
+      .send({ downtime: 'yes' });
+    expect(res.status).toBe(400);
+  });
+
+  it('player can flip their own character but not someone else’s', async () => {
+    const myCharId = '69d73ea49162ece35897a481';
+    const otherCharId = '69d73ea49162ece35897a482';
+    const sessRes = await getCollection('game_sessions').insertOne({
+      session_date: '2026-05-06',
+      attendance: [
+        { character_id: myCharId, downtime: false },
+        { character_id: otherCharId, downtime: false },
+      ],
+    });
+    cleanupIds.game_sessions.push(sessRes.insertedId);
+
+    const okRes = await request(app)
+      .patch(`/api/attendance/${sessRes.insertedId}/${myCharId}`)
+      .set('X-Test-User', playerUser([myCharId]))
+      .send({ downtime: true });
+    expect(okRes.status).toBe(200);
+
+    const blockRes = await request(app)
+      .patch(`/api/attendance/${sessRes.insertedId}/${otherCharId}`)
+      .set('X-Test-User', playerUser([myCharId]))
+      .send({ downtime: true });
+    expect(blockRes.status).toBe(403);
+  });
+});

--- a/specs/stories/dt-form.16-character-picker.story.md
+++ b/specs/stories/dt-form.16-character-picker.story.md
@@ -2,7 +2,7 @@
 id: dt-form.16
 task: 16
 epic: epic-dt-form-mvp-redesign
-status: Ready for Review
+status: Done
 priority: high
 depends_on: []
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q6, §Q10)

--- a/specs/stories/dt-form.17-minimal-advanced-lifecycle.story.md
+++ b/specs/stories/dt-form.17-minimal-advanced-lifecycle.story.md
@@ -2,7 +2,7 @@
 id: dt-form.17
 task: 17
 epic: epic-dt-form-mvp-redesign
-status: Ready for Dev
+status: Ready for Review
 priority: high
 depends_on: ['dt-form.16']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q1, §Q2, §Q3, §Q4, §Q8, §Q11)
@@ -210,16 +210,68 @@ If this endpoint doesn't exist yet, surface in DAR — may need a new route. Mos
 
 ## Definition of Done
 
-- [ ] `public/js/data/dt-completeness.js` ships with `isMinimalComplete(responses)` exported
-- [ ] Mode selector renders at top of form; persistence in `responses._mode` works; default MINIMAL; switch preserves data
-- [ ] Lifecycle wiring in `scheduleSave()`/`saveDraft()` PATCHes both submission status + attendance.downtime on transition
-- [ ] All three UI affordances ship: banner, XP-Available annotation, negative-XP-Left red treatment
-- [ ] Cycle-close server gate returns 423 Locked
-- [ ] Schema documents new fields (`_mode`, `_has_minimum`, `_final_submitted_at`) under `downtime_submission.schema.js properties`
-- [ ] No `game_session.schema.js` delta (per ADR rev 2)
-- [ ] Server tests green; new 423 test added
-- [ ] Browser smoke completes the 7-step plan in §Test Plan §3
-- [ ] PR opened by `tm-gh-pr-for-branch` into `dev`, body links ADR-003 §Q1/Q2/Q3/Q4/Q8/Q11
+- [x] `public/js/data/dt-completeness.js` ships with `isMinimalComplete(responses)` exported
+- [x] Mode selector renders at top of form; persistence in `responses._mode` works; default MINIMAL; switch preserves data
+- [x] Lifecycle wiring in `scheduleSave()`/`saveDraft()` PATCHes both submission status + attendance.downtime on transition
+- [x] All three UI affordances ship: banner, XP-Available annotation, negative-XP-Left red treatment
+- [x] Cycle-close server gate returns 423 Locked
+- [x] Schema documents new fields (`_mode`, `_has_minimum`, `_final_submitted_at`) under `downtime_submission.schema.js properties`
+- [x] No `game_session.schema.js` delta (per ADR rev 2)
+- [x] Server tests green; new 423 test added (plus 5 new tests for the attendance.downtime PATCH route)
+- [ ] Browser smoke completes the 7-step plan in §Test Plan §3 *(deferred to user/SM per Test Plan)*
+- [x] PR opened by `tm-gh-pr-for-branch` into `dev`, body links ADR-003 §Q1/Q2/Q3/Q4/Q8/Q11
+
+---
+
+## Dev Agent Record
+
+**Agent Model Used:** James (BMAD `dev`) — Claude Opus 4.7
+
+### Tasks
+- [x] Build `public/js/data/dt-completeness.js` — pure ESM, no DOM. Exports `isMinimalComplete(responses, ctx)` and `missingMinimumPieces(responses, ctx)`.
+- [x] Top-of-form Minimal/Advanced mode selector + section rendering gate. Mode-switch preserves entered data via spread-base in `collectResponses` and per-block mode gating.
+- [x] Soft-submit lifecycle hook in `saveDraft()`: writes `_has_minimum` to responses; on transition pushes `submission.status` (in the PUT body) and `attendance[i].downtime` (PATCH `/api/attendance/:session_id/:character_id`).
+- [x] UI affordance #1 — persistent below-minimum banner with locked copy + missing-pieces list at top of form.
+- [x] UI affordance #2 — `(downtime credit on hold)` annotation in player XP panel + suite sheet badge. Cached on `c._dtHoldFlag` via new `loadDowntimeHoldFlag()` (browser-only loader).
+- [x] UI affordance #3 — `xpLeft()` rendered red with hover tooltip when negative.
+- [x] Server middleware `requireOpenCycle` on `PUT /api/downtime_submissions/:id` returns 423 `CYCLE_CLOSED`.
+- [x] New PATCH route `/api/attendance/:session_id/:character_id { downtime }` for the lifecycle mirror (player-accessible; ST may flip any).
+- [x] Schema additions on `downtime_submission` (`_mode`, `_has_minimum`, `_final_submitted_at`). No `game_session.schema` delta.
+- [x] 7 new server tests (2 cycle-close + 5 attendance PATCH) — all green; 641/643 total pass (2 pre-existing dev failures unrelated).
+- [x] Story status → Ready for Review; PR opened.
+
+### File List
+
+**New**
+- `public/js/data/dt-completeness.js`
+- `public/js/data/dt-hold-flag.js`
+
+**Modified**
+- `public/js/tabs/downtime-form.js`
+- `public/js/tabs/xp-log-tab.js`
+- `public/js/suite/sheet.js`
+- `public/js/player.js`
+- `public/js/app.js`
+- `public/css/components.css`
+- `server/routes/downtime.js`
+- `server/routes/attendance.js`
+- `server/schemas/downtime_submission.schema.js`
+- `server/tests/api-downtime.test.js`
+- `server/tests/api-game-sessions.test.js`
+- `specs/stories/dt-form.17-minimal-advanced-lifecycle.story.md` (Dev Agent Record only)
+
+### Completion Notes
+
+- DAR raised early (chat → Khepri) on the missing `attendance[i].downtime` PATCH route. Implemented option 1 from the DAR — added `PATCH /api/attendance/:session_id/:character_id { downtime: bool }` under the player-accessible `/api/attendance` mount (the `/api/game_sessions` route is `requireRole('coordinator')` in prod, so the new route had to live elsewhere). Also extended `GET /api/attendance` to surface `session_id` so the client can address the PATCH without reaching the ST-only `/api/game_sessions` listing.
+- Cycle-close gate: ADR §Q11 wording is `PATCH /api/downtime_submissions/:id`, but the live mutation path is `PUT /api/downtime_submissions/:id` (the route is named PUT but accepts partial-body patch-semantic updates via `$set`). Gate applied to PUT with the AC's contract (423 + `CYCLE_CLOSED` body) preserved verbatim. If a literal HTTP-PATCH alias is wanted later, it's a one-line addition.
+- Mode-switch data preservation: `collectResponses()` now starts from `..._prior` spread and skips iteration over ADVANCED-only blocks (sorcery, spheres, status, contacts, retainers, acquisitions, equipment, skill acq) when the form is in MINIMAL mode. Project slot collection caps at slot 1 in MINIMAL; slots 2-4 retain their prior values from the spread. ADVANCED-only sections are not rendered in MINIMAL (per ADR §Q2 lock — "not rendered, not just display:none").
+- The XP-Available annotation needs the active cycle's submission status to be known on every char render. Added `loadDowntimeHoldFlag(chars)` (browser-only, in `dt-hold-flag.js` to keep `dt-completeness.js` pure ESM importable server-side). Called from both `player.js` and `app.js` after `loadGameXP`. Trusts persisted `_has_minimum` when present; falls back to the submission's coarse `status` when not.
+- Two pre-existing server test failures on `dev` are unrelated to this branch (`api-relationships-player-create.test.js > GET /api/npcs/directory`; `rule_engine_grep.test.js` flagging `m.cp || 0` and `m.xp || 0` in `auto-bonus-evaluator.js` and `pool-evaluator.js`). Same as the dt-form.16 PR.
+
+### Change Log
+| Date | Author | Change |
+|---|---|---|
+| 2026-05-06 | James (dev) | Implemented all six ADR-locked decisions (§Q1, §Q2, §Q3, §Q4, §Q8, §Q11) plus the three non-negotiable UI affordances. Added the player-accessible attendance PATCH route per DAR. Status → Ready for Review. |
 
 ---
 


### PR DESCRIPTION
## Summary

Implements story `dt-form.17` — foundation #2 of 2. References [ADR-003 §Q1, §Q2, §Q3, §Q4, §Q8, §Q11](../blob/dev/specs/architecture/adr-003-dt-form-cross-cutting.md) (mode selector, MINIMAL set, hard-mirror lifecycle, auto-XP timing, location of `isMinimalComplete`, cycle-close gate).

- New pure-ESM module `public/js/data/dt-completeness.js` exporting `isMinimalComplete(responses, ctx)` + `missingMinimumPieces(responses, ctx)` per ADR §Q8.
- Top-of-form Minimal/Advanced toggle, default Minimal. Switching preserves entered data — `collectResponses()` now spreads the prior responses and skips iteration over ADVANCED-only blocks (sorcery, spheres, status, contacts, retainers, acquisitions, equipment, skill acq, project slots 2–4) when in MINIMAL.
- Hard-mirror lifecycle in `saveDraft()`: writes `_has_minimum` on every save; on transition includes `status: 'submitted' | 'draft'` in the PUT body and PATCHes `attendance[i].downtime` for the player's character on the active cycle's game session.
- Three locked UI affordances: persistent below-minimum banner with dynamic missing-pieces list, `(downtime credit on hold)` annotation immediately after XP-Available (cached on `c._dtHoldFlag` via the new `loadDowntimeHoldFlag()` loader called from `player.js` and `app.js`), and negative-`xpLeft()` red treatment with hover tooltip in the player XP panel + suite badge.
- Cycle-close gate: `requireOpenCycle` middleware on `PUT /api/downtime_submissions/:id` returns 423 `CYCLE_CLOSED` when `cycle.status === 'closed'`.
- Schema additions on `downtime_submission.responses`: `_mode`, `_has_minimum`, `_final_submitted_at`. No `game_session.schema` delta per ADR rev 2.

Closes #56

## Notes

### DAR-resolved: new attendance PATCH route

ADR §Q3 sketches `PATCH /api/game_sessions/.../attendance/:char_id`, but no such route existed. DAR raised to Khepri at start of work; implemented option 1 from the DAR — added the route under `/api/attendance` rather than `/api/game_sessions` (the latter is `requireRole('coordinator')` in prod, so a player-side lifecycle PATCH had to live elsewhere). New path: `PATCH /api/attendance/:session_id/:character_id { downtime: bool }`. Players may flip their own character; ST may flip any. Idempotent both ways. `GET /api/attendance` extended to surface `session_id` so the client can address the PATCH without reaching the ST-only `/api/game_sessions` listing.

### Cycle-close gate verb

ADR §Q11's literal text says "PATCH /api/downtime_submissions/:id" but the live mutation path is `PUT /api/downtime_submissions/:id` (the route is named PUT but accepts partial-body patch-semantic updates via `$set`). Gate applied to PUT; AC's contract (423 + `CYCLE_CLOSED` body) preserved verbatim. If a literal HTTP-PATCH alias on the same path is wanted later, it's a one-line `submissionsRouter.patch(...)` addition.

### Test results

- 7 new server tests (2 cycle-close 423 happy/sad + 5 attendance PATCH paths including ST/player auth + 404 + 400)
- 641/643 pass overall. The 2 pre-existing failures on `dev` (`api-relationships-player-create > GET /api/npcs/directory`; `rule_engine_grep` flagging `m.cp || 0` and `m.xp || 0` in `auto-bonus-evaluator.js` and `pool-evaluator.js`) are unchanged by this branch — same set as the dt-form.16 PR.

## Test plan

- [ ] Static review by Ma'at — three UI affordances are present, lifecycle PATCH calls are idempotent, mode-switch preserves data
- [ ] Browser smoke (deferred):
  - [ ] Open a fresh submission → MINIMAL by default → only MINIMAL sections visible
  - [ ] Fill enough fields to flip `_has_minimum` true → banner disappears, annotation disappears, XP-Available updates
  - [ ] Empty a field to flip back to false → banner reappears, annotation reappears, XP-Available drops
  - [ ] Spend XP while above minimum, then drop below → red XP-Left + tooltip appears
  - [ ] Switch MINIMAL → ADVANCED → MINIMAL → no data lost
  - [ ] ST closes cycle → player attempts edit → 423 + locked message
  - [ ] Regent character: regency section appears in MINIMAL; non-regent: it does not