### PR TITLE
test(dev): clear two pre-existing failures so dev runs green-on-green

### DIFF
--- a/public/js/editor/rule_engine/auto-bonus-evaluator.js
+++ b/public/js/editor/rule_engine/auto-bonus-evaluator.js
@@ -81,6 +81,7 @@ function _ratingOfPartner(c, partnerMeritName) {
   let total = 0;
   (c.merits || []).forEach(m => {
     if (m.name !== partnerMeritName) return;
+    // inherent-intentional: partner-rating sum must use purchased dots only (cp+xp); engine-derived bonuses (m.bonus) are excluded by design.
     total += (m.cp || 0) + (m.xp || 0);
   });
   return total;

--- a/public/js/editor/rule_engine/pool-evaluator.js
+++ b/public/js/editor/rule_engine/pool-evaluator.js
@@ -72,6 +72,7 @@ function _vmPool(c) {
       total += (m.cp || 0) + (m.xp || 0) + (m.free_mci || 0); // inherent-intentional: free_mci counts because MCI Allies are real influence resources
     } else if (m.name === 'Herd') {
       if (m.derived) return;
+      // inherent-intentional: Herd dice-pool contribution counts purchased dots only (cp+xp); derived/granted Herd is filtered above.
       total += (m.cp || 0) + (m.xp || 0);
     }
   });

--- a/server/tests/api-relationships-player-create.test.js
+++ b/server/tests/api-relationships-player-create.test.js
@@ -73,30 +73,6 @@ function validPlayerBody(overrides = {}) {
   };
 }
 
-// ── NPC directory ───────────────────────────────────────────────────────────
-
-describe('GET /api/npcs/directory', () => {
-  it('returns active + pending NPCs with minimal projection', async () => {
-    const res = await request(app)
-      .get('/api/npcs/directory')
-      .set('X-Test-User', playerUser([MY_CHAR]));
-    expect(res.status).toBe(200);
-    const names = res.body.map(n => n.name);
-    expect(names).toContain('Alice NPC');
-    expect(names).toContain('Pending NPC');
-    expect(names).not.toContain('Archived NPC');
-    // Minimal projection: no notes / linked_character_ids
-    const alice = res.body.find(n => n.name === 'Alice NPC');
-    expect(alice.notes).toBeUndefined();
-    expect(alice.linked_character_ids).toBeUndefined();
-  });
-
-  it('401 without auth', async () => {
-    const res = await request(app).get('/api/npcs/directory');
-    expect(res.status).toBe(401);
-  });
-});
-
 // ── Player POST: happy path ─────────────────────────────────────────────────
 
 describe('POST /api/relationships — player happy path', () => {


### PR DESCRIPTION
## Summary

Pure tech-debt cleanup of the two pre-existing failures flagged on PRs #57 and #60. Server tests now run 661/661 green.

- **Issue #63** — remove the stale `GET /api/npcs/directory` describe block from `server/tests/api-relationships-player-create.test.js` (predates NPCR.14 privacy scoping; equivalent coverage lives in `api-npcs-directory.test.js`).
- **Issue #64** — annotate the two purchased-dots-only `m.cp + m.xp` reads in `rule_engine/auto-bonus-evaluator.js:84` and `rule_engine/pool-evaluator.js:75` with `// inherent-intentional:` markers per ADR-001's grep contract. Marker text matches the convention from `pool-evaluator.js:72` (Allies MCI sum).

Closes #63
Closes #64

## Notes

- Diff is 3 files, +2 / -24 lines. No surrounding refactors, no new tests, no renames — per Khepri's scope-discipline directive.
- `api-npcs-directory.test.js` 3/3 pass after the deletion (verified locally) so no coverage regression.
- One unrelated working-tree edit was visible (dt-form.17 story status `Ready for Review` → `Done`) — restored to keep this PR scoped to #63/#64. Story status bookkeeping is for Khepri to land separately.

## Test plan

- [x] `server/tests/api-relationships-player-create.test.js` no longer contains the `GET /api/npcs/directory` describe
- [x] `tests/rule_engine_grep.test.js` passes (zero unmarked violations)
- [x] `tests/api-npcs-directory.test.js` still passes (3/3)
- [x] Full server suite green (661/661)