### PR TITLE
fix(dt-form): remove Save Draft button; surface live auto-save indicator

### DIFF
--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -814,6 +814,11 @@ function collectResponses() {
   return responses;
 }
 
+function _saveTimestamp() {
+  const now = new Date();
+  return now.getHours().toString().padStart(2, '0') + ':' + now.getMinutes().toString().padStart(2, '0');
+}
+
 async function saveDraft() {
   const statusEl = document.getElementById('dt-save-status');
   if (!currentCycle) {
@@ -824,6 +829,7 @@ async function saveDraft() {
     if (statusEl) statusEl.textContent = '[Dev] Save skipped';
     return;
   }
+  if (statusEl) statusEl.textContent = 'Saving…';
   const responses = collectResponses();
 
   // dt-form.17 (ADR-003 §Q3, §Q4): hard-mirror lifecycle. Compute the
@@ -853,8 +859,7 @@ async function saveDraft() {
       responseDoc = await apiPut(`/api/downtime_submissions/${responseDoc._id}`, body);
     }
     // Residency is now saved in the Regency tab
-    if (statusEl) statusEl.textContent = 'Saved';
-    setTimeout(() => { if (statusEl) statusEl.textContent = ''; }, 2000);
+    if (statusEl) statusEl.textContent = 'Saved ' + _saveTimestamp();
     // DTU-2: server now has the truth, drop the local mirror.
     _clearLocalSnapshot();
 
@@ -1809,7 +1814,6 @@ function renderForm(container) {
   }
   h += '<span id="dt-save-status" class="qf-save-status"></span>';
   h += '</div>';
-  h += '<p class="qf-intro">Your responses auto-save as you type.</p>';
 
   // Status badges
   h += '<div class="dt-status-badges">';
@@ -1944,7 +1948,6 @@ function renderForm(container) {
   // Actions
   const submitLabel = responseDoc?.status === 'submitted' ? 'Update Submission' : 'Submit Downtime';
   h += '<div class="qf-actions">';
-  h += '<button class="qf-btn qf-btn-save" id="dt-btn-save">Save Draft</button>';
   h += `<button class="qf-btn qf-btn-submit" id="dt-btn-submit">${esc(submitLabel)}</button>`;
   h += '</div>';
 
@@ -3021,7 +3024,6 @@ function renderForm(container) {
     updateSectionTicks(container);
   });
 
-  document.getElementById('dt-btn-save')?.addEventListener('click', saveDraft);
   document.getElementById('dt-btn-submit')?.addEventListener('click', submitForm);
 }
 

--- a/server/tests/save-draft-indicator.test.js
+++ b/server/tests/save-draft-indicator.test.js
@@ -1,0 +1,52 @@
+/**
+ * Static grep contract — hotfix #47 save-draft indicator.
+ *
+ * Verifies that the four code-level changes in downtime-form.js are present
+ * and the removed artefacts are absent. These are guard-rails against
+ * accidental revert, not runtime tests.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../');
+const src = readFileSync(
+  resolve(REPO_ROOT, 'public/js/tabs/downtime-form.js'),
+  'utf8'
+);
+
+describe('hotfix #47 — save-draft indicator', () => {
+
+  it('Save Draft button is not rendered', () => {
+    expect(src).not.toMatch(/id="dt-btn-save"/);
+  });
+
+  it('static "auto-save as you type" text is removed', () => {
+    expect(src).not.toMatch(/auto-save as you type/);
+  });
+
+  it('saveDraft() sets Saving… status text', () => {
+    expect(src).toMatch(/statusEl\.textContent\s*=\s*'Saving…'/);
+  });
+
+  it('success path sets Saved HH:MM via _saveTimestamp()', () => {
+    expect(src).toMatch(/'Saved ' \+ _saveTimestamp\(\)/);
+  });
+
+  it('_saveTimestamp helper is defined', () => {
+    expect(src).toMatch(/function _saveTimestamp\(\)/);
+  });
+
+  it('setTimeout clear of save-status is removed', () => {
+    // The old clear: setTimeout(() => { if (statusEl) statusEl.textContent = ''; }, 2000)
+    // Should not exist anywhere near the success path
+    expect(src).not.toMatch(/statusEl\.textContent\s*=\s*''\s*}\s*,\s*2000/);
+  });
+
+  it('#dt-btn-save click listener is removed', () => {
+    expect(src).not.toMatch(/dt-btn-save.*addEventListener/);
+    expect(src).not.toMatch(/addEventListener.*dt-btn-save/);
+  });
+
+});

--- a/specs/stories/hotfix.47-save-draft-indicator.story.md
+++ b/specs/stories/hotfix.47-save-draft-indicator.story.md
@@ -1,0 +1,149 @@
+---
+id: hotfix.47
+issue: 47
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/47
+branch: angelus/issue-47-save-draft-indicator
+status: done
+priority: critical
+depends_on: []
+labels: [bug, cycle-blocker, dt-form]
+---
+
+# Story hotfix.47 — Remove redundant Save Draft button; surface live auto-save indicator
+
+As a player filling in the DT form,
+I should see continuous feedback on whether my responses are saving,
+So that I don't experience data-loss anxiety during a live cycle.
+
+---
+
+## Context
+
+`saveDraft()` in `public/js/tabs/downtime-form.js` is the backbone — it POSTs/PUTs to `/api/downtime_submissions` and writes status text to `#dt-save-status`. Auto-save runs on a 2s debounce via `scheduleSave()`. The explicit Save Draft button (`#dt-btn-save`) is therefore redundant.
+
+The status indicator (`#dt-save-status`) already exists at line 1810, next to the submission badge. The current writes to it are:
+
+| State | Current text | Gap |
+|-------|-------------|-----|
+| In-flight | *(nothing)* | Missing "Saving…" |
+| Success | `"Saved"` — clears after 2s | Should show timestamp and persist |
+| Error | `"Save failed: <reason>"` | Fine |
+| Cycle closed | `"Cycle closed; submission locked"` | Fine |
+| No active cycle | `"No active cycle — contact your ST"` | Fine |
+
+ADR-003 Q12 specifies option (a): remove the button, keep the indicator.
+
+### Files in scope
+
+- `public/js/tabs/downtime-form.js` only:
+  - Line 1947: remove the Save Draft button from the render
+  - Line 1812: remove the static "Your responses auto-save as you type." text (replaced by live indicator)
+  - Line 818: add `statusEl.textContent = 'Saving…'` before the try block
+  - Line 856-857: change success write from `'Saved'` (clears after 2s) to `'Saved ' + HH:MM` (persists)
+
+### Files NOT in scope
+
+- `scheduleSave()` — behaviour unchanged
+- localStorage mirror (`_clearLocalSnapshot`) — DTU-2 safety net, do not touch
+- Any other file — this is a render + status-text change only
+
+---
+
+## Acceptance Criteria
+
+**Given** the form renders
+**When** a player views the actions area
+**Then** no Save Draft button is visible.
+
+**Given** a player makes a change (triggering auto-save)
+**When** `saveDraft()` begins its API call
+**Then** `#dt-save-status` shows `"Saving…"`.
+
+**Given** the save completes successfully
+**When** `saveDraft()` resolves
+**Then** `#dt-save-status` shows `"Saved HH:MM"` (local time, 24h, e.g. `"Saved 14:23"`) and does not clear automatically.
+
+**Given** the save fails
+**When** `saveDraft()` rejects
+**Then** `#dt-save-status` shows `"Save failed: <reason>"` and persists until the next save attempt.
+
+**Given** the cycle is closed (423)
+**When** `saveDraft()` catches the error
+**Then** `#dt-save-status` shows `"Cycle closed; submission locked"` (unchanged).
+
+**Given** the static "Your responses auto-save as you type." text
+**When** the form renders
+**Then** it is removed (the live indicator replaces it).
+
+**Given** the localStorage mirror (DTU-2)
+**When** any save occurs
+**Then** the mirror behaviour is unchanged.
+
+---
+
+## Implementation Notes
+
+### Timestamp helper
+
+```js
+function _saveTimestamp() {
+  const now = new Date();
+  return now.getHours().toString().padStart(2, '0') + ':' + now.getMinutes().toString().padStart(2, '0');
+}
+```
+
+Place near the top of `saveDraft()` or as a module-level helper.
+
+### saveDraft() changes (line 817 area)
+
+```js
+async function saveDraft() {
+  const statusEl = document.getElementById('dt-save-status');
+  if (!currentCycle) {
+    if (statusEl) statusEl.textContent = 'No active cycle — contact your ST';
+    return;
+  }
+  if (currentCycle._id === 'dev-stub') {
+    if (statusEl) statusEl.textContent = '[Dev] Save skipped';
+    return;
+  }
+  if (statusEl) statusEl.textContent = 'Saving…';   // ← ADD THIS
+  // ... rest of function unchanged ...
+  // success:
+  if (statusEl) statusEl.textContent = 'Saved ' + _saveTimestamp();  // ← CHANGE (remove the setTimeout clear)
+```
+
+Remove the `setTimeout(() => { if (statusEl) statusEl.textContent = ''; }, 2000)` line entirely.
+
+### Render changes
+
+- Line 1947: delete `h += '<button class="qf-btn qf-btn-save" id="dt-btn-save">Save Draft</button>';`
+- Line 1812: delete `h += '<p class="qf-intro">Your responses auto-save as you type.</p>';`
+
+### Button event listener
+
+After removing the render, search for the click handler wired to `#dt-btn-save` and remove it too. Check around line 2804 (referenced in issue body).
+
+---
+
+## Test Plan
+
+- Static review: button render line deleted, "Saving…" added, timestamp format correct, setTimeout clear removed
+- Browser smoke:
+  - Open any character's DT form
+  - Make a field change — confirm "Saving…" appears then "Saved HH:MM"
+  - Confirm no Save Draft button visible
+  - Confirm no "Your responses auto-save as you type." text
+
+---
+
+## Definition of Done
+
+- [x] Save Draft button removed from render
+- [x] Static auto-save text removed
+- [x] `#dt-save-status` shows "Saving…" during in-flight save
+- [x] `#dt-save-status` shows "Saved HH:MM" on success (persists)
+- [x] Error and cycle-closed states unchanged
+- [x] localStorage mirror unaffected
+- [x] Button click listener removed
+- [ ] PR opened from `angelus/issue-47-save-draft-indicator` into `dev`


### PR DESCRIPTION
## Summary

- Eliminates data-loss anxiety for players by surfacing continuous auto-save feedback — the explicit Save Draft button was silent and redundant since auto-save already runs on a 2s debounce
- Removes `#dt-btn-save` render and its click listener; replaces the static "auto-save as you type" text with the live `#dt-save-status` span
- Adds `Saving…` in-flight state and changes the success write from a 2s-clearing `'Saved'` to a persistent `'Saved HH:MM'` timestamp

## Closes

- Closes #47

## Story

- specs/stories/hotfix.47-save-draft-indicator.story.md

## ADR / Design

- specs/architecture/adr-003 (Q12: remove button, keep indicator)

## Test plan

- [ ] 7/7 static grep tests green (`server/tests/save-draft-indicator.test.js`)
- [ ] CI green
- [ ] Manual: open any character DT form, make a field change — confirm "Saving…" then "Saved HH:MM" appears; confirm no Save Draft button; confirm no static auto-save text

## Branch flow

- From: `angelus/issue-47-save-draft-indicator`
- Into: `dev`