### PR TITLE
docs(story): mark dt-form.17 status as Done

### DIFF
--- a/specs/stories/dt-form.17-minimal-advanced-lifecycle.story.md
+++ b/specs/stories/dt-form.17-minimal-advanced-lifecycle.story.md
@@ -2,7 +2,7 @@
 id: dt-form.17
 task: 17
 epic: epic-dt-form-mvp-redesign
-status: Ready for Review
+status: Done
 priority: high
 depends_on: ['dt-form.16']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q1, §Q2, §Q3, §Q4, §Q8, §Q11)


### PR DESCRIPTION
## Summary

One-line frontmatter flip on `specs/stories/dt-form.17-minimal-advanced-lifecycle.story.md`: `status: Ready for Review` → `status: Done`. The implementation was merged in PR #60 (foundation #2 of the DT form epic); this PR closes the documentation gap.

## Closes

_None_

## Story

- specs/stories/dt-form.17-minimal-advanced-lifecycle.story.md (status field only)

## Test plan

- [x] No code change — diff is one line in story frontmatter
- [x] CI green (no logic affected)

## Branch flow

- From: `piatra/bookkeeping-dt-form-17-status`
- Into: `dev`