### PR TITLE
feat(dt-form): Submit Final modal + Admin section removal (story dt-form.31)

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -5102,6 +5102,106 @@ html:not([data-theme="dark"]) .char-picker__pill { font-weight: 600; }
 }
 
 /* ════════════════════════════════════════════════════════════════════
+   .dt-min-toast — MINIMAL auto-submit confirmation (ADR-003 §Q5, dt-form.31)
+   ════════════════════════════════════════════════════════════════════ */
+.dt-min-toast {
+  margin: 0 0 14px;
+  padding: 10px 14px;
+  background: var(--gold-a10);
+  border: 1px solid var(--gold-a30);
+  border-left: 4px solid var(--gold);
+  border-radius: 4px;
+  color: var(--txt);
+}
+
+.dt-min-toast__lead {
+  margin: 0;
+  font-family: var(--fl);
+  font-size: 0.95em;
+}
+
+/* ════════════════════════════════════════════════════════════════════
+   .dt-modal — Submit Final modal (ADR-003 §Q5, story dt-form.31)
+   Mirrors the existing .npcr-modal pattern (admin-layout.css) but lives in
+   components.css so the player surface (player.html) picks it up.
+   ════════════════════════════════════════════════════════════════════ */
+.dt-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 16px;
+}
+
+.dt-modal {
+  background: var(--surf2);
+  border: 1px solid var(--gold);
+  border-radius: 4px;
+  min-width: 320px;
+  max-width: 560px;
+  width: 100%;
+  max-height: calc(100vh - 32px);
+  overflow-y: auto;
+  padding: 18px 20px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  outline: none;
+}
+
+.dt-modal-title {
+  font-family: var(--fh);
+  font-size: 1.2em;
+  color: var(--gold2);
+  margin: 0 0 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--bdr);
+}
+
+.dt-modal-subhead {
+  font-family: var(--fh);
+  font-size: 1em;
+  color: var(--gold);
+  margin: 14px 0 6px;
+}
+
+.dt-modal-body {
+  margin-bottom: 14px;
+  font-family: var(--fl);
+  color: var(--txt);
+}
+
+.dt-modal-summary-list {
+  margin: 4px 0 0;
+  padding-left: 22px;
+  font-family: var(--fl);
+  font-size: 0.95em;
+  color: var(--txt2);
+}
+
+.dt-modal-summary-list li {
+  margin: 2px 0;
+}
+
+.dt-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.qf-btn-submit-final {
+  background: var(--gold);
+  color: var(--txt-on-gold, var(--bg));
+  border: 1px solid var(--gold);
+}
+
+.qf-btn-submit-final:hover {
+  background: var(--gold2);
+  border-color: var(--gold2);
+}
+
+/* ════════════════════════════════════════════════════════════════════
    .char-picker — universal character picker (ADR-003 §Q6, story dt-form.16)
    Form-local consumption: downtime-form.js + regency-tab.js
    ════════════════════════════════════════════════════════════════════ */

--- a/public/js/data/dt-action-summary.js
+++ b/public/js/data/dt-action-summary.js
@@ -1,0 +1,141 @@
+/**
+ * Action-spent summary for the Submit Final modal (ADR-003 §Q5,
+ * story dt-form.31). Walks `responses` and the caller-supplied totals
+ * to produce a structured `{ used, total }` count per category.
+ *
+ * Pure ESM. No DOM. The caller (downtime-form.js) supplies the
+ * total counts since they depend on character-derived state
+ * (detectedMerits, projectSlots, dynamic acquisition/equipment
+ * slot counts) that lives in the form module.
+ *
+ * Per ADR §Q9: an ADVANCED player who only filled MINIMAL still
+ * sees the modal — their counts will read mostly 0/N. The helper
+ * makes that legible rather than exceptional.
+ *
+ * Returned shape:
+ *   {
+ *     personal_actions: { used, total },
+ *     sphere_actions:   { used, total },
+ *     status_actions:   { used, total },
+ *     contact_actions:  { used, total },
+ *     retainer_actions: { used, total },
+ *     acquisition_slots:{ used, total },
+ *     sorcery_slots:    { used, total },
+ *     equipment_slots:  { used, total },
+ *     xp_spend_slots:   { used, total },  // projects whose action === 'xp_spend'
+ *   }
+ */
+
+function _nonEmpty(v) {
+  return typeof v === 'string' ? v.trim().length > 0 : !!v;
+}
+
+/**
+ * @param {object} responses              — submission.responses
+ * @param {object} totals                 — caller-supplied per-category caps
+ * @param {number} totals.projectSlots
+ * @param {number} totals.sphereSlots
+ * @param {number} totals.statusSlots
+ * @param {number} totals.contactSlots
+ * @param {number} totals.retainerSlots
+ * @param {number} totals.acquisitionSlots
+ * @param {number} totals.sorcerySlots
+ * @param {number} totals.equipmentSlots
+ */
+export function actionSpentSummary(responses, totals = {}) {
+  const r = responses || {};
+  const t = {
+    projectSlots:     totals.projectSlots     ?? 4,
+    sphereSlots:      totals.sphereSlots      ?? 0,
+    statusSlots:      totals.statusSlots      ?? 0,
+    contactSlots:     totals.contactSlots     ?? 0,
+    retainerSlots:    totals.retainerSlots    ?? 0,
+    acquisitionSlots: totals.acquisitionSlots ?? 1,
+    sorcerySlots:     totals.sorcerySlots     ?? 0,
+    equipmentSlots:   totals.equipmentSlots   ?? 0,
+  };
+
+  let projectsUsed = 0;
+  let xpSpendUsed = 0;
+  for (let n = 1; n <= t.projectSlots; n++) {
+    const action = r[`project_${n}_action`];
+    if (_nonEmpty(action)) {
+      projectsUsed++;
+      if (action === 'xp_spend') xpSpendUsed++;
+    }
+  }
+
+  let spheresUsed = 0;
+  for (let n = 1; n <= t.sphereSlots; n++) {
+    if (_nonEmpty(r[`sphere_${n}_action`])) spheresUsed++;
+  }
+
+  let statusUsed = 0;
+  for (let n = 1; n <= t.statusSlots; n++) {
+    if (_nonEmpty(r[`status_${n}_action`])) statusUsed++;
+  }
+
+  let contactsUsed = 0;
+  for (let n = 1; n <= t.contactSlots; n++) {
+    if (_nonEmpty(r[`contact_${n}_request`]) || _nonEmpty(r[`contact_${n}_info`])) contactsUsed++;
+  }
+
+  let retainersUsed = 0;
+  for (let n = 1; n <= t.retainerSlots; n++) {
+    if (_nonEmpty(r[`retainer_${n}_task`]) || _nonEmpty(r[`retainer_${n}_type`])) retainersUsed++;
+  }
+
+  let acquisitionsUsed = 0;
+  for (let n = 1; n <= t.acquisitionSlots; n++) {
+    if (_nonEmpty(r[`acq_${n}_description`])) acquisitionsUsed++;
+  }
+  // Legacy single-slot fallback for pre-multi-slot acquisitions.
+  if (acquisitionsUsed === 0 && _nonEmpty(r.acq_description)) acquisitionsUsed = 1;
+
+  let sorceriesUsed = 0;
+  for (let n = 1; n <= t.sorcerySlots; n++) {
+    if (_nonEmpty(r[`sorcery_${n}_rite`])) sorceriesUsed++;
+  }
+
+  let equipmentUsed = 0;
+  for (let n = 1; n <= t.equipmentSlots; n++) {
+    if (_nonEmpty(r[`equipment_${n}_name`])) equipmentUsed++;
+  }
+
+  return {
+    personal_actions:  { used: projectsUsed,     total: t.projectSlots     },
+    sphere_actions:    { used: spheresUsed,      total: t.sphereSlots      },
+    status_actions:    { used: statusUsed,       total: t.statusSlots      },
+    contact_actions:   { used: contactsUsed,     total: t.contactSlots     },
+    retainer_actions:  { used: retainersUsed,    total: t.retainerSlots    },
+    acquisition_slots: { used: acquisitionsUsed, total: t.acquisitionSlots },
+    sorcery_slots:     { used: sorceriesUsed,    total: t.sorcerySlots     },
+    equipment_slots:   { used: equipmentUsed,    total: t.equipmentSlots   },
+    xp_spend_slots:    { used: xpSpendUsed,      total: t.projectSlots     },
+  };
+}
+
+/**
+ * Render the summary as a flat list of "used/total Label" strings,
+ * skipping categories with total === 0 so the modal isn't padded with
+ * irrelevant rows for characters who have no contacts merits, etc.
+ */
+export function formatActionSpentSummary(summary) {
+  const labels = {
+    personal_actions:  'Personal Actions',
+    sphere_actions:    'Sphere actions',
+    status_actions:    'Status actions',
+    contact_actions:   'Contact actions',
+    retainer_actions:  'Retainer actions',
+    acquisition_slots: 'Acquisition slots',
+    sorcery_slots:     'Blood Sorcery slots',
+    equipment_slots:   'Equipment items',
+  };
+  const out = [];
+  for (const [key, label] of Object.entries(labels)) {
+    const cell = summary[key];
+    if (!cell || cell.total === 0) continue;
+    out.push(`${cell.used}/${cell.total} ${label}`);
+  }
+  return out;
+}

--- a/public/js/tabs/downtime-data.js
+++ b/public/js/tabs/downtime-data.js
@@ -361,42 +361,31 @@ export const DOWNTIME_SECTIONS = [
     ],
   },
 
-  // 13. Admin — always shown
+  // dt-form.31 (ADR-003 §Q5): the Admin section is removed. The form-rating +
+  // form-feedback widgets move to the ADVANCED Submit Final modal; XP Spend
+  // moves to a project-action variant under #26. Existing legacy submissions
+  // keep `xp_spend` / `lore_request` / `form_rating` / `form_feedback` keys
+  // on `responses` — ST views read them directly.
+];
+
+// dt-form.31: Submit Final modal questions. Lifted from the removed Admin
+// section's `form_rating` + `form_feedback`. The modal renders these via the
+// existing renderQuestion() switch (star_rating + textarea types) so the
+// widgets are not re-implemented.
+export const SUBMIT_FINAL_MODAL_QUESTIONS = [
   {
-    key: 'admin',
-    title: 'Admin: Crunching Numbers and Asking Questions',
-    gate: null,
-    intro: null,
-    questions: [
-      {
-        key: 'xp_spend',
-        label: 'XP Spend',
-        type: 'xp_grid',
-        required: false,
-        desc: null,
-      },
-      {
-        key: 'lore_request',
-        label: 'What game rules, elements, or Lore would you like more information about?',
-        type: 'textarea',
-        required: false,
-        desc: 'Ask anything — rules clarifications, in-character history, covenant doctrine, NPC backgrounds, or setting details.',
-      },
-      {
-        key: 'form_rating',
-        label: 'How would you rate this Downtime form for clarity and ease of use?',
-        type: 'star_rating',
-        required: false,
-        desc: null,
-      },
-      {
-        key: 'form_feedback',
-        label: 'Any comments or recommendations on the Downtime form?',
-        type: 'textarea',
-        required: false,
-        desc: 'We iterate on this form each cycle. Your feedback helps us make it clearer and more useful.',
-      },
-    ],
+    key: 'form_rating',
+    label: 'How would you rate this Downtime form for clarity and ease of use?',
+    type: 'star_rating',
+    required: false,
+    desc: null,
+  },
+  {
+    key: 'form_feedback',
+    label: 'Any comments or recommendations on the Downtime form?',
+    type: 'textarea',
+    required: false,
+    desc: 'We iterate on this form each cycle. Your feedback helps us make it clearer and more useful.',
   },
 ];
 

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -13,7 +13,8 @@ import { apiGet, apiPost, apiPut, apiPatch } from '../data/api.js';
 import { saveDraft as saveLocalDraft, loadDraft as loadLocalDraft, clearDraft as clearLocalDraft, pickFreshestDraft } from './draft-persist.js';
 import { esc, displayName, parseOutcomeSections, redactPlayer, redactCharName, hasAoE, isSpecs, findRegentTerritory } from '../data/helpers.js';
 import { applyDerivedMerits } from '../editor/mci.js';
-import { DOWNTIME_SECTIONS, DOWNTIME_GATES, SPHERE_ACTIONS, TERRITORY_DATA, FEEDING_TERRITORIES, PROJECT_ACTIONS, FEED_METHODS, MAINTENANCE_MERITS, FEED_VIOLENCE_DEFAULTS, JOINT_ELIGIBLE_ACTIONS, ACTION_DESCRIPTIONS, ACTION_APPROACH_PROMPTS } from './downtime-data.js';
+import { DOWNTIME_SECTIONS, DOWNTIME_GATES, SPHERE_ACTIONS, TERRITORY_DATA, FEEDING_TERRITORIES, PROJECT_ACTIONS, FEED_METHODS, MAINTENANCE_MERITS, FEED_VIOLENCE_DEFAULTS, JOINT_ELIGIBLE_ACTIONS, ACTION_DESCRIPTIONS, ACTION_APPROACH_PROMPTS, SUBMIT_FINAL_MODAL_QUESTIONS } from './downtime-data.js';
+import { actionSpentSummary, formatActionSpentSummary } from '../data/dt-action-summary.js';
 import { ALL_ATTRS, ALL_SKILLS, CLAN_DISCS, BLOODLINE_DISCS, CORE_DISCS, RITUAL_DISCS } from '../data/constants.js';
 import { calcTotalInfluence, domMeritTotal, attacheBonusDots, effectiveInvictusStatus, ssjHerdBonus, flockHerdBonus, meritEffectiveRating } from '../editor/domain.js';
 import { calcVitaeMax, skTotal, skNineAgain, riteCost, skillAcqPoolStr, getAttrEffective, getAttrTotal, discDots } from '../data/accessors.js';
@@ -1720,6 +1721,110 @@ function _isRegencyConfirmedThisCycle() {
   );
 }
 
+// dt-form.31 (ADR-003 §Q5): Submit Final modal. ADVANCED-only affordance
+// that lets a player declare "I am done editing" via responses._final_submitted_at.
+// Mirrors the existing .npcr-modal pattern (admin-layout.css) but lives in
+// components.css under .dt-modal-* so the player surface picks it up.
+function openSubmitFinalModal(container) {
+  // Render fresh markup each time so the action-spent counts reflect the
+  // current responses (per §Q9, ADVANCED + MINIMAL-filled shows zeros).
+  closeSubmitFinalModal();
+  const saved = responseDoc?.responses || {};
+  const totals = {
+    projectSlots:     DOWNTIME_SECTIONS.find(s => s.key === 'projects')?.projectSlots || 4,
+    sphereSlots:      Math.min((detectedMerits.spheres || []).length, 5),
+    statusSlots:      Math.min((detectedMerits.status || []).length, 5),
+    contactSlots:     Math.min((detectedMerits.contacts || []).length, 5),
+    retainerSlots:    (detectedMerits.retainers || []).length,
+    acquisitionSlots: parseInt(saved.acq_slot_count || '1', 10) || 1,
+    sorcerySlots:     parseInt(saved.sorcery_slot_count || '0', 10) || 0,
+    equipmentSlots:   parseInt(saved.equipment_slot_count || '0', 10) || 0,
+  };
+  const summary = actionSpentSummary(saved, totals);
+  const lines = formatActionSpentSummary(summary);
+
+  const overlay = document.createElement('div');
+  overlay.className = 'dt-modal-overlay';
+  overlay.id = 'dt-submit-final-overlay';
+  overlay.setAttribute('role', 'presentation');
+
+  const titleId = 'dt-submit-final-title';
+  let h = '';
+  h += `<div class="dt-modal" role="dialog" aria-modal="true" aria-labelledby="${titleId}">`;
+  h += `<h3 class="dt-modal-title" id="${titleId}">Submit Final</h3>`;
+  h += '<div class="dt-modal-body">';
+  h += '<p class="qf-section-intro">Use this when you are done editing. Your downtime will continue auto-saving until the cycle deadline; this just records the moment you stopped.</p>';
+
+  // Action-spent summary
+  h += '<h4 class="dt-modal-subhead">This cycle so far</h4>';
+  if (lines.length) {
+    h += '<ul class="dt-modal-summary-list">';
+    for (const line of lines) {
+      h += `<li>${esc(line)}</li>`;
+    }
+    h += '</ul>';
+  } else {
+    h += '<p class="qf-desc">No actions filled in yet.</p>';
+  }
+
+  // Optional rate-the-form widget — lifted from the removed Admin section
+  // (SUBMIT_FINAL_MODAL_QUESTIONS in downtime-data.js) so the existing
+  // star_rating + textarea widgets render via renderQuestion(), unchanged.
+  h += '<h4 class="dt-modal-subhead">Rate the form (optional)</h4>';
+  for (const q of SUBMIT_FINAL_MODAL_QUESTIONS) {
+    h += renderQuestion(q, saved[q.key] || '');
+  }
+  h += '</div>'; // dt-modal-body
+
+  // Actions
+  h += '<div class="dt-modal-actions">';
+  h += '<button type="button" class="qf-btn qf-btn-save" data-dt-final-cancel>Cancel</button>';
+  h += '<button type="button" class="qf-btn qf-btn-submit-final" data-dt-final-confirm>Submit Final</button>';
+  h += '</div>';
+
+  h += '</div>'; // dt-modal
+  overlay.innerHTML = h;
+  document.body.appendChild(overlay);
+
+  // Focus management: send focus to the dialog so screen readers announce it.
+  overlay.querySelector('.dt-modal')?.focus({ preventScroll: true });
+
+  // Escape closes the modal.
+  overlay.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') { e.preventDefault(); closeSubmitFinalModal(); }
+  });
+}
+
+function closeSubmitFinalModal() {
+  const el = document.getElementById('dt-submit-final-overlay');
+  if (el) el.remove();
+}
+
+async function handleSubmitFinalConfirm(container) {
+  // Collect the rating widget values from the modal so they round-trip on
+  // the next save. Star rating writes to a hidden input; textarea writes
+  // straight to its DOM node. We seed them onto responseDoc so collectResponses
+  // (which iterates over rendered form fields, not the modal) keeps the values.
+  if (!responseDoc) responseDoc = { responses: {} };
+  if (!responseDoc.responses) responseDoc.responses = {};
+  for (const q of SUBMIT_FINAL_MODAL_QUESTIONS) {
+    const el = document.getElementById('dt-' + q.key);
+    if (el) responseDoc.responses[q.key] = el.value;
+  }
+  responseDoc.responses._final_submitted_at = new Date().toISOString();
+  closeSubmitFinalModal();
+  // Re-render the form so the button label flips to "Update Final Submission",
+  // then save so the new field reaches the server. Save handles the toast
+  // status banner via the auto-mirror lifecycle.
+  renderForm(container);
+  scheduleSave();
+  const statusEl = document.getElementById('dt-save-status');
+  if (statusEl) {
+    statusEl.textContent = 'Final submission recorded; keep editing until the deadline.';
+    setTimeout(() => { if (statusEl) statusEl.textContent = ''; }, 4000);
+  }
+}
+
 function renderForm(container) {
   const saved = responseDoc?.responses || {};
   const status = responseDoc?.status || 'new';
@@ -1955,6 +2060,16 @@ function renderForm(container) {
   h += '<div class="qf-actions">';
   h += '<button class="qf-btn qf-btn-save" id="dt-btn-save">Save Draft</button>';
   h += `<button class="qf-btn qf-btn-submit" id="dt-btn-submit">${esc(submitLabel)}</button>`;
+  // dt-form.31 (ADR-003 §Q5): ADVANCED-only Submit Final affordance. Opens
+  // the modal; the modal sets responses._final_submitted_at on confirm.
+  // Per §Q9 the button is mode-conditional, not state-conditional — an
+  // ADVANCED player who only filled MINIMAL still sees it (the modal
+  // shows zeros in that case).
+  if (mode === 'advanced') {
+    const finalAt = saved._final_submitted_at;
+    const finalLabel = finalAt ? 'Update Final Submission' : 'Submit Final';
+    h += `<button type="button" class="qf-btn qf-btn-submit-final" id="dt-btn-submit-final">${esc(finalLabel)}</button>`;
+  }
   h += '</div>';
 
   // Capture expanded sections before re-render
@@ -2004,6 +2119,30 @@ function renderForm(container) {
       else responseDoc = { responses: cur };
       renderForm(container);
       scheduleSave();
+      return;
+    }
+    // dt-form.31: Submit Final button (ADVANCED only) opens the modal.
+    if (e.target.closest('#dt-btn-submit-final')) {
+      e.preventDefault();
+      openSubmitFinalModal(container);
+      return;
+    }
+    // dt-form.31: Submit Final modal action delegations.
+    const modalConfirm = e.target.closest('[data-dt-final-confirm]');
+    if (modalConfirm) {
+      e.preventDefault();
+      handleSubmitFinalConfirm(container);
+      return;
+    }
+    const modalCancel = e.target.closest('[data-dt-final-cancel]');
+    if (modalCancel) {
+      e.preventDefault();
+      closeSubmitFinalModal();
+      return;
+    }
+    // Click on the overlay (outside the modal box) dismisses the modal.
+    if (e.target.classList?.contains('dt-modal-overlay')) {
+      closeSubmitFinalModal();
       return;
     }
     // DTOSL.2 choice chip handler — removed in NPCR.12 (replaced by the

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -1785,6 +1785,13 @@ function renderForm(container) {
       h += '</ul>';
     }
     h += '</div>';
+  } else if (mode === 'minimal') {
+    // dt-form.31 (ADR-003 §Q5): MINIMAL auto-submit confirmation toast.
+    // Locked copy. Persistent — stays as long as the form is above minimum
+    // in MINIMAL mode. ADVANCED uses the Submit Final modal instead.
+    h += '<div class="dt-min-toast" role="status" aria-live="polite">';
+    h += '<p class="dt-min-toast__lead"><strong>Submitted</strong> — keep editing until the deadline.</p>';
+    h += '</div>';
   }
 
   // Header
@@ -1842,6 +1849,8 @@ function renderForm(container) {
     if (section.key === 'blood_sorcery') continue;
     if (section.key === 'equipment') continue;
     if (section.key === 'vamping') continue;
+    // dt-form.31: admin section removed from DOWNTIME_SECTIONS. Defensive skip
+    // kept in case legacy data or imports re-introduce the key.
     if (section.key === 'admin') continue;
     if (section.key === 'territory') continue;
     if (section.key === 'feeding') continue;
@@ -1908,7 +1917,9 @@ function renderForm(container) {
     h += renderEquipmentSection(saved);
   }
 
-  for (const key of ['vamping', 'admin']) {
+  // dt-form.31: 'admin' removed from DOWNTIME_SECTIONS — find() returns
+  // undefined for it and the body is skipped. Loop kept for vamping.
+  for (const key of ['vamping']) {
     if (!_isSectionVisibleInMode(key, mode)) continue;
     const section = DOWNTIME_SECTIONS.find(s => s.key === key);
     if (!section) continue;
@@ -1936,10 +1947,8 @@ function renderForm(container) {
     h += '</div></div>';
   }
 
-  // Hide feedback textarea until a rating is provided
-  if (!saved['form_rating']) {
-    h = h.replace('dt-feedback-field', 'dt-feedback-field dt-feedback-hidden');
-  }
+  // dt-form.31: form-rating hide hack removed — the rating widget now lives
+  // in the Submit Final modal (ADVANCED only); not in the form body.
 
   // Actions
   const submitLabel = responseDoc?.status === 'submitted' ? 'Update Submission' : 'Submit Downtime';

--- a/server/schemas/downtime_submission.schema.js
+++ b/server/schemas/downtime_submission.schema.js
@@ -180,7 +180,11 @@ export const downtimeSubmissionSchema = {
         // _final_submitted_at: ADVANCED-mode "I'm done editing" hint set by the
         // Submit Final modal (story #31). Not a status flip — submission.status
         // already mirrors _has_minimum from the soft-submit lifecycle.
-        _final_submitted_at: { type: 'string' },  // ISO timestamp
+        // dt-form.31: spec called for `format: 'date-time'`; the codebase's AJV
+        // is configured without ajv-formats so the format keyword would throw
+        // at compile time. Following the existing convention used for
+        // `submitted_at` (line 155) — type: 'string' with an ISO comment.
+        _final_submitted_at: { type: 'string' },  // ISO timestamp (RFC 3339 / ISO 8601)
 
         // ── Merit toggle states (legacy, preserved for contacts/retainers) ──
         // Dynamic keys: _merit_<merit_key> = "yes" | "no"

--- a/specs/stories/dt-form.31-submit-final-modal.story.md
+++ b/specs/stories/dt-form.31-submit-final-modal.story.md
@@ -2,7 +2,7 @@
 id: dt-form.31
 task: 31
 epic: epic-dt-form-mvp-redesign
-status: Ready for Dev
+status: Ready for Review
 priority: high
 depends_on: ['dt-form.17']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q5)
@@ -108,12 +108,53 @@ Coordinate merge with #26 (XP Spend overhaul + Admin section removal). Both touc
 
 ## Definition of Done
 
-- [ ] ADVANCED-only "Submit Final" button + modal with summary + optional rating widget
-- [ ] MINIMAL toast on auto-submit
-- [ ] Admin section removed from `DOWNTIME_SECTIONS`
-- [ ] `_final_submitted_at` schema field documented
-- [ ] Coordination with #26 in place
-- [ ] PR opened into `dev`
+- [x] ADVANCED-only "Submit Final" button + modal with summary + optional rating widget
+- [x] MINIMAL toast on auto-submit
+- [x] Admin section removed from `DOWNTIME_SECTIONS`
+- [x] `_final_submitted_at` schema field documented
+- [x] Coordination with #26 in place (Admin section removed structurally; XP Spend relocation is #26's scope)
+- [x] PR opened into `dev`
+
+---
+
+## Dev Agent Record
+
+**Agent Model Used:** James / Ptah (BMAD `dev`) — Claude Opus 4.7
+
+### Tasks
+- [x] Delete `admin` section entry from `DOWNTIME_SECTIONS` (`public/js/tabs/downtime-data.js`); lift `form_rating` + `form_feedback` definitions into a new exported `SUBMIT_FINAL_MODAL_QUESTIONS` constant the modal renders via the existing `renderQuestion()` switch.
+- [x] Clean up the dead admin references in `downtime-form.js` render loops + remove the `dt-feedback-hidden` hack.
+- [x] Document `responses._final_submitted_at` on `downtime_submission.schema.js`.
+- [x] Persistent MINIMAL-mode auto-submit toast at the top of the form when `_has_minimum && mode === 'minimal'` with locked copy.
+- [x] New pure-ESM `public/js/data/dt-action-summary.js` exporting `actionSpentSummary(responses, totals)` + `formatActionSpentSummary(summary)`.
+- [x] ADVANCED-only `Submit Final` button + modal scaffold in `downtime-form.js`. Modal mirrors the existing `.npcr-modal` pattern with new `.dt-modal-*` classes in `components.css` (loaded on every surface; `.npcr-modal` lives in admin-only `admin-layout.css`).
+- [x] Lifecycle: confirm sets `responses._final_submitted_at = ISO`, fires save (status doesn't flip — already auto per #17). Dismiss (Cancel button, overlay click, Escape) leaves the field unset.
+- [x] Status set to Ready for Review; PR opened.
+
+### File List
+
+**New**
+- `public/js/data/dt-action-summary.js`
+
+**Modified**
+- `public/js/tabs/downtime-form.js`
+- `public/js/tabs/downtime-data.js`
+- `public/css/components.css`
+- `server/schemas/downtime_submission.schema.js`
+- `specs/stories/dt-form.31-submit-final-modal.story.md` (Dev Agent Record only)
+
+### Completion Notes
+
+- HALT-DAR raised early to Khepri on the modal CSS path (promote `.npcr-modal-*` from admin-layout.css to components.css vs new `.dt-modal-*` set in components.css). Piatra subsequently dispatched implementation directly with the guidance "mirror existing modal patterns" + "Likely components.css". Settled on **new `.dt-modal-*` classes that mirror the existing shape** — the existing admin-layout.css `.npcr-modal` is unchanged, the player surface gets a working modal via components.css. Trade-off: a small amount of CSS duplication vs. the latent-bug exposure of moving CSS that other admin paths depend on.
+- ADR §Q5 spec asked for `_final_submitted_at: { type: 'string', format: 'date-time' }`. The codebase's AJV is configured without `ajv-formats`, so the `format` keyword would throw at compile time. Adopted the existing convention (see `submitted_at` at line 155 of the same schema) — `{ type: 'string' }` with an explicit ISO-8601 comment. Documented in the schema. Not a behavioural deviation; just dropping a keyword AJV doesn't recognise.
+- `actionSpentSummary` is data-driven and pure (`PROCEED-WITH-NOTICE` per Khepri). Caller in `openSubmitFinalModal` supplies the per-category totals from form module-scope (`detectedMerits`, slot counts) so the helper has no DOM dependency. `formatActionSpentSummary` flattens to an "N/M Label" string list and skips categories whose total is zero so characters with no contacts merits don't see an irrelevant "0/0 Contact actions" row.
+- Modal close paths: Cancel button, overlay click, Escape key. Confirm path remounts the form (so the button label flips to "Update Final Submission") and triggers `scheduleSave()`. Player can re-open and re-confirm to stamp a fresh ISO; idempotent.
+- Server tests 671/671 green.
+
+### Change Log
+| Date | Author | Change |
+|---|---|---|
+| 2026-05-06 | James (dev) | Implemented dt-form.31. Admin section removed; Submit Final modal + toast + action-spent summary shipped; status → Ready for Review. |
 
 ## Dependencies
 

--- a/specs/stories/dt-form.31-submit-final-modal.story.md
+++ b/specs/stories/dt-form.31-submit-final-modal.story.md
@@ -2,10 +2,13 @@
 id: dt-form.31
 task: 31
 epic: epic-dt-form-mvp-redesign
-status: Draft
+status: Ready for Dev
 priority: high
 depends_on: ['dt-form.17']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q5)
+issue: 72
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/72
+branch: piatra/issue-72-submit-final-modal
 ---
 
 # Story dt-form.31 — Submit Final modal (ADVANCED) + Admin section removal


### PR DESCRIPTION
## Summary

Implements story `dt-form.31` — the ADVANCED-only Submit Final modal + Admin section removal. References [ADR-003 §Q5 (modal locked design) and §Q9 (ADVANCED + MINIMAL-filled shows the modal with zeros)](../blob/dev/specs/architecture/adr-003-dt-form-cross-cutting.md). Lifecycle is unchanged — the modal sets `responses._final_submitted_at` as a player-stated "I am done editing" hint; `submission.status` is already auto-mirrored from `_has_minimum` per #17.

- Admin section deleted from `DOWNTIME_SECTIONS`. `form_rating` + `form_feedback` question definitions lifted into a new exported `SUBMIT_FINAL_MODAL_QUESTIONS` constant the modal renders via the existing `renderQuestion()` switch — no widget re-implementation.
- ADVANCED-only Submit Final button added next to the legacy Save Draft / Submit Downtime buttons. Opens a dismissable modal with action-spent summary + optional Likert-1-5 + free-text rating widget + Submit Final button.
- Confirm sets `_final_submitted_at` to a fresh ISO timestamp, dismisses the modal, re-renders (button label flips to "Update Final Submission"), and saves. Idempotent — re-confirming overwrites with a new timestamp. Cancel / overlay click / Escape close without setting the field.
- MINIMAL-mode auto-submit toast (locked copy: "Submitted — keep editing until the deadline.") at the top of the form when `_has_minimum && mode === 'minimal'`.
- New pure-ESM `public/js/data/dt-action-summary.js` exporting `actionSpentSummary(responses, totals)` + `formatActionSpentSummary(summary)`. Caller supplies per-category totals so the helper stays DOM-free; categories with `total === 0` are skipped so characters without contacts merits don't see irrelevant `0/0 Contact actions`.
- Modal CSS in `public/css/components.css` under `.dt-modal-*`. Mirrors the existing `.npcr-modal` shape (admin-layout.css, admin surfaces only) without modifying it — components.css loads on every surface, so the player view picks the modal up cleanly.
- Schema: `responses._final_submitted_at` documented in `downtime_submission.schema.js` as `{ type: 'string' }` with explicit ISO-8601 comment. Story spec asked for `format: 'date-time'`; the codebase's AJV is configured without `ajv-formats` and would throw on the format keyword at compile time. Adopted the existing convention used for `submitted_at`.

Server tests **671/671 green**. Coordination with #26: Admin section structure removed in this PR; XP Spend relocation into a project slot is #26's scope (per ADR rev-3 §Q3A sequencing).

Closes #72.

## Notes

- HALT-DAR raised to Khepri on the modal CSS path before scaffolding. Resolved in favour of new `.dt-modal-*` classes in components.css that mirror the existing pattern, rather than promoting the admin-only `.npcr-modal-*` rules out of admin-layout.css. Trade-off: a small amount of CSS duplication vs. exposure to latent admin-side regressions.
- `actionSpentSummary` was a `PROCEED-WITH-NOTICE` flag — implemented as a pure ESM module with the caller supplying totals from form module-scope (`detectedMerits`, slot counts), which keeps the helper DOM-free and importable from server-side later if Q7 (server-side enforcement) ever lands.
- The modal mounts/unmounts on demand (single overlay element appended to `document.body`); no DOM persists between modal opens, so the action-spent counts reflect the current responses on every open.

## Test plan

- [x] Static review — ADVANCED-only button + modal; MINIMAL toast; Admin section removed from `DOWNTIME_SECTIONS`; schema documents `_final_submitted_at`
- [x] Server tests green (671/671)
- [ ] Browser smoke (deferred per story Test Plan):
  - [ ] ADVANCED → click Submit Final → modal shows summary + rating → confirm → button flips to "Update Final Submission"
  - [ ] ADVANCED → click Submit Final → dismiss (button / overlay / Escape) → no `_final_submitted_at`
  - [ ] MINIMAL → fill enough to flip `_has_minimum` true → toast appears, no modal
  - [ ] ADVANCED + MINIMAL-only filled → click Submit Final → modal shows with zeros
  - [ ] Admin section absent in all modes