### PR TITLE
style(css): promote .npcr-modal-* from admin-layout.css to components.css

### DIFF
--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -7897,47 +7897,6 @@ html:not([data-theme="dark"]) .rules-tbl tbody tr:hover            { background:
   font-style: italic;
 }
 
-/* Themed modal for resolve-note entry (replaces prompt()). */
-.npcr-modal-overlay {
-  position: fixed;
-  inset: 0;
-  background: rgba(0, 0, 0, 0.6);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-}
-
-.npcr-modal {
-  background: var(--surf2, #1a1814);
-  border: 1px solid var(--accent, #E0C47A);
-  border-radius: 4px;
-  min-width: 360px;
-  max-width: 520px;
-  width: 90%;
-  padding: 16px;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
-}
-
-.npcr-modal-title {
-  font-family: 'Cinzel', serif;
-  font-size: 18px;
-  color: var(--accent, #E0C47A);
-  margin-bottom: 12px;
-  padding-bottom: 8px;
-  border-bottom: 1px solid var(--border, rgba(255, 255, 255, 0.1));
-}
-
-.npcr-modal-body {
-  margin-bottom: 12px;
-}
-
-.npcr-modal-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
 .npcr-card-desc {
   font-size: 13px;
   color: var(--txt2, var(--txt));

--- a/public/css/components.css
+++ b/public/css/components.css
@@ -5121,9 +5121,58 @@ html:not([data-theme="dark"]) .char-picker__pill { font-weight: 600; }
 }
 
 /* ════════════════════════════════════════════════════════════════════
+   .npcr-modal — themed modal pattern (issue #93)
+   Promoted from admin-layout.css so non-admin surfaces (player.html, suite)
+   that reference these classes (relationships-tab.js, dt-form.31 modal,
+   etc.) pick up the styling. Verbatim move; rule bodies unchanged.
+   Used by: relationships-tab.js, admin/npc-register.js, editor/edit.js.
+   ════════════════════════════════════════════════════════════════════ */
+/* Themed modal for resolve-note entry (replaces prompt()). */
+.npcr-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.npcr-modal {
+  background: var(--surf2, #1a1814);
+  border: 1px solid var(--accent, #E0C47A);
+  border-radius: 4px;
+  min-width: 360px;
+  max-width: 520px;
+  width: 90%;
+  padding: 16px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+}
+
+.npcr-modal-title {
+  font-family: 'Cinzel', serif;
+  font-size: 18px;
+  color: var(--accent, #E0C47A);
+  margin-bottom: 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border, rgba(255, 255, 255, 0.1));
+}
+
+.npcr-modal-body {
+  margin-bottom: 12px;
+}
+
+.npcr-modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+/* ════════════════════════════════════════════════════════════════════
    .dt-modal — Submit Final modal (ADR-003 §Q5, story dt-form.31)
-   Mirrors the existing .npcr-modal pattern (admin-layout.css) but lives in
-   components.css so the player surface (player.html) picks it up.
+   Mirrors the .npcr-modal pattern above (issue #93 promoted both rule
+   sets into this file). Future cleanup may consolidate these into one
+   shared modal class set; tracked separately.
    ════════════════════════════════════════════════════════════════════ */
 .dt-modal-overlay {
   position: fixed;


### PR DESCRIPTION
## Summary

Pure CSS transplant per [issue #93](https://github.com/angelusvmorningstar/TerraMortis/issues/93). The `.npcr-modal-*` rule block previously lived in `public/css/admin-layout.css` — loaded only on `admin.html`. Player-surface code paths reference these classes too (`relationships-tab.js` runs on `player.html`, and the dt-form.31 modal added a parallel `.dt-modal-*` set in `components.css` precisely to work around the missing styling).

Verbatim move: rule bodies unchanged, no rename, no JS change. Diff is a 41-line deletion + 53-line insertion (53 includes the moved 41 lines plus an explanatory comment block above and a small comment update on the adjacent dt-form.31 modal block whose old comment pointed to the now-empty location).

Closes #93

## Verification

- `grep -rn 'npcr-modal' public/css/admin-layout.css` returns zero matches.
- `grep -rn 'npcr-modal' public/css/` shows the rule definitions are in `components.css` only.
- Server tests 37/37 spot-pass on the downtime + game-sessions suites (CSS-only branch; nothing more invasive expected).

## Notes

- PR #88 (story dt-form.31) was already merged in parallel before Khepri's DAR-resolution dispatch reached me. That PR shipped `.dt-modal-*` as new classes in `components.css`. Future cleanup can consolidate `.npcr-modal-*` and `.dt-modal-*` into one shared class set; tracked separately. Out of scope here.
- Existing admin consumers (`relationships-tab.js`, `admin/npc-register.js`, `editor/edit.js`) keep rendering correctly because `components.css` loads on `admin.html` before `admin-layout.css`. Browser smoke deferred — no risk surface from a verbatim rule-body move.

## Test plan

- [x] Static review — verbatim move, no rename, no JS change
- [x] DoD grep contract — `npcr-modal` only present in `components.css`
- [ ] Browser smoke (deferred — admin pages confirm `.npcr-modal` users still styled, player pages confirm `.npcr-modal` consumers like relationships-tab.js now styled correctly for the first time)