### PR TITLE
docs(story): mark dt-form.31 status as Done

### DIFF
--- a/specs/stories/dt-form.31-submit-final-modal.story.md
+++ b/specs/stories/dt-form.31-submit-final-modal.story.md
@@ -2,7 +2,7 @@
 id: dt-form.31
 task: 31
 epic: epic-dt-form-mvp-redesign
-status: Ready for Review
+status: Done
 priority: high
 depends_on: ['dt-form.17']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q5)


### PR DESCRIPTION
## Summary

One-line frontmatter flip on `specs/stories/dt-form.31-submit-final-modal.story.md`: `status: Ready for Review` → `status: Done`. The implementation was merged in PR #88 (Submit Final modal + Admin section removal); this PR closes the documentation gap.

## Closes

_None_

## Story

- specs/stories/dt-form.31-submit-final-modal.story.md (status field only)

## Test plan

- [x] No code change — diff is one line in story frontmatter
- [x] CI green (no logic affected)

## Branch flow

- From: `piatra/bookkeeping-dt-form-31-status`
- Into: `dev`