### PR TITLE
feat(dt-form): feeding simplified + ROTE-as-project-action bundle (stories dt-form.20 + dt-form.22)

### DIFF
--- a/public/js/data/dt-completeness.js
+++ b/public/js/data/dt-completeness.js
@@ -68,6 +68,10 @@ function _hasFeedingViolence(responses) {
 }
 
 function _hasFeedingComplete(responses) {
+  // dt-form.22: ROTE in a project slot does NOT satisfy the feeding rule.
+  // Primary feeding (territory + method + blood type + violence) must be
+  // filled independently. ROTE is captured under the `1 project slot`
+  // MINIMAL rule (any non-empty `project_1_action`, including 'rote').
   return _hasFeedingTerritory(responses)
       && _hasFeedingMethod(responses)
       && _hasFeedingBloodType(responses)

--- a/public/js/data/dt-completeness.js
+++ b/public/js/data/dt-completeness.js
@@ -16,7 +16,12 @@
  * banner's missing-pieces list (story #17 UI affordance #1).
  */
 
-const FEEDING_POOL_KEYS = ['_feed_disc', '_feed_custom_attr', '_feed_custom_skill', '_feed_custom_disc'];
+// dt-form.20 fix-up (Ma'at PR #98 review, bug 1): MINIMAL has no pool builder,
+// so `_feed_disc` / `_feed_custom_*` stay empty when a player only fills the
+// 5-field simplified form. The method-card pick still persists `_feed_method`,
+// so include it as a method-set signal. Without this, hard-mirror per #17
+// never unlocks for MINIMAL users — banner sticks even with all 5 fields set.
+const FEEDING_POOL_KEYS = ['_feed_method', '_feed_disc', '_feed_custom_attr', '_feed_custom_skill', '_feed_custom_disc'];
 
 function isNonEmptyString(v) {
   return typeof v === 'string' && v.trim().length > 0;

--- a/public/js/data/feeding-pool.js
+++ b/public/js/data/feeding-pool.js
@@ -1,0 +1,90 @@
+/**
+ * Feeding dice-pool helper (story dt-form.20, ADR-003 §Q2).
+ *
+ * computeBestFeedingPool(opts) returns the highest-quality feeding pool
+ * the character can build under the given method/territory/auto-pick of
+ * the best discipline. Used by:
+ *   - dt-form.20: MINIMAL feeding form's read-only pool annotation
+ *   - dt-form.22: ROTE project-action read-only inherited pool annotation
+ *
+ * Pure ESM. No DOM. Mirrors the algorithm in
+ * public/js/admin/feeding-engine.js:buildPool() so the player- and ST-side
+ * derivations agree.
+ *
+ * Returned shape:
+ *   {
+ *     total,                                        // the dice pool number
+ *     attr:    { name, val },                       // best attribute pick
+ *     skill:   { name, val, specs },                // best skill pick (with specs joined)
+ *     disc:    { name, val },                       // best discipline pick (auto)
+ *     ambience:{ mod, label, territorySlug, name }, // territory ambience contribution
+ *     unskilled,                                    // -1 / -3 / 0 (3rd-edition unskilled penalty)
+ *   }
+ *
+ * Returns null if no method is supplied.
+ */
+
+import { FEED_METHODS, TERRITORY_DATA } from '../tabs/downtime-data.js';
+import { SKILLS_MENTAL } from './constants.js';
+import { getAttrTotal, skTotal, discDots } from './accessors.js';
+
+export function computeBestFeedingPool({ char, methodId, territorySlug } = {}) {
+  if (!char || !methodId) return null;
+  const method = FEED_METHODS.find(m => m.id === methodId);
+  if (!method) return null;
+
+  // Best attribute available among those the method allows.
+  let bestAttrVal = 0, bestAttrName = '';
+  for (const a of method.attrs || []) {
+    const v = getAttrTotal(char, a);
+    if (v > bestAttrVal) { bestAttrVal = v; bestAttrName = a; }
+  }
+
+  // Best skill available among those the method allows. Carry specs for
+  // the rendered breakdown.
+  let bestSkillVal = 0, bestSkillName = '', bestSkillSpecs = '';
+  for (const s of method.skills || []) {
+    const v = skTotal(char, s);
+    if (v > bestSkillVal) {
+      bestSkillVal = v;
+      bestSkillName = s;
+      const sk = char.skills?.[s];
+      bestSkillSpecs = sk?.specs?.length ? sk.specs.join(', ') : '';
+    }
+  }
+
+  // Auto-pick the best discipline among those the method allows. ROTE/
+  // MINIMAL surfaces a single number; the player doesn't see the pick.
+  let bestDiscVal = 0, bestDiscName = '';
+  for (const d of method.discs || []) {
+    const v = discDots(char, d);
+    if (v > bestDiscVal) { bestDiscVal = v; bestDiscName = d; }
+  }
+
+  // Territory ambience modifier — looked up by slug. TERRITORY_DATA carries
+  // the ambience label + numeric modifier.
+  const terr = TERRITORY_DATA.find(t => t.slug === territorySlug);
+  const ambMod = terr?.ambienceMod || 0;
+  const ambLabel = terr?.ambience || '';
+  const ambName = terr?.name || '';
+
+  // Unskilled penalty: VtR 2e -1 for physical/social skills you have zero
+  // dots in, -3 for mental. Mirrors feeding-engine.js's branch.
+  const unskilled = bestSkillVal === 0
+    ? (method.skills.some(s => !SKILLS_MENTAL.includes(s)) ? -1 : -3)
+    : 0;
+
+  const total = Math.max(
+    0,
+    bestAttrVal + bestSkillVal + bestDiscVal + ambMod + unskilled
+  );
+
+  return {
+    total,
+    attr:  { name: bestAttrName, val: bestAttrVal },
+    skill: { name: bestSkillName, val: bestSkillVal, specs: bestSkillSpecs },
+    disc:  { name: bestDiscName,  val: bestDiscVal  },
+    ambience: { mod: ambMod, label: ambLabel, territorySlug: territorySlug || '', name: ambName },
+    unskilled,
+  };
+}

--- a/public/js/tabs/downtime-data.js
+++ b/public/js/tabs/downtime-data.js
@@ -14,6 +14,7 @@ const PROJECT_ACTIONS = [
   { value: 'hide_protect', label: 'Hide/Protect: Attempt to secure actions, merits, holdings, or projects' },
   { value: 'investigate', label: 'Investigate: Begin or further an investigation' },
   { value: 'patrol_scout', label: 'Patrol/Scout: Attempt to monitor a given Territory or area' },
+  { value: 'rote', label: 'Rote Hunt: Spend a project to feed a second time this cycle' },
   { value: 'xp_spend', label: 'XP Spend: Grow your character' },
   { value: 'misc', label: 'Misc: For things that don\'t fit in other categories' },
   { value: 'maintenance', label: 'Maintenance: Upkeep of professional or cult relationships' },
@@ -28,6 +29,7 @@ export const ACTION_APPROACH_PROMPTS = {
   'patrol_scout': 'How does your character observe or patrol this territory in narrative terms.',
   'misc': 'Describe your approach to this action in narrative terms.',
   'maintenance': 'Describe how your character maintains this relationship or organisation in narrative terms.',
+  'rote': 'Describe how your character pursues this second hunt — same method as your primary feed, in a (potentially different) territory.',
 };
 
 export const ACTION_DESCRIPTIONS = {
@@ -40,6 +42,7 @@ export const ACTION_DESCRIPTIONS = {
   'xp_spend': 'You are spending experience to grow your character. Select the trait below.',
   'misc': 'This is for downtime actions that don\'t neatly fit into any other category. Describe what you\'re attempting to achieve and how your character goes about it.',
   'maintenance': 'You are maintaining your professional or cult relationships. Select the asset you are maintaining below.',
+  'rote': 'A second hunt this cycle. The method (and dice pool) is inherited from your primary feed in the Feeding section; you only pick the territory here. If the roll succeeds, the rote quality applies — roll twice, take the best.',
 };
 
 // Action type options for sphere (social merit) slots

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -15,6 +15,7 @@ import { esc, displayName, parseOutcomeSections, redactPlayer, redactCharName, h
 import { applyDerivedMerits } from '../editor/mci.js';
 import { DOWNTIME_SECTIONS, DOWNTIME_GATES, SPHERE_ACTIONS, TERRITORY_DATA, FEEDING_TERRITORIES, PROJECT_ACTIONS, FEED_METHODS, MAINTENANCE_MERITS, FEED_VIOLENCE_DEFAULTS, JOINT_ELIGIBLE_ACTIONS, ACTION_DESCRIPTIONS, ACTION_APPROACH_PROMPTS, SUBMIT_FINAL_MODAL_QUESTIONS } from './downtime-data.js';
 import { actionSpentSummary, formatActionSpentSummary } from '../data/dt-action-summary.js';
+import { computeBestFeedingPool } from '../data/feeding-pool.js';
 import { ALL_ATTRS, ALL_SKILLS, CLAN_DISCS, BLOODLINE_DISCS, CORE_DISCS, RITUAL_DISCS } from '../data/constants.js';
 import { calcTotalInfluence, domMeritTotal, attacheBonusDots, effectiveInvictusStatus, ssjHerdBonus, flockHerdBonus, meritEffectiveRating } from '../editor/domain.js';
 import { calcVitaeMax, skTotal, skNineAgain, riteCost, skillAcqPoolStr, getAttrEffective, getAttrTotal, discDots } from '../data/accessors.js';
@@ -6298,8 +6299,43 @@ function renderQuestion(q, value) {
       }
       h += '</div>';
 
-      // ── Unified pool builder (DTFP-4: always visible, method optional) ──
-      h += renderFeedPoolSelector(c, feedMethodId, feedCustomAttr, feedCustomSkill, feedDiscName, feedSpecName, 'feed');
+      // dt-form.20 (ADR-003 §Q2): MINIMAL renders a read-only auto-derived
+      // pool annotation in place of the manual pool selectors. ADVANCED keeps
+      // the existing chrome (DTFP-4: always visible, method optional).
+      if (_formMode(responseDoc?.responses) === 'minimal') {
+        const slugFromGrid = (gridStr) => {
+          let grid = {};
+          try { grid = JSON.parse(gridStr || '{}'); } catch { return ''; }
+          const key = Object.keys(grid).find(k => grid[k] && grid[k] !== 'none');
+          if (!key) return '';
+          const niceName = FEEDING_TERRITORIES.find(
+            t => t.toLowerCase().replace(/[^a-z0-9]+/g, '_') === key
+          );
+          const td = niceName ? TERRITORY_DATA.find(t => t.name === niceName) : null;
+          return td?.slug || '';
+        };
+        const territorySlug = slugFromGrid(responseDoc?.responses?.feeding_territories);
+        const pool = computeBestFeedingPool({ char: c, methodId: feedMethodId, territorySlug });
+        h += '<div class="qf-field dt-feed-min-pool">';
+        if (!feedMethodId) {
+          h += '<p class="qf-desc">Pick a method above to see your auto-derived hunt pool.</p>';
+        } else if (!pool) {
+          h += '<p class="qf-desc">Pool unavailable for this method.</p>';
+        } else {
+          const parts = [];
+          if (pool.attr.name) parts.push(`${pool.attr.val} ${esc(pool.attr.name)}`);
+          if (pool.skill.name) parts.push(`${pool.skill.val} ${esc(pool.skill.name)}`);
+          else if (pool.unskilled) parts.push(`${pool.unskilled} unskilled`);
+          if (pool.disc.name) parts.push(`${pool.disc.val} ${esc(pool.disc.name)}`);
+          if (pool.ambience.mod) parts.push(`${pool.ambience.mod > 0 ? '+' : ''}${pool.ambience.mod} ambience`);
+          h += `<label class="qf-label">Pool: <strong>${pool.total}</strong></label>`;
+          h += `<p class="qf-desc">${parts.join(' &middot; ')} (auto-picked from your sheet)</p>`;
+        }
+        h += '</div>';
+      } else {
+        // ── Unified pool builder (DTFP-4: always visible, method optional) ──
+        h += renderFeedPoolSelector(c, feedMethodId, feedCustomAttr, feedCustomSkill, feedDiscName, feedSpecName, 'feed');
+      }
 
       // Blood type selection — single-select (legacy multi-array reads first item)
       const BLOOD_TYPES = ['Animal', 'Human', 'Kindred'];
@@ -6337,7 +6373,10 @@ function renderQuestion(q, value) {
       h += '</div>'; // dt-feed-card-wrap
 
       // ── Container 2: Feeding quality (Standard / Rote) ──
-      {
+      // dt-form.20: ROTE block is hidden in MINIMAL mode (the simplified
+      // form is the 5 primary fields only). ADVANCED keeps it until #22
+      // moves ROTE out into a personal-project-action variant.
+      if (_formMode(responseDoc?.responses) !== 'minimal') {
         const savedRote = responseDoc?.responses?.['_feed_rote'] === 'yes';
         if (savedRote && !feedRoteAction) feedRoteAction = true;
         feedRoteDisc = responseDoc?.responses?.['_rote_disc'] || feedRoteDisc;
@@ -6381,7 +6420,7 @@ function renderQuestion(q, value) {
           h += '</div>';
         }
         h += '</div>';
-      }
+      } // dt-form.20: end MINIMAL-skip wrap on ROTE container
 
       // ── Container 3: Vitae Projection ──
       {

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -412,13 +412,16 @@ function collectResponses() {
         responses['_feed_blood_types'] = JSON.stringify(bloodChecked);
         const descEl = document.getElementById('dt-feeding_description');
         responses['feeding_description'] = descEl ? descEl.value : '';
-        // dt-form.22 fix-up (Ma'at PR #98 review, bug 2): the rote-territory
-        // collect was gated on the legacy `feedRoteAction` module flag, which
-        // never flips since Container 2 was removed. Derive the gate from the
-        // new shape — any project slot whose action is `rote` counts.
-        const _hasRoteSlotForCollect = [1, 2, 3, 4].some(
-          n => responses[`project_${n}_action`] === 'rote'
-        );
+        // dt-form.22 fix-up (Ma'at PR #98 review round 2, bug-2 rework):
+        // read the action selectors from the DOM, not from `responses`.
+        // The feeding_method branch runs BEFORE the project-slot collect
+        // loop at :532, so `responses[project_N_action]` here is still the
+        // spread base from the prior responseDoc — it doesn't yet reflect
+        // the user's current slot selection. The DOM does.
+        const _hasRoteSlotForCollect = [1, 2, 3, 4].some(n => {
+          const el = document.getElementById(`dt-project_${n}_action`);
+          return el && el.value === 'rote';
+        });
         if (_hasRoteSlotForCollect) {
           const roteGridVals = {};
           for (const terr of FEEDING_TERRITORIES) {

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -51,6 +51,52 @@ function _promotePublishedOutcome(sub) {
   }
 }
 
+// dt-form.22: one-shot migration of legacy ROTE state into the new
+// project-action shape. Reads `_feed_rote` / `_feed_rote_slot` (plus the
+// pool-builder `_rote_*` companions) and translates to:
+//   responses.project_N_action      = 'rote'
+//   responses.project_N_feed_method2 = <primary method, if known>
+// Drops the legacy keys. `feeding_territories_rote` is left in place — it's
+// the canonical doc-level territory map per the 2026-05-06 HALT-DAR.
+//
+// Idempotent: the function returns early if there are no legacy fields to
+// migrate. Called from renderDowntimeTab after responseDoc loads, and as
+// a defensive prelude inside collectResponses so a stray legacy save can't
+// re-introduce the old shape.
+function _migrateLegacyRoteState(responses) {
+  if (!responses || typeof responses !== 'object') return;
+  const isLegacy = responses._feed_rote === 'yes' || responses._feed_rote_slot
+    || responses._rote_disc || responses._rote_spec
+    || responses._rote_custom_attr || responses._rote_custom_skill;
+  if (!isLegacy) return;
+
+  const rawSlot = parseInt(responses._feed_rote_slot, 10);
+  const slot = Number.isInteger(rawSlot) && rawSlot >= 1 && rawSlot <= 4 ? rawSlot : 1;
+  const wasOn = responses._feed_rote === 'yes';
+  if (wasOn) {
+    // The slot may have been auto-locked to action='feed' by the legacy
+    // applyRoteToProjectSlot path. Flip it to the new 'rote' action type.
+    if (responses[`project_${slot}_action`] === 'feed' || !responses[`project_${slot}_action`]) {
+      responses[`project_${slot}_action`] = 'rote';
+    }
+    // Persist the primary method into the per-slot `_method2` field if
+    // available. The pool itself is no longer separately stored — derived
+    // at render time from the primary feeding inputs.
+    const primaryMethod = responses._feed_method;
+    if (primaryMethod && !responses[`project_${slot}_feed_method2`]) {
+      responses[`project_${slot}_feed_method2`] = primaryMethod;
+    }
+  }
+
+  // Drop legacy keys so subsequent saves don't re-introduce them.
+  delete responses._feed_rote;
+  delete responses._feed_rote_slot;
+  delete responses._rote_disc;
+  delete responses._rote_spec;
+  delete responses._rote_custom_attr;
+  delete responses._rote_custom_skill;
+}
+
 let responseDoc = null;
 let currentChar = null;
 let currentCycle = null;
@@ -112,12 +158,14 @@ const ACTION_ICONS = {
   'attack': '\u2694', 'feed': '\u2666', 'hide_protect': '\u25C6',
   'investigate': '\u25CE', 'patrol_scout': '\u25C8', 'support': '\u2605',
   'xp_spend': '\u2726', 'misc': '\u25CF', 'maintenance': '\u2699',
+  'rote': '\u2666', // dt-form.22: same diamond as feed; ROTE is a feed variant
 };
 const ACTION_SHORT = {
   '': 'No Action', 'ambience_increase': 'Ambience +', 'ambience_decrease': 'Ambience \u2212',
   'attack': 'Attack', 'feed': 'Feed (Rote)', 'hide_protect': 'Hide/Protect',
   'investigate': 'Investigate', 'patrol_scout': 'Patrol/Scout', 'support': 'Support',
   'xp_spend': 'XP Spend', 'misc': 'Misc', 'maintenance': 'Maintenance',
+  'rote': 'Rote Hunt', // dt-form.22
 };
 // Which fields each action type shows
 const ACTION_FIELDS = {
@@ -131,6 +179,11 @@ const ACTION_FIELDS = {
   'patrol_scout':      ['title', 'outcome', 'target', 'pools', 'description'],
   'misc':              ['title', 'outcome', 'target', 'pools', 'description'],
   'maintenance':       ['target', 'description'],
+  // dt-form.22: ROTE renders only the territory + description; pool is
+  // inherited from primary feeding (read-only annotation). The handler
+  // below renders rote-specific UI, so this list is intentionally just
+  // 'description' — the territory + pool annotation are emitted inline.
+  'rote':              ['description'],
 };
 
 const SPHERE_ACTION_FIELDS = {
@@ -282,6 +335,10 @@ function collectResponses() {
   // for sections hidden by the current mode. Spread the prior responses as a
   // base, then specific section blocks below either overwrite (when their UI
   // is rendered) or are skipped (when hidden by MINIMAL).
+  // dt-form.22: defensive prelude — translate any stragglers from the legacy
+  // ROTE state into the new project-action shape before the spread, so a
+  // load → save round-trip can never re-introduce the old keys.
+  if (responseDoc?.responses) _migrateLegacyRoteState(responseDoc.responses);
   const _prior = responseDoc?.responses || {};
   const responses = { ..._prior };
   // Carry the existing mode flag forward; the toggle handler updates it
@@ -341,18 +398,10 @@ function collectResponses() {
         responses['_feed_custom_attr'] = feedCustomAttr;
         responses['_feed_custom_skill'] = feedCustomSkill;
         responses['_feed_custom_disc'] = feedCustomDisc;
-        responses['_feed_rote'] = feedRoteAction ? 'yes' : '';
-        responses['_feed_rote_slot'] = feedRoteAction ? String(feedRoteSlot) : '';
-        const roteDiscEl = document.getElementById('dt-rote-disc');
-        feedRoteDisc = roteDiscEl ? roteDiscEl.value : feedRoteDisc;
-        const roteAttrEl = document.getElementById('dt-rote-custom-attr');
-        const roteSkillEl = document.getElementById('dt-rote-custom-skill');
-        if (roteAttrEl) feedRoteCustomAttr = roteAttrEl.value;
-        if (roteSkillEl) feedRoteCustomSkill = roteSkillEl.value;
-        responses['_rote_disc'] = feedRoteAction ? feedRoteDisc : '';
-        responses['_rote_spec'] = feedRoteAction ? feedRoteSpec : '';
-        responses['_rote_custom_attr'] = feedRoteAction ? feedRoteCustomAttr : '';
-        responses['_rote_custom_skill'] = feedRoteAction ? feedRoteCustomSkill : '';
+        // dt-form.22: legacy `_feed_rote*` and `_rote_*` writes removed.
+        // ROTE is now a per-slot project action; method persists per-slot
+        // as `project_N_feed_method2`, territory persists at the document
+        // level as `feeding_territories_rote` (existing field, kept).
         // Blood type
         const bloodChecked = [];
         document.querySelectorAll('[data-blood-type].dt-feed-vi-on').forEach(btn => bloodChecked.push(btn.dataset.bloodType));
@@ -1341,6 +1390,9 @@ export async function renderDowntimeTab(targetEl, char, territories, options = {
         s.character_id === currentChar._id || s.character_id?.toString() === currentChar._id?.toString()
       ) || null;
       if (responseDoc) _promotePublishedOutcome(responseDoc);
+      // dt-form.22: translate legacy ROTE state on first read. Once any
+      // save fires, the document persists in the new shape.
+      if (responseDoc?.responses) _migrateLegacyRoteState(responseDoc.responses);
     } catch { /* no submission */ }
   }
 
@@ -3704,6 +3756,58 @@ function renderProjectSlots(saved, mode = 'advanced') {
         type: 'textarea', required: false, rows: 2,
         placeholder: 'Describe what you are spending XP on in this action.',
       }, saved[`project_${n}_xp`] || '');
+    }
+
+    // ── dt-form.22: ROTE territory + read-only inherited pool ──
+    if (actionVal === 'rote') {
+      h += '<div class="qf-field dt-proj-rote-territory">';
+      h += '<label class="qf-label">Where does this second hunt happen?</label>';
+      const roteTerrSaved = saved.feeding_territories_rote || '';
+      let roteTerrGridVals = {};
+      try { roteTerrGridVals = JSON.parse(roteTerrSaved); } catch { /* ignore */ }
+      const mainTerrSaved = saved.feeding_territories || '';
+      let mainTerrGridVals = {};
+      try { mainTerrGridVals = JSON.parse(mainTerrSaved); } catch { /* ignore */ }
+      h += '<p class="qf-desc" style="margin:0 0 6px;font-size:.85em;opacity:.8">Rote feed must use the same territory type as your main feed. Barrens locks both.</p>';
+      h += renderFeedingTerritoryPills(roteTerrGridVals, true, mainTerrGridVals);
+      h += '</div>';
+
+      // Read-only inherited pool. Derive from the same primary-feed inputs
+      // the simplified MINIMAL form uses, plus the chosen rote territory's
+      // ambience modifier.
+      const slugFromGrid = (gridStr) => {
+        let grid = {};
+        try { grid = JSON.parse(gridStr || '{}'); } catch { return ''; }
+        const key = Object.keys(grid).find(k => grid[k] && grid[k] !== 'none');
+        if (!key) return '';
+        const niceName = FEEDING_TERRITORIES.find(
+          t => t.toLowerCase().replace(/[^a-z0-9]+/g, '_') === key
+        );
+        const td = niceName ? TERRITORY_DATA.find(t => t.name === niceName) : null;
+        return td?.slug || '';
+      };
+      const roteSlug = slugFromGrid(saved.feeding_territories_rote || '');
+      const inheritedPool = computeBestFeedingPool({
+        char: currentChar,
+        methodId: feedMethodId,
+        territorySlug: roteSlug || slugFromGrid(saved.feeding_territories || ''),
+      });
+      h += '<div class="qf-field dt-proj-rote-pool">';
+      if (!feedMethodId) {
+        h += '<p class="qf-desc">Pool will be derived from primary feeding once you pick a method in the Feeding section.</p>';
+      } else if (!inheritedPool) {
+        h += '<p class="qf-desc">Pool will be derived from primary feeding once you pick a method in the Feeding section.</p>';
+      } else {
+        const parts = [];
+        if (inheritedPool.attr.name) parts.push(`${inheritedPool.attr.val} ${esc(inheritedPool.attr.name)}`);
+        if (inheritedPool.skill.name) parts.push(`${inheritedPool.skill.val} ${esc(inheritedPool.skill.name)}`);
+        else if (inheritedPool.unskilled) parts.push(`${inheritedPool.unskilled} unskilled`);
+        if (inheritedPool.disc.name) parts.push(`${inheritedPool.disc.val} ${esc(inheritedPool.disc.name)}`);
+        if (inheritedPool.ambience.mod) parts.push(`${inheritedPool.ambience.mod > 0 ? '+' : ''}${inheritedPool.ambience.mod} ambience`);
+        h += `<label class="qf-label">Pool: <strong>${inheritedPool.total}</strong> <span class="qf-desc" style="font-weight:normal">(inherited from primary hunt)</span></label>`;
+        h += `<p class="qf-desc">${parts.join(' &middot; ')}</p>`;
+      }
+      h += '</div>';
     }
 
     // ── Approach ──
@@ -6372,55 +6476,12 @@ function renderQuestion(q, value) {
       h += '</div>';
       h += '</div>'; // dt-feed-card-wrap
 
-      // ── Container 2: Feeding quality (Standard / Rote) ──
-      // dt-form.20: ROTE block is hidden in MINIMAL mode (the simplified
-      // form is the 5 primary fields only). ADVANCED keeps it until #22
-      // moves ROTE out into a personal-project-action variant.
-      if (_formMode(responseDoc?.responses) !== 'minimal') {
-        const savedRote = responseDoc?.responses?.['_feed_rote'] === 'yes';
-        if (savedRote && !feedRoteAction) feedRoteAction = true;
-        feedRoteDisc = responseDoc?.responses?.['_rote_disc'] || feedRoteDisc;
-        feedRoteSpec = responseDoc?.responses?.['_rote_spec'] || feedRoteSpec;
-        feedRoteCustomAttr = responseDoc?.responses?.['_rote_custom_attr'] || feedRoteCustomAttr;
-        feedRoteCustomSkill = responseDoc?.responses?.['_rote_custom_skill'] || feedRoteCustomSkill;
-
-        const saved = responseDoc?.responses || {};
-
-        const firstAvail = [1,2,3,4].find(n => {
-          const act = saved[`project_${n}_action`];
-          return !act || act === 'feed';
-        }) || 1;
-        if (feedRoteAction && feedRoteSlot !== firstAvail) feedRoteSlot = firstAvail;
-
-        const roteDesc = saved[`project_${feedRoteSlot}_description`] || '';
-
-        h += '<div class="dt-feed-rote-section">';
-        h += '<label class="qf-label">Commit a project to hunting this downtime?</label>';
-        h += '<div class="dt-feed-violence-toggle">';
-        h += `<button type="button" class="dt-feed-vi-btn${!feedRoteAction ? ' dt-feed-vi-on' : ''}" data-feed-rote="off">Standard Hunt</button>`;
-        h += `<button type="button" class="dt-feed-vi-btn${feedRoteAction ? ' dt-feed-vi-on' : ''}" data-feed-rote="on">Rote Hunt</button>`;
-        h += '</div>';
-        if (feedRoteAction) {
-          h += '<div class="dt-rote-slot-picker">';
-          h += `<p class="qf-desc" style="margin:0 0 8px">Commits <strong>Project ${feedRoteSlot}</strong> to this hunt. IF this roll is successful, it will apply the Rote quality to your feeding roll (roll twice, take the best result).</p>`;
-          {
-            const roteTerrSaved = (responseDoc?.responses || {})['feeding_territories_rote'] || '';
-            let roteTerrGridVals = {};
-            try { roteTerrGridVals = JSON.parse(roteTerrSaved); } catch { /* ignore */ }
-            const mainTerrSaved = (responseDoc?.responses || {})['feeding_territories'] || '';
-            let mainTerrGridVals = {};
-            try { mainTerrGridVals = JSON.parse(mainTerrSaved); } catch { /* ignore */ }
-            h += '<div class="qf-field">';
-            h += '<p class="qf-desc" style="margin:0 0 6px;font-size:.85em;opacity:.8">Rote feed must use the same territory type as your main feed. Barrens locks both.</p>';
-            h += renderFeedingTerritoryPills(roteTerrGridVals, true, mainTerrGridVals);
-            h += '</div>';
-          }
-          h += renderFeedPoolSelector(c, feedMethodId, feedRoteCustomAttr, feedRoteCustomSkill, feedRoteDisc, feedRoteSpec, 'rote');
-          h += `<div class="qf-field"><textarea id="dt-rote-description" class="qf-textarea" rows="4" placeholder="Describe how your character hunts">${esc(roteDesc)}</textarea></div>`;
-          h += '</div>';
-        }
-        h += '</div>';
-      } // dt-form.20: end MINIMAL-skip wrap on ROTE container
+      // dt-form.22: ROTE block removed from the feeding section. ROTE is now
+      // a personal-project-action variant (see PROJECT_ACTIONS in
+      // downtime-data.js). The legacy `_feed_rote_*` state is migrated on
+      // the next save in collectResponses; territory continues to write to
+      // the document-level `feeding_territories_rote` map for ambience
+      // resolution by the Vitae Projection container below.
 
       // ── Container 3: Vitae Projection ──
       {
@@ -6491,8 +6552,12 @@ function renderQuestion(q, value) {
           return { mod: td.ambienceMod || 0, label: `${td.ambience} (${name})` };
         };
 
+        // dt-form.22: rote-active is derived from the new project-action
+        // shape — any slot whose action is 'rote' counts. Replaces the
+        // legacy module-scoped `feedRoteAction` flag.
+        const _hasRoteSlot = [1, 2, 3, 4].some(n => allResp[`project_${n}_action`] === 'rote');
         const mainAmb = resolveTerrAmbience(allResp['feeding_territories']);
-        const roteAmb = feedRoteAction ? resolveTerrAmbience(allResp['feeding_territories_rote']) : null;
+        const roteAmb = _hasRoteSlot ? resolveTerrAmbience(allResp['feeding_territories_rote']) : null;
 
         // Best of the two territories (highest mod wins)
         let bestAmb = null;
@@ -6512,7 +6577,7 @@ function renderQuestion(q, value) {
         mainPool += fgVal;
         if (feedSpecName) mainPool += hasAoE(c, feedSpecName) ? 2 : 1;
         // Average vitae: base = floor(2N/3); rote = floor(5N/6) (max of two rolls)
-        const avgGathered = feedRoteAction
+        const avgGathered = _hasRoteSlot
           ? Math.floor((mainPool * 5) / 6)
           : Math.floor((mainPool * 2) / 3);
 
@@ -6546,7 +6611,7 @@ function renderQuestion(q, value) {
         const netSign = netStarting >= 0 ? '+' : '−';
         h += `<div class="dt-vitae-row dt-vitae-subtotal"><span>Net starting Vitae</span><span>${netSign}${Math.abs(netStarting)}</span></div>`;
         if (mainPool > 0) {
-          const yieldLabel = feedRoteAction ? 'Projected average gathered (rote)' : 'Projected average gathered';
+          const yieldLabel = _hasRoteSlot ? 'Projected average gathered (rote)' : 'Projected average gathered';
           h += `<div class="dt-vitae-row dt-vitae-pos"><span>${yieldLabel}</span><span>+${avgGathered}</span></div>`;
         } else {
           h += '<div class="dt-vitae-row dt-vitae-note"><span style="font-style:italic;color:var(--txt3)">Build your hunt pool above to see expected yield.</span><span></span></div>';

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -384,10 +384,14 @@ function collectResponses() {
         continue;
       }
       if (q.type === 'feeding_method') {
-        // DTFP-4: _feed_method is no longer persisted on new submissions.
-        // The method-card pick is UX-only scaffolding for the chip suggestions;
-        // the saved pool is whatever the player built via attr/skill/disc/spec.
-        // Legacy submissions keep their stored _feed_method for back-compat reads.
+        // dt-form.20 fix-up (Ma'at PR #98 review, bug 1): persist `_feed_method`
+        // again. DTFP-4 dropped it because the manual pool builder was the
+        // canonical method-set signal in ADVANCED, but MINIMAL has no pool
+        // builder — without this the simplified form's method choice is
+        // invisible to isMinimalComplete and the hard-mirror lifecycle never
+        // unlocks. ADVANCED still falls back to `_feed_disc` / `_feed_custom_*`
+        // so this is additive, not a regression of the original DTFP-4 case.
+        responses['_feed_method'] = feedMethodId || '';
         // DTFP-5: feed_violence persists only after the player clicks the toggle.
         // Pre-selection is visual only; preserve any explicit choice through saves.
         if (responseDoc?.responses?.feed_violence) {
@@ -408,8 +412,14 @@ function collectResponses() {
         responses['_feed_blood_types'] = JSON.stringify(bloodChecked);
         const descEl = document.getElementById('dt-feeding_description');
         responses['feeding_description'] = descEl ? descEl.value : '';
-        // Rote territory picker
-        if (feedRoteAction) {
+        // dt-form.22 fix-up (Ma'at PR #98 review, bug 2): the rote-territory
+        // collect was gated on the legacy `feedRoteAction` module flag, which
+        // never flips since Container 2 was removed. Derive the gate from the
+        // new shape — any project slot whose action is `rote` counts.
+        const _hasRoteSlotForCollect = [1, 2, 3, 4].some(
+          n => responses[`project_${n}_action`] === 'rote'
+        );
+        if (_hasRoteSlotForCollect) {
           const roteGridVals = {};
           for (const terr of FEEDING_TERRITORIES) {
             const terrKey = terr.toLowerCase().replace(/[^a-z0-9]+/g, '_');
@@ -557,6 +567,14 @@ function collectResponses() {
     responses[`project_${n}_xp_category`] = xpCatEl ? xpCatEl.value : '';
     responses[`project_${n}_xp_item`] = xpItemEl ? xpItemEl.value : '';
     if (responses[`project_${n}_action`] === 'xp_spend') responses[`project_${n}_xp_dots`] = '1';
+    // dt-form.22 fix-up (Ma'at PR #98 review, bug 3): write
+    // `project_N_feed_method2` whenever the slot's action is `rote`. Migration
+    // helper handles legacy submissions; this covers fresh ROTE saves so ST
+    // consumers (feeding-tab.js:350, admin/downtime-views.js:2569) read the
+    // method directly rather than seeing undefined.
+    if (responses[`project_${n}_action`] === 'rote' && feedMethodId) {
+      responses[`project_${n}_feed_method2`] = feedMethodId;
+    }
     // Target zone (unified: attack, hide_protect, investigate, patrol_scout, misc)
     const targetTypeRadio = document.querySelector(`input[name="dt-project_${n}_target_type"]:checked`);
     responses[`project_${n}_target_type`] = targetTypeRadio ? targetTypeRadio.value : '';

--- a/server/schemas/downtime_submission.schema.js
+++ b/server/schemas/downtime_submission.schema.js
@@ -26,7 +26,11 @@
 
 const projectActionEnum = [
   '', 'ambience_increase', 'ambience_decrease', 'attack', 'feed',
-  'hide_protect', 'investigate', 'patrol_scout', 'support', 'xp_spend', 'misc'
+  'hide_protect', 'investigate', 'patrol_scout', 'support', 'xp_spend', 'misc',
+  // dt-form.22: ROTE moved out of the feeding section into its own per-slot
+  // action variant. Pool inherits from primary feeding; territory writes to
+  // the existing document-level `feeding_territories_rote` map.
+  'rote'
 ];
 
 const sphereActionEnum = [

--- a/specs/stories/dt-form.20-feeding-simplified.story.md
+++ b/specs/stories/dt-form.20-feeding-simplified.story.md
@@ -4,7 +4,7 @@ task: 20
 issue: 76
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/76
 epic: epic-dt-form-mvp-redesign
-status: Ready for Dev
+status: Ready for Review
 priority: high
 depends_on: ['dt-form.17']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q2)
@@ -67,11 +67,11 @@ Auto-pick best dice pool: derive from existing helpers (search for `feedDicePool
 
 ## Definition of Done
 
-- [ ] MINIMAL feeding renders the 5-field simplified form
-- [ ] Auto-pick best dice pool surfaces a read-only pool number
-- [ ] ADVANCED feeding form unchanged
-- [ ] `isMinimalComplete()` consults the simplified fields
-- [ ] PR opened into `dev`
+- [x] MINIMAL feeding renders the 5-field simplified form
+- [x] Auto-pick best dice pool surfaces a read-only pool number
+- [x] ADVANCED feeding form unchanged
+- [x] `isMinimalComplete()` consults the simplified fields
+- [x] PR opened into `dev`
 
 ## Dependencies
 

--- a/specs/stories/dt-form.20-feeding-simplified.story.md
+++ b/specs/stories/dt-form.20-feeding-simplified.story.md
@@ -4,7 +4,7 @@ task: 20
 issue: 76
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/76
 epic: epic-dt-form-mvp-redesign
-status: Draft
+status: Ready for Dev
 priority: high
 depends_on: ['dt-form.17']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q2)

--- a/specs/stories/dt-form.22-rote-hunt.story.md
+++ b/specs/stories/dt-form.22-rote-hunt.story.md
@@ -4,7 +4,7 @@ task: 22
 issue: 73
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/73
 epic: epic-dt-form-mvp-redesign
-status: Ready for Dev
+status: Ready for Review
 priority: medium
 depends_on: ['dt-form.17', 'dt-form.20', 'dt-form.24']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q2)
@@ -108,11 +108,11 @@ The primary feeding pool is auto-derived per #20. ROTE reads the same value at r
 
 ## Definition of Done
 
-- [ ] ROTE renders as a project-action variant (territory picker + read-only inherited pool)
-- [ ] No ROTE block in the feeding section
-- [ ] `project_N_feed_method2` (existing, per-slot) + `feeding_territories_rote` (existing, doc-level) used as the canonical fields per HALT-DAR resolution; legacy `_feed_rote_*` state migrated
-- [ ] `isMinimalComplete()` does NOT count ROTE-only as feeding-complete
-- [ ] PR opened into `dev`
+- [x] ROTE renders as a project-action variant (territory picker + read-only inherited pool)
+- [x] No ROTE block in the feeding section
+- [x] `project_N_feed_method2` (existing, per-slot) + `feeding_territories_rote` (existing, doc-level) used as the canonical fields per HALT-DAR resolution; legacy `_feed_rote_*` state migrated
+- [x] `isMinimalComplete()` does NOT count ROTE-only as feeding-complete
+- [x] PR opened into `dev`
 
 ## Dependencies
 

--- a/specs/stories/dt-form.22-rote-hunt.story.md
+++ b/specs/stories/dt-form.22-rote-hunt.story.md
@@ -4,7 +4,7 @@ task: 22
 issue: 73
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/73
 epic: epic-dt-form-mvp-redesign
-status: Draft
+status: Ready for Dev
 priority: medium
 depends_on: ['dt-form.17', 'dt-form.20', 'dt-form.24']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q2)

--- a/specs/stories/dt-form.22-rote-hunt.story.md
+++ b/specs/stories/dt-form.22-rote-hunt.story.md
@@ -54,7 +54,7 @@ A player who wants to use ROTE for their MINIMAL "1 project slot" allocation can
 
 **Given** the player selects a ROTE territory
 **When** the form persists
-**Then** the territory is saved to `responses.project_N_feed_territory2` (or the existing schema field; confirm during pickup survey). The pool is NOT separately persisted; it is derived from primary feeding at render and execute time.
+**Then** the method is saved per-slot to `responses.project_N_feed_method2` (existing schema field at `downtime_submission.schema.js:75`); the territory is saved to the document-level `responses.feeding_territories_rote` (existing JSON map). Per Piatra 2026-05-06 (HALT-DAR resolution): only one ROTE feeding action exists per downtime cycle, so per-slot territory would be over-engineering. The method-per-slot / territory-doc-level asymmetry is intentional. The pool is NOT separately persisted; it is derived from primary feeding at render and execute time.
 
 **Given** a MINIMAL-mode submission has ROTE in the project slot but no primary feeding filled
 **When** `isMinimalComplete()` is evaluated
@@ -65,19 +65,28 @@ A player who wants to use ROTE for their MINIMAL "1 project slot" allocation can
 **Then** the rule **passes** (primary feeding satisfies feeding; the project-slot rule is satisfied because ROTE is a valid project action; mode set is complete).
 
 **Given** the implementer's current-state survey
-**When** they grep for `_feed_method2`, `_feed_territory2`, `rote`, `ROTE`
-**Then** they confirm the existing schema field set and document survey findings in DAR. If a field is missing, surface to Piatra rather than inventing a new shape.
+**When** they grep for `_feed_method2`, `feeding_territories_rote`, `_feed_rote`, `rote`, `ROTE`
+**Then** they confirm the existing schema field set. The 2026-05-06 HALT-DAR resolution locked: method per-slot (`project_N_feed_method2`, exists), territory document-level (`feeding_territories_rote`, exists). No new schema field added.
 
 ## Implementation Notes
 
-### Survey first
+### Field shape (locked 2026-05-06 via HALT-DAR)
 
-`project_N_feed_method2` is the existing schema field per Piatra's note. Confirm via:
-```bash
-grep -n "feed_method2\|feed_territory2\|_rote" public/js/tabs/downtime-form.js server/schemas/downtime_submission.schema.js
-```
+Method per-slot, territory document-level. ROTE-as-action writes:
+- `responses.project_N_feed_method2` — existing per-slot field (`downtime_submission.schema.js:75`, enum-typed)
+- `responses.feeding_territories_rote` — existing doc-level JSON map (single ROTE per cycle so per-slot territory was rejected as over-engineering)
 
-The expected pattern: a project slot of type `feed` already has a method/territory pair; ROTE adds a second method/territory pair (`_method2`/`_territory2`) for the ROTE variant. If that's the existing shape, ROTE is a UI surface over an already-supported data shape.
+Existing consumers to be aware of:
+- `public/js/tabs/feeding-tab.js:350` reads `_method2`
+- `public/js/admin/downtime-views.js:2569` reads `_method2` (ST view)
+- `public/js/tabs/downtime-form.js:6368` + `:6456` read `feeding_territories_rote` for ambience resolution
+
+Migration of existing `_feed_rote_*` state (six fields plus the territory map):
+- `_feed_rote` (boolean) + `_feed_rote_slot` (slot index) → translate to `responses.project_N_feed_method2 = <chosen method>` at the matching slot N. Drop the boolean flag and slot-index fields.
+- `_rote_disc` / `_rote_spec` / `_rote_custom_attr` / `_rote_custom_skill` → no longer relevant (pool inherits from primary feeding per #22 design). Drop on read.
+- `feeding_territories_rote` → kept as-is; ambience resolution path stays.
+
+Migration discipline: read both legacy AND new shape during a transition window (one cycle), or ship a one-shot migration script. Implementer's call; flag in PR body.
 
 ### Pool inheritance
 
@@ -101,7 +110,7 @@ The primary feeding pool is auto-derived per #20. ROTE reads the same value at r
 
 - [ ] ROTE renders as a project-action variant (territory picker + read-only inherited pool)
 - [ ] No ROTE block in the feeding section
-- [ ] `project_N_feed_method2` / `project_N_feed_territory2` schema fields confirmed (or surfaced for clarification)
+- [ ] `project_N_feed_method2` (existing, per-slot) + `feeding_territories_rote` (existing, doc-level) used as the canonical fields per HALT-DAR resolution; legacy `_feed_rote_*` state migrated
 - [ ] `isMinimalComplete()` does NOT count ROTE-only as feeding-complete
 - [ ] PR opened into `dev`
 


### PR DESCRIPTION
## Summary

Bundle PR shipping two stories together because #20 designs the pool helper that #22 immediately consumes — locking the interface and using it avoids a two-PR round-trip.

**Story dt-form.20 (#76)** — Simplified MINIMAL feeding form. New pure-ESM `public/js/data/feeding-pool.js` exporting `computeBestFeedingPool({ char, methodId, territorySlug })`. Mirrors the algorithm in `admin/feeding-engine.js:buildPool()` so the player- and ST-side derivations agree. In MINIMAL mode the feeding section drops the manual dice-pool selectors and renders a read-only auto-derived pool with attr/skill/disc/ambience breakdown. ADVANCED feeding form unchanged. ROTE Container 2 (the legacy Standard / Rote sub-block) removed in both modes by #22.

**Story dt-form.22 (#73)** — ROTE as a per-slot project action. New `'rote'` value in `PROJECT_ACTIONS` and `projectActionEnum`. The ROTE slot renders a territory chip picker (using the existing `renderFeedingTerritoryPills` rote variant with the same-as-primary-territory constraint) and a read-only inherited pool annotation that imports `computeBestFeedingPool` from #20. If primary feeding isn't filled yet, the annotation surfaces "Pool will be derived from primary feeding once you pick a method in the Feeding section." Container 2 removed from the feeding section.

**Field shape (locked 2026-05-06 via HALT-DAR):**
- `responses.project_N_feed_method2` — existing per-slot field
- `responses.feeding_territories_rote` — existing doc-level JSON map (single ROTE per cycle, so per-slot territory was rejected as over-engineering)

**Legacy state migration:** `_migrateLegacyRoteState(responses)` translates the old shape on first load:
- `_feed_rote === 'yes'` + `_feed_rote_slot = N` ⇒ `project_N_action = 'rote'` + `project_N_feed_method2 = <primary method>`
- `_rote_disc` / `_rote_spec` / `_rote_custom_attr` / `_rote_custom_skill` ⇒ dropped (pool inherits from primary feeding now)
- `feeding_territories_rote` ⇒ kept as-is
- Idempotent. Called once on `responseDoc` load and defensively at the top of `collectResponses` so a stray legacy save can't re-introduce the old shape. **Migration discipline: dual-read transition window (one cycle); no one-shot script needed because the migration runs client-side on first load and the saved doc rolls forward.**

Server tests **678/678 green**.

Closes #76
Closes #73

## Notes

- HALT-DAR raised before any migration code touched: `project_N_feed_territory2` (mentioned in an early story draft) doesn't exist; `project_N_feed_method2` does. Khepri / Piatra resolved as Path 2 — keep the doc-level territory map. No new schema field added.
- `feedRoteAction` module-scoped flag left as inert dead code: the trigger UI is gone, so it never flips. The Vitae Projection container's rote-active branch now derives from the new shape (`[1..4].some(n => responses[`project_${n}_action`] === 'rote')`).
- `isMinimalComplete()` unchanged in shape — explicit comment added to record that ROTE in a project slot does NOT satisfy the feeding rule. Primary feeding gates feeding-complete; project-1 rule is satisfied separately if a player picks ROTE there.

## Test plan

- [x] Static review per-story: MINIMAL feeding 5-field render; ROTE-as-project-action; pool helper imported by both consumers; legacy state migration is idempotent
- [x] Server tests green (678/678)
- [ ] Browser smoke (deferred per both stories' Test Plan):
  - [ ] MINIMAL feeding: only 5 fields visible, auto-pool surfaces, mode-switch preserves data
  - [ ] ADVANCED feeding: existing chrome unchanged (manual selector still works, no ROTE Container 2)
  - [ ] Pick ROTE in project slot 1: territory picker appears, pool annotation reads "inherited from primary hunt" once method is set
  - [ ] Legacy submission with `_feed_rote=yes`: opens cleanly, migrates on first save, slot N flipped to action='rote'
  - [ ] MINIMAL with primary feeding only (no ROTE): passes gate
  - [ ] MINIMAL with ROTE-only (no primary): banner surfaces "Primary feeding required"