### PR TITLE
docs(stories): mark dt-form.20 + dt-form.22 status as Done

### DIFF
--- a/specs/stories/dt-form.20-feeding-simplified.story.md
+++ b/specs/stories/dt-form.20-feeding-simplified.story.md
@@ -4,7 +4,7 @@ task: 20
 issue: 76
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/76
 epic: epic-dt-form-mvp-redesign
-status: Ready for Review
+status: Done
 priority: high
 depends_on: ['dt-form.17']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q2)

--- a/specs/stories/dt-form.22-rote-hunt.story.md
+++ b/specs/stories/dt-form.22-rote-hunt.story.md
@@ -4,7 +4,7 @@ task: 22
 issue: 73
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/73
 epic: epic-dt-form-mvp-redesign
-status: Ready for Review
+status: Done
 priority: medium
 depends_on: ['dt-form.17', 'dt-form.20', 'dt-form.24']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q2)


### PR DESCRIPTION
## Summary

Two-line frontmatter flip: `status: Ready for Review` → `status: Done` on `specs/stories/dt-form.20-feeding-simplified.story.md` and `specs/stories/dt-form.22-rote-hunt.story.md`. The bundle implementation was merged in PR #98 (closed issues #76 and #73); this PR closes the documentation gap.

## Closes

_None_

## Story

- specs/stories/dt-form.20-feeding-simplified.story.md (status field only)
- specs/stories/dt-form.22-rote-hunt.story.md (status field only)

## Test plan

- [x] No code change — diff is two lines in story frontmatter
- [x] CI green (no logic affected)

## Branch flow

- From: `piatra/bookkeeping-dt-form-20-22-status`
- Into: `dev`