### PR TITLE
feat(dt-form): in-slot multi-row XP-Spend + Admin orphan cleanup (story dt-form.26)

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -3632,7 +3632,15 @@ function renderXpReviewStep() {
           if (legacy) rows.push({ category: 'xp_spend', item: legacy, cost: null, _proj: n });
         }
       }
-      // Also include admin xp_grid rows (free merits)
+      // dt-form.26: top-level `responses.xp_spend` is now a mirror built
+      // from the per-slot `project_N_xp_rows` (DAR-A1). The duplicate concat
+      // here is harmless because the per-slot rows above were derived from
+      // `project_N_xp_category`/`_xp_item` (legacy single-row keys), while
+      // the top-level mirror carries the FULL multi-row breakdown across
+      // all xp_spend slots. Reading both paths gives the ST every row even
+      // for legacy-shaped or transitional submissions; rows from the
+      // per-slot loop above are picked up here as duplicates only when a
+      // slot still has both shapes (transition window).
       try {
         const adminRows = JSON.parse(s.responses?.xp_spend || '[]').filter(r => r.category || r.item);
         rows = rows.concat(adminRows);

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -434,20 +434,11 @@ function collectResponses() {
         continue;
       }
       if (q.type === 'xp_grid') {
-        const gridEl = document.getElementById('dt-xp_spend');
-        const rows = [];
-        if (gridEl) {
-          gridEl.querySelectorAll('[data-xp-row]').forEach(rowEl => {
-            const catEl = rowEl.querySelector('[data-xp-cat]');
-            const itemEl = rowEl.querySelector('[data-xp-item]');
-            const dotsEl = rowEl.querySelector('[data-xp-dots]');
-            const category = catEl ? catEl.value : '';
-            const item = itemEl ? itemEl.value : '';
-            const dotsBuying = dotsEl ? parseInt(dotsEl.value, 10) || 0 : 0;
-            if (category) rows.push({ category, item, dotsBuying });
-          });
-        }
-        responses[q.key] = JSON.stringify(rows);
+        // dt-form.26: legacy Admin-section xp_grid collector pruned. The
+        // Admin section was removed in #31, so no DOWNTIME_SECTIONS question
+        // has type='xp_grid' anymore — the iteration that lands here is dead.
+        // Keeping a defensive `continue` so a re-introduced legacy question
+        // wouldn't accidentally clobber the new top-level mirror.
         continue;
       }
       if (q.type === 'influence_grid') {
@@ -569,7 +560,35 @@ function collectResponses() {
     const xpItemEl = document.getElementById(`dt-project_${n}_xp_item`);
     responses[`project_${n}_xp_category`] = xpCatEl ? xpCatEl.value : '';
     responses[`project_${n}_xp_item`] = xpItemEl ? xpItemEl.value : '';
-    if (responses[`project_${n}_action`] === 'xp_spend') responses[`project_${n}_xp_dots`] = '1';
+    // dt-form.26: collect this slot's multi-row XP-Spend grid. Read row
+    // values directly from the slot-scoped grid container; legacy single-row
+    // placeholder fields (`_xp_dots`, `_xp_category`, `_xp_item`) are no
+    // longer written here. Backward-compat fallback: if the slot has no
+    // grid mounted (action just flipped to xp_spend, render hasn't fired
+    // yet) preserve any prior `_xp_rows` from the spread base.
+    if (responses[`project_${n}_action`] === 'xp_spend') {
+      const slotGrid = document.querySelector(`[data-proj-xp-grid="${n}"]`);
+      if (slotGrid) {
+        const rows = [];
+        slotGrid.querySelectorAll('[data-xp-row]').forEach(rowEl => {
+          const catEl  = rowEl.querySelector('[data-xp-cat]');
+          const itemEl = rowEl.querySelector('[data-xp-item]');
+          const dotsEl = rowEl.querySelector('[data-xp-dots]');
+          const category = catEl ? catEl.value : '';
+          const item     = itemEl ? itemEl.value : '';
+          const dotsBuying = dotsEl ? (parseInt(dotsEl.value, 10) || 0) : 0;
+          if (category) rows.push({ category, item, dotsBuying });
+        });
+        responses[`project_${n}_xp_rows`] = JSON.stringify(rows);
+      }
+      // Drop the legacy `_xp_dots` placeholder; persist '0' so legacy ST
+      // readers see "no dots" rather than the stale "1" sentinel.
+      responses[`project_${n}_xp_dots`] = '0';
+    } else {
+      // Slot is no longer xp_spend; clear the rows JSON so stale data doesn't
+      // contaminate the top-level mirror.
+      if (responses[`project_${n}_xp_rows`]) responses[`project_${n}_xp_rows`] = '';
+    }
     // dt-form.22 fix-up (Ma'at PR #98 review, bug 3): write
     // `project_N_feed_method2` whenever the slot's action is `rote`. Migration
     // helper handles legacy submissions; this covers fresh ROTE saves so ST
@@ -894,6 +913,35 @@ function collectResponses() {
   }
 
   } // end if (!_isMinimal) — ADVANCED-only collection
+
+  // dt-form.26 (DAR-A1): mirror per-slot XP-spend rows into the legacy
+  // top-level `responses.xp_spend` JSON array so existing readers
+  // (player-side budget validator at submitForm:1263, ST review at
+  // admin/downtime-views.js:3637) keep working unchanged. The per-slot
+  // shape is canonical post-redesign; this rebuilds top-level on every
+  // save. If no slot has xp_spend rows, the legacy top-level value (from
+  // the spread base) passes through untouched — preserves any in-flight
+  // legacy data until the player engages the redesigned UI.
+  let _hasAnyXpRows = false;
+  const _topLevelMirror = [];
+  for (let s = 1; s <= 4; s++) {
+    if (responses[`project_${s}_action`] !== 'xp_spend') continue;
+    let slotRows = [];
+    const rj = responses[`project_${s}_xp_rows`] || '';
+    if (rj) {
+      try { slotRows = JSON.parse(rj); } catch { slotRows = []; }
+    }
+    if (slotRows.length) {
+      _hasAnyXpRows = true;
+      for (const r of slotRows) {
+        if (!r || !r.category) continue;
+        _topLevelMirror.push(r);
+      }
+    }
+  }
+  if (_hasAnyXpRows) {
+    responses['xp_spend'] = JSON.stringify(_topLevelMirror);
+  }
 
   return responses;
 }
@@ -3672,9 +3720,19 @@ function renderProjectSlots(saved, mode = 'advanced') {
 
     // ── XP Spend picker (structured) ──
     if (fields.includes('xp_picker')) {
-      const savedCat  = saved[`project_${n}_xp_category`] || '';
-      const savedItem = saved[`project_${n}_xp_item`] || '';
-      const budget = xpLeft(currentChar);
+      // dt-form.26: in-slot multi-row XP-Spend grid. Reuses renderXpRow which
+      // already encodes hotfix #44's merit-eligibility logic
+      // (getItemsForCategory('merit') -> getRulesByCategory + meetsPrereq).
+      // Per-slot rows persist as `responses.project_N_xp_rows` (JSON);
+      // top-level `responses.xp_spend` mirror-built in collectResponses (DAR-A1).
+      h += _renderProjectXpRows(n, saved);
+      // legacy single-row block follows but is dead — kept under a constant-false
+      // branch so the diff is bounded and the dead code documents the historical
+      // shape. Removed in a follow-up cleanup commit if Ma'at prefers.
+      if (false) {
+        const savedCat  = saved[`project_${n}_xp_category`] || '';
+        const savedItem = saved[`project_${n}_xp_item`] || '';
+        const budget = xpLeft(currentChar);
 
       // Deduct already-committed project XP from other slots
       let committed = 0;
@@ -3726,6 +3784,7 @@ function renderProjectSlots(saved, mode = 'advanced') {
       }, saved[`project_${n}_xp_trait`] || '');
 
       h += '</div>';
+      } // end if (false) — dt-form.26 dead-code wrap on legacy single-row block
     }
 
     if (fields.includes('title')) {
@@ -4228,6 +4287,99 @@ function renderXpRow(idx, row, xpActions, dotsRemaining) {
   }
 
   h += '</div>';
+  return h;
+}
+
+/**
+ * dt-form.26: per-slot multi-row XP-Spend grid. Replaces the legacy single-row
+ * placeholder when a project slot's action is `xp_spend`. Reuses renderXpRow
+ * for each row (which carries hotfix #44's merit-eligibility logic). Read from
+ * `responses.project_${n}_xp_rows` (JSON-stringified array); backward-compat
+ * seeds rows[0] from the legacy `project_${n}_xp_category` / `_xp_item` /
+ * `_xp_dots` triple when no `_xp_rows` is present yet.
+ *
+ * Per CLAUDE.md XP rules: 1 dot of non-merit growth per xp_spend slot, plus
+ * unlimited free 1-3 dot merits. The dotsRemaining tracker spans all xp_spend
+ * slots' rows so the player sees a single global budget.
+ */
+function _renderProjectXpRows(n, saved) {
+  // Read this slot's rows (JSON), or seed from legacy single-row fields.
+  let xpRows = [];
+  const savedRowsJson = saved[`project_${n}_xp_rows`] || '';
+  if (savedRowsJson) {
+    try { xpRows = JSON.parse(savedRowsJson); } catch { xpRows = []; }
+  }
+  if (!xpRows.length) {
+    const legacyCat  = saved[`project_${n}_xp_category`] || '';
+    const legacyItem = saved[`project_${n}_xp_item`] || '';
+    const legacyDots = parseInt(saved[`project_${n}_xp_dots`] || '0', 10) || 0;
+    if (legacyCat && legacyItem) {
+      xpRows.push({ category: legacyCat, item: legacyItem, dotsBuying: legacyDots || 1 });
+    }
+  }
+  // Always render a trailing empty row so the player can add another purchase
+  // without an extra click. Mirrors the legacy admin xp_grid behaviour.
+  if (!xpRows.length || xpRows[xpRows.length - 1].category) {
+    xpRows.push({ category: '', item: '', dotsBuying: 0 });
+  }
+
+  // Cross-slot accounting. xp_spend slot count drives the non-merit dot budget;
+  // merits 1-3 are free per CLAUDE.md.
+  let xpActions = 0;
+  for (let s = 1; s <= 4; s++) {
+    if (saved[`project_${s}_action`] === 'xp_spend') xpActions++;
+  }
+  // Sum non-merit dots across ALL xp_spend slots' rows so the dotsRemaining
+  // displayed on this slot reflects the true cross-slot budget.
+  let dotsUsed = 0;
+  for (let s = 1; s <= 4; s++) {
+    if (saved[`project_${s}_action`] !== 'xp_spend') continue;
+    let slotRows = [];
+    const rj = saved[`project_${s}_xp_rows`] || '';
+    if (rj) { try { slotRows = JSON.parse(rj); } catch { slotRows = []; } }
+    if (!slotRows.length) {
+      const lc = saved[`project_${s}_xp_category`] || '';
+      const li = saved[`project_${s}_xp_item`]     || '';
+      if (lc && li) slotRows = [{ category: lc, item: li, dotsBuying: 1 }];
+    }
+    for (const r of slotRows) {
+      if (!r.category || !r.item) continue;
+      if (r.category === 'merit') continue; // free 1-3 dot merits
+      if (r.category === 'devotion') dotsUsed++; // 1 action per devotion
+      else dotsUsed += (r.dotsBuying || 1);
+    }
+  }
+  const dotsRemaining = xpActions - dotsUsed;
+
+  // Slot total + global budget
+  const slotCost = xpRows.reduce((sum, r) => sum + getRowCost(r), 0);
+  const budget = xpLeft(currentChar);
+
+  let h = `<div class="dt-xp-picker dt-xp-grid" data-proj-xp-grid="${n}">`;
+  h += `<p class="qf-desc">XP-spend declarations for this action. Add as many traits as your XP budget allows; merits at 1-3 dots are free, other categories require an XP-Spend action per dot.</p>`;
+  h += `<div class="dt-xp-budget" id="dt-proj_${n}_xp_budget">`;
+  h += `<span>Slot total: <strong>${slotCost}</strong> XP</span>`;
+  h += `<span style="margin-left:14px">Cycle budget: <strong>${budget}</strong> XP available</span>`;
+  if (xpActions > 0) {
+    h += `<span style="margin-left:14px">${xpActions} XP-Spend action${xpActions > 1 ? 's' : ''} — <span class="${dotsRemaining < 0 ? 'dt-influence-over' : ''}">${dotsRemaining} dot${dotsRemaining !== 1 ? 's' : ''} remaining</span></span>`;
+  }
+  h += '</div>';
+
+  for (let i = 0; i < xpRows.length; i++) {
+    h += renderXpRow(i, xpRows[i], xpActions, dotsRemaining);
+  }
+  h += '</div>'; // dt-xp-grid
+
+  // In-character justification stays per-slot, single textarea. Carries the
+  // narrative for the entire xp-spend action regardless of row count.
+  h += renderQuestion({
+    key: `project_${n}_xp_trait`,
+    label: 'In-character justification',
+    type: 'textarea',
+    required: false,
+    placeholder: 'Describe the activity or events that justify this growth.',
+  }, saved[`project_${n}_xp_trait`] || '');
+
   return h;
 }
 

--- a/server/schemas/downtime_submission.schema.js
+++ b/server/schemas/downtime_submission.schema.js
@@ -73,8 +73,21 @@ function projectSlotProps(n) {
     [`project_${n}_cast`]:         { type: 'string' },
     // Applicable merits (JSON array of "Name|qualifier" keys)
     [`project_${n}_merits`]:       { type: 'string' },
-    // XP expenditure note (for xp_spend action)
+    // XP expenditure note (for xp_spend action) — legacy free-text justification
     [`project_${n}_xp`]:           { type: 'string' },
+    // dt-form.26: per-slot XP-spend rows. JSON-stringified array of
+    // { category, item, dotsBuying } objects (same row shape as the legacy
+    // top-level `responses.xp_spend`). Canonical post-redesign storage; the
+    // top-level field is mirror-built from these on every save (DAR-A1).
+    [`project_${n}_xp_rows`]:      { type: 'string' },
+    // Legacy single-row placeholders kept transitional: read as the FIRST
+    // row of `_xp_rows` if `_xp_rows` is empty/missing. Newly-saved
+    // submissions populate `_xp_rows` directly; these stay as compatibility
+    // surface for ST consumers that still read them in older code paths.
+    [`project_${n}_xp_category`]:  { type: 'string' },
+    [`project_${n}_xp_item`]:      { type: 'string' },
+    [`project_${n}_xp_dots`]:      { type: 'string' },
+    [`project_${n}_xp_trait`]:     { type: 'string' },
     // Secondary hunt method (for feed/rote action)
     [`project_${n}_feed_method2`]: { type: 'string', enum: feedMethodEnum },
     // JDT-2: Joint project authoring scratch fields. Persisted on the

--- a/specs/stories/dt-form.26-xp-spend-action.story.md
+++ b/specs/stories/dt-form.26-xp-spend-action.story.md
@@ -4,7 +4,7 @@ task: 26
 issue: 82
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/82
 epic: epic-dt-form-mvp-redesign
-status: Draft
+status: Ready for Dev
 priority: high
 depends_on: ['dt-form.17', 'dt-form.24', 'dt-form.31']
 hotfix_predecessor: 'GitHub issue #44'

--- a/specs/stories/dt-form.26-xp-spend-action.story.md
+++ b/specs/stories/dt-form.26-xp-spend-action.story.md
@@ -4,7 +4,7 @@ task: 26
 issue: 82
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/82
 epic: epic-dt-form-mvp-redesign
-status: Ready for Dev
+status: Ready for Review
 priority: high
 depends_on: ['dt-form.17', 'dt-form.24', 'dt-form.31']
 hotfix_predecessor: 'GitHub issue #44'
@@ -78,11 +78,11 @@ Survey current Admin xp_spend UI before move — its persistence keys, its compu
 
 ## Definition of Done
 
-- [ ] In-slot `xp_spend` action has full XP-spend UI (amount, target type, target selector, cost)
-- [ ] Merit selector category-filter logic (#44 hotfix) preserved as source of truth
-- [ ] Admin section's xp_spend sub-section removed from `DOWNTIME_SECTIONS`
-- [ ] Coordination with #31 documented
-- [ ] PR opened into `dev`
+- [x] In-slot `xp_spend` action has full XP-spend UI (amount, target type, target selector, cost) — multi-row grid via new `_renderProjectXpRows(n, saved)`
+- [x] Merit selector category-filter logic (#44 hotfix) preserved as source of truth — `getItemsForCategory('merit')` calls `getRulesByCategory('merit')` + `meetsPrereq` unchanged; `renderXpRow` reused as the row component
+- [x] Admin section's xp_spend sub-section removed from `DOWNTIME_SECTIONS` — already gone via #31; orphan collect block at downtime-form.js:436 neutered
+- [x] Coordination with #31 documented — PR body covers it
+- [x] PR opened into `dev` (with `Closes #82`)
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

Moves the full XP-spend UI out of the now-removed Admin section (lifted in #31) and into each Personal Action slot whose action type is `xp_spend`. One canonical XP-spend surface; multiple traits in one slot; full feature parity with the legacy Admin grid plus per-slot accounting.

New helper `_renderProjectXpRows(n, saved)` reuses the existing `renderXpRow()` row component — which already encodes [hotfix #44](https://github.com/angelusvmorningstar/TerraMortis/issues/44)'s merit-eligibility logic via `getItemsForCategory('merit')` → `getRulesByCategory('merit')` + `meetsPrereq`. **Source-of-truth preserved verbatim — no duplication, no override.**

Closes #82

## Schema + persistence (DAR-A1 mirror, DAR-B1 sub-array shape)

Both DAR-A and DAR-B were locked upfront by Khepri before any implementation:

- **Per-slot canonical (DAR-B1):** `responses.project_N_xp_rows` — JSON-stringified array of `{ category, item, dotsBuying }`. Documented in `downtime_submission.schema.js` projectSlotProps under explicit properties (rather than relying on `additionalProperties: true`) per Khepri's explicit-documentation directive.
- **Top-level mirror (DAR-A1):** `responses.xp_spend` rebuilt at the end of `collectResponses` by concatenating rows from every xp_spend slot. Existing readers keep working unchanged: the player-side budget validator at `submitForm:1263` and the ST-side `renderXpReviewStep()` at `admin/downtime-views.js:3637` both still parse `responses.xp_spend` as a JSON array — they get the canonical row set across all slots.
- **Backward-compat read:** when `_xp_rows` is empty/missing, `_renderProjectXpRows` seeds rows[0] from the legacy `_xp_category` / `_xp_item` / `_xp_dots` triple. Preserves any in-flight pre-redesign drafts in dev/ST test data.
- **Legacy `_xp_dots = '1'` placeholder dropped:** written as `'0'` so legacy readers see "no dots" rather than the stale sentinel.
- **Mirror only fires when at least one slot has rows.** Otherwise the spread base in collectResponses preserves any legacy top-level value untouched.

### Migration notes (DAR-A1 path chosen)

Top-level `responses.xp_spend` is mirror-built from per-slot on every `collectResponses`. Legacy in-flight drafts may show empty `xp_spend` slots after the player engages the redesigned UI. Acceptable because no production submissions exist (only dev/ST test data) at PR-merge time per Khepri/Piatra.

## Coordination with #31

#31 removed the Admin section structure entirely; this PR puts the XP-Spend functionality back in via the project-slot UI. The orphan `xp_grid` collector at `collectResponses:436` (which was reading the now-non-existent `dt-xp_spend` element) is neutered to a defensive `continue` — no DOWNTIME_SECTIONS question of type='xp_grid' exists anywhere, so the iteration never lands there in practice. Stale comment 'Also include admin xp_grid rows (free merits)' at `admin/downtime-views.js:3637` updated to reflect the new mirror semantics.

## Test plan

- [x] Static review — multi-row UI, hotfix #44 logic preserved (no edit to `getItemsForCategory('merit')`), schema additions, mirror semantics, orphan cleanup
- [x] Server tests 678/678 green (no schema-level test impact; additions are additive and the existing schemas tests load the file successfully)
- [ ] Browser smoke (deferred per story Test Plan):
  - [ ] Pick `xp_spend` in a project slot → multi-row grid appears with all categories including merit
  - [ ] Buy a Carthian Law / Invictus Oath → eligible with correct covenant gating (#44 logic)
  - [ ] Add 2-3 rows in one slot → cost annotation per row + slot total updates
  - [ ] Multiple xp_spend slots → cross-slot dots-remaining tracker correct
  - [ ] Save → reload → rows round-trip via `project_N_xp_rows`; top-level `responses.xp_spend` mirror has all rows concatenated
  - [ ] Legacy submission with only `_xp_category`/`_xp_item` → seeds rows[0] cleanly on first render
  - [ ] Player budget validator at submit time still catches over-budget across all slots