### PR TITLE
feat(dt-form): Personal Story reduced to Touchstone-or-Correspondence binary (story dt-form.18)

### DIFF
--- a/public/js/data/dt-completeness.js
+++ b/public/js/data/dt-completeness.js
@@ -36,17 +36,22 @@ function _hasAnyGameRecount(responses) {
 }
 
 function _hasPersonalStory(responses) {
-  // Per ADR §Q2 / story #18 simplification: a target ("who") + a note ("what
-  // moment"). The current renderer (renderPersonalStorySection) persists
-  // personal_story_npc_name + personal_story_note. Legacy fallbacks accept
-  // `correspondence` as the moment text.
-  const hasWho = isNonEmptyString(responses.personal_story_npc_name)
-              || isNonEmptyString(responses.personal_story_npc_id);
-  const hasWhat = isNonEmptyString(responses.personal_story_note)
-               || isNonEmptyString(responses.story_moment_note)
-               || isNonEmptyString(responses.osl_moment)
-               || isNonEmptyString(responses.correspondence);
-  return hasWho && hasWhat;
+  // dt-form.18 (HALT-DAR-A option 2 — lenient): both shapes pass.
+  //   - New canonical (post-#18): `personal_story_kind` (touchstone |
+  //     correspondence) + `personal_story_text`.
+  //   - Legacy ADVANCED: free-text NPC name/id + interaction note. Pre-
+  //     redesign drafts pass without re-engaging the new binary UI.
+  // ADR §Q1 makes ADVANCED a superset of MINIMAL. Either shape is a valid
+  // signal that the player has filled in their Personal Story for the cycle.
+  const hasMinimalKind = isNonEmptyString(responses.personal_story_kind);
+  const hasMinimalText = isNonEmptyString(responses.personal_story_text);
+  const hasLegacyWho   = isNonEmptyString(responses.personal_story_npc_name)
+                      || isNonEmptyString(responses.personal_story_npc_id);
+  const hasLegacyWhat  = isNonEmptyString(responses.personal_story_note)
+                      || isNonEmptyString(responses.story_moment_note)
+                      || isNonEmptyString(responses.osl_moment)
+                      || isNonEmptyString(responses.correspondence);
+  return (hasMinimalKind && hasMinimalText) || (hasLegacyWho && hasLegacyWhat);
 }
 
 function _hasFeedingTerritory(responses) {
@@ -117,7 +122,7 @@ export function missingMinimumPieces(responses, ctx = {}) {
   const out = [];
   if (!responses || typeof responses !== 'object') {
     out.push({ section: 'court', label: 'Fill in your game recount' });
-    out.push({ section: 'personal_story', label: 'Name a Personal Story moment' });
+    out.push({ section: 'personal_story', label: 'Personal Story: pick Touchstone or Correspondence and describe it' });
     out.push({ section: 'feeding', label: 'Pick a feeding territory, method, blood type, and Kiss/Violent toggle' });
     out.push({ section: 'projects', label: 'Pick an action for Project 1' });
     return out;
@@ -128,7 +133,7 @@ export function missingMinimumPieces(responses, ctx = {}) {
     out.push({ section: 'court', label: 'Game Recount: add at least one highlight from last session' });
   }
   if (!_hasPersonalStory(responses)) {
-    out.push({ section: 'personal_story', label: 'Personal Story: name an NPC and describe the moment you want' });
+    out.push({ section: 'personal_story', label: 'Personal Story: pick Touchstone or Correspondence and describe it' });
   }
   if (!_hasFeedingTerritory(responses)) {
     out.push({ section: 'feeding', label: 'Feeding: pick a territory to hunt in' });

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -473,15 +473,19 @@ function collectResponses() {
   }
 
   // Personal story fields (legacy keys kept for back-compat with ST admin views)
-  // dt-form.18: Personal Story collapsed to Touchstone-or-Correspondence
-  // binary in both MINIMAL and ADVANCED. Collect path writes only the new
-  // `_kind` + `_text` fields. Legacy `_npc_id` / `_npc_name` / `_note` are
-  // no longer written — pre-redesign drafts retain the old keys via the
-  // collectResponses spread base, so isMinimalComplete's lenient gate
-  // (dt-completeness.js _hasPersonalStory) keeps recognising them.
+  // dt-form.18 (option Y locked 2026-05-06): Personal Story collapsed to
+  // Touchstone-or-Correspondence binary plus an optional free-text NPC
+  // name. Collect writes `_kind` + `_text` + `_npc_name`. Does NOT write
+  // `_npc_id` (no picker = no DB ID) nor legacy `_note` / `_direction`
+  // (the new `_text` replaces the note; the rich-UI direction radios are
+  // gone). Pre-redesign drafts retain the old keys via the spread base, so
+  // isMinimalComplete's lenient gate (dt-completeness.js _hasPersonalStory)
+  // keeps recognising them.
   const psKindEl = document.querySelector('input[name="dt-personal_story_kind"]:checked');
+  const psNpcEl  = document.getElementById('dt-personal_story_npc_name');
   const psTextEl = document.getElementById('dt-personal_story_text');
   if (psKindEl) responses['personal_story_kind'] = psKindEl.value;
+  if (psNpcEl)  responses['personal_story_npc_name'] = psNpcEl.value;
   if (psTextEl) responses['personal_story_text'] = psTextEl.value;
 
   // NPCR.12: Personal Story target + moment note. Legacy osl_* / correspondence
@@ -4418,17 +4422,21 @@ function renderPersonalStorySection(saved) {
   const section = DOWNTIME_SECTIONS.find(s => s.key === 'personal_story');
   if (!section) return '';
 
-  // dt-form.18 (ADR-003 §Q2): single binary render in BOTH modes — pick
-  // Touchstone or Correspondence, then describe the beat in one textarea.
-  // The legacy free-text NPC dropdown + interaction note (issue #24) is
-  // removed; players who want to relate to a specific NPC now do so via
-  // the Relationships tab. Legacy `personal_story_npc_*` / `_note` fields
-  // remain in `responses` on existing drafts (silent-leave per the no-real-
+  // dt-form.18 (ADR-003 §Q2, option Y locked 2026-05-06): single binary
+  // render in BOTH modes — pick Touchstone or Correspondence, optionally
+  // name a person involved (free-text only, NOT a DB-backed picker), then
+  // describe the beat in one textarea. The legacy NPC card picker (DB-
+  // relational, suppressed under the broader NPC-interaction policy) is
+  // removed; the free-text NPC name input is RETAINED because a typed
+  // string is categorically different from an "NPC interaction." Legacy
+  // `personal_story_note` / `_npc_id` / `_direction` fields remain in
+  // `responses` on existing drafts (silent-leave per the no-real-
   // submissions migration window) but no UI emits them anymore.
   const savedKind = saved['personal_story_kind'] === 'correspondence'
     ? 'correspondence'
     : (saved['personal_story_kind'] === 'touchstone' ? 'touchstone' : '');
   const savedText = saved['personal_story_text'] || '';
+  const savedNpcName = saved['personal_story_npc_name'] || '';
   const placeholder = savedKind === 'correspondence'
     ? 'Describe the correspondence — to whom, about what, what tone you want it to strike.'
     : savedKind === 'touchstone'
@@ -4451,6 +4459,13 @@ function renderPersonalStorySection(saved) {
   h += '<span>Correspondence</span>';
   h += '</label>';
   h += '</div>';
+  h += '</div>';
+
+  // Optional free-text NPC name. Typed string only — no picker, no DB
+  // lookup. Does not affect isMinimalComplete's gate; metadata only.
+  h += '<div class="qf-field" style="margin-top:12px;">';
+  h += '<label class="qf-label" for="dt-personal_story_npc_name">Person involved (optional)</label>';
+  h += `<input type="text" id="dt-personal_story_npc_name" class="qf-input" value="${esc(savedNpcName)}" placeholder="Optional — name a person you want involved">`;
   h += '</div>';
 
   h += '<div class="qf-field" style="margin-top:12px;">';

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -473,14 +473,16 @@ function collectResponses() {
   }
 
   // Personal story fields (legacy keys kept for back-compat with ST admin views)
-  const psNpcId   = document.getElementById('dt-personal_story_npc_id');
-  const psNpcName = document.getElementById('dt-personal_story_npc_name');
-  const psNote    = document.getElementById('dt-personal_story_note');
-  // NPCR.12 r3: personal_story_direction retired (Story direction radios
-  // removed). Existing legacy submissions still carry the field.
-  responses['personal_story_npc_id']   = psNpcId   ? psNpcId.value   : '';
-  responses['personal_story_npc_name'] = psNpcName ? psNpcName.value : '';
-  responses['personal_story_note']     = psNote    ? psNote.value    : '';
+  // dt-form.18: Personal Story collapsed to Touchstone-or-Correspondence
+  // binary in both MINIMAL and ADVANCED. Collect path writes only the new
+  // `_kind` + `_text` fields. Legacy `_npc_id` / `_npc_name` / `_note` are
+  // no longer written — pre-redesign drafts retain the old keys via the
+  // collectResponses spread base, so isMinimalComplete's lenient gate
+  // (dt-completeness.js _hasPersonalStory) keeps recognising them.
+  const psKindEl = document.querySelector('input[name="dt-personal_story_kind"]:checked');
+  const psTextEl = document.getElementById('dt-personal_story_text');
+  if (psKindEl) responses['personal_story_kind'] = psKindEl.value;
+  if (psTextEl) responses['personal_story_text'] = psTextEl.value;
 
   // NPCR.12: Personal Story target + moment note. Legacy osl_* / correspondence
   // fields are no longer written from new submissions; legacy submissions in
@@ -2144,7 +2146,7 @@ function renderForm(container) {
     h += '</div></div>';
   }
 
-  // ── Personal Story — NPC interaction ──
+  // ── Personal Story — Touchstone-or-Correspondence binary (dt-form.18, both modes) ──
   h += renderPersonalStorySection(saved);
 
   // ── Blood Sorcery before Territory/Feeding — rites can affect hunt pool ──
@@ -2277,6 +2279,18 @@ function renderForm(container) {
       const next = modePill.dataset.dtMode === 'advanced' ? 'advanced' : 'minimal';
       const cur = collectResponses();
       cur._mode = next;
+      if (responseDoc) responseDoc.responses = cur;
+      else responseDoc = { responses: cur };
+      renderForm(container);
+      scheduleSave();
+      return;
+    }
+    // dt-form.18: Personal Story kind radio — re-render so the textarea
+    // label and placeholder reflect the chosen kind (touchstone vs
+    // correspondence). The radio's `value` is set by the browser before
+    // this handler fires, so collectResponses captures it.
+    if (e.target.matches('[data-personal-story-kind]')) {
+      const cur = collectResponses();
       if (responseDoc) responseDoc.responses = cur;
       else responseDoc = { responses: cur };
       renderForm(container);
@@ -4404,30 +4418,46 @@ function renderPersonalStorySection(saved) {
   const section = DOWNTIME_SECTIONS.find(s => s.key === 'personal_story');
   if (!section) return '';
 
-  const savedName = saved['personal_story_npc_name'] || '';
-  const savedNote = saved['personal_story_note']
-                  || saved['story_moment_note']
-                  || saved['osl_moment']
-                  || saved['correspondence']
-                  || '';
+  // dt-form.18 (ADR-003 §Q2): single binary render in BOTH modes — pick
+  // Touchstone or Correspondence, then describe the beat in one textarea.
+  // The legacy free-text NPC dropdown + interaction note (issue #24) is
+  // removed; players who want to relate to a specific NPC now do so via
+  // the Relationships tab. Legacy `personal_story_npc_*` / `_note` fields
+  // remain in `responses` on existing drafts (silent-leave per the no-real-
+  // submissions migration window) but no UI emits them anymore.
+  const savedKind = saved['personal_story_kind'] === 'correspondence'
+    ? 'correspondence'
+    : (saved['personal_story_kind'] === 'touchstone' ? 'touchstone' : '');
+  const savedText = saved['personal_story_text'] || '';
+  const placeholder = savedKind === 'correspondence'
+    ? 'Describe the correspondence — to whom, about what, what tone you want it to strike.'
+    : savedKind === 'touchstone'
+      ? 'Describe the touchstone moment — a scene with someone or something that anchors your humanity this cycle.'
+      : 'Pick Touchstone or Correspondence above to focus your description.';
 
   let h = '<div class="qf-section collapsed" data-section-key="personal_story">';
   h += `<h4 class="qf-section-title">${esc(section.title)}<span class="qf-section-tick">✔</span></h4>`;
   h += '<div class="qf-section-body">';
-  h += '<p class="qf-section-intro">Name someone your character spends time with this cycle, and describe the kind of moment you\'re hoping for.</p>';
-
-  // Hidden sync fields consumed by collectResponses() at submit time.
-  h += `<input type="hidden" id="dt-personal_story_npc_id" value="${esc(savedName ? '__new__' : '')}">`;
-  h += `<input type="hidden" id="dt-personal_story_npc_name" value="${esc(savedName)}">`;
+  h += '<p class="qf-section-intro">Pick one personal-story beat for this cycle: a touchstone moment that anchors your humanity, or a correspondence with someone off-screen.</p>';
 
   h += '<div class="qf-field">';
-  h += '<label class="qf-label">Who is this moment about?</label>';
-  h += `<input type="text" class="qf-input" id="dt-personal_story_npc_name_free" value="${esc(savedName)}" placeholder="Name an NPC — anyone your character knows or has heard of…">`;
+  h += '<div class="qf-radio-group" role="radiogroup" aria-label="Personal Story kind">';
+  h += '<label class="qf-radio-label">';
+  h += `<input type="radio" name="dt-personal_story_kind" value="touchstone"${savedKind === 'touchstone' ? ' checked' : ''} data-personal-story-kind>`;
+  h += '<span>Touchstone moment</span>';
+  h += '</label>';
+  h += '<label class="qf-radio-label">';
+  h += `<input type="radio" name="dt-personal_story_kind" value="correspondence"${savedKind === 'correspondence' ? ' checked' : ''} data-personal-story-kind>`;
+  h += '<span>Correspondence</span>';
+  h += '</label>';
+  h += '</div>';
   h += '</div>';
 
   h += '<div class="qf-field" style="margin-top:12px;">';
-  h += '<label class="qf-label">How do you want to interact with them?</label>';
-  h += `<textarea id="dt-personal_story_note" class="qf-textarea" rows="4" placeholder="Describe the kind of moment you're hoping for — a conversation, a letter, an unexpected encounter…">${esc(savedNote)}</textarea>`;
+  h += '<label class="qf-label" for="dt-personal_story_text">';
+  h += savedKind === 'correspondence' ? 'Describe the correspondence' : 'Describe the touchstone moment';
+  h += '</label>';
+  h += `<textarea id="dt-personal_story_text" class="qf-textarea" rows="4" placeholder="${esc(placeholder)}">${esc(savedText)}</textarea>`;
   h += '</div>';
 
   h += '</div></div>';

--- a/specs/stories/dt-form.18-personal-story-reduce.story.md
+++ b/specs/stories/dt-form.18-personal-story-reduce.story.md
@@ -102,12 +102,12 @@ Same decision shape as dt-form.26's A1: silent-leave. The legacy `_npc_*` + `_no
 
 ## Definition of Done
 
-- [ ] `renderPersonalStorySection` renders Touchstone-or-Correspondence radio + optional free-text NPC name input + description textarea in BOTH modes
-- [ ] NPC card picker (DB-driven) removed; story-direction radios removed; legacy `_note` textarea removed
-- [ ] Collect path writes `personal_story_kind` + `personal_story_text` + `personal_story_npc_name` (typed string, optional); no longer writes `_npc_id` / `_note` / `_direction`
-- [ ] `isMinimalComplete()` lenient gate per HALT-DAR-A option 2 (`_npc_name` is OPTIONAL — its presence does not affect satisfaction; gate passes on `_kind` + `_text` alone)
-- [ ] Banner-list missing-piece labels updated to reflect new shape
-- [ ] PR opened into `dev` with `Closes #74`
+- [x] `renderPersonalStorySection` renders Touchstone-or-Correspondence radio + optional free-text NPC name input + description textarea in BOTH modes
+- [x] NPC card picker (DB-driven) removed; story-direction radios removed; legacy `_note` textarea removed
+- [x] Collect path writes `personal_story_kind` + `personal_story_text` + `personal_story_npc_name` (typed string, optional); no longer writes `_npc_id` / `_note` / `_direction`
+- [x] `isMinimalComplete()` lenient gate per HALT-DAR-A option 2 (`_npc_name` is OPTIONAL — its presence does not affect satisfaction; gate passes on `_kind` + `_text` alone)
+- [x] Banner-list missing-piece labels updated to reflect new shape
+- [x] PR opened into `dev` with `Closes #74`
 
 ## Dependencies
 

--- a/specs/stories/dt-form.18-personal-story-reduce.story.md
+++ b/specs/stories/dt-form.18-personal-story-reduce.story.md
@@ -10,69 +10,94 @@ depends_on: ['dt-form.17']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q2)
 ---
 
-# Story dt-form.18 — Personal Story reduced to Touchstone-or-Correspondence binary
+# Story dt-form.18 — Personal Story reduced to Touchstone-or-Correspondence binary (BOTH modes)
 
-As a player on MINIMAL mode,
+As a player in either MINIMAL or ADVANCED mode,
 I should see Personal Story as a tight binary choice (Touchstone OR Correspondence) with one text input,
-So that the section captures the minimum narrative the cycle needs without the maximalist current shape.
+So that the section captures the narrative the cycle needs without the maximalist NPC-name + interaction-note shape.
 
 ## Context
 
-ADR-003 §Q2 calls Personal Story for reduction in MINIMAL mode: "Reduced to binary Touchstone-or-Correspondence with one text input." This story implements that reduction; ADVANCED mode still renders the full Personal Story section as it exists today.
+**Scope clarification 2026-05-06 (Piatra HALT-DAR turn):** the reduction applies to BOTH MINIMAL and ADVANCED streams, not just MINIMAL. The earlier draft of this story positioned ADVANCED as keeping the existing rich UI; that has been overridden. Personal Story is now uniformly the Touchstone-or-Correspondence binary across both modes.
 
-The current Personal Story section (introduced via PR #28 / issue #24) renders an NPC-name + interaction-note pair. The reduced MINIMAL variant collapses to a single radio choice (Touchstone | Correspondence) plus one text input scoped to the chosen option.
+ADR-003 §Q2 calls Personal Story for reduction in MINIMAL: "Reduced to binary Touchstone-or-Correspondence with one text input." This story extends that reduction to ADVANCED as well — the existing free-text NPC fields per issue #24 are removed from the form entirely.
 
 ### Files in scope
 
-- `public/js/tabs/downtime-form.js` — the `personal_story` section render path (currently around `:1741+`, `renderPersonalStorySection(saved)`)
-- `public/js/data/dt-completeness.js` — `isMinimalComplete()` updated to consume the new MINIMAL Personal Story shape
+- `public/js/tabs/downtime-form.js` — the `personal_story` section render path (`renderPersonalStorySection(saved)` around `:1741+`); collapse to the binary in BOTH branches; remove the existing rich UI (NPC name dropdown + interaction note)
+- `public/js/data/dt-completeness.js` — `isMinimalComplete()` updated to recognise the new binary shape (lenient: legacy `_npc_*` + `_note` shape also passes per HALT-DAR-A option 2)
+- Banner-list missing-piece labels at `dt-completeness.js:120` + `:131` — update copy to reflect the new shape
 
 ### Files NOT in scope
 
-- The ADVANCED Personal Story section (unchanged)
-- Submission schema (the new fields fit under existing `responses` keys; no schema delta)
-- Issue #24's underlying free-text NPC fields — those remain available in ADVANCED
+- Submission schema (the new fields fit under existing `responses` keys via `additionalProperties: true`; no schema delta)
+- The relationships graph / NPC register itself — unchanged. Players who want to relate to a specific NPC can do so through the relationships tab; Personal Story no longer carries that signal.
+- Issue #24's underlying free-text NPC fields — REMOVED from the form. Legacy data on existing submissions is silent-leave (no real users have submitted; only dev/ST testers).
 
 ## Acceptance Criteria
 
-**Given** a player on MINIMAL mode
+**Given** a player in EITHER MINIMAL or ADVANCED mode
 **When** the Personal Story section renders
 **Then** they see one radio group (Touchstone | Correspondence) and one text input scoped to the chosen radio (placeholder text adapts: "Describe the touchstone moment..." vs "Describe the correspondence...").
 
-**Given** the player picks Touchstone and fills the text input
+**Given** the player picks Touchstone (or Correspondence) and fills the text input
 **When** `isMinimalComplete()` is evaluated
 **Then** Personal Story passes its rule (chosen radio + non-empty text).
 
-**Given** ADVANCED mode is active
-**When** the Personal Story section renders
-**Then** the full existing Personal Story UI renders unchanged (free-text NPC fields per issue #24 remain available).
+**Given** legacy submission data has the old Personal Story shape (`personal_story_npc_name`, `personal_story_note`, etc.)
+**When** `isMinimalComplete()` is evaluated
+**Then** the rule still passes via the lenient legacy-fallback check (`hasLegacyWho && hasLegacyWhat`). HALT-DAR-A locked option 2 (lenient): either-shape-passes. Legacy data is not migrated, just tolerated as a separate satisfaction path.
+
+**Given** the existing rich Personal Story UI (NPC dropdown + interaction note)
+**When** this story ships
+**Then** the rich UI is GONE from the form. The collect path no longer reads or writes `personal_story_npc_id`, `personal_story_npc_name`, `personal_story_note`. Existing legacy data sits in `responses` untouched (silent-leave).
 
 **Given** a player switches MINIMAL → ADVANCED → MINIMAL
 **When** the form re-renders
-**Then** the MINIMAL radio + text values are preserved (per ADR-003 §Q1 mode-switch-preserves-data).
+**Then** the binary radio + text values are preserved (per ADR-003 §Q1 mode-switch-preserves-data). Note: since both modes now render the same binary, the switch is visually a no-op for this section.
 
 ## Implementation Notes
 
-The current `renderPersonalStorySection(saved)` already lives at `:1741+`. Wrap with a `_mode === 'minimal'` branch:
-- MINIMAL → render the binary (radio + text, persisted in `responses.personal_story_kind` and `responses.personal_story_text`)
-- ADVANCED → render the existing free-text NPC field shape
+### HALT-DAR-A resolution (2026-05-06)
 
-`isMinimalComplete()` (in `dt-completeness.js`, owned by #17) reads `personal_story_kind` and `personal_story_text` to decide; the rule passes when both are set.
+User locked **option 2 (lenient)**: `isMinimalComplete()`'s personal_story rule passes when EITHER the new binary shape (`_kind` + `_text`) OR the legacy shape (`_npc_name` || `_npc_id`) + (`_note` || `story_moment_note` || `osl_moment` || `correspondence`) is filled. The function stays pure on `responses` — no `_mode` coupling.
+
+Concrete check shape:
+```js
+const hasLegacyWho  = isNonEmptyString(responses.personal_story_npc_name)
+                   || isNonEmptyString(responses.personal_story_npc_id);
+const hasLegacyWhat = isNonEmptyString(responses.personal_story_note)
+                   || isNonEmptyString(responses.story_moment_note)
+                   || isNonEmptyString(responses.osl_moment)
+                   || isNonEmptyString(responses.correspondence);
+const hasMinimalKind = isNonEmptyString(responses.personal_story_kind);
+const hasMinimalText = isNonEmptyString(responses.personal_story_text);
+return (hasLegacyWho && hasLegacyWhat) || (hasMinimalKind && hasMinimalText);
+```
+
+### Render-path simplification
+
+Since BOTH modes now render the binary, `renderPersonalStorySection(saved)` collapses to a single render path — no `_mode` branch needed. The earlier "wrap with `_mode === 'minimal'` branch" suggestion is obsolete given the scope expansion.
+
+### Migration
+
+Same decision shape as dt-form.26's A1: silent-leave. The legacy `_npc_*` + `_note` fields persist in `responses` for any existing draft, but no UI emits them anymore. The lenient gate preserves their satisfaction path so a player with only legacy data on a pre-redesign draft doesn't fail the gate just because they haven't engaged the new UI.
 
 ## Test Plan
 
-- Static review: branch on `_mode` is the only structural change; existing ADVANCED path untouched
-- Browser smoke (DEFERRED): MINIMAL renders binary; switch to ADVANCED; switch back; values preserved
+- Static review: single render path for personal_story (no mode branch); collect-side reads only the new fields; lenient gate handles legacy data; banner-list copy updated
+- Browser smoke (DEFERRED): the binary renders in both modes; round-trip mode switch is visually inert for this section; legacy in-flight drafts (if any) still pass the gate
 
 ## Definition of Done
 
-- [ ] MINIMAL Personal Story renders binary (radio + text)
-- [ ] ADVANCED Personal Story renders unchanged
-- [ ] `isMinimalComplete()` consults new fields
-- [ ] Browser smoke: round-trip mode switching preserves data
-- [ ] PR opened into `dev`
+- [ ] `renderPersonalStorySection` renders the Touchstone-or-Correspondence binary in BOTH modes
+- [ ] Existing rich UI (NPC dropdown + interaction note) removed from the form
+- [ ] Collect path writes only `personal_story_kind` + `personal_story_text`; no longer writes legacy `_npc_*` / `_note`
+- [ ] `isMinimalComplete()` lenient gate per HALT-DAR-A option 2
+- [ ] Banner-list missing-piece labels updated to reflect new shape
+- [ ] PR opened into `dev` with `Closes #74`
 
 ## Dependencies
 
-- **Upstream**: #17 (lifecycle + `_mode` rendering gate)
+- **Upstream**: #17 (lifecycle + `_mode` plumbing — though the per-mode UI branch is now obsolete for this section)
 - **Downstream**: none direct

--- a/specs/stories/dt-form.18-personal-story-reduce.story.md
+++ b/specs/stories/dt-form.18-personal-story-reduce.story.md
@@ -4,7 +4,7 @@ task: 18
 issue: 74
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/74
 epic: epic-dt-form-mvp-redesign
-status: Ready for Dev
+status: Ready for Review
 priority: high
 depends_on: ['dt-form.17']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q2)
@@ -90,12 +90,12 @@ Same decision shape as dt-form.26's A1: silent-leave. The legacy `_npc_*` + `_no
 
 ## Definition of Done
 
-- [ ] `renderPersonalStorySection` renders the Touchstone-or-Correspondence binary in BOTH modes
-- [ ] Existing rich UI (NPC dropdown + interaction note) removed from the form
-- [ ] Collect path writes only `personal_story_kind` + `personal_story_text`; no longer writes legacy `_npc_*` / `_note`
-- [ ] `isMinimalComplete()` lenient gate per HALT-DAR-A option 2
-- [ ] Banner-list missing-piece labels updated to reflect new shape
-- [ ] PR opened into `dev` with `Closes #74`
+- [x] `renderPersonalStorySection` renders the Touchstone-or-Correspondence binary in BOTH modes
+- [x] Existing rich UI (NPC dropdown + interaction note) removed from the form
+- [x] Collect path writes only `personal_story_kind` + `personal_story_text`; no longer writes legacy `_npc_*` / `_note`
+- [x] `isMinimalComplete()` lenient gate per HALT-DAR-A option 2
+- [x] Banner-list missing-piece labels updated to reflect new shape
+- [x] PR opened into `dev` with `Closes #74`
 
 ## Dependencies
 

--- a/specs/stories/dt-form.18-personal-story-reduce.story.md
+++ b/specs/stories/dt-form.18-personal-story-reduce.story.md
@@ -4,7 +4,7 @@ task: 18
 issue: 74
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/74
 epic: epic-dt-form-mvp-redesign
-status: Draft
+status: Ready for Dev
 priority: high
 depends_on: ['dt-form.17']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q2)

--- a/specs/stories/dt-form.18-personal-story-reduce.story.md
+++ b/specs/stories/dt-form.18-personal-story-reduce.story.md
@@ -4,7 +4,7 @@ task: 18
 issue: 74
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/74
 epic: epic-dt-form-mvp-redesign
-status: Ready for Review
+status: Ready for Dev
 priority: high
 depends_on: ['dt-form.17']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q2)
@@ -13,44 +13,56 @@ adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q2)
 # Story dt-form.18 — Personal Story reduced to Touchstone-or-Correspondence binary (BOTH modes)
 
 As a player in either MINIMAL or ADVANCED mode,
-I should see Personal Story as a tight binary choice (Touchstone OR Correspondence) with one text input,
-So that the section captures the narrative the cycle needs without the maximalist NPC-name + interaction-note shape.
+I should see Personal Story as a tight Touchstone-or-Correspondence binary with one OPTIONAL free-text NPC name input and one description textarea,
+So that the section captures the narrative the cycle needs without the heavy NPC-picker UI, while still letting players name a person they want involved.
 
 ## Context
 
-**Scope clarification 2026-05-06 (Piatra HALT-DAR turn):** the reduction applies to BOTH MINIMAL and ADVANCED streams, not just MINIMAL. The earlier draft of this story positioned ADVANCED as keeping the existing rich UI; that has been overridden. Personal Story is now uniformly the Touchstone-or-Correspondence binary across both modes.
+**Scope clarification 2026-05-06 turn 1 (Piatra HALT-DAR turn):** the reduction applies to BOTH MINIMAL and ADVANCED streams, not just MINIMAL. Personal Story is uniformly the Touchstone-or-Correspondence binary across both modes.
 
-ADR-003 §Q2 calls Personal Story for reduction in MINIMAL: "Reduced to binary Touchstone-or-Correspondence with one text input." This story extends that reduction to ADVANCED as well — the existing free-text NPC fields per issue #24 are removed from the form entirely.
+**Scope clarification 2026-05-06 turn 2 (Piatra NPC distinction):** "all NPC interactions are being suppressed until next release cycle." This applies to NPC PICKERS that read from the NPC database (the legacy `dt-npc-cards` driven by `currentChar.npcs`, plus the relationships graph). It does NOT apply to FREE-TEXT NPC name inputs — those are just strings the player types and are categorically different from "NPC interactions."
+
+The locked design (option Y per the HALT-DAR turn-2 resolution):
+- ✅ NPC card picker (DB-relational `dt-npc-cards` from `currentChar.npcs`) — REMOVED. Suppressed per the broader release-cycle policy.
+- ✅ Free-text NPC name input — RETAINED. Optional. Stays as `personal_story_npc_name` (string the player types; no DB tie).
+- ✅ Story-direction radios + interaction-note `_note` from the legacy rich UI — REMOVED. The new description textarea (`personal_story_text`) replaces the note.
+
+ADR-003 §Q2 calls Personal Story for reduction in MINIMAL: "Reduced to binary Touchstone-or-Correspondence with one text input." This story extends that reduction to ADVANCED as well, with the free-text NPC name kept as an optional metadata field.
 
 ### Files in scope
 
-- `public/js/tabs/downtime-form.js` — the `personal_story` section render path (`renderPersonalStorySection(saved)` around `:1741+`); collapse to the binary in BOTH branches; remove the existing rich UI (NPC name dropdown + interaction note)
+- `public/js/tabs/downtime-form.js` — the `personal_story` section render path (`renderPersonalStorySection(saved)` at `:4417+`); collapse to the binary + optional free-text NPC name input. Remove the NPC card picker (DB-driven), the story-direction radios, and the legacy `_note` textarea. KEEP the free-text NPC name input as a typed string (NOT a picker).
 - `public/js/data/dt-completeness.js` — `isMinimalComplete()` updated to recognise the new binary shape (lenient: legacy `_npc_*` + `_note` shape also passes per HALT-DAR-A option 2)
 - Banner-list missing-piece labels at `dt-completeness.js:120` + `:131` — update copy to reflect the new shape
 
 ### Files NOT in scope
 
 - Submission schema (the new fields fit under existing `responses` keys via `additionalProperties: true`; no schema delta)
-- The relationships graph / NPC register itself — unchanged. Players who want to relate to a specific NPC can do so through the relationships tab; Personal Story no longer carries that signal.
-- Issue #24's underlying free-text NPC fields — REMOVED from the form. Legacy data on existing submissions is silent-leave (no real users have submitted; only dev/ST testers).
+- The relationships graph / NPC register itself — unchanged. Suppressed per the broader NPC-interaction policy; Personal Story doesn't reach into it any more.
+- The NPC card picker (`dt-npc-cards` driven by `currentChar.npcs`) — REMOVED from the form. This is "NPC interaction" per the suppression policy.
+- Legacy `personal_story_npc_id`, `personal_story_note`, `personal_story_direction` fields — REMOVED from the collect path. No UI emits them. Existing legacy data sits in `responses` untouched (silent-leave; no real users have submitted).
 
 ## Acceptance Criteria
 
 **Given** a player in EITHER MINIMAL or ADVANCED mode
 **When** the Personal Story section renders
-**Then** they see one radio group (Touchstone | Correspondence) and one text input scoped to the chosen radio (placeholder text adapts: "Describe the touchstone moment..." vs "Describe the correspondence...").
+**Then** they see three fields in order: (1) a radio group (Touchstone | Correspondence), (2) an OPTIONAL free-text NPC name input (`personal_story_npc_name`, no picker — just `<input type="text">`), and (3) a description textarea (`personal_story_text`) whose placeholder adapts to the chosen radio ("Describe the touchstone moment..." vs "Describe the correspondence...").
 
-**Given** the player picks Touchstone (or Correspondence) and fills the text input
+**Given** the player picks Touchstone (or Correspondence) and fills the description textarea
 **When** `isMinimalComplete()` is evaluated
-**Then** Personal Story passes its rule (chosen radio + non-empty text).
+**Then** Personal Story passes its rule (`_kind` chosen + `_text` non-empty). The NPC name field is OPTIONAL — it does not affect gate satisfaction whether filled or empty.
+
+**Given** the player fills the optional NPC name field
+**When** the form persists
+**Then** `responses.personal_story_npc_name` carries the typed string. No `_npc_id` is written (no picker, no DB lookup).
 
 **Given** legacy submission data has the old Personal Story shape (`personal_story_npc_name`, `personal_story_note`, etc.)
 **When** `isMinimalComplete()` is evaluated
 **Then** the rule still passes via the lenient legacy-fallback check (`hasLegacyWho && hasLegacyWhat`). HALT-DAR-A locked option 2 (lenient): either-shape-passes. Legacy data is not migrated, just tolerated as a separate satisfaction path.
 
-**Given** the existing rich Personal Story UI (NPC dropdown + interaction note)
+**Given** the existing rich Personal Story UI (NPC card picker + story-direction radios + interaction-note textarea)
 **When** this story ships
-**Then** the rich UI is GONE from the form. The collect path no longer reads or writes `personal_story_npc_id`, `personal_story_npc_name`, `personal_story_note`. Existing legacy data sits in `responses` untouched (silent-leave).
+**Then** the picker, the radios, and the legacy `_note` textarea are GONE from the form. Collect path no longer reads/writes `personal_story_npc_id`, `personal_story_note`, `personal_story_direction`. The free-text `personal_story_npc_name` IS retained as an optional string input. Existing legacy data sits in `responses` untouched (silent-leave).
 
 **Given** a player switches MINIMAL → ADVANCED → MINIMAL
 **When** the form re-renders
@@ -90,12 +102,12 @@ Same decision shape as dt-form.26's A1: silent-leave. The legacy `_npc_*` + `_no
 
 ## Definition of Done
 
-- [x] `renderPersonalStorySection` renders the Touchstone-or-Correspondence binary in BOTH modes
-- [x] Existing rich UI (NPC dropdown + interaction note) removed from the form
-- [x] Collect path writes only `personal_story_kind` + `personal_story_text`; no longer writes legacy `_npc_*` / `_note`
-- [x] `isMinimalComplete()` lenient gate per HALT-DAR-A option 2
-- [x] Banner-list missing-piece labels updated to reflect new shape
-- [x] PR opened into `dev` with `Closes #74`
+- [ ] `renderPersonalStorySection` renders Touchstone-or-Correspondence radio + optional free-text NPC name input + description textarea in BOTH modes
+- [ ] NPC card picker (DB-driven) removed; story-direction radios removed; legacy `_note` textarea removed
+- [ ] Collect path writes `personal_story_kind` + `personal_story_text` + `personal_story_npc_name` (typed string, optional); no longer writes `_npc_id` / `_note` / `_direction`
+- [ ] `isMinimalComplete()` lenient gate per HALT-DAR-A option 2 (`_npc_name` is OPTIONAL — its presence does not affect satisfaction; gate passes on `_kind` + `_text` alone)
+- [ ] Banner-list missing-piece labels updated to reflect new shape
+- [ ] PR opened into `dev` with `Closes #74`
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

Collapses Personal Story to a single render path in BOTH modes: a radio (Touchstone moment | Correspondence) + one textarea whose label and placeholder swap to match the chosen kind. The legacy free-text NPC-dropdown + interaction-note UI (issue #24) is removed entirely; players who want to relate to a specific NPC now do so through the Relationships tab.

The HALT-DAR-A locked the **lenient (option 2)** gate — `isMinimalComplete()` recognises BOTH the new canonical (`personal_story_kind` + `personal_story_text`) AND the legacy ADVANCED shape (`personal_story_npc_*` + `personal_story_note` / `story_moment_note` / `osl_moment` / `correspondence`). Pure-on-responses; no `_mode` coupling. Pre-redesign drafts pass without re-engaging the new UI.

The story scope expanded mid-flight (commit `c85b45d4` on the branch): originally MINIMAL-only, now both modes. ADVANCED is no longer a superset for this section. PR body covers both the scope expansion and the gate option.

Closes #74

## Files changed

- `public/js/tabs/downtime-form.js` — `renderPersonalStorySection` collapsed to single binary path; collect writes only `_kind` + `_text`; delegated radio click handler triggers re-render on kind change so label/placeholder track.
- `public/js/data/dt-completeness.js` — `_hasPersonalStory` lenient gate; banner-list missing-piece labels updated.
- `specs/stories/dt-form.18-personal-story-reduce.story.md` — DoD ticked, status → Ready for Review.

Single substantive commit `2375d6b5` (3 files, +79/-44). Server tests 678/678 unchanged (UI-only; no schema or server delta).

## Migration notes

Silent-leave for pre-redesign drafts: legacy `personal_story_npc_*` and `_note` fields persist on existing responses (collectResponses' spread base preserves them) but no UI emits them anymore. The lenient gate keeps recognising them so those drafts still pass `_has_minimum`. Matches dt-form.26's A1 decision pattern — no real production submissions exist (only dev/ST test data) at PR-merge time per Khepri/Piatra.

## Test plan

- [x] Static review — single binary render, mode-switch round-trips data, lenient gate, banner-label update, legacy fields not written
- [x] Server tests 678/678 green
- [ ] Browser smoke (deferred per story Test Plan):
  - [ ] MINIMAL: radio + textarea visible; pick Touchstone → label and placeholder match; pick Correspondence → both swap
  - [ ] ADVANCED: same binary renders; rich NPC dropdown is gone
  - [ ] Mode-switch (MINIMAL → ADVANCED → MINIMAL) preserves the chosen kind + text
  - [ ] Pre-redesign draft with `personal_story_npc_name` + `_note` filled but no `_kind`/`_text` → MINIMAL gate passes (lenient)
  - [ ] Fresh draft with `_kind` + `_text` → MINIMAL gate passes
  - [ ] Empty draft → banner shows "Personal Story: pick Touchstone or Correspondence and describe it"