### PR TITLE
fix(dt-form): submit button loses handler after re-render — event delegation fix (dt-form.34)

### DIFF
--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -856,7 +856,7 @@ async function saveDraft() {
   const nextStatus = hasMinimum ? 'submitted' : 'draft';
 
   try {
-    if (!responseDoc) {
+    if (!responseDoc?._id) {
       responseDoc = await apiPost('/api/downtime_submissions', {
         character_id: currentChar._id,
         character_name: currentChar.name,
@@ -1201,7 +1201,7 @@ async function submitForm() {
   if (btn) { btn.disabled = true; btn.textContent = 'Submitting\u2026'; }
 
   try {
-    if (!responseDoc) {
+    if (!responseDoc?._id) {
       responseDoc = await apiPost('/api/downtime_submissions', {
         character_id: currentChar._id,
         character_name: currentChar.name,

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -2161,6 +2161,12 @@ function renderForm(container) {
       scheduleSave();
       return;
     }
+    // dt-form.34: delegated submit — survives re-renders; direct listener below was lost
+    // after any inline renderForm() call (sorcery rite change, feed pool, mode toggle).
+    if (e.target.closest('#dt-btn-submit')) {
+      submitForm();
+      return;
+    }
     // dt-form.31: Submit Final button (ADVANCED only) opens the modal.
     if (e.target.closest('#dt-btn-submit-final')) {
       e.preventDefault();
@@ -3195,7 +3201,7 @@ function renderForm(container) {
     updateSectionTicks(container);
   });
 
-  document.getElementById('dt-btn-submit')?.addEventListener('click', submitForm);
+  // dt-form.34: submit handled via delegated click listener above (survives re-renders).
 }
 
 // ── Cast picker modal ──

--- a/specs/stories/dt-form.34-submit-btn-lost-after-rerender.story.md
+++ b/specs/stories/dt-form.34-submit-btn-lost-after-rerender.story.md
@@ -1,0 +1,172 @@
+---
+id: dt-form.34
+task: 34
+issue: 95
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/95
+branch: morningstar-issue-95-blood-sorcery-rite-persist
+epic: epic-dt-form-mvp-redesign
+status: done
+priority: high
+depends_on: ['dt-form.17']
+adr: specs/architecture/adr-003-dt-form-cross-cutting.md
+---
+
+# Story dt-form.34 — Fix: Submit button loses click handler after inline re-render
+
+As a player using the downtime form,
+I should be able to click "Submit Downtime" / "Update Submission" after any inline re-render (e.g. selecting a Blood Sorcery rite, changing the feed pool selectors),
+So that my form actually saves when I click the button, regardless of how many re-renders have occurred.
+
+## Context
+
+GH #95 was filed after Anichka's Blood Sorcery rite selection did not persist after save + hard refresh. Investigation traced the root cause to a broken event delegation pattern — not to the sorcery collection logic itself.
+
+### Root Cause
+
+`renderForm(container)` sets `container.innerHTML = h` on every render, which destroys all existing child DOM elements (including the Submit button) and inserts fresh ones. Event wiring is guarded:
+
+```javascript
+// downtime-form.js line 2144
+if (container._dtWired) return;
+container._dtWired = true;
+```
+
+All event listeners are wired **once only** on the first render. The `#dt-btn-submit` listener is bound directly to the button element:
+
+```javascript
+// downtime-form.js line 3198
+document.getElementById('dt-btn-submit')?.addEventListener('click', submitForm);
+```
+
+When any inline re-render fires (sorcery rite change, feed pool select change, mode toggle), `container.innerHTML = h` replaces the DOM. The old button element — and its click listener — is destroyed. The new button has no listener. Subsequent clicks on "Submit Downtime" fire nothing, silently.
+
+The container's delegated click handler (wired once to `container` which itself is not replaced) already handles `#dt-btn-submit-final` via `e.target.closest()`:
+
+```javascript
+// downtime-form.js line 2165
+if (e.target.closest('#dt-btn-submit-final')) {
+  e.preventDefault();
+  openSubmitFinalModal(container);
+  return;
+}
+```
+
+The `#dt-btn-submit` button has no equivalent delegated handler — an oversight.
+
+### Why This Showed Up with Story #27
+
+Before dt-form.27, blood sorcery rendered before the mode toggle affected it for ADVANCED users. Story #27 moved the section inside `if (mode === 'advanced')`, so every user now switches from MINIMAL → ADVANCED to reach it. That mode switch triggers `renderForm()`, which is the first re-render, which loses the submit listener. The bug pre-existed #27 but was invisible to sorcery users who never triggered a re-render before submitting.
+
+### Files in Scope
+
+- `public/js/tabs/downtime-form.js` — two changes:
+  1. Add `#dt-btn-submit` to the delegated click handler (~line 2165)
+  2. Remove the direct `addEventListener` at line 3198
+
+### Files NOT in Scope
+
+- `collectResponses()` — sorcery collection logic is correct; no change needed
+- `renderSorcerySection()` — no change needed
+- `scheduleSave()` — no change needed
+- Server-side downtime route — no change needed
+- Any other story's code
+
+## Acceptance Criteria
+
+**Given** a player opens the downtime form in MINIMAL mode and switches to ADVANCED
+**When** they fill in the Blood Sorcery section and click "Submit Downtime" / "Update Submission"
+**Then** the form saves (status indicator shows "Saved HH:MM" or transitions to submitted state) and the rite selection persists on hard refresh
+
+**Given** a player changes the feed pool selectors (attr / skill / discipline dropdowns) which trigger a re-render
+**When** they then click "Submit Downtime"
+**Then** the form saves correctly
+
+**Given** any inline re-render (sorcery rite, feed pool, mode toggle)
+**When** the Submit button is clicked
+**Then** `submitForm()` is invoked — button shows "Submitting…" while in-flight
+
+**Given** the form loads fresh (no prior re-render)
+**When** the Submit button is clicked
+**Then** behaviour is unchanged (submit still works as before — regression check)
+
+## Implementation Notes
+
+### The Fix — `public/js/tabs/downtime-form.js`
+
+**Step 1 — add delegated handler for `#dt-btn-submit` inside the container click listener (~line 2165):**
+
+```javascript
+// dt-form.34: delegated submit — survives re-renders unlike the direct listener below.
+if (e.target.closest('#dt-btn-submit')) {
+  submitForm();
+  return;
+}
+// dt-form.31: Submit Final button (ADVANCED only) opens the modal.
+if (e.target.closest('#dt-btn-submit-final')) {
+  e.preventDefault();
+  openSubmitFinalModal(container);
+  return;
+}
+```
+
+**Step 2 — remove the now-redundant direct listener at line 3198:**
+
+```javascript
+// DELETE this line:
+document.getElementById('dt-btn-submit')?.addEventListener('click', submitForm);
+```
+
+That is the entire fix. Two lines changed. No other logic touched.
+
+### What NOT to Change
+
+- The `_dtWired` guard pattern — correct; keep it
+- The `#dt-btn-submit-final` handler — already correctly delegated; leave it
+- `collectResponses()` — the sorcery collection was correct all along
+- The mode toggle handler or sorcery select change handler
+
+## Test Plan
+
+- Static review: `document.getElementById('dt-btn-submit')` line removed; `e.target.closest('#dt-btn-submit')` case added before the submit-final case
+- Browser smoke (required before PR):
+  1. Open form as Anichka (Crúac). Switch to ADVANCED. Select a rite. Click "Submit Downtime" — confirm status shows "Saved" or submitted state. Hard refresh — confirm rite persists.
+  2. Change a feed pool selector (triggers re-render). Click "Submit Downtime" — confirm saves.
+  3. Open form as a non-sorcery character in MINIMAL. Click "Submit Downtime" — confirm saves (regression check).
+
+## Definition of Done
+
+- [x] `document.getElementById('dt-btn-submit')` direct listener removed from line 3198
+- [x] `e.target.closest('#dt-btn-submit')` delegated handler added to container click listener
+- [x] Smoke test 1: rite persists after switch MINIMAL→ADVANCED → select → submit → hard refresh
+- [x] Smoke test 2: submit works after feed pool re-render
+- [x] Smoke test 3: submit works on fresh form with no prior re-render (regression)
+- [ ] PR opened into `dev`
+
+## Dev Agent Record
+
+**Agent:** Claude Sonnet 4.6 (James)
+**Date:** 2026-05-06
+
+### File List
+
+**Modified**
+- `public/js/tabs/downtime-form.js` — delegated `#dt-btn-submit` handler; removed direct listener; fixed `saveDraft`/`submitForm` POST-vs-PUT guard to check `_id` presence
+
+### Completion Notes
+
+Three changes total. (1) Added delegated handler for `#dt-btn-submit` inside the container click listener — same pattern as `#dt-btn-submit-final`, survives `container.innerHTML` re-renders. (2) Removed the direct `document.getElementById` listener that was destroyed on every re-render. (3) Fixed `saveDraft()` and `submitForm()` POST-vs-PUT guard: changed `!responseDoc` to `!responseDoc?._id` so the mode-toggle's in-memory responseDoc (which has no `_id`) routes to POST rather than PUT to `/undefined`.
+
+Smoke tests confirmed on live server (localhost:8080 against real API, no dev fixtures): test 1 with Charles Mercer (rite persists), tests 2–3 with any character. Anichka's form has unrelated blocking issues logged separately.
+
+### Change Log
+
+| Date | Author | Change |
+|---|---|---|
+| 2026-05-06 | James (story) | Story created from GH #95. Root cause identified during create-story analysis: submit button loses delegated handler after re-renders. Status → ready. |
+| 2026-05-06 | James (dev) | Implemented fix: delegated #dt-btn-submit handler; removed direct listener. Status → review. |
+| 2026-05-06 | James (dev) | Additional fix: POST-vs-PUT guard uses `!responseDoc?._id`; diagnostic logs added then removed; all smoke tests passed. Status → done. |
+
+## Dependencies
+
+- **Upstream**: #17 (MINIMAL/ADVANCED mode lifecycle — the re-render pattern that triggers the bug)
+- **Downstream**: dt-form.27 (Blood Sorcery reorder) — unblock that story once this fix is verified; the reorder itself is correct

--- a/tests/dt-form-34-submit-delegation.spec.js
+++ b/tests/dt-form-34-submit-delegation.spec.js
@@ -1,0 +1,244 @@
+/**
+ * E2E tests for dt-form.34 — Submit button delegation fix (GH #95)
+ *
+ * Verifies that #dt-btn-submit's click handler survives container.innerHTML
+ * re-renders (mode toggle, feed pool selector change) because the handler is
+ * now delegated to the stable container element rather than bound directly to
+ * the button element that gets replaced on every renderForm() call.
+ *
+ * Also verifies the POST-vs-PUT guard checks responseDoc?._id (not !responseDoc)
+ * so a mode-toggle-created in-memory responseDoc routes to POST, not PUT /undefined.
+ *
+ * Technique: mounts the form module directly in a sandbox overlay via
+ * page.evaluate (same approach as dt-vitae-projection.spec.js). The submit
+ * button click is confirmed by the validation toast that appears when
+ * submitForm() runs but feeding territory is unselected — a signal that the
+ * handler fired even though no full submission is made.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const PLAYER_USER = {
+  id: '987654321', username: 'test_player', global_name: 'Test Player',
+  avatar: null, role: 'player', player_id: 'p-002',
+  character_ids: ['char-001'], is_dual_role: false,
+};
+
+const ACTIVE_CYCLE = {
+  _id: 'cycle-dt34', status: 'active', label: 'Test Cycle DT34',
+  feeding_rights_confirmed: true, is_chapter_finale: false,
+  created_at: '2026-05-06T00:00:00.000Z',
+};
+
+function buildChar(overrides = {}) {
+  return {
+    _id: 'char-001', name: 'Test Subject', moniker: null, honorific: null,
+    clan: 'Mekhet', covenant: 'Invictus', player: 'Test Player',
+    blood_potency: 2, humanity: 7, humanity_base: 7, court_title: null, retired: false,
+    status: {
+      city: 1, clan: 1,
+      covenant: { 'Carthian Movement': 0, 'Circle of the Crone': 0, 'Invictus': 1, 'Lancea et Sanctum': 0, 'Ordo Dracul': 0 },
+    },
+    attributes: {
+      Intelligence: { dots: 3, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+      Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+      Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+    },
+    skills: {
+      Stealth: { dots: 2, bonus: 0, specs: [], nine_again: false },
+      Persuasion: { dots: 2, bonus: 0, specs: [], nine_again: false },
+    },
+    disciplines: { Auspex: { dots: 2 } },
+    merits: [], powers: [], ordeals: [],
+    ...overrides,
+  };
+}
+
+// ── Setup helpers ─────────────────────────────────────────────────────────────
+
+async function setupSuite(page, char) {
+  await page.addInitScript((u) => {
+    localStorage.removeItem('tm-mode');
+    // Use 'fake-test-token' to hit mocked /api/auth/me instead of the
+    // local-test-token dev-fixtures path that bypasses Playwright's route mocks.
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 36000000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(u));
+  }, PLAYER_USER);
+
+  // Catch-all first — last-registered wins in Playwright, so specific routes
+  // registered below take precedence over this fallback.
+  await page.route('**/api/**', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.route('**/api/auth/me', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(PLAYER_USER) })
+  );
+  await page.route(/\/api\/characters\/char-001$/, r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(char) })
+  );
+  await page.route(/\/api\/characters$/, r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([char]) })
+  );
+  await page.route('**/api/characters/names', r =>
+    r.fulfill({ status: 200, contentType: 'application/json',
+      body: JSON.stringify([{ _id: char._id, name: char.name }]) })
+  );
+  await page.route('**/api/downtime_cycles', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([ACTIVE_CYCLE]) })
+  );
+  // Submissions: GET returns empty (no prior submission), POST returns a saved doc with _id
+  await page.route('**/api/downtime_submissions', r => {
+    if (r.request().method() === 'POST') {
+      return r.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify({
+          _id: 'sub-dt34-new', cycle_id: ACTIVE_CYCLE._id,
+          character_id: char._id, status: 'submitted', responses: {},
+        }),
+      });
+    }
+    return r.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+  });
+
+  await page.goto('/');
+  await page.waitForSelector('#app', { state: 'visible', timeout: 15000 });
+}
+
+// Mount the downtime form directly in a full-page sandbox overlay using the same
+// technique as dt-vitae-projection.spec.js. This bypasses the app's character
+// picker and mounts the module's exported renderDowntimeTab directly.
+async function openDowntimeForm(page, char) {
+  await page.evaluate(async (c) => {
+    const sandbox = document.createElement('div');
+    sandbox.id = 'dt-sandbox';
+    sandbox.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;background:#1a1208;z-index:99999;overflow:auto;';
+    document.body.appendChild(sandbox);
+    const mod = await import('/js/tabs/downtime-form.js');
+    await mod.renderDowntimeTab(sandbox, c, []);
+  }, char);
+  await page.waitForSelector('#dt-sandbox #dt-btn-submit', { timeout: 10000 });
+}
+
+// Helper: click the submit button and expect the validation toast to appear.
+// The toast "Please complete required fields … Feeding Territory" proves
+// submitForm() was invoked — the handler fired even if the form isn't fully
+// complete. Used for tests where we only need to confirm the click delegation
+// works, not that a full submission is made.
+async function expectSubmitHandlerFired(page) {
+  await page.locator('#dt-sandbox #dt-btn-submit').click();
+  await expect(page.locator('#dt-toast')).toBeVisible({ timeout: 3000 });
+  await expect(page.locator('#dt-toast')).toContainText('required fields');
+}
+
+// ── dt-form.34: Delegated handler survives re-renders ─────────────────────────
+
+test.describe('dt-form.34: #dt-btn-submit handler survives re-renders', () => {
+
+  test('submit fires on fresh form with no prior re-render (regression)', async ({ page }) => {
+    const char = buildChar();
+    await setupSuite(page, char);
+    await openDowntimeForm(page, char);
+
+    // No re-render has occurred yet. This confirms the baseline still works and
+    // acts as a regression check: the delegated path handles the first render too.
+    await expectSubmitHandlerFired(page);
+  });
+
+  test('submit fires after MINIMAL→ADVANCED mode toggle (first re-render)', async ({ page }) => {
+    const char = buildChar();
+    await setupSuite(page, char);
+    await openDowntimeForm(page, char);
+
+    // Mode toggle replaces container.innerHTML — a direct listener on the old
+    // button element would be lost here; the delegated listener survives.
+    await page.locator('#dt-sandbox [data-dt-mode="advanced"]').click();
+    // The Submit Final button only appears in ADVANCED — its presence confirms
+    // the re-render completed before we click submit.
+    await page.waitForSelector('#dt-sandbox #dt-btn-submit-final', { timeout: 5000 });
+
+    await expectSubmitHandlerFired(page);
+  });
+
+  test('submit fires after feed pool attribute selector change (second re-render path)', async ({ page }) => {
+    const char = buildChar();
+    await setupSuite(page, char);
+    await openDowntimeForm(page, char);
+
+    // The feed pool attribute selector (#dt-feed-custom-attr) is a <select> in
+    // the always-rendered feeding section. A change event on it triggers
+    // renderForm() via the container's delegated change listener.
+    const selectorFound = await page.evaluate(() => {
+      const sel = document.querySelector('#dt-sandbox #dt-feed-custom-attr');
+      if (!sel || sel.options.length < 2) return false;
+      sel.selectedIndex = 1;
+      sel.dispatchEvent(new Event('change', { bubbles: true }));
+      return true;
+    });
+    expect(selectorFound).toBe(true);
+    await page.waitForTimeout(150); // renderForm() is synchronous but allow paint
+
+    await expectSubmitHandlerFired(page);
+  });
+
+  test('submit fires after ADVANCED→MINIMAL mode toggle (consecutive re-renders)', async ({ page }) => {
+    const char = buildChar();
+    await setupSuite(page, char);
+    await openDowntimeForm(page, char);
+
+    // First re-render: switch to ADVANCED
+    await page.locator('#dt-sandbox [data-dt-mode="advanced"]').click();
+    await page.waitForSelector('#dt-sandbox #dt-btn-submit-final', { timeout: 5000 });
+
+    // Second re-render: switch back to MINIMAL
+    await page.locator('#dt-sandbox [data-dt-mode="minimal"]').click();
+    // Submit Final is ADVANCED-only — its absence confirms the re-render completed
+    await expect(page.locator('#dt-sandbox #dt-btn-submit-final')).toHaveCount(0);
+
+    await expectSubmitHandlerFired(page);
+  });
+
+});
+
+// ── dt-form.34: POST-vs-PUT guard uses responseDoc?._id ───────────────────────
+
+test.describe('dt-form.34: POST-vs-PUT guard uses responseDoc?._id', () => {
+
+  test('submit POSTs when mode-toggle created in-memory responseDoc with no _id', async ({ page }) => {
+    const char = buildChar();
+    await setupSuite(page, char);
+    await openDowntimeForm(page, char);
+
+    // Mode toggle creates responseDoc = { responses: cur } with no _id (no prior
+    // server submission existed). Old guard: !responseDoc → false → PUT /undefined.
+    // Fixed guard: !responseDoc?._id → true → POST /api/downtime_submissions.
+    await page.locator('#dt-sandbox [data-dt-mode="advanced"]').click();
+    await page.waitForSelector('#dt-sandbox #dt-btn-submit-final', { timeout: 5000 });
+
+    // Pre-fill the feeding territory hidden input so validation passes and the
+    // API call is actually reached. The hidden input is always in the DOM
+    // (feeding section has no gate); its ID is 'feed-val-the_academy'.
+    await page.evaluate(() => {
+      const el = document.getElementById('feed-val-the_academy');
+      if (el) el.value = 'poaching';
+    });
+
+    // Capture the outgoing request. waitForRequest must be registered before the
+    // action that triggers it — Promise.all handles both concurrently.
+    const [request] = await Promise.all([
+      page.waitForRequest(
+        req => req.url().includes('/api/downtime_submissions') && req.method() === 'POST',
+        { timeout: 5000 }
+      ),
+      page.locator('#dt-sandbox #dt-btn-submit').click(),
+    ]);
+
+    expect(request).toBeTruthy();
+    expect(request.method()).toBe('POST');
+    // The specific bug: old code sent PUT to /api/downtime_submissions/undefined
+    expect(request.url()).not.toMatch(/\/undefined$/);
+  });
+
+});


### PR DESCRIPTION
## Summary

- Submit button click handler was bound directly to the button element on first render; any inline re-render (mode toggle, feed pool selector, sorcery rite change) destroyed the element and its listener silently — manifested as saves appearing to succeed but data vanishing on hard refresh
- Fix: handle `#dt-btn-submit` via the container's stable delegated click listener, matching the existing pattern for `#dt-btn-submit-final`
- `saveDraft()` and `submitForm()` POST-vs-PUT guard tightened to `!responseDoc?._id` so a mode-toggle's in-memory doc (no `_id`) routes to POST, not PUT `/undefined`

## Closes

- Closes #95

## Story

- specs/stories/dt-form.34-submit-btn-lost-after-rerender.story.md

## Test plan

- [x] 5/5 Playwright tests pass (`tests/dt-form-34-submit-delegation.spec.js`)
- [ ] CI green
- [ ] Manual: open DT form, switch MINIMAL→ADVANCED, select a Blood Sorcery rite, submit — confirm rite persists on hard refresh

## Branch flow

- From: `morningstar-issue-95-blood-sorcery-rite-persist`
- Into: `dev`