### PR TITLE
fix(dt-form): feeding_method required:false — custom pool no longer blocked

### DIFF
--- a/public/js/tabs/downtime-data.js
+++ b/public/js/tabs/downtime-data.js
@@ -270,7 +270,7 @@ export const DOWNTIME_SECTIONS = [
         key: 'feeding_method',
         label: 'How does your character hunt?',
         type: 'feeding_method',
-        required: true,
+        required: false,   // DTFP-4: pool components (_feed_method/_feed_custom_*) are the gate
         desc: null,
       },
     ],

--- a/specs/stories/dt-form.36-hunt-pool-required-check.story.md
+++ b/specs/stories/dt-form.36-hunt-pool-required-check.story.md
@@ -1,0 +1,234 @@
+---
+id: dt-form.36
+issue: 115
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/115
+branch: morningstar-issue-115-hunt-pool-required-check
+epic: epic-dt-form-mvp-redesign
+status: review
+priority: high
+depends_on: ['dt-form.20', 'dt-form.34', 'dt-form.35']
+---
+
+# Story dt-form.36 — Fix: DOWNTIME_SECTIONS feeding_method required:true always blocks submission
+
+As a player filling out the ADVANCED feeding section,
+When I have built a custom hunting pool and selected a blood type and violence mode,
+The form should accept my submission without demanding "How does your character hunt?".
+
+## Root Cause
+
+### The three-way mismatch
+
+`DOWNTIME_SECTIONS` (in `downtime-data.js` ~line 273) declares the `feeding_method` question with `required: true`:
+
+```javascript
+{
+  key: 'feeding_method',
+  label: 'How does your character hunt?',
+  type: 'feeding_method',
+  required: true,
+  desc: null,
+},
+```
+
+`submitForm()` (in `downtime-form.js` ~line 1294) loops over `DOWNTIME_SECTIONS` and checks:
+
+```javascript
+for (const q of (section.questions || [])) {
+  if (!q.required) continue;
+  // ... special case for highlight_slots only ...
+  const val = responses[q.key];          // responses['feeding_method']
+  if (!val || (typeof val === 'string' && !val.trim())) {
+    missing.push(q.label || q.key);      // always fires!
+  }
+}
+```
+
+`collectResponses()` (in `downtime-form.js` ~line 391) handles `feeding_method` type by writing to
+`_feed_method`, `_feed_disc`, `_feed_custom_attr`, `_feed_custom_skill`, `_feed_custom_disc` — and
+then calls `continue`, **so `responses['feeding_method']` is never written**.
+
+Result: `responses['feeding_method']` is always `undefined` → the required check always fires →
+"Please complete required fields before submitting: How does your character hunt?" for **every player**
+who tries to submit the ADVANCED form, regardless of whether they have built a valid hunting pool.
+
+### The DTFP-4 intent already exists in the codebase
+
+The comment immediately after the validation loop in `submitForm()` (line 1310) already documents
+the intended fix:
+
+```javascript
+// DTFP-4: feeding-method requirement dropped — pool components are the gate now
+// (the existing pool-validation logic already flags incomplete attr/skill/disc).
+```
+
+This comment was added when DTFP-4 was designed, but the corresponding data change (`required: false`
+in `DOWNTIME_SECTIONS`) was stashed and never landed. The stash exists on the
+`morningstar-issue-95-blood-sorcery-rite-persist` branch but was not merged.
+
+### Why the minimum-complete check is unaffected
+
+`_hasFeedingMethod()` in `dt-completeness.js` correctly checks all five `FEEDING_POOL_KEYS`:
+
+```javascript
+const FEEDING_POOL_KEYS = ['_feed_method', '_feed_disc', '_feed_custom_attr', '_feed_custom_skill', '_feed_custom_disc'];
+function _hasFeedingMethod(responses) {
+  return FEEDING_POOL_KEYS.some(k => isNonEmptyString(responses[k]));
+}
+```
+
+This is the gate for the minimum-complete banner. It is correct and does not need changing.
+
+### Why territory validation is unaffected
+
+The feeding territory check in `submitForm()` is hardcoded **after** the `DOWNTIME_SECTIONS` loop and
+does not depend on the `feeding_method` entry's `required` flag:
+
+```javascript
+const territories = (() => { try { return JSON.parse(responses['feeding_territories'] || '{}'); } catch { return {}; } })();
+if (!Object.values(territories).some(v => v && v !== 'none')) missing.push('Feeding Territory');
+```
+
+This remains unchanged.
+
+## The Fix — `public/js/tabs/downtime-data.js`
+
+Change `required: true` → `required: false` on the `feeding_method` question in `DOWNTIME_SECTIONS`
+(~line 273). One character change. That is the entire fix.
+
+**Before:**
+```javascript
+{
+  key: 'feeding_method',
+  label: 'How does your character hunt?',
+  type: 'feeding_method',
+  required: true,
+  desc: null,
+},
+```
+
+**After:**
+```javascript
+{
+  key: 'feeding_method',
+  label: 'How does your character hunt?',
+  type: 'feeding_method',
+  required: false,   // DTFP-4: pool components (_feed_method/_feed_custom_*) are the gate
+  desc: null,
+},
+```
+
+`submitForm()`'s existing comment (line 1310) already explains this:
+> "DTFP-4: feeding-method requirement dropped — pool components are the gate now"
+
+No changes to `downtime-form.js`. No changes to `dt-completeness.js`. No other files.
+
+## Files in Scope
+
+- `public/js/tabs/downtime-data.js` — `DOWNTIME_SECTIONS` feeding_method question only (~line 273)
+
+## Files NOT in Scope
+
+- `public/js/tabs/downtime-form.js` — `submitForm()` validation loop is correct; DTFP-4 comment is already accurate
+- `public/js/data/dt-completeness.js` — `_hasFeedingMethod()` is correct; no changes
+- Render code — no changes
+- MINIMAL mode — not affected (MINIMAL does not render the custom pool builder)
+
+## Acceptance Criteria
+
+- [ ] Given a player in ADVANCED mode who builds a custom pool (attr/skill/disc) without selecting a method card, when blood type and violence are also set, then Submit does not fire "How does your character hunt?"
+- [ ] Given a player who selects a method card only (no custom pool), Submit does not fire "How does your character hunt?"
+- [ ] Given a player who has neither a method card selected nor any custom pool field set, feeding territory validation still works (feeding territory check is separate and unchanged)
+- [ ] No regression on MINIMAL mode feeding
+- [ ] No regression on existing required fields (court travel, game recount, etc.)
+
+## Dev Notes
+
+### Module-level state variables for feeding
+
+These live at module scope in `downtime-form.js` (~line 131) and are the source of truth for what
+`collectResponses()` writes:
+
+```javascript
+let feedMethodId = '';        // populated when player clicks a method card
+let feedDiscName = '';        // populated from pool builder discipline dropdown
+let feedSpecName = '';
+let feedCustomAttr = '';      // populated from custom pool attr dropdown
+let feedCustomSkill = '';     // populated from custom pool skill dropdown
+let feedCustomDisc = '';      // populated from custom pool disc dropdown
+```
+
+When loaded from a prior submission (line 1576-1582), these are seeded from `responseDoc.responses`.
+
+### collectResponses() feeding_method branch
+
+Located at `downtime-form.js` ~line 391. The `continue` at line 439 skips the default
+`responses[q.key] = el.value` write — which is why `responses['feeding_method']` is never populated.
+This is intentional: the feeding data lives under the `_feed_*` keys, not `feeding_method`.
+
+### DOWNTIME_SECTIONS structure
+
+Located at `downtime-data.js` line 174. The feeding section is section index 4 (0-based) with two
+questions: `feeding_territories` and `feeding_method`. Only `feeding_territories` should remain
+`required: true` — but that field is validated by the hardcoded territory check in `submitForm()`,
+not the generic loop. Setting `feeding_method` to `required: false` means the generic loop skips
+it entirely.
+
+### Reproduce the bug (current state)
+
+1. Open any character in ADVANCED feeding
+2. Build a custom pool (attr/skill/disc) — do NOT click a method card
+3. Select blood type and violence
+4. Click Submit → "How does your character hunt?" fires
+
+Alternately: even if you DO click a method card, the bug still fires because `responses['feeding_method']`
+is never written by collectResponses.
+
+## Test Plan
+
+Static review:
+- `downtime-data.js`: `feeding_method` question now has `required: false`
+- `downtime-form.js` DTFP-4 comment (line 1310) matches the data state
+- `dt-completeness.js` `_hasFeedingMethod()` unchanged
+
+Browser smoke (required before PR):
+1. Open Cyrus in ADVANCED. Build pool, select blood type and The Kiss. Submit → confirm no "How does your character hunt?" toast
+2. Open any character in ADVANCED. Select a method card only (no custom pool). Submit → confirm no toast
+3. Open any character in MINIMAL. Submit → confirm no regression in MINIMAL feeding
+4. Confirm territory required check still fires: open character, select no territory, click Submit → "Feeding Territory" error still appears
+
+## Definition of Done
+
+- [x] Root cause identified: `required: true` on `feeding_method` with `responses['feeding_method']` never written → always blocks
+- [x] `downtime-data.js` feeding_method question: `required: false`
+- [ ] Smoke test 1: Cyrus submits without "How does your character hunt?" toast
+- [ ] Smoke test 2: method-card-only selection also clears the block
+- [ ] Smoke test 3: MINIMAL mode unaffected
+- [ ] Smoke test 4: territory check still fires when no territory selected
+- [ ] PR opened into `dev`
+
+## Dev Agent Record
+
+**Agent:** Claude Sonnet 4.6
+**Date:** 2026-05-07
+
+### File List
+
+**Modified**
+- `public/js/tabs/downtime-data.js` — feeding_method question: required: true → required: false (~line 273)
+
+**New**
+- `tests/dt-form-36-hunt-pool-required-check.spec.js` — 4 Playwright E2E tests
+
+### Completion Notes
+
+Single one-character change in DOWNTIME_SECTIONS. The DTFP-4 comment in submitForm() (line 1310) already accurately documented the intent — the stash had simply never landed. Setting required:false means the generic required-field loop in submitForm() skips feeding_method entirely. The minimum-complete gate (_hasFeedingMethod in dt-completeness.js) already uses FEEDING_POOL_KEYS and is unchanged.
+
+4 Playwright tests added covering: MINIMAL mode baseline, ADVANCED with custom pool only, ADVANCED with method card only, ADVANCED empty form. All 4 pass. The pre-existing dt-form-34 test "submit fires after feed pool attribute selector change" continues to fail (it checks for #dt-feed-custom-attr in MINIMAL mode where it doesn't render — unrelated to this story).
+
+### Change Log
+
+| Date | Author | Change |
+|---|---|---|
+| 2026-05-07 | Claude Sonnet 4.6 | Story created from issue #115. Root cause: DTFP-4 stash never landed; required:true on feeding_method combined with collectResponses never writing responses['feeding_method']. Status → ready-for-dev. |
+| 2026-05-07 | Claude Sonnet 4.6 | Implemented fix: required:false on feeding_method in DOWNTIME_SECTIONS. 4 tests added, all pass. Status → review. |

--- a/tests/dt-form-36-hunt-pool-required-check.spec.js
+++ b/tests/dt-form-36-hunt-pool-required-check.spec.js
@@ -224,4 +224,22 @@ test.describe('dt-form.36: feeding_method required:false no longer blocks submis
     await expect(toast).toContainText('Feeding Territory');
   });
 
+  test('DOWNTIME_SECTIONS feeding_method question has required:false (data contract)', async ({ page }) => {
+    const char = buildChar();
+    await setupSuite(page, char, null);
+    await openDowntimeForm(page, char);
+
+    // Import the module and check the data directly — pins the one-line fix so
+    // a future edit that accidentally re-enables required:true will be caught here.
+    const feedingMethodRequired = await page.evaluate(async () => {
+      const mod = await import('/js/tabs/downtime-data.js');
+      const feedingSection = mod.DOWNTIME_SECTIONS.find(s => s.key === 'feeding');
+      if (!feedingSection) return null;
+      const q = feedingSection.questions.find(q => q.key === 'feeding_method');
+      return q ? q.required : null;
+    });
+
+    expect(feedingMethodRequired).toBe(false);
+  });
+
 });

--- a/tests/dt-form-36-hunt-pool-required-check.spec.js
+++ b/tests/dt-form-36-hunt-pool-required-check.spec.js
@@ -1,0 +1,227 @@
+/**
+ * Tests for dt-form.36 — feeding_method required:true always blocked submission (GH #115)
+ *
+ * The bug: DOWNTIME_SECTIONS feeding_method question had required:true, but
+ * collectResponses() never writes to responses['feeding_method'] — it writes to
+ * _feed_method/_feed_custom_attr etc. So responses['feeding_method'] was always
+ * undefined, making the required check always fire.
+ *
+ * The fix: required:false on feeding_method in DOWNTIME_SECTIONS (DTFP-4 intent).
+ * The minimum-complete gate (_hasFeedingMethod in dt-completeness.js) correctly
+ * checks FEEDING_POOL_KEYS and is unchanged.
+ *
+ * Technique: mounts the DT form in a sandbox overlay (same pattern as
+ * dt-form-34-submit-delegation.spec.js). Clicks submit with feeding territory
+ * absent so the form fails at the territory gate — proving submitForm() ran past
+ * the feeding_method check without firing "How does your character hunt?".
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const PLAYER_USER = {
+  id: '987654321', username: 'test_player', global_name: 'Test Player',
+  avatar: null, role: 'player', player_id: 'p-002',
+  character_ids: ['char-001'], is_dual_role: false,
+};
+
+const ACTIVE_CYCLE = {
+  _id: 'cycle-dt36', status: 'active', label: 'Test Cycle DT36',
+  feeding_rights_confirmed: true, is_chapter_finale: false,
+  created_at: '2026-05-07T00:00:00.000Z',
+};
+
+function buildChar(overrides = {}) {
+  return {
+    _id: 'char-001', name: 'Test Subject', moniker: null, honorific: null,
+    clan: 'Mekhet', covenant: 'Invictus', player: 'Test Player',
+    blood_potency: 2, humanity: 7, humanity_base: 7, court_title: null, retired: false,
+    status: {
+      city: 1, clan: 1,
+      covenant: { 'Carthian Movement': 0, 'Circle of the Crone': 0, 'Invictus': 1, 'Lancea et Sanctum': 0, 'Ordo Dracul': 0 },
+    },
+    attributes: {
+      Intelligence: { dots: 3, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+      Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+      Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+    },
+    skills: {
+      Stealth: { dots: 2, bonus: 0, specs: [], nine_again: false },
+      Persuasion: { dots: 2, bonus: 0, specs: [], nine_again: false },
+    },
+    disciplines: { Auspex: { dots: 2 } },
+    merits: [], powers: [], ordeals: [],
+    ...overrides,
+  };
+}
+
+// Prior submission with a persisted feed method (but no territory)
+function buildPriorSub(responses = {}) {
+  return {
+    _id: 'sub-dt36-prior',
+    cycle_id: ACTIVE_CYCLE._id,
+    character_id: 'char-001',
+    status: 'draft',
+    responses,
+  };
+}
+
+// ── Setup helpers ─────────────────────────────────────────────────────────────
+
+async function setupSuite(page, char, priorSub = null) {
+  await page.addInitScript((u) => {
+    localStorage.removeItem('tm-mode');
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 36000000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(u));
+  }, PLAYER_USER);
+
+  await page.route('**/api/**', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.route('**/api/auth/me', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(PLAYER_USER) })
+  );
+  await page.route(/\/api\/characters\/char-001$/, r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(char) })
+  );
+  await page.route(/\/api\/characters$/, r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([char]) })
+  );
+  await page.route('**/api/characters/names', r =>
+    r.fulfill({ status: 200, contentType: 'application/json',
+      body: JSON.stringify([{ _id: char._id, name: char.name }]) })
+  );
+  await page.route('**/api/downtime_cycles', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([ACTIVE_CYCLE]) })
+  );
+  // Regex matches both bare /api/downtime_submissions and ?cycle_id=... variants
+  await page.route(/\/api\/downtime_submissions($|\?)/, r => {
+    if (r.request().method() === 'GET') {
+      return r.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify(priorSub ? [priorSub] : []),
+      });
+    }
+    if (r.request().method() === 'POST') {
+      return r.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify({
+          _id: 'sub-dt36-new', cycle_id: ACTIVE_CYCLE._id,
+          character_id: char._id, status: 'submitted', responses: {},
+        }),
+      });
+    }
+    return r.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+  });
+  if (priorSub) {
+    await page.route(new RegExp(`/api/downtime_submissions/${priorSub._id}`), r =>
+      r.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify({ ...priorSub, status: 'submitted' }),
+      })
+    );
+  }
+
+  await page.goto('/');
+  await page.waitForSelector('#app', { state: 'visible', timeout: 15000 });
+}
+
+async function openDowntimeForm(page, char) {
+  await page.evaluate(async (c) => {
+    const sandbox = document.createElement('div');
+    sandbox.id = 'dt-sandbox';
+    sandbox.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;background:#1a1208;z-index:99999;overflow:auto;';
+    document.body.appendChild(sandbox);
+    const mod = await import('/js/tabs/downtime-form.js');
+    await mod.renderDowntimeTab(sandbox, c, []);
+  }, char);
+  await page.waitForSelector('#dt-sandbox #dt-btn-submit', { timeout: 10000 });
+}
+
+// Click #dt-btn-submit (calls submitForm() in both MINIMAL and ADVANCED modes)
+// and confirm the validation toast fired. #dt-btn-submit-final opens a confirmation
+// modal and does NOT call submitForm() — do not use it as the click target here.
+// In all tests the feeding territory is not selected, so the toast should mention
+// "Feeding Territory" — proving submitForm ran past the feeding_method check.
+async function submitAndCheckToast(page) {
+  await page.locator('#dt-sandbox #dt-btn-submit').click();
+  const toast = page.locator('#dt-toast');
+  await expect(toast).toBeVisible({ timeout: 3000 });
+  return toast;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('dt-form.36: feeding_method required:false no longer blocks submission', () => {
+
+  test('MINIMAL mode: submit reaches territory gate, no "How does your character hunt?" toast', async ({ page }) => {
+    const char = buildChar();
+    // No prior sub → no method, no territory
+    await setupSuite(page, char, null);
+    await openDowntimeForm(page, char);
+
+    // MINIMAL is the default mode — submit button is #dt-btn-submit
+    const toast = await submitAndCheckToast(page);
+
+    // submitForm ran past the feeding_method check
+    await expect(toast).not.toContainText('How does your character hunt?');
+    // Territory gate (hardcoded in submitForm after the DOWNTIME_SECTIONS loop) fires
+    await expect(toast).toContainText('Feeding Territory');
+  });
+
+  test('ADVANCED mode: custom pool (no method card) → no "How does your character hunt?" toast', async ({ page }) => {
+    const char = buildChar();
+    // Prior sub has custom pool fields but no _feed_method
+    const priorSub = buildPriorSub({
+      _feed_custom_attr: 'Presence',
+      _feed_custom_skill: 'Empathy',
+      _feed_custom_disc: '',
+    });
+    await setupSuite(page, char, priorSub);
+    await openDowntimeForm(page, char);
+
+    await page.locator('#dt-sandbox [data-dt-mode="advanced"]').click();
+    await page.waitForSelector('#dt-sandbox #dt-btn-submit-final', { timeout: 5000 });
+
+    const toast = await submitAndCheckToast(page);
+
+    await expect(toast).not.toContainText('How does your character hunt?');
+    await expect(toast).toContainText('Feeding Territory');
+  });
+
+  test('ADVANCED mode: method card selected (no custom pool) → no "How does your character hunt?" toast', async ({ page }) => {
+    const char = buildChar();
+    // Prior sub has _feed_method set (player clicked a method card)
+    const priorSub = buildPriorSub({ _feed_method: 'seduction' });
+    await setupSuite(page, char, priorSub);
+    await openDowntimeForm(page, char);
+
+    await page.locator('#dt-sandbox [data-dt-mode="advanced"]').click();
+    await page.waitForSelector('#dt-sandbox #dt-btn-submit-final', { timeout: 5000 });
+
+    const toast = await submitAndCheckToast(page);
+
+    await expect(toast).not.toContainText('How does your character hunt?');
+    await expect(toast).toContainText('Feeding Territory');
+  });
+
+  test('ADVANCED mode: no method, no pool, no territory → still fails on territory only', async ({ page }) => {
+    const char = buildChar();
+    // Completely empty form
+    await setupSuite(page, char, null);
+    await openDowntimeForm(page, char);
+
+    await page.locator('#dt-sandbox [data-dt-mode="advanced"]').click();
+    await page.waitForSelector('#dt-sandbox #dt-btn-submit-final', { timeout: 5000 });
+
+    const toast = await submitAndCheckToast(page);
+
+    // feeding_method is no longer a required gate
+    await expect(toast).not.toContainText('How does your character hunt?');
+    // Territory gate still fires
+    await expect(toast).toContainText('Feeding Territory');
+  });
+
+});


### PR DESCRIPTION
## Summary

- `DOWNTIME_SECTIONS` had `required: true` on the `feeding_method` question, but `collectResponses()` never writes `responses['feeding_method']` (it writes `_feed_method`/`_feed_custom_*` and calls `continue`) — so the required check always fired, blocking every player from submitting regardless of their pool state
- DTFP-4 intent ("feeding-method requirement dropped — pool components are the gate now") was already documented in `submitForm()`'s comment since a prior PR, but the corresponding data change was stashed and never landed
- Fix: `required: true` → `required: false` on the `feeding_method` question in `DOWNTIME_SECTIONS` — one character change in `downtime-data.js`; minimum-complete gate (`_hasFeedingMethod`) is unchanged

## Closes

- Closes #115

## Story

- `specs/stories/dt-form.36-hunt-pool-required-check.story.md`

## Test plan

- [x] 5 Playwright tests, all pass: MINIMAL baseline, ADVANCED custom pool, ADVANCED method card only, ADVANCED empty form, data-contract check on `required: false`
- [ ] CI green
- [ ] Manual: Open Cyrus in ADVANCED, build pool, select blood type + Kiss, click Submit — confirm no "How does your character hunt?" toast

## Branch flow

- From: `morningstar-issue-115-hunt-pool-required-check`
- Into: `dev`