### PR TITLE
feat(dt-form): hide Equipment section for this DT cycle (closes #85)

### DIFF
--- a/public/js/tabs/downtime-data.js
+++ b/public/js/tabs/downtime-data.js
@@ -330,11 +330,12 @@ export const DOWNTIME_SECTIONS = [
     ],
   },
 
-  // 11. Equipment — always shown
+  // 11. Equipment — dt-form.30: hidden for this DT cycle; set hidden: false to re-enable
   {
     key: 'equipment',
     title: 'Equipment: Items and Gear',
     gate: null,
+    hidden: true,
     intro: 'List any items, weapons, or equipment you want your character to have access to this Downtime. Sourcing is subject to ST approval and availability.',
     questions: [], // rendered dynamically
   },

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -946,17 +946,19 @@ function collectResponses() {
       : '',
   ].filter(Boolean).join('\n');
 
-  // Collect equipment slots
-  const equipCountEl = document.getElementById('dt-equipment-slot-count');
-  const equipSlotCount = equipCountEl ? parseInt(equipCountEl.value, 10) || 1 : 1;
-  responses['equipment_slot_count'] = String(equipSlotCount);
-  for (let n = 1; n <= equipSlotCount; n++) {
-    const nameEl = document.getElementById(`dt-equipment_${n}_name`);
-    const qtyEl = document.getElementById(`dt-equipment_${n}_qty`);
-    const notesEl = document.getElementById(`dt-equipment_${n}_notes`);
-    responses[`equipment_${n}_name`] = nameEl ? nameEl.value : '';
-    responses[`equipment_${n}_qty`] = qtyEl ? qtyEl.value : '';
-    responses[`equipment_${n}_notes`] = notesEl ? notesEl.value : '';
+  // Collect equipment slots (skipped when hidden — prior values preserved via _prior spread)
+  if (!DOWNTIME_SECTIONS.find(s => s.key === 'equipment')?.hidden) {
+    const equipCountEl = document.getElementById('dt-equipment-slot-count');
+    const equipSlotCount = equipCountEl ? parseInt(equipCountEl.value, 10) || 1 : 1;
+    responses['equipment_slot_count'] = String(equipSlotCount);
+    for (let n = 1; n <= equipSlotCount; n++) {
+      const nameEl = document.getElementById(`dt-equipment_${n}_name`);
+      const qtyEl = document.getElementById(`dt-equipment_${n}_qty`);
+      const notesEl = document.getElementById(`dt-equipment_${n}_notes`);
+      responses[`equipment_${n}_name`] = nameEl ? nameEl.value : '';
+      responses[`equipment_${n}_qty`] = qtyEl ? qtyEl.value : '';
+      responses[`equipment_${n}_notes`] = notesEl ? notesEl.value : '';
+    }
   }
 
   } // end if (!_isMinimal) — ADVANCED-only collection
@@ -4925,7 +4927,7 @@ function renderAcquisitionsSection(saved) {
 
 function renderEquipmentSection(saved) {
   const section = DOWNTIME_SECTIONS.find(s => s.key === 'equipment');
-  if (!section) return '';
+  if (!section || section.hidden) return '';  // dt-form.30: hidden for this cycle
 
   const savedCount = parseInt(saved['equipment_slot_count'] || '1', 10);
   const slotCount = Math.max(1, savedCount);

--- a/specs/stories/dt-form.30-equipment-hide.story.md
+++ b/specs/stories/dt-form.30-equipment-hide.story.md
@@ -3,8 +3,9 @@ id: dt-form.30
 task: 30
 issue: 85
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/85
+branch: morningstar-issue-85-hide-equipment-section
 epic: epic-dt-form-mvp-redesign
-status: Draft
+status: review
 priority: low
 depends_on: ['dt-form.17']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Audit-baseline)
@@ -20,51 +21,158 @@ So that players are not asked questions about equipment that the cycle's mechani
 
 ADR-003 §Audit-baseline marks Equipment as: *"Hidden for this DT cycle per task #30."*
 
-This is a hide, not a remove. The section's render path is gated off; data already in `responses.equipment_*` keys is preserved and ignored. If a future cycle wants Equipment back, the gate is flipped.
+This is a hide, not a remove. The section's render path is gated off via a `hidden: true` flag on the DOWNTIME_SECTIONS entry. Data already in `responses.equipment_*` keys is preserved across saves. Flipping `hidden` back to `false` re-enables the section without code archaeology.
 
-### Files in scope
+## Files in Scope
 
-- `public/js/tabs/downtime-form.js` — Equipment section render path; gate it off
-- `public/js/tabs/downtime-data.js` — `DOWNTIME_SECTIONS` Equipment entry annotated as hidden (or removed; either works)
+- `public/js/tabs/downtime-data.js` — add `hidden: true` to the Equipment entry in `DOWNTIME_SECTIONS`
+- `public/js/tabs/downtime-form.js` — two changes: (1) `renderEquipmentSection` bail-out; (2) collect block guard
 
-### Files NOT in scope
+## Files NOT in Scope
 
-- Existing Equipment data (preserved as-is in `responses`; ignored by the form)
-- Equipment-related helpers elsewhere in the codebase (no audit of those; the form just stops surfacing)
+- Existing `equipment_*` values in MongoDB — preserved as-is; form just stops surfacing them
+- `server/schemas/downtime_submission.schema.js` — no change; schema still accepts equipment fields
+- Any equipment-related helpers not in these two files
 
 ## Acceptance Criteria
 
-**Given** a player opens the DT form (any mode)
+**Given** a player opens the DT form (MINIMAL or ADVANCED mode)
 **When** the form renders
-**Then** the Equipment section is not visible. No header, no fields, no chrome.
+**Then** the Equipment section is not visible — no heading, no fields, no chrome
 
-**Given** legacy submission data has `equipment_*` fields populated
-**When** the form loads
-**Then** no error. The data is in `responses` but not surfaced. Persistence on next save is unchanged (legacy fields stay; form-level is hidden).
+**Given** a legacy submission with `equipment_*` fields populated is loaded
+**When** the form renders and the player saves (without touching equipment)
+**Then** the equipment fields are preserved in the saved responses (not overwritten with empty strings)
 
-**Given** the gate is implemented as a configurable flag (recommended)
-**When** a future cycle wants Equipment back
-**Then** flipping the flag re-enables the section without code archaeology.
+**Given** `hidden: true` is set on the Equipment DOWNTIME_SECTIONS entry
+**When** a developer wants to re-enable Equipment for a future cycle
+**Then** setting `hidden: false` (or removing the flag) restores the section without any other code change
 
 ## Implementation Notes
 
-Simplest implementation: a top-of-file `EQUIPMENT_HIDDEN = true` const that the section render path checks. Or a per-section `hidden` flag in `DOWNTIME_SECTIONS` and the render loop respects it.
+### How the data-preservation invariant works
 
-Recommend the per-section flag — generalises to any future "hide this section temporarily" need.
+`collectResponses()` opens with (line 348):
+```javascript
+const _prior = responseDoc?.responses || {};
+const responses = { ..._prior };
+```
+This spreads all previously-saved responses (including any `equipment_*` keys) as the base. If the equipment collect block is skipped, those keys are never overwritten — they survive the save as-is.
+
+The equipment collect block (lines 949–960) is inside `if (!_isMinimal)`. In MINIMAL mode it's already skipped and prior values survive. In ADVANCED mode (when `!_isMinimal` is true) we must also skip it when hidden — otherwise `getElementById` returns null, `equipSlotCount` defaults to 1, and the block writes empty strings that overwrite prior data.
+
+### Change 1 — Add `hidden: true` to Equipment entry (`downtime-data.js` lines 333–340)
+
+```javascript
+// BEFORE
+{
+  key: 'equipment',
+  title: 'Equipment: Items and Gear',
+  gate: null,
+  intro: 'List any items, weapons, or equipment...',
+  questions: [],
+},
+
+// AFTER
+{
+  key: 'equipment',
+  title: 'Equipment: Items and Gear',
+  gate: null,
+  hidden: true,  // dt-form.30: hidden for this DT cycle; set false to re-enable
+  intro: 'List any items, weapons, or equipment...',
+  questions: [],
+},
+```
+
+### Change 2 — `renderEquipmentSection` hidden bail-out (`downtime-form.js` line 4927–4928)
+
+```javascript
+// BEFORE
+function renderEquipmentSection(saved) {
+  const section = DOWNTIME_SECTIONS.find(s => s.key === 'equipment');
+  if (!section) return '';
+
+// AFTER
+function renderEquipmentSection(saved) {
+  const section = DOWNTIME_SECTIONS.find(s => s.key === 'equipment');
+  if (!section || section.hidden) return '';  // dt-form.30: hidden for this cycle
+```
+
+### Change 3 — Equipment collect block guard (`downtime-form.js` lines 949–960)
+
+Inside the `if (!_isMinimal)` block, wrap the equipment collection:
+
+```javascript
+// BEFORE
+  // Collect equipment slots
+  const equipCountEl = document.getElementById('dt-equipment-slot-count');
+  const equipSlotCount = equipCountEl ? parseInt(equipCountEl.value, 10) || 1 : 1;
+  responses['equipment_slot_count'] = String(equipSlotCount);
+  for (let n = 1; n <= equipSlotCount; n++) {
+    const nameEl = document.getElementById(`dt-equipment_${n}_name`);
+    const qtyEl = document.getElementById(`dt-equipment_${n}_qty`);
+    const notesEl = document.getElementById(`dt-equipment_${n}_notes`);
+    responses[`equipment_${n}_name`] = nameEl ? nameEl.value : '';
+    responses[`equipment_${n}_qty`] = qtyEl ? qtyEl.value : '';
+    responses[`equipment_${n}_notes`] = notesEl ? notesEl.value : '';
+  }
+
+// AFTER
+  // Collect equipment slots (skipped when hidden — prior values preserved via _prior spread)
+  if (!DOWNTIME_SECTIONS.find(s => s.key === 'equipment')?.hidden) {
+    const equipCountEl = document.getElementById('dt-equipment-slot-count');
+    const equipSlotCount = equipCountEl ? parseInt(equipCountEl.value, 10) || 1 : 1;
+    responses['equipment_slot_count'] = String(equipSlotCount);
+    for (let n = 1; n <= equipSlotCount; n++) {
+      const nameEl = document.getElementById(`dt-equipment_${n}_name`);
+      const qtyEl = document.getElementById(`dt-equipment_${n}_qty`);
+      const notesEl = document.getElementById(`dt-equipment_${n}_notes`);
+      responses[`equipment_${n}_name`] = nameEl ? nameEl.value : '';
+      responses[`equipment_${n}_qty`] = qtyEl ? qtyEl.value : '';
+      responses[`equipment_${n}_notes`] = notesEl ? notesEl.value : '';
+    }
+  }
+```
+
+### What NOT to change
+
+- The `if (section.key === 'equipment') continue;` skip at line 2152 in the main loop — already correct, leave it
+- The `renderEquipmentRow` function — unchanged, still used if section is ever re-enabled
+- The server schema — equipment fields are still valid; the form just stops writing them when hidden
 
 ## Test Plan
 
-- Static review: section gate is in place; data preservation confirmed
-- Browser smoke: form renders without Equipment; legacy data loads without error
+- Static review: `hidden: true` in downtime-data.js; `section.hidden` bail in `renderEquipmentSection`; collect block wrapped in hidden check
+- Browser smoke:
+  1. Open form as any character (MINIMAL and ADVANCED). Confirm no Equipment heading or fields appear.
+  2. Load a submission that has `equipment_1_name` populated. Save it. Confirm the field persists in the response (via network tab or re-load).
 
 ## Definition of Done
 
-- [ ] Equipment section not rendered in MINIMAL or ADVANCED
-- [ ] Legacy `equipment_*` data preserved on save
-- [ ] Gate is configurable (flag-flip restores)
+- [x] `hidden: true` added to Equipment entry in `DOWNTIME_SECTIONS` (downtime-data.js)
+- [x] `renderEquipmentSection` returns `''` when `section.hidden` is true
+- [x] Equipment collect block in `collectResponses()` skipped when hidden
+- [x] Equipment section absent in both MINIMAL and ADVANCED renders
+- [x] Legacy equipment data preserved on save (prior spread + skip collect)
 - [ ] PR opened into `dev`
 
-## Dependencies
+## Dev Agent Record
 
-- **Upstream**: #17 (rendering gate); independent otherwise
-- **Downstream**: none
+**Agent:** Claude (Morningstar)
+**Date:** 2026-05-07
+
+### File List
+
+**Modified**
+- `public/js/tabs/downtime-data.js`
+- `public/js/tabs/downtime-form.js`
+
+**Added**
+- `tests/dt-form-30-equipment-hide.spec.js`
+
+### Change Log
+
+| Date | Author | Change |
+|---|---|---|
+| 2026-05-07 | James (story) | Story enriched from Draft to ready-for-dev. 3 precise changes across 2 files. Key invariant: _prior spread preserves equipment data; collect block must be skipped (not just rendered-empty) in ADVANCED mode when hidden. |
+| 2026-05-07 | Claude (Morningstar) | Implemented: hidden: true on Equipment DOWNTIME_SECTIONS entry; renderEquipmentSection bail; collect block guard. 3 Playwright tests added and passing. |

--- a/tests/dt-form-30-equipment-hide.spec.js
+++ b/tests/dt-form-30-equipment-hide.spec.js
@@ -1,0 +1,175 @@
+/**
+ * E2E tests for dt-form.30 — Equipment section hidden for this DT cycle (GH #85)
+ *
+ * Verifies that:
+ * 1. The Equipment section heading is not rendered in ADVANCED mode.
+ * 2. The Equipment section heading is not rendered in MINIMAL mode.
+ * 3. Legacy equipment_* data in a saved submission is preserved on re-save
+ *    (i.e., the collect block skips equipment when hidden, leaving prior values intact).
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const PLAYER_USER = {
+  id: '333444555', username: 'test_player', global_name: 'Test Player',
+  avatar: null, role: 'player', player_id: 'p-dt30',
+  character_ids: ['char-dt30'], is_dual_role: false,
+};
+
+const ACTIVE_CYCLE = {
+  _id: 'cycle-dt30', status: 'active', label: 'Test Cycle DT30',
+  feeding_rights_confirmed: true, is_chapter_finale: false,
+  created_at: '2026-05-07T00:00:00.000Z',
+};
+
+function buildChar() {
+  return {
+    _id: 'char-dt30', name: 'Equipment Tester', moniker: null, honorific: null,
+    clan: 'Daeva', covenant: 'Carthian Movement', player: 'Test Player',
+    blood_potency: 1, humanity: 7, humanity_base: 7, court_title: null, retired: false,
+    status: { city: 0, clan: 0, covenant: {} },
+    attributes: {
+      Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+      Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+      Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+    },
+    skills: {}, disciplines: {}, merits: [], ordeals: [], powers: [],
+  };
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+async function setupSuite(page, char, existingSubmission = null) {
+  await page.addInitScript((u) => {
+    localStorage.removeItem('tm-mode');
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 36000000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(u));
+  }, PLAYER_USER);
+
+  await page.route('**/api/**', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.route('**/api/auth/me', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(PLAYER_USER) })
+  );
+  await page.route(new RegExp(`/api/characters/${char._id}$`), r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(char) })
+  );
+  await page.route(/\/api\/characters$/, r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([char]) })
+  );
+  await page.route('**/api/characters/names', r =>
+    r.fulfill({ status: 200, contentType: 'application/json',
+      body: JSON.stringify([{ _id: char._id, name: char.name }]) })
+  );
+  await page.route('**/api/downtime_cycles', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([ACTIVE_CYCLE]) })
+  );
+  await page.route(/\/api\/downtime_submissions/, r => {
+    if (r.request().method() === 'POST' || r.request().method() === 'PUT') {
+      const reqBody = JSON.parse(r.request().postData() || '{}');
+      return r.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify({
+          _id: existingSubmission?._id || 'sub-dt30-new',
+          cycle_id: ACTIVE_CYCLE._id, character_id: char._id,
+          status: 'draft', responses: reqBody.responses || {},
+        }),
+      });
+    }
+    const list = existingSubmission ? [existingSubmission] : [];
+    return r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(list) });
+  });
+
+  await page.goto('/');
+  await page.waitForSelector('#app', { state: 'visible', timeout: 15000 });
+}
+
+async function openDowntimeForm(page, char) {
+  await page.evaluate(async (c) => {
+    const sandbox = document.createElement('div');
+    sandbox.id = 'dt-sandbox';
+    sandbox.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;background:#1a1208;z-index:99999;overflow:auto;';
+    document.body.appendChild(sandbox);
+    const mod = await import('/js/tabs/downtime-form.js');
+    await mod.renderDowntimeTab(sandbox, c, []);
+  }, char);
+  await page.waitForSelector('#dt-sandbox #dt-btn-submit', { timeout: 10000 });
+}
+
+async function switchToAdvanced(page) {
+  await page.locator('#dt-sandbox [data-dt-mode="advanced"]').click();
+  await page.waitForSelector('#dt-sandbox #dt-btn-submit-final', { timeout: 5000 });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('dt-form.30: Equipment section hidden for this DT cycle', () => {
+
+  test('Equipment section heading absent in ADVANCED mode', async ({ page }) => {
+    await setupSuite(page, buildChar());
+    await openDowntimeForm(page, buildChar());
+    await switchToAdvanced(page);
+
+    // The section heading contains "Equipment" — must not be present
+    const equipSection = page.locator('#dt-sandbox [data-section-key="equipment"]');
+    await expect(equipSection).toHaveCount(0);
+
+    // Double-check: no heading text "Equipment: Items and Gear"
+    const equipHeading = page.locator('#dt-sandbox :text("Equipment: Items and Gear")');
+    await expect(equipHeading).toHaveCount(0);
+  });
+
+  test('Equipment section heading absent in MINIMAL mode', async ({ page }) => {
+    await setupSuite(page, buildChar());
+    await openDowntimeForm(page, buildChar());
+    // MINIMAL is the default mode — no mode switch needed
+
+    const equipSection = page.locator('#dt-sandbox [data-section-key="equipment"]');
+    await expect(equipSection).toHaveCount(0);
+
+    const equipHeading = page.locator('#dt-sandbox :text("Equipment: Items and Gear")');
+    await expect(equipHeading).toHaveCount(0);
+  });
+
+  test('Legacy equipment_* data preserved in POST body when section is hidden', async ({ page }) => {
+    const char = buildChar();
+    const existingSub = {
+      _id: 'sub-dt30-legacy',
+      cycle_id: ACTIVE_CYCLE._id,
+      character_id: char._id,
+      status: 'draft',
+      responses: {
+        equipment_slot_count: '1',
+        equipment_1_name: 'Silver Dagger',
+        equipment_1_qty: '1',
+        equipment_1_notes: 'For defence',
+      },
+    };
+    await setupSuite(page, char, existingSub);
+    await openDowntimeForm(page, char);
+    await switchToAdvanced(page);
+
+    // Intercept the save request and verify equipment fields are preserved
+    const [request] = await Promise.all([
+      page.waitForRequest(
+        req => req.url().includes('/api/downtime_submissions') &&
+               (req.method() === 'POST' || req.method() === 'PUT'),
+        { timeout: 5000 }
+      ),
+      page.locator('#dt-sandbox #dt-btn-submit').click(),
+    ]);
+
+    const body = JSON.parse(request.postData() || '{}');
+    const responses = body?.responses || {};
+
+    // Equipment data from prior submission must survive the save
+    expect(responses['equipment_1_name']).toBe('Silver Dagger');
+    expect(responses['equipment_1_qty']).toBe('1');
+    expect(responses['equipment_1_notes']).toBe('For defence');
+  });
+
+});


### PR DESCRIPTION
## Summary

- Adds `hidden: true` to the Equipment entry in `DOWNTIME_SECTIONS` so the section is excluded from both MINIMAL and ADVANCED renders without removing any code
- `renderEquipmentSection` bails immediately when `section.hidden` is true
- `collectResponses()` skips the equipment collect block when hidden, preserving any prior `equipment_*` values via the existing `_prior` spread invariant at line 348
- Flip `hidden` to `false` to re-enable Equipment for a future cycle — no further code changes needed

## Closes

- Closes #85

## Story

- specs/stories/dt-form.30-equipment-hide.story.md

## Test plan

- [x] `hidden: true` in downtime-data.js
- [x] `renderEquipmentSection` returns `''` when `section.hidden` is true
- [x] Equipment collect block wrapped in hidden guard
- [x] 3 Playwright E2E tests passing: MINIMAL absent, ADVANCED absent, legacy data preserved
- [ ] CI green
- [ ] Manual: open form as any character in MINIMAL and ADVANCED — no Equipment heading or fields visible

## Branch flow

- From: `morningstar-issue-85-hide-equipment-section`
- Into: `dev`