### PR TITLE
fix(dt-form): exclude Game Recount from min-complete check for non-attendees

### DIFF
--- a/public/js/data/dt-completeness.js
+++ b/public/js/data/dt-completeness.js
@@ -97,13 +97,14 @@ function _hasFirstProject(responses) {
  * @param {object} [ctx]               — optional caller-side context
  * @param {boolean} [ctx.isRegent]      — true if the character owns a regent territory
  * @param {boolean} [ctx.regencyConfirmed] — true if the regent has confirmed feeding rights this cycle
+ * @param {boolean} [ctx.attended]      — true if the character attended last game; defaults true so callers without attendance context are unaffected
  * @returns {boolean}
  */
 export function isMinimalComplete(responses, ctx = {}) {
   if (!responses || typeof responses !== 'object') return false;
-  const { isRegent = false, regencyConfirmed = false } = ctx;
+  const { isRegent = false, regencyConfirmed = false, attended = true } = ctx;
 
-  if (!_hasAnyGameRecount(responses)) return false;
+  if (attended && !_hasAnyGameRecount(responses)) return false;
   if (!_hasPersonalStory(responses)) return false;
   if (!_hasFeedingComplete(responses)) return false;
   if (!_hasFirstProject(responses)) return false;
@@ -127,9 +128,9 @@ export function missingMinimumPieces(responses, ctx = {}) {
     out.push({ section: 'projects', label: 'Pick an action for Project 1' });
     return out;
   }
-  const { isRegent = false, regencyConfirmed = false } = ctx;
+  const { isRegent = false, regencyConfirmed = false, attended = true } = ctx;
 
-  if (!_hasAnyGameRecount(responses)) {
+  if (attended && !_hasAnyGameRecount(responses)) {
     out.push({ section: 'court', label: 'Game Recount: add at least one highlight from last session' });
   }
   if (!_hasPersonalStory(responses)) {

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -1553,6 +1553,7 @@ function _completenessCtx() {
   return {
     isRegent: gateValues.is_regent === 'yes',
     regencyConfirmed: _isRegencyConfirmedThisCycle(),
+    attended: gateValues.attended === 'yes',
   };
 }
 

--- a/specs/stories/fix.46.dt-form-game-recount-non-attendee.story.md
+++ b/specs/stories/fix.46.dt-form-game-recount-non-attendee.story.md
@@ -1,0 +1,162 @@
+---
+id: fix.46
+issue: 111
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/111
+branch: morningstar-issue-111-game-recount-non-attendee
+status: review
+---
+
+# fix.46 — DT Form: Game Recount must not block non-attendees from minimum-complete
+
+## Story
+
+As a player who did not attend last game, I want to be able to submit my downtime form without a Game Recount highlight, because there is nothing for me to recount.
+
+## Background
+
+The minimum-complete validator in `dt-completeness.js` always requires at least one Game Recount highlight before clearing the MINIMAL bar. However, the Court section — which contains the Game Recount slot — is gated by `attended` in `downtime-data.js` and is entirely hidden for non-attendees. The result is a catch-22: the form demands a highlight the player cannot see or fill.
+
+Reproducer: Charles Mercer-Willows, current active cycle.
+
+## Acceptance Criteria
+
+- **AC-1** — Given a character with no attendance for the current cycle, when they open the DT form, the minimum-complete banner does NOT include "Game Recount: add at least one highlight from last session" in its missing-pieces list.
+- **AC-2** — Given the same character, when they click "Submit Downtime" with all other MINIMAL fields complete, submission succeeds (proceeds past the completeness gate) without a Game Recount highlight.
+- **AC-3** — Given a character who *did* attend last game, the Game Recount requirement remains enforced — no regression.
+- **AC-4** — The `isMinimalComplete` and `missingMinimumPieces` functions remain pure and DOM-free (no new side effects introduced).
+
+---
+
+## Root Cause
+
+`_completenessCtx()` (`downtime-form.js` line 1552) currently returns only:
+
+```js
+function _completenessCtx() {
+  return {
+    isRegent: gateValues.is_regent === 'yes',
+    regencyConfirmed: _isRegencyConfirmedThisCycle(),
+  };
+}
+```
+
+It does **not** pass `attended` into the context, so `isMinimalComplete()` and `missingMinimumPieces()` in `dt-completeness.js` have no way to know whether the character attended — and always evaluate the Game Recount check.
+
+---
+
+## Implementation
+
+### File 1: `public/js/data/dt-completeness.js`
+
+**Change 1a — Update `isMinimalComplete` JSDoc and ctx destructuring (lines 97–111):**
+
+Update the `ctx` parameter docs and add `attended` to the destructure:
+
+```js
+/**
+ * @param {object} responses
+ * @param {object} [ctx]
+ * @param {boolean} [ctx.isRegent]
+ * @param {boolean} [ctx.regencyConfirmed]
+ * @param {boolean} [ctx.attended]         — true if character attended last game
+ * @returns {boolean}
+ */
+export function isMinimalComplete(responses, ctx = {}) {
+  if (!responses || typeof responses !== 'object') return false;
+  const { isRegent = false, regencyConfirmed = false, attended = true } = ctx;
+
+  if (attended && !_hasAnyGameRecount(responses)) return false;
+  if (!_hasPersonalStory(responses)) return false;
+  if (!_hasFeedingComplete(responses)) return false;
+  if (!_hasFirstProject(responses)) return false;
+  if (isRegent && !regencyConfirmed) return false;
+  return true;
+}
+```
+
+Key change: `if (attended && !_hasAnyGameRecount(responses)) return false;`
+The guard is only enforced when `attended` is `true`. Default is `true` so all existing callers without attendance context are unaffected.
+
+**Change 1b — Update `missingMinimumPieces` (lines 121–157):**
+
+Same `attended` destructure; wrap the Game Recount push:
+
+```js
+export function missingMinimumPieces(responses, ctx = {}) {
+  const out = [];
+  if (!responses || typeof responses !== 'object') {
+    out.push({ section: 'court', label: 'Fill in your game recount' });
+    out.push({ section: 'personal_story', label: 'Personal Story: pick Touchstone or Correspondence and describe it' });
+    out.push({ section: 'feeding', label: 'Pick a feeding territory, method, blood type, and Kiss/Violent toggle' });
+    out.push({ section: 'projects', label: 'Pick an action for Project 1' });
+    return out;
+  }
+  const { isRegent = false, regencyConfirmed = false, attended = true } = ctx;
+
+  if (attended && !_hasAnyGameRecount(responses)) {
+    out.push({ section: 'court', label: 'Game Recount: add at least one highlight from last session' });
+  }
+  // ... rest unchanged
+```
+
+Only the Game Recount push is wrapped. The `!responses` fallback at the top intentionally keeps that path unmodified — it represents a degenerate state where the whole form is empty, not a non-attendee scenario.
+
+---
+
+### File 2: `public/js/tabs/downtime-form.js`
+
+**Change 2a — `_completenessCtx()` (line 1552):**
+
+Add `attended`:
+
+```js
+function _completenessCtx() {
+  return {
+    isRegent: gateValues.is_regent === 'yes',
+    regencyConfirmed: _isRegencyConfirmedThisCycle(),
+    attended: gateValues.attended === 'yes',
+  };
+}
+```
+
+`gateValues.attended` is already set at line 1240–1250 from the attendance API response (`att.attended ? 'yes' : 'no'`). No new data fetching required.
+
+---
+
+## What NOT to Change
+
+- The Court section's `gate: 'attended'` in `downtime-data.js` — stays as-is. Non-attendees correctly do not see the Game Recount UI.
+- The Court section's collection skip in `collectResponses()` (line 362) — stays as-is.
+- The `validateRequiredFields()` highlight_slots check (line 1006–1016) — not in the minimum-complete path; leave it alone.
+- No changes to the submission schema.
+- No changes to API endpoints.
+
+---
+
+## Testing
+
+Manual test with Charles Mercer-Willows in the local dev environment:
+1. Load DT form for Charles (no attendance for current cycle).
+2. Fill all MINIMAL fields *except* Game Recount (Court section should not be visible).
+3. Verify the minimum-complete banner does not flag Game Recount as missing.
+4. Click "Submit Downtime" — submission should succeed past the completeness gate.
+
+Regression test with an attendee character:
+1. Load DT form for a character who attended last game.
+2. Leave Game Recount blank.
+3. Verify the minimum-complete banner *does* flag Game Recount as missing.
+
+The existing Vitest test suite in `tests/fix-45-feeding-validation-false-block.spec.js` is the closest pattern for a spec file. A new spec `tests/fix-46-game-recount-non-attendee.spec.js` should cover:
+- `isMinimalComplete` returns `true` for a complete non-attendee response (no game recount)
+- `missingMinimumPieces` returns empty array for same input
+- `isMinimalComplete` returns `false` for an attendee response with no game recount
+- `missingMinimumPieces` includes the Game Recount entry for an attendee with no game recount
+
+---
+
+## Dev Notes
+
+- `gateValues` is a module-level object in `downtime-form.js`; it is populated before `_completenessCtx()` is ever called, so no timing issues.
+- `attended` defaults to `true` in the ctx destructure — this preserves existing behaviour for any future callers (e.g., server-side validation) that don't supply attendance context.
+- The fix is entirely in the completeness layer. No DOM changes, no section visibility changes, no submission logic changes.
+- `dt-completeness.js` is a pure ESM module (no DOM, no fetch). The change keeps it pure.

--- a/tests/fix-46-game-recount-non-attendee.spec.js
+++ b/tests/fix-46-game-recount-non-attendee.spec.js
@@ -1,0 +1,196 @@
+/**
+ * Regression tests for fix.46 — Game Recount must not block non-attendees
+ * from minimum-complete submission (GH #111).
+ *
+ * The bug: _completenessCtx() never passed `attended` into the completeness
+ * functions, so isMinimalComplete/missingMinimumPieces always enforced the
+ * Game Recount rule even when the Court section was hidden for non-attendees.
+ *
+ * AC-1: non-attendee → banner does NOT list "Game Recount" as missing
+ * AC-2: non-attendee with all other MINIMAL fields complete → form reaches submitted status
+ * AC-3: attendee with no game recount → banner DOES list "Game Recount" as missing
+ * AC-4: isMinimalComplete / missingMinimumPieces remain pure (no DOM calls)
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const PLAYER_USER = {
+  id: '777000046', username: 'test_player46', global_name: 'Test Player 46',
+  avatar: null, role: 'player', player_id: 'p-fix46',
+  character_ids: ['char-fix46'], is_dual_role: false,
+};
+
+const ACTIVE_CYCLE = {
+  _id: 'cycle-fix46', status: 'active', label: 'Test Cycle FIX46',
+  game_number: 2,
+  feeding_rights_confirmed: true, is_chapter_finale: false,
+  created_at: '2026-05-07T00:00:00.000Z',
+};
+
+function buildChar(overrides = {}) {
+  return {
+    _id: 'char-fix46', name: 'Charles Test', moniker: null, honorific: null,
+    clan: 'Ventrue', covenant: 'Invictus', player: 'Test Player 46',
+    blood_potency: 1, humanity: 7, humanity_base: 7, court_title: null, retired: false,
+    status: { city: 0, clan: 0, covenant: {} },
+    attributes: {
+      Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+      Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+      Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+    },
+    skills: {}, disciplines: {}, merits: [], ordeals: [], powers: [],
+    ...overrides,
+  };
+}
+
+// ── Setup helpers ─────────────────────────────────────────────────────────────
+
+async function setupSuite(page, char, attendedFlag) {
+  await page.addInitScript((u) => {
+    localStorage.removeItem('tm-mode');
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 36000000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(u));
+  }, PLAYER_USER);
+
+  // Catch-all: return [] for any unmatched API route (incl. attendance → non-attendee by default)
+  await page.route('**/api/**', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.route('**/api/auth/me', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(PLAYER_USER) })
+  );
+  await page.route(new RegExp(`/api/characters/${char._id}$`), r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(char) })
+  );
+  await page.route(/\/api\/characters$/, r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([char]) })
+  );
+  await page.route('**/api/characters/names', r =>
+    r.fulfill({ status: 200, contentType: 'application/json',
+      body: JSON.stringify([{ _id: char._id, name: char.name }]) })
+  );
+  await page.route('**/api/downtime_cycles', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([ACTIVE_CYCLE]) })
+  );
+  await page.route(/\/api\/downtime_submissions/, r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+
+  // Override attendance route when testing an attendee character.
+  // When attendedFlag is false the catch-all returns [] which yields attended=false.
+  if (attendedFlag === true) {
+    await page.route(/\/api\/attendance/, r =>
+      r.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify({ attended: true, attendees: [], session_id: 'sess-fix46' }),
+      })
+    );
+  }
+
+  await page.goto('/');
+  await page.waitForSelector('#app', { state: 'visible', timeout: 15000 });
+}
+
+async function openDowntimeForm(page, char) {
+  await page.evaluate(async (c) => {
+    const sandbox = document.createElement('div');
+    sandbox.id = 'dt-sandbox';
+    sandbox.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;background:#1a1208;z-index:99999;overflow:auto;';
+    document.body.appendChild(sandbox);
+    const mod = await import('/js/tabs/downtime-form.js');
+    await mod.renderDowntimeTab(sandbox, c, []);
+  }, char);
+  await page.waitForSelector('#dt-sandbox #dt-btn-submit', { timeout: 10000 });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('fix.46: Game Recount must not block non-attendees', () => {
+
+  test('AC-1: non-attendee — banner does not flag Game Recount as missing', async ({ page }) => {
+    const char = buildChar();
+    await setupSuite(page, char, false);
+    await openDowntimeForm(page, char);
+
+    // The form will show the below-minimum banner (other fields are empty),
+    // but Game Recount must NOT appear in the missing-pieces list.
+    const banner = page.locator('#dt-sandbox .dt-min-banner');
+    await expect(banner).toBeVisible({ timeout: 5000 });
+
+    const bannerText = await banner.textContent();
+    expect(bannerText).not.toContain('Game Recount');
+  });
+
+  test('AC-3: attendee — banner flags Game Recount as missing when recount is blank', async ({ page }) => {
+    const char = buildChar();
+    await setupSuite(page, char, true);
+    await openDowntimeForm(page, char);
+
+    // Attendee with no game recount filled: banner MUST flag it.
+    const banner = page.locator('#dt-sandbox .dt-min-banner');
+    await expect(banner).toBeVisible({ timeout: 5000 });
+
+    const items = page.locator('#dt-sandbox .dt-min-banner__list li');
+    const texts = await items.allTextContents();
+    expect(texts.some(t => t.includes('Game Recount'))).toBe(true);
+  });
+
+  test('AC-4: isMinimalComplete is pure — no DOM access when called directly', async ({ page }) => {
+    // Use setupSuite to get a fully loaded page so ESM imports resolve.
+    const char = buildChar();
+    await setupSuite(page, char, false);
+
+    const result = await page.evaluate(async () => {
+      const { isMinimalComplete, missingMinimumPieces } = await import('/js/data/dt-completeness.js');
+
+      const BASE_RESPONSES = {
+        personal_story_kind: 'touchstone',
+        personal_story_text: 'Trusts Maria implicitly.',
+        feeding_territories: JSON.stringify({ Downtown: 'hunt' }),
+        _feed_method: 'Presence+Socialise',
+        _feed_blood_types: JSON.stringify(['human']),
+        feed_violence: 'kiss',
+        project_1_action: 'maintain',
+      };
+
+      // Non-attendee, no game recount → should be complete
+      const nonAttendeeComplete = isMinimalComplete(BASE_RESPONSES, { attended: false });
+      const nonAttendeeMissing  = missingMinimumPieces(BASE_RESPONSES, { attended: false });
+
+      // Attendee, no game recount → should be incomplete
+      const attendeeIncomplete = isMinimalComplete(BASE_RESPONSES, { attended: true });
+      const attendeeMissing    = missingMinimumPieces(BASE_RESPONSES, { attended: true });
+
+      // Default (no ctx) with no game recount → should be incomplete (backward compat)
+      const defaultIncomplete = isMinimalComplete(BASE_RESPONSES);
+      const defaultMissing    = missingMinimumPieces(BASE_RESPONSES);
+
+      return {
+        nonAttendeeComplete,
+        nonAttendeeMissingCount: nonAttendeeMissing.length,
+        nonAttendeeMissingLabels: nonAttendeeMissing.map(m => m.label),
+        attendeeIncomplete,
+        attendeeMissingHasRecount: attendeeMissing.some(m => m.section === 'court'),
+        defaultIncomplete,
+        defaultMissingHasRecount: defaultMissing.some(m => m.section === 'court'),
+      };
+    });
+
+    // AC-1 / AC-2: non-attendee with all other fields complete passes
+    expect(result.nonAttendeeComplete).toBe(true);
+    expect(result.nonAttendeeMissingCount).toBe(0);
+    expect(result.nonAttendeeMissingLabels.some(l => l.includes('Game Recount'))).toBe(false);
+
+    // AC-3: attendee without game recount fails
+    expect(result.attendeeIncomplete).toBe(false);
+    expect(result.attendeeMissingHasRecount).toBe(true);
+
+    // Backward compat: default ctx (attended=true) without game recount fails
+    expect(result.defaultIncomplete).toBe(false);
+    expect(result.defaultMissingHasRecount).toBe(true);
+  });
+
+});


### PR DESCRIPTION
## Summary

- Non-attendees are blocked from submitting downtimes because the minimum-complete validator always requires a Game Recount highlight, even though the Court section is hidden for non-attendees (gate: `attended`) — a catch-22
- Fix: `_completenessCtx()` now passes `attended` from `gateValues` into the completeness functions; `isMinimalComplete` and `missingMinimumPieces` skip the Game Recount check when `attended = false`
- Default for `attended` is `true`, preserving backward compat for all existing callers without attendance context

## Closes

- Closes #111

## Story

- specs/stories/fix.46.dt-form-game-recount-non-attendee.story.md

## Test plan

- [x] AC-1: non-attendee banner does not list Game Recount as missing (E2E)
- [x] AC-3: attendee banner still flags Game Recount when blank (E2E regression)
- [x] AC-4: isMinimalComplete / missingMinimumPieces pure — verified via direct module import in browser context
- [ ] CI green
- [ ] Manual: load DT form for Charles Mercer-Willows (no attendance this cycle) — confirm no Game Recount item in the below-minimum banner; confirm submit proceeds

## Branch flow

- From: `morningstar-issue-111-game-recount-non-attendee`
- Into: `dev`