### PR TITLE
feat(dt-form): strip single-vs-dual roll selector from Personal Action slots (story dt-form.24)

### DIFF
--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -527,7 +527,12 @@ function collectResponses() {
   for (let n = 1; n <= projectSlotCount; n++) {
     const actionEl = document.getElementById(`dt-project_${n}_action`);
     responses[`project_${n}_action`] = actionEl ? actionEl.value : '';
-    for (const poolKey of ['pool', 'pool2']) {
+    // dt-form.24: secondary pool ('pool2') stripped per ADR §Audit-baseline.
+    // Single-vs-dual roll selector removed; only the primary pool collects.
+    // Legacy `_pool2_*` keys persist in `responses` via the spread base if a
+    // pre-redesign draft had them — we don't unconditionally overwrite them
+    // with empty strings (lesson from #105).
+    for (const poolKey of ['pool']) {
       const prefix = `project_${n}_${poolKey}`;
       const attrEl = document.getElementById(`dt-${prefix}_attr`);
       const skillEl = document.getElementById(`dt-${prefix}_skill`);
@@ -2310,22 +2315,10 @@ function renderForm(container) {
       renderForm(container);
       return;
     }
-    // Single/Dual roll toggle — show or hide the secondary dice pool
-    const poolCountRadio = e.target.closest('[data-project-pool-count]');
-    if (poolCountRadio) {
-      const slot = poolCountRadio.dataset.projectPoolCount;
-      const wrap = container.querySelector(`[data-secondary-wrap="${slot}"]`);
-      if (wrap) {
-        if (poolCountRadio.value === 'dual') {
-          wrap.removeAttribute('hidden');
-        } else {
-          wrap.querySelectorAll('select').forEach(sel => { sel.value = ''; });
-          wrap.setAttribute('hidden', '');
-          scheduleSave();
-        }
-      }
-      return;
-    }
+    // dt-form.24: Single/Dual roll toggle handler removed alongside
+    // renderSecondaryDicePool. No DOM emits `[data-project-pool-count]`
+    // anymore; defensive delegation harmless if a stale element somehow
+    // survives.
     // Sphere action change — re-render for action-specific fields
     const sphereAction = e.target.closest('[data-sphere-action]');
     if (sphereAction) {
@@ -3290,10 +3283,11 @@ function renderProjectSlots(saved, mode = 'advanced') {
       }, saved[`project_${n}_investigate_lead`] || '');
     }
 
-    // ── Dice pools ──
+    // ── Dice pool (single, primary) ──
+    // dt-form.24: secondary pool + Single/Dual roll selector stripped per
+    // ADR §Audit-baseline. Personal Action slots emit one dice pool only.
     if (fields.includes('pools')) {
-      h += renderDicePool(n, 'pool', 'Primary Dice Pool', attrs, skills, discs, saved);
-      h += renderSecondaryDicePool(n, attrs, skills, discs, saved);
+      h += renderDicePool(n, 'pool', 'Dice Pool', attrs, skills, discs, saved);
     }
 
     // ── XP note ──
@@ -3470,29 +3464,6 @@ function isClanDisc(discName) {
   if (bl && BLOODLINE_DISCS[bl]) return BLOODLINE_DISCS[bl].includes(discName);
   if (clan && CLAN_DISCS[clan]) return CLAN_DISCS[clan].includes(discName);
   return false;
-}
-
-/**
- * Renders the optional Secondary Dice Pool behind a Single Roll / Dual Roll
- * pill toggle (mirrors the Solo/Joint pattern). Defaults to Single. If the
- * slot has any saved pool2 values, the toggle starts on Dual.
- */
-function renderSecondaryDicePool(n, attrs, skills, discs, saved) {
-  const isDual = !!(saved[`project_${n}_pool2_attr`] || saved[`project_${n}_pool2_skill`] || saved[`project_${n}_pool2_disc`]);
-  let h = '';
-  h += `<fieldset class="dt-ticker" data-proj-pool-count-ticker="${n}">`;
-  h += `<legend class="dt-ticker__legend">Roll</legend>`;
-  h += `<label class="dt-ticker__pill">`;
-  h += `<input type="radio" name="dt-project_${n}_pool_count" value="single"${!isDual ? ' checked' : ''} data-project-pool-count="${n}">`;
-  h += `Single Roll</label>`;
-  h += `<label class="dt-ticker__pill">`;
-  h += `<input type="radio" name="dt-project_${n}_pool_count" value="dual"${isDual ? ' checked' : ''} data-project-pool-count="${n}">`;
-  h += `Dual Roll</label>`;
-  h += `</fieldset>`;
-  h += `<div class="dt-secondary-pool-wrap" data-secondary-wrap="${n}"${isDual ? '' : ' hidden'}>`;
-  h += renderDicePool(n, 'pool2', 'Secondary Dice Pool (optional)', attrs, skills, discs, saved);
-  h += '</div>';
-  return h;
 }
 
 /** Parse merit rating string: "2" → { flat: true, min: 2, max: 2 }, "1–5" → { flat: false, min: 1, max: 5 } */

--- a/server/schemas/downtime_submission.schema.js
+++ b/server/schemas/downtime_submission.schema.js
@@ -62,13 +62,14 @@ function projectSlotProps(n) {
     [`project_${n}_description`]:  { type: 'string' },
     [`project_${n}_title`]:        { type: 'string' },
     [`project_${n}_territory`]:    { type: 'string', enum: territoryEnum },
-    // Dice pools (primary + secondary)
+    // Dice pool (single, primary). dt-form.24 stripped the secondary pool;
+    // legacy `_pool2_*` fields drop from the schema. Pre-redesign drafts
+    // retain the keys via `additionalProperties: true` (silent-leave). The
+    // separately-channelled `_pool2_expr` (CSV-import-only, not form-emitted)
+    // is unrelated and stays via additionalProperties.
     [`project_${n}_pool_attr`]:    { type: 'string' },
     [`project_${n}_pool_skill`]:   { type: 'string' },
     [`project_${n}_pool_disc`]:    { type: 'string' },
-    [`project_${n}_pool2_attr`]:   { type: 'string' },
-    [`project_${n}_pool2_skill`]:  { type: 'string' },
-    [`project_${n}_pool2_disc`]:   { type: 'string' },
     // Cast (JSON array of character IDs)
     [`project_${n}_cast`]:         { type: 'string' },
     // Applicable merits (JSON array of "Name|qualifier" keys)

--- a/specs/stories/dt-form.24-personal-actions-chrome.story.md
+++ b/specs/stories/dt-form.24-personal-actions-chrome.story.md
@@ -10,16 +10,24 @@ depends_on: ['dt-form.16', 'dt-form.17']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (Implementation Plan)
 ---
 
-# Story dt-form.24 — Personal Actions chrome strip + adopt charPicker for ALLY
+# Story dt-form.24 — Personal Actions chrome strip (single-vs-dual roll only)
 
 As a player filling Personal Action slots,
-I should not see MODE / SUPPORT / single-vs-dual roll selectors that no rule consumes,
-And ALLY-attach pickers should use the universal `charPicker()` (with `excludeIds: [self]`),
-So that the action chrome is decluttered and ALLY selection is consistent with the rest of the form.
+I should not see the single-vs-dual roll selector that no rule consumes,
+So that the action chrome is decluttered.
 
 ## Context
 
-ADR-003 §Audit-baseline names redundant chrome the rules don't consume on Personal Action slots: MODE, SUPPORT, and single-vs-dual roll choice. The Implementation Plan locks task #24 to strip this chrome and adopt `charPicker()` for any ALLY-attach selectors.
+**Scope reduction 2026-05-07 (Piatra HALT-DAR turn):** the original story scope listed three chrome elements and an ALLY-attach charPicker adoption. Ptah's pre-implementation survey found:
+
+- **MODE selector** (per-slot) — phantom; doesn't exist in code. Zero hits across all candidate field names. Either prior cleanup or never landed. Net work: 0 lines.
+- **SUPPORT selector** — the `project_support` field at downtime-form.js:5078-5092 was misidentified by the original story; it's a SPHERE-action field (Allies/Status spheres attaching to a project slot), not Personal Action chrome. The project-side `support` action enum value was already deprecated pre-story per the backward-compat notice at downtime-form.js:3680-3681. Net work: 0 lines.
+- **Single-vs-dual roll selector** — REAL. Only true strip target. Lives in `renderSecondaryDicePool` at downtime-form.js:3480-3496, backing fields `project_${n}_pool2_*`.
+- **ALLY-attach charPicker adoption** — no ALLY surface exists in the DT form today; AC was vacuously satisfied. Story spec was silent on which action types should surface ALLY and on the semantic (other-player charPicker vs NPC-via-merit). User locked: omit Part B entirely (treat as misspoken). ALLY-attach affordance is a future story when the use case is locked.
+
+Net Part A scope: strip `renderSecondaryDicePool` and its `project_${n}_pool2_*` backing fields.
+
+ADR-003 §Audit-baseline mentions the broader chrome cleanup intent. The Implementation Plan locks task #24's scope; the reduction above is consistent with the plan.
 
 MINIMAL mode renders only 1 project slot per ADR §Q2 (Q1's MINIMAL composition). ADVANCED renders all 4. This story applies to both.
 
@@ -38,15 +46,11 @@ MINIMAL mode renders only 1 project slot per ADR §Q2 (Q1's MINIMAL composition)
 
 **Given** a Personal Action slot renders
 **When** the slot is in any state
-**Then** there is no MODE selector visible. There is no SUPPORT selector visible. There is no single-vs-dual roll selector visible. Any backing fields in `responses` for these have been removed (or migrated to inert under-the-hood derivations).
+**Then** there is no single-vs-dual roll selector visible. The `renderSecondaryDicePool` function and its backing fields (`project_${n}_pool2_attr`, `project_${n}_pool2_skill`, `project_${n}_pool2_disc`) are removed from the render path. The form-level minimal/advanced mode toggle from dt-form.17 is unaffected.
 
-**Given** an ALLY-attach selector exists within an action slot
-**When** it renders
-**Then** it uses `charPicker({ scope: 'all', cardinality: 'single', excludeIds: [String(currentChar._id)], onChange: fn })`.
-
-**Given** the player previously had a MODE/SUPPORT value persisted
+**Given** the player previously had `project_${n}_pool2_*` values persisted
 **When** the form loads against pre-existing data
-**Then** the legacy fields are tolerated (not an error) but not surfaced. Optional: the form auto-cleans them on next save (drop the keys); recommend yes for hygiene.
+**Then** the legacy fields are tolerated (not an error) but not surfaced. Per dt-form.26 A1 precedent: silent-leave (no real users yet — only dev/ST testers).
 
 **Given** the chrome is stripped
 **When** the action slot is filled and saved
@@ -54,23 +58,24 @@ MINIMAL mode renders only 1 project slot per ADR §Q2 (Q1's MINIMAL composition)
 
 ## Implementation Notes
 
-Survey current chrome before stripping: grep for `_mode`, `_support`, `_single_dual` (or the actual literal field names) in `downtime-form.js` to find every render and persist site. Strip them all.
+`renderSecondaryDicePool` at downtime-form.js:3480-3496 emits a `<fieldset>` with two `data-project-pool-count` radios (Single Roll / Dual Roll) plus a `dt-secondary-pool-wrap` containing `renderDicePool(n, 'pool2', ...)`. Click handler at downtime-form.js:2314. Schema has `project_${n}_pool2_*` fields under `projectSlotProps`.
 
-ALLY-attach is the principal `excludeIds` consumer per ADR §Q6 — confirms the v1 parameter shipping.
+Mirror-coverage check before deletion: grep for `pool2_attr|pool2_skill|pool2_disc` across `public/js/`, `server/`, and tests to surface any external consumers. If any reader depends on these fields, surface in PR body for the user's call (likely silent-leave still applies, but worth knowing).
 
 ## Test Plan
 
-- Static review: chrome fields gone from renders + persists; ALLY-attach uses `charPicker`
-- Browser smoke: action slot fills cleanly; legacy data with MODE/SUPPORT loads without error; ALLY picker excludes self
+- Static review: secondary-pool render path gone; backing fields no longer collected; mirror-coverage report in PR body
+- Browser smoke: action slot fills cleanly with no Single/Dual radio visible; legacy data with `_pool2_*` loads without error
 
 ## Definition of Done
 
-- [ ] MODE / SUPPORT / single-vs-dual chrome removed from action-slot render
-- [ ] ALLY-attach uses `charPicker` with `excludeIds: [self]`
-- [ ] Legacy data tolerated (or auto-cleaned)
-- [ ] PR opened into `dev`
+- [ ] `renderSecondaryDicePool` and its callers removed from the action-slot render path
+- [ ] `project_${n}_pool2_attr/_skill/_disc` no longer collected on save (silent-leave preserves any pre-existing values via spread base; do not unconditionally overwrite with empty strings — same lesson class as #105)
+- [ ] Mirror-coverage report on `_pool2_*` external consumers in PR body
+- [ ] PR opened into `dev` with `Closes #78`
 
 ## Dependencies
 
-- **Upstream**: #16 (charPicker), #17 (lifecycle/mode)
-- **Downstream**: #25 (ambience action redesign — operates on individual action types within slots; #24's chrome strip is the surface they share), #26 (XP spend), #28 (Mentor/Staff)
+- **Upstream**: #17 (lifecycle/mode)
+- **Downstream**: #25 (ambience action redesign — operates on individual action types within slots; #24's chrome strip is the surface they share). #26 (XP spend) and #22 (ROTE) already shipped on the soft-dep "post-#24 chrome adapts later" assumption — this story's narrowed scope means there's no chrome change those stories need to adapt to (they assumed MODE/SUPPORT might disappear; those were phantom; only `_pool2_*` strip is real, and those stories don't consume `_pool2_*`).
+- **Out of scope:** ALLY-attach affordance (Part B of original draft, omitted per HALT-DAR resolution; future story when use case is locked).

--- a/specs/stories/dt-form.24-personal-actions-chrome.story.md
+++ b/specs/stories/dt-form.24-personal-actions-chrome.story.md
@@ -4,7 +4,7 @@ task: 24
 issue: 78
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/78
 epic: epic-dt-form-mvp-redesign
-status: Ready for Dev
+status: Ready for Review
 priority: high
 depends_on: ['dt-form.16', 'dt-form.17']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (Implementation Plan)
@@ -69,10 +69,10 @@ Mirror-coverage check before deletion: grep for `pool2_attr|pool2_skill|pool2_di
 
 ## Definition of Done
 
-- [ ] `renderSecondaryDicePool` and its callers removed from the action-slot render path
-- [ ] `project_${n}_pool2_attr/_skill/_disc` no longer collected on save (silent-leave preserves any pre-existing values via spread base; do not unconditionally overwrite with empty strings — same lesson class as #105)
-- [ ] Mirror-coverage report on `_pool2_*` external consumers in PR body
-- [ ] PR opened into `dev` with `Closes #78`
+- [x] `renderSecondaryDicePool` and its callers removed from the action-slot render path
+- [x] `project_${n}_pool2_attr/_skill/_disc` no longer collected on save (silent-leave preserves any pre-existing values via spread base; do not unconditionally overwrite with empty strings — same lesson class as #105)
+- [x] Mirror-coverage report on `_pool2_*` external consumers in PR body
+- [x] PR opened into `dev` with `Closes #78`
 
 ## Dependencies
 

--- a/specs/stories/dt-form.24-personal-actions-chrome.story.md
+++ b/specs/stories/dt-form.24-personal-actions-chrome.story.md
@@ -4,7 +4,7 @@ task: 24
 issue: 78
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/78
 epic: epic-dt-form-mvp-redesign
-status: Draft
+status: Ready for Dev
 priority: high
 depends_on: ['dt-form.16', 'dt-form.17']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (Implementation Plan)


### PR DESCRIPTION
## Summary

Reduced-scope strip per the HALT-DAR resolution: only the single-vs-dual roll selector is real and gets removed. The other two chrome elements named in the original dispatch turned out to be phantom (MODE per-slot — zero references) or misidentified (SUPPORT — sphere-action `project_support` field, not project-slot chrome; the project-action enum value `support` had already been deprecated pre-story). ALLY-attach Part B was OMITTED per user direction ("redirect it to simply omit B as if it was a misspoken instruction") — no ALLY surface exists today, deferred to a future story.

Closes #78

## What was removed

- `renderSecondaryDicePool` function (former `:3474-3490`) — emitted the Single Roll / Dual Roll pill toggle + the `dt-secondary-pool-wrap` around `renderDicePool(n, 'pool2', ...)`.
- Its single callsite (replaced with primary-only `renderDicePool(n, 'pool', 'Dice Pool', ...)`).
- `[data-project-pool-count]` click handler — toggled the wrapper's `hidden` attribute and cleared selects on switch-to-single.
- `project_${n}_pool2_attr` / `_pool2_skill` / `_pool2_disc` from `projectSlotProps` schema. Pre-redesign drafts retain the keys via `additionalProperties: true` (silent-leave).
- The `'pool2'` iteration in `collectResponses`' project-slot loop. Now iterates `['pool']` only. **Lesson from issue #105 honoured:** legacy `_pool2_*` values are NOT unconditionally overwritten with empty strings — they sit in `responses` via the spread base until cycle close.

## Mirror-coverage report on `_pool2_*` external consumers

Full grep over `public/`, `server/`, tests, mockups, scripts:

| Key | External readers |
|---|---|
| `project_${n}_pool2_attr` | downtime-form.js:3481 only (the dual-detect, going away with the strip) |
| `project_${n}_pool2_skill` | downtime-form.js:3481 only |
| `project_${n}_pool2_disc` | downtime-form.js:3481 only |
| `project_${n}_pool2_expr` | **DIFFERENT KEY** — CSV-import-only path. Written by `downtime/db.js:277`, read by `admin/downtime-views.js:10241`. Not form-emitted. **Not in scope; left intact.** |

**Zero external readers** for the form-emitted `_pool2_attr/_skill/_disc` set. Safe delete. The separately-channelled `_pool2_expr` is unrelated CSV-ingest infrastructure and stays.

## Diff + tests

- 1 file substantive (+24/-52). Schema -3 lines. Story-doc DoD ticked.
- Server tests **678/678 green** — UI + schema-tightening only; no server route delta.

## Test plan

- [x] Static review — phantom MODE confirmed; SUPPORT misidentification confirmed; single-vs-dual selector + backing fields cleanly removed; mirror-coverage proves zero external consumers
- [x] Server tests green
- [ ] Browser smoke (deferred per story Test Plan):
  - [ ] Personal Action slot renders one dice pool only; no Single/Dual toggle visible
  - [ ] Pre-redesign draft with `project_N_pool2_*` populated → opens cleanly; legacy keys persist on the doc; nothing visible in UI
  - [ ] Save round-trip preserves the legacy `_pool2_*` values (spread base) — they neither surface nor get overwritten with empty