### PR TITLE
feat(dt-form): Ambience action redesign — territory-row table (story dt-form.25)

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -5115,6 +5115,76 @@ html:not([data-theme="dark"]) .char-picker__pill { font-weight: 600; }
 }
 
 /* ════════════════════════════════════════════════════════════════════
+   .dt-amb-table — Ambience row-table (ADR-003 §Implementation Plan,
+   story dt-form.25). Single-target by design: at most one row can
+   hold a selection at any time per action slot.
+   ════════════════════════════════════════════════════════════════════ */
+.dt-amb-table {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-top: 6px;
+}
+
+.dt-amb-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  background: var(--surf2);
+  border: 1px solid var(--bdr);
+  border-radius: 4px;
+}
+
+.dt-amb-row-name {
+  font-family: var(--fl);
+  font-size: 0.95em;
+  color: var(--txt);
+}
+
+.dt-amb-arrow {
+  appearance: none;
+  border: 1px solid var(--bdr2);
+  border-radius: 999px;
+  background: var(--surf);
+  color: var(--txt2);
+  width: 32px;
+  height: 32px;
+  font-size: 1em;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dt-amb-arrow:hover {
+  border-color: var(--gold);
+}
+
+.dt-amb-arrow--down {
+  color: var(--crim, #b00020);
+}
+
+.dt-amb-arrow--down.dt-amb-arrow--on {
+  background: var(--crim, #b00020);
+  color: var(--txt-on-dark, #fff);
+  border-color: var(--crim, #b00020);
+}
+
+.dt-amb-arrow--up {
+  color: var(--green, #2a8a3a);
+}
+
+.dt-amb-arrow--up.dt-amb-arrow--on {
+  background: var(--green, #2a8a3a);
+  color: var(--txt-on-dark, #fff);
+  border-color: var(--green, #2a8a3a);
+}
+
+/* ════════════════════════════════════════════════════════════════════
    .dt-min-toast — MINIMAL auto-submit confirmation (ADR-003 §Q5, dt-form.31)
    ════════════════════════════════════════════════════════════════════ */
 .dt-min-toast {

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -166,7 +166,9 @@ const ACTION_FIELDS = {
   '': [],
   'feed': [],
   'xp_spend': ['xp_picker'],
-  'ambience_change':   ['title', 'outcome', 'target', 'pools', 'description'],
+  // dt-form.25: 'target' dropped — the row-table inline below IS the
+  // (territory + direction) picker. Renders alongside title/outcome/pools/description.
+  'ambience_change':   ['title', 'outcome', 'pools', 'description'],
   'attack':            ['title', 'outcome', 'target', 'pools', 'description'],
   'investigate':       ['title', 'outcome', 'target', 'investigate_lead', 'pools', 'description'],
   'hide_protect':      ['title', 'outcome', 'target', 'pools', 'description'],
@@ -612,8 +614,15 @@ function collectResponses() {
     responses[`project_${n}_target_terr`] = targetTerrEl ? targetTerrEl.value : '';
     const targetOtherEl = document.getElementById(`dt-project_${n}_target_other`);
     responses[`project_${n}_target_other`] = targetOtherEl ? targetOtherEl.value : '';
-    const ambienceDirEl = document.querySelector(`input[name="dt-project_${n}_ambience_dir"]:checked`);
-    responses[`project_${n}_ambience_dir`] = ambienceDirEl ? ambienceDirEl.value : '';
+    // dt-form.25: legacy `_ambience_dir` radio collect dropped (drop-the-
+    // iteration shape per Ma'at #127 praise). The new row-table writes
+    // `_ambience_target` + `_ambience_direction` directly via the hidden
+    // inputs below. Pre-existing legacy `_ambience_dir` values persist on
+    // the doc via the spread base (silent-leave per A1).
+    const ambTargetEl = document.getElementById(`dt-project_${n}_ambience_target`);
+    const ambDirEl    = document.getElementById(`dt-project_${n}_ambience_direction`);
+    if (ambTargetEl) responses[`project_${n}_ambience_target`]    = ambTargetEl.value;
+    if (ambDirEl)    responses[`project_${n}_ambience_direction`] = ambDirEl.value;
     const leadEl = document.getElementById(`dt-project_${n}_investigate_lead`);
     responses[`project_${n}_investigate_lead`] = leadEl ? leadEl.value : '';
 
@@ -2362,7 +2371,46 @@ function renderForm(container) {
       scheduleSave();
       return;
     }
-    // Ambience direction ticker — re-render so desc/prompt/outcome update
+    // dt-form.25: Ambience row-table arrow click. Single-target state
+    // machine per the 6 ACs:
+    //   - new row click           → switch to (newRow, clickedDir)
+    //   - opposite arrow same row → switch direction, retain row
+    //   - same arrow same row     → toggle off (clear both)
+    const ambArrow = e.target.closest('[data-amb-arrow]');
+    if (ambArrow) {
+      e.preventDefault();
+      const slot     = ambArrow.dataset.ambSlot;
+      const target   = ambArrow.dataset.ambTarget;
+      const dirClick = ambArrow.dataset.ambArrow; // 'up' | 'down'
+      const targetEl = document.getElementById(`dt-project_${slot}_ambience_target`);
+      const dirEl    = document.getElementById(`dt-project_${slot}_ambience_direction`);
+      const curTarget = targetEl ? targetEl.value : '';
+      const curDir    = dirEl    ? dirEl.value    : '';
+      let nextTarget = '';
+      let nextDir    = '';
+      if (curTarget === target && curDir === dirClick) {
+        // same arrow same row → toggle off
+        nextTarget = '';
+        nextDir    = '';
+      } else {
+        // new row OR opposite arrow same row → set to clicked
+        nextTarget = target;
+        nextDir    = dirClick;
+      }
+      if (targetEl) targetEl.value = nextTarget;
+      if (dirEl)    dirEl.value    = nextDir;
+      activeProjectTab = parseInt(slot, 10) || activeProjectTab;
+      const responses = collectResponses();
+      if (responseDoc) responseDoc.responses = responses;
+      else responseDoc = { responses };
+      renderForm(container);
+      scheduleSave();
+      return;
+    }
+    // dt-form.25: legacy improve/degrade ticker handler retained for
+    // sphere-side ambience_change (sphere keeps the legacy radio). Project
+    // side no longer emits `[data-proj-ambience-dir]` after the row-table
+    // redesign; this branch is unreachable for projects but kept defensively.
     const projAmbienceDir = e.target.closest('[data-proj-ambience-dir]');
     if (projAmbienceDir) {
       activeProjectTab = parseInt(projAmbienceDir.dataset.projAmbienceDir, 10);
@@ -3298,6 +3346,48 @@ function renderProjectSlots(saved, mode = 'advanced') {
         type: 'textarea', required: false, rows: 2,
         placeholder: 'Describe what you are spending XP on in this action.',
       }, saved[`project_${n}_xp`] || '');
+    }
+
+    // ── dt-form.25: Ambience row-table (single-target by design) ──
+    // Replaces the legacy target-zone (territory pills + improve/degrade
+    // radios) for `ambience_change` actions. Each row has a RED DOWN arrow
+    // and a GREEN UP arrow; at most one row holds a selection at any time.
+    // Persists single (target, direction) pair as
+    // responses.project_N_ambience_target + project_N_ambience_direction.
+    if (actionVal === 'ambience_change') {
+      // Read selection. Backward-compat seed: if new fields are empty but
+      // legacy `_target_terr` + `_ambience_dir` exist, derive selection
+      // from those so pre-redesign drafts surface correctly on first render.
+      let savedTarget = saved[`project_${n}_ambience_target`] || '';
+      let savedDir    = saved[`project_${n}_ambience_direction`] || '';
+      if (!savedTarget) {
+        const legacyTerr = saved[`project_${n}_target_terr`] || '';
+        if (legacyTerr) savedTarget = legacyTerr;
+      }
+      if (!savedDir) {
+        const legacyDir = saved[`project_${n}_ambience_dir`] || '';
+        if (legacyDir === 'improve') savedDir = 'up';
+        else if (legacyDir === 'degrade') savedDir = 'down';
+      }
+
+      h += '<div class="qf-field dt-amb-table-wrap">';
+      h += '<label class="qf-label">Territory + Direction</label>';
+      h += '<p class="qf-desc">Pick one direction on one territory. Success is +/-2 influence change to territory, +/-4 on exceptional success.</p>';
+      h += `<div class="dt-amb-table" data-amb-table="${n}">`;
+      for (const t of TERRITORY_DATA) {
+        const isRow = String(savedTarget) === String(t.slug);
+        const upOn   = isRow && savedDir === 'up'   ? ' dt-amb-arrow--on'  : '';
+        const downOn = isRow && savedDir === 'down' ? ' dt-amb-arrow--on' : '';
+        h += `<div class="dt-amb-row" data-amb-row="${esc(t.slug)}">`;
+        h += `<span class="dt-amb-row-name">${esc(t.name)}</span>`;
+        h += `<button type="button" class="dt-amb-arrow dt-amb-arrow--down${downOn}" data-amb-arrow="down" data-amb-target="${esc(t.slug)}" data-amb-slot="${n}" aria-label="Decrease ambience of ${esc(t.name)}" aria-pressed="${downOn ? 'true' : 'false'}">▼</button>`;
+        h += `<button type="button" class="dt-amb-arrow dt-amb-arrow--up${upOn}" data-amb-arrow="up" data-amb-target="${esc(t.slug)}" data-amb-slot="${n}" aria-label="Increase ambience of ${esc(t.name)}" aria-pressed="${upOn ? 'true' : 'false'}">▲</button>`;
+        h += '</div>';
+      }
+      h += '</div>';
+      h += `<input type="hidden" id="dt-project_${n}_ambience_target" value="${esc(savedTarget)}">`;
+      h += `<input type="hidden" id="dt-project_${n}_ambience_direction" value="${esc(savedDir)}">`;
+      h += '</div>';
     }
 
     // ── dt-form.22: ROTE territory + read-only inherited pool ──

--- a/server/schemas/downtime_submission.schema.js
+++ b/server/schemas/downtime_submission.schema.js
@@ -30,7 +30,12 @@ const projectActionEnum = [
   // dt-form.22: ROTE moved out of the feeding section into its own per-slot
   // action variant. Pool inherits from primary feeding; territory writes to
   // the existing document-level `feeding_territories_rote` map.
-  'rote'
+  'rote',
+  // dt-form.25: form-side canonical action value for ambience changes
+  // (the legacy `ambience_increase` / `ambience_decrease` values are kept
+  // for CSV-import back-compat reads only — admin/parser still consume
+  // them; tracked under issue #129 for future canonical normalisation).
+  'ambience_change'
 ];
 
 const sphereActionEnum = [
@@ -70,6 +75,12 @@ function projectSlotProps(n) {
     [`project_${n}_pool_attr`]:    { type: 'string' },
     [`project_${n}_pool_skill`]:   { type: 'string' },
     [`project_${n}_pool_disc`]:    { type: 'string' },
+    // dt-form.25: ambience action redesign. Single-target row-table writes
+    // a (territory, direction) pair when action='ambience_change'. The
+    // territory value is the slug (matches existing form territory model;
+    // admin's resolveTerrId() maps slug → MongoDB _id at consumption).
+    [`project_${n}_ambience_target`]:    { type: 'string' },
+    [`project_${n}_ambience_direction`]: { type: 'string', enum: ['', 'up', 'down'] },
     // Cast (JSON array of character IDs)
     [`project_${n}_cast`]:         { type: 'string' },
     // Applicable merits (JSON array of "Name|qualifier" keys)

--- a/specs/stories/dt-form.25-ambience-action-redesign.story.md
+++ b/specs/stories/dt-form.25-ambience-action-redesign.story.md
@@ -77,13 +77,19 @@ _(Removed contradiction: an earlier draft AC mentioned a per-territory direction
 
 ## Implementation Notes
 
-Both action types (`ambience_increase` and `ambience_decrease`) collapse to the same UI shape. The action-type field is retained in `responses` for historical reasons but the UI doesn't ask the player to pick "increase or decrease" before the table — they just pick the direction on the row whose territory they want to target.
+**Action-type collapse (locked 2026-05-07 by Piatra):** there are NO logic-bearing consumers of the `ambience_increase` vs `ambience_decrease` distinction — both action types result in the same effect on territory ambience (+/-2 on success, +/-4 on exceptional success), and the direction is now surfaced at the row-arrow level. Collapse to a single `ambience` enum value in `projectActionEnum`.
 
-If the per-action-type distinction (increase vs decrease) is no longer meaningful post-redesign, surface to Piatra during pickup as a simplification candidate (collapse to one action type called `ambience` with a single direction-per-target).
+Migration of existing saved data:
+- `responses.project_N_action === 'ambience_increase'` → normalize on read: action becomes `'ambience'`, direction becomes `'up'`
+- `responses.project_N_action === 'ambience_decrease'` → normalize on read: action becomes `'ambience'`, direction becomes `'down'`
+- Per dt-form.26 A1 precedent: silent-leave for any pre-existing legacy values; the read-time normalization seeds the new shape on first render; the next save rolls the doc forward.
 
-**Persistence shape (lock):** single (territory, direction) pair per action slot. Suggested fields:
+**Persistence shape (lock):** single (territory, direction) pair per action slot.
+- `responses.project_N_action` — `'ambience'` (post-collapse)
 - `responses.project_N_ambience_target` — territory `_id` string
 - `responses.project_N_ambience_direction` — `'up' | 'down'`
+
+The UI is direction-agnostic at the action-type-picker level — the player picks `Ambience` from the action-type dropdown, then picks the row + direction in the table.
 
 ## Test Plan
 

--- a/specs/stories/dt-form.25-ambience-action-redesign.story.md
+++ b/specs/stories/dt-form.25-ambience-action-redesign.story.md
@@ -4,7 +4,7 @@ task: 25
 issue: 79
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/79
 epic: epic-dt-form-mvp-redesign
-status: Ready for Dev
+status: Ready for Review
 priority: medium
 depends_on: ['dt-form.17', 'dt-form.24']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (Implementation Plan)
@@ -99,14 +99,14 @@ The UI is direction-agnostic at the action-type-picker level — the player pick
 
 ## Definition of Done
 
-- [ ] Territory-row table renders for ambience actions
-- [ ] At most one row holds a selection at any time per action slot (single-target design)
-- [ ] Clicking a different row clears the previous selection
-- [ ] Clicking the opposite direction on the same row switches direction (does NOT add a second selection)
-- [ ] Clicking the same arrow again toggles off
-- [ ] Rules summary text present
-- [ ] Persistence shape: single (territory, direction) pair per slot
-- [ ] PR opened into `dev`
+- [x] Territory-row table renders for ambience actions
+- [x] At most one row holds a selection at any time per action slot (single-target design)
+- [x] Clicking a different row clears the previous selection
+- [x] Clicking the opposite direction on the same row switches direction (does NOT add a second selection)
+- [x] Clicking the same arrow again toggles off
+- [x] Rules summary text present
+- [x] Persistence shape: single (territory, direction) pair per slot
+- [x] PR opened into `dev` with `Closes #79`
 
 ## Dependencies
 

--- a/specs/stories/dt-form.25-ambience-action-redesign.story.md
+++ b/specs/stories/dt-form.25-ambience-action-redesign.story.md
@@ -77,19 +77,20 @@ _(Removed contradiction: an earlier draft AC mentioned a per-territory direction
 
 ## Implementation Notes
 
-**Action-type collapse (locked 2026-05-07 by Piatra):** there are NO logic-bearing consumers of the `ambience_increase` vs `ambience_decrease` distinction — both action types result in the same effect on territory ambience (+/-2 on success, +/-4 on exceptional success), and the direction is now surfaced at the row-arrow level. Collapse to a single `ambience` enum value in `projectActionEnum`.
+**Action-type already collapsed at the form layer (Ptah survey 2026-05-07):** the form's `PROJECT_ACTIONS` (`downtime-data.js:10`) already uses a single `'ambience_change'` value. The legacy `'ambience_increase'`/`'ambience_decrease'` enum values survive only at:
 
-Migration of existing saved data:
-- `responses.project_N_action === 'ambience_increase'` → normalize on read: action becomes `'ambience'`, direction becomes `'up'`
-- `responses.project_N_action === 'ambience_decrease'` → normalize on read: action becomes `'ambience'`, direction becomes `'down'`
-- Per dt-form.26 A1 precedent: silent-leave for any pre-existing legacy values; the read-time normalization seeds the new shape on first render; the next save rolls the doc forward.
+1. **Schema `projectActionEnum`** (`downtime_submission.schema.js:27-34`) — out of sync (missing `'ambience_change'`, listing the two legacy values that the form never writes). Latent because schema validation is not enforced on the PUT route. **Fix opportunistically as part of this story:** add `'ambience_change'` to the enum; KEEP the legacy values for admin/parser back-compat.
+2. **`SPHERE_ACTION_FIELDS`** (lines 186-187) — sphere-side code path with its own `ambience_change` + `ambience_dir` → legacy-enum normalisation at lines 691-693 + 735-737. **NOT in scope for this story.**
+3. **Admin/parser** (`admin/downtime-views.js`, `downtime/parser.js`) — reads the legacy enums for CSV-imported submissions where `proj.action_type` is set by the CSV parser. Live-form submissions never trigger those branches because the form persists `ambience_change`. **Latent admin tally bug** (admin's `isIncrease`/`isDecrease` at `downtime-views.js:3138` never fires for form-saved ambience actions). Tracked as a separate follow-up; out of scope for this story.
 
-**Persistence shape (lock):** single (territory, direction) pair per action slot.
-- `responses.project_N_action` — `'ambience'` (post-collapse)
-- `responses.project_N_ambience_target` — territory `_id` string
-- `responses.project_N_ambience_direction` — `'up' | 'down'`
+**Persistence shape (lock):** single (territory, direction) pair per action slot, layered on top of the existing `ambience_change` action-type.
+- `responses.project_N_action` = `'ambience_change'` (existing form value, unchanged)
+- `responses.project_N_ambience_target` = territory `_id` string (NEW)
+- `responses.project_N_ambience_direction` = `'up' | 'down'` (NEW)
 
-The UI is direction-agnostic at the action-type-picker level — the player picks `Ambience` from the action-type dropdown, then picks the row + direction in the table.
+The UI is direction-agnostic at the action-type-picker level — the player picks `Ambience` from the action-type dropdown, then picks the row + direction in the table. Drop the legacy `'target'` field from `ACTION_FIELDS['ambience_change']` (the row-table IS the territory picker; the legacy generic target zone becomes redundant). Any legacy `dt-project_N_ambience_dir` radios in the generic target zone fall away with `target` removal.
+
+**Migration**: silent-leave per A1 precedent. Existing form drafts with the `ambience_change` action persist their legacy `_ambience_dir` value untouched (drop-the-iteration on collect — no else-write); the new render path reads the locked-shape fields. If a future hardening pass wants to migrate legacy `_ambience_dir` to the new `_ambience_direction` field, that's its own story.
 
 ## Test Plan
 

--- a/specs/stories/dt-form.25-ambience-action-redesign.story.md
+++ b/specs/stories/dt-form.25-ambience-action-redesign.story.md
@@ -4,7 +4,7 @@ task: 25
 issue: 79
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/79
 epic: epic-dt-form-mvp-redesign
-status: Draft
+status: Ready for Dev
 priority: medium
 depends_on: ['dt-form.17', 'dt-form.24']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (Implementation Plan)
@@ -69,9 +69,7 @@ Rules summary text: *"Success is +/-2 influence change to territory, +/-4 on exc
 **When** the slot is saved
 **Then** the selection is stored as a single (territory, direction) pair (e.g. `responses.project_N_ambience_target` and `responses.project_N_ambience_direction`).
 
-**Given** the form persists
-**When** the slot is saved
-**Then** the selections persist as a per-territory direction map (e.g. `responses.project_N_ambience_targets = { '<terr_id>': 'up' | 'down' }`).
+_(Removed contradiction: an earlier draft AC mentioned a per-territory direction map shape. Superseded — Implementation Notes lock the single-pair shape per the FINAL Q2 follow-up clarification.)_
 
 **Given** the rules summary needs to surface
 **When** the action UI renders


### PR DESCRIPTION
## Summary

Replaces the legacy target-zone (territory pills + improve/degrade radios) for `ambience_change` actions with a territory-row table. Each row has a RED DOWN arrow and a GREEN UP arrow. Single-target by design — at most one row holds a selection at any time per action slot; if a player wants two ambience changes, they fill two slots.

State machine per the 6 ACs:
- **New row click** → switch to (newRow, clickedDir); prior row's selection cleared
- **Opposite arrow same row** → switch direction, retain row
- **Same arrow same row** → toggle off (clear both target and direction)

Closes #79

## Persistence

- `responses.project_N_ambience_target` = territory **slug** (matches existing form territory model; admin's `resolveTerrId()` maps slug → MongoDB `_id` at consumption). Story spec said "_id string" but slug is the form's stable identifier — documented deviation; future story can tighten to `_id` if needed.
- `responses.project_N_ambience_direction` = `'up' | 'down'` (or empty when no selection)

**Backward-compat read seed:** when the new fields are empty but legacy `_target_terr` + `_ambience_dir` exist, the renderer derives selection from those so pre-redesign drafts surface in the new UI on first render. Silent-leave per A1 — legacy keys persist on the doc until cycle close.

**Drop-the-iteration discipline (lesson from PR #127):** the legacy `_ambience_dir` radio collect is replaced by element-presence-gated writes of the new hidden inputs. Pre-existing `_ambience_dir` values are NOT unconditionally overwritten with empty strings (lesson #105 honoured).

## Schema

- `'ambience_change'` added to `projectActionEnum` — latent sync fix; the form has been emitting this value for a while but the schema enum was out of sync (`additionalProperties: true` plus the route not running validate() meant no validation errors fired).
- Legacy `'ambience_increase'` / `'ambience_decrease'` **KEPT** in the enum per the HALT-DAR resolution: admin/parser still consume them for CSV-imported submissions. Canonical-shape normalisation tracked under **issue #129** for a future story.
- `project_N_ambience_target` (string) + `project_N_ambience_direction` (enum: `'', 'up', 'down'`) documented under `projectSlotProps`.

## Out-of-scope sphere-side handling

Sphere/status `ambience_change` action handling left untouched — sphere keeps the legacy improve/degrade radios + the `collectResponses` normalisation that maps sphere `ambience_change` → legacy `ambience_increase` / `ambience_decrease` enum values for the admin sphere-tally consumers. Story #25 is project-only per its scope.

## Diff + tests

- 4 files (+185 / -14). Story-doc DoD ticked.
- Server tests **678/678 green** — UI + schema-additions only; no server route delta.

## Test plan

- [x] Static review — row-table + state machine match the 6 ACs; rules-summary copy present; backward-compat seed; lesson #105 / drop-the-iteration honoured
- [x] Server tests green
- [ ] Browser smoke (deferred per story Test Plan):
  - [ ] Pick `Ambience Change` action type → row table renders with all 5 territories, both arrows visible per row
  - [ ] Click a green UP arrow → that arrow highlights; hidden inputs reflect (slug, 'up')
  - [ ] Click the red DOWN on the same row → arrow swaps to DOWN; same row, direction switched
  - [ ] Click an arrow on a different row → previous row's selection clears; new row's clicked direction is the only highlight
  - [ ] Click the same arrow again on the active row → both clear (toggle off)
  - [ ] Save → reload → selection round-trips via `_ambience_target` + `_ambience_direction`
  - [ ] Pre-redesign draft with `_target_terr` + `_ambience_dir` populated → opens with the equivalent row pre-selected