### PR TITLE
feat(dt-form): Regency confirmation UI (dt-form.23)

### DIFF
--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -1884,6 +1884,12 @@ function renderForm(container) {
   // dt-form.17: in MINIMAL only the first project slot renders.
   h += renderProjectSlots(saved, mode);
 
+  // ── Regency confirmation (regent-only, both modes) ──
+  // dt-form.23 (ADR-003 §Q2): confirmation UI for regents; writes to
+  // cycle.regent_confirmations via the existing /confirm-feeding endpoint.
+  // Non-regents see nothing (renderRegencySection returns '' on is_regent !== 'yes').
+  if (_isSectionVisibleInMode('regency', mode)) h += renderRegencySection();
+
   // dt-form.17: ADVANCED-only sections below the projects.
   if (mode === 'advanced') {
     // ── Blood Sorcery — between Personal Actions and Sphere Actions (dt-form.27) ──
@@ -2019,6 +2025,39 @@ function renderForm(container) {
     if (e.target.closest('#dt-btn-submit-final')) {
       e.preventDefault();
       openSubmitFinalModal(container);
+      return;
+    }
+    // dt-form.23 (ADR-003 §Q2): regent confirmation. POSTs to the same
+    // /confirm-feeding endpoint regency-tab uses; rights[] is a snapshot
+    // of the territory's current feeding_rights. After success, replace
+    // currentCycle with the server response so the predicate sees the new
+    // entry on re-render.
+    const regencyConfirmBtn = e.target.closest('#dt-btn-confirm-regency');
+    if (regencyConfirmBtn) {
+      e.preventDefault();
+      const ri = findRegentTerritory(_territories, currentChar);
+      const statusEl = container.querySelector('#dt-regency-confirm-status');
+      if (!ri?.territoryId || !currentCycle?._id) return;
+      if (currentCycle._id === 'dev-stub') {
+        if (statusEl) statusEl.textContent = 'Dev preview — confirmation requires a live cycle.';
+        return;
+      }
+      const terr = (_territories || []).find(t => String(t._id) === String(ri.territoryId));
+      const rights = Array.isArray(terr?.feeding_rights) ? terr.feeding_rights : [];
+      regencyConfirmBtn.disabled = true;
+      regencyConfirmBtn.textContent = 'Confirming…';
+      if (statusEl) statusEl.textContent = '';
+      apiPost(`/api/downtime_cycles/${currentCycle._id}/confirm-feeding`, {
+        territory_id: ri.territoryId,
+        rights,
+      }).then(updated => {
+        currentCycle = updated;
+        renderForm(container);
+      }).catch(err => {
+        regencyConfirmBtn.disabled = false;
+        regencyConfirmBtn.textContent = 'Confirm regency this cycle';
+        if (statusEl) statusEl.textContent = 'Confirm failed: ' + (err?.message || 'unknown error');
+      });
       return;
     }
     // dt-form.31 modal click delegations moved to the overlay element in
@@ -3958,6 +3997,42 @@ function renderPersonalStorySection(saved) {
 // orphan plus its associated click handler and the now-unused
 // `_linkedNpcs` / `_myRelationships` data loads.
 
+// dt-form.23 (ADR-003 §Q2): regent-only confirmation section. Canonical
+// store is `cycle.regent_confirmations[]` (same as the regency tab);
+// this surface POSTs to /api/downtime_cycles/:id/confirm-feeding with
+// the territory's current `feeding_rights[]` as the rights snapshot,
+// and the predicate `_isRegencyConfirmedThisCycle()` reads it back.
+// Multi-territory regents are not modelled — `findRegentTerritory()`
+// returns a single territory by design (helpers.js:153).
+function renderRegencySection() {
+  if (gateValues.is_regent !== 'yes') return '';
+  const ri = findRegentTerritory(_territories, currentChar);
+  if (!ri?.territoryId) return '';
+  const terrName = ri.territory || 'your territory';
+
+  const myConfirmation = (currentCycle?.regent_confirmations || [])
+    .find(c => String(c.territory_id) === String(ri.territoryId));
+
+  let h = '<div class="qf-section" data-section-key="regency">';
+  h += '<h4 class="qf-section-title">Regency<span class="qf-section-tick">✔</span></h4>';
+  h += '<div class="qf-section-body">';
+
+  if (myConfirmation) {
+    const at = myConfirmation.confirmed_at ? new Date(myConfirmation.confirmed_at) : null;
+    const atStr = at && !isNaN(at) ? at.toLocaleString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' }) : '';
+    h += `<p class="qf-section-intro">Confirmed as Regent of <strong>${esc(terrName)}</strong> for this cycle${atStr ? ` — ${esc(atStr)}` : ''}.</p>`;
+  } else {
+    h += `<p class="qf-section-intro">I am acting as Regent of <strong>${esc(terrName)}</strong> for this cycle.</p>`;
+    h += '<div class="qf-actions">';
+    h += '<button type="button" class="qf-btn qf-btn-submit" id="dt-btn-confirm-regency">Confirm regency this cycle</button>';
+    h += '<span id="dt-regency-confirm-status" class="qf-save-status"></span>';
+    h += '</div>';
+  }
+
+  h += '</div></div>';
+  return h;
+}
+
 function renderSorcerySection(saved) {
   const section = DOWNTIME_SECTIONS.find(s => s.key === 'blood_sorcery');
   const hasMandragora = (currentChar.merits || []).some(m => m.name === 'Mandragora Garden');
@@ -5493,6 +5568,13 @@ function updateSectionTicks(container) {
         if (el && el.value) { anyAction = true; break; }
       }
       tick.classList.toggle('visible', anyAction);
+      return;
+    }
+
+    // dt-form.23: Regency tick reflects the cycle.regent_confirmations entry,
+    // not a form field — predicate is the source of truth.
+    if (key === 'regency') {
+      tick.classList.toggle('visible', _isRegencyConfirmedThisCycle());
       return;
     }
 

--- a/specs/stories/dt-form.23-regency-confirm.story.md
+++ b/specs/stories/dt-form.23-regency-confirm.story.md
@@ -40,12 +40,12 @@ The current regency tab UI may have its own affordances; this story scopes the D
 **Then** the regency section appears with a confirmation UI: "I am acting as regent of [Territory] for this cycle" with a positive affirmation control (button or checkbox).
 
 **Given** the regent confirms
-**When** the form auto-saves
-**Then** `responses.regency_confirmed === true` (or equivalent persisted value); `isMinimalComplete()` for regents passes its regency rule.
+**When** the button is clicked
+**Then** the DT-form POSTs to the existing `cycle.regent_confirmations` append-only endpoint with `{territory_id, regent_char_id, rights: territory.feeding_rights}`. `_isRegencyConfirmedThisCycle()` returns true (via the existing predicate); `isMinimalComplete()` for regents passes its regency rule.
 
-**Given** the regent declines
-**When** the form auto-saves
-**Then** `responses.regency_confirmed === false`; `isMinimalComplete()` for regents fails its regency rule until they affirm or stop being a regent.
+**Given** the regent has not confirmed (no entry in `cycle.regent_confirmations`)
+**When** the form renders / auto-saves
+**Then** the gate fails (predicate returns false on absence). `isMinimalComplete()` for regents fails its regency rule until they confirm. Per HALT-DAR resolution: explicit "decline" is reinterpreted as "absence of entry" — append-only API has no decline affordance and that's acceptable for MVP.
 
 **Given** a non-regent character
 **When** the form renders
@@ -57,7 +57,15 @@ The current regency tab UI may have its own affordances; this story scopes the D
 
 ## Implementation Notes
 
-`is_regent` detection at `:1337` is already in place. The new UI is the confirmation interaction layered on that detection. Persistence under `responses.regency_*` keys.
+**Persistence shape (locked 2026-05-07 by Piatra HALT-DAR):** the brief's original `responses.regency_confirmed` shape is SUPERSEDED. Canonical store is `cycle.regent_confirmations[]` — the existing append-only system that the regency-tab and admin already consume. DT-form's confirmation button POSTs to the same endpoint as regency-tab (`server/routes/downtime.js:90-155`), with `rights[]` populated from the regent's territory's current `feeding_rights[]` (snapshot at confirmation time).
+
+Predicate: `_isRegencyConfirmedThisCycle()` (already wired by foundation #17 in `_completenessCtx()`) reads `cycle.regent_confirmations[]` for the regent — UNCHANGED. No predicate edit needed for this story; the UI is the new piece.
+
+**AC #3 reinterpretation:** "decline" = "absence of confirmation entry" = gate fails. The existing predicate already maps absence→false correctly. No new "false" state needed. If a regent un-confirms (rare; the API is append-only), that's a future API-extension issue.
+
+**Multi-territory regents:** structural assumption is one regent → one territory (`findRegentTerritory()` at `helpers.js:153-168` is singular). Single-block UI is correct. Document the structural assumption in PR body.
+
+`is_regent` detection at `:1337` is already in place. The new UI is the confirmation interaction layered on that detection.
 
 Visual treatment: keep light. A regent section that's a wall of legalese will feel heavy in MINIMAL. The confirmation is a single sentence + button.
 

--- a/specs/stories/dt-form.23-regency-confirm.story.md
+++ b/specs/stories/dt-form.23-regency-confirm.story.md
@@ -4,7 +4,7 @@ task: 23
 issue: 81
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/81
 epic: epic-dt-form-mvp-redesign
-status: Draft
+status: Ready for Dev
 priority: high
 depends_on: ['dt-form.17']
 adr: specs/architecture/adr-003-dt-form-cross-cutting.md (§Q2)

--- a/specs/stories/dt-form.23-regency-confirm.story.md
+++ b/specs/stories/dt-form.23-regency-confirm.story.md
@@ -76,12 +76,36 @@ Visual treatment: keep light. A regent section that's a wall of legalese will fe
 
 ## Definition of Done
 
-- [ ] Regency confirmation UI lives in the `regency` section
-- [ ] `isMinimalComplete()` consults regency confirmation for regents
-- [ ] Non-regents see no section (existing gate preserved)
+- [x] Regency confirmation UI lives in the `regency` section
+- [x] `isMinimalComplete()` consults regency confirmation for regents
+- [x] Non-regents see no section (existing gate preserved)
 - [ ] PR opened into `dev`
 
 ## Dependencies
 
 - **Upstream**: #17 (lifecycle + `_mode`)
 - **Downstream**: none
+
+## Dev Agent Record
+
+### Agent Model Used
+claude-opus-4-7 (Ptah / James persona, BMAD dev)
+
+### Completion Notes
+- Locked design (Khepri SM dispatch 2026-05-07): canonical store `cycle.regent_confirmations[]`; DT-form button POSTs to `/api/downtime_cycles/:id/confirm-feeding` (the same endpoint regency-tab.js uses); `rights[]` payload is a snapshot of the regent's territory `feeding_rights[]`.
+- Predicate `_isRegencyConfirmedThisCycle()` (downtime-form.js:1574) untouched — already wired into `_completenessCtx()` by foundation #17. No second source of truth introduced; `responses.regency_confirmed` (per the original story brief) was superseded and not written.
+- Section render replaces the explicit `continue` skip pattern (downtime-form.js:1841) with a dedicated `renderRegencySection()` invocation, mirroring how personal-story / projects sections are rendered.
+- Multi-territory regents not modelled — `findRegentTerritory()` returns a single territory by design (helpers.js:153); single-block UI matches the structural assumption already baked into every consumer.
+- Decline = absence-of-entry per AC #3 reinterpretation: append-only API has no un-confirm affordance.
+- Dev-stub cycle (`location.hostname === 'localhost'` fallback at downtime-form.js:1167) handled with a friendly "Dev preview — confirmation requires a live cycle." status message.
+- Tick rule in `updateSectionTicks` reads the predicate (not a form field) — matches the source of truth.
+- Lesson #105 / drop-the-iteration: no legacy `regency_*` keys in collect path required removal. `regency_action` (vamping section) and `regent_territory` (gate metadata) are out of scope and not superseded by this story.
+- Server tests baseline preserved: 678/678 passing on full suite with changes applied.
+
+### File List
+- Modified: `public/js/tabs/downtime-form.js` (added `renderRegencySection()` helper, render call after projects, delegated click handler, regency tick rule)
+
+### Change Log
+| Date | Change | Notes |
+|---|---|---|
+| 2026-05-07 | Implemented regency confirmation section in DT form (Option A: cycle.regent_confirmations canonical) | downtime-form.js: +82/-0 |


### PR DESCRIPTION
## Summary
Adds a regent-only confirmation section to the downtime form per story dt-form.23 (ADR-003 §Q2). When a regent character opens the DT form, a "Regency" section now appears with a single sentence ("I am acting as Regent of [Territory] for this cycle") and a confirm button. Clicking it POSTs to the existing `/api/downtime_cycles/:id/confirm-feeding` endpoint that the regency tab already uses, snapshotting the territory's current `feeding_rights[]` as the rights array. After confirmation, the section shows a "Confirmed as Regent of … — [date]" badge.

`isMinimalComplete()` for regents already consults `_isRegencyConfirmedThisCycle()` (wired by foundation #17); that predicate reads `cycle.regent_confirmations[]`. This story only adds the UI that produces the entries the predicate reads — no predicate edits, no new persisted shape.

Closes #81

## HALT-DAR resolution
The original story brief locked `responses.regency_confirmed` (submission-doc) as the persisted shape, but the existing predicate at `downtime-form.js:1574` reads `cycle.regent_confirmations[]` (cycle-doc, append-only API, full schema, full test coverage at `server/tests/api-downtime-regent-gate.test.js`, also consumed by `regency-tab.js` and `admin/city-views.js`). Surfaced as HALT-DAR; Khepri/user locked **Option A**: cycle-canonical, no rename. Story doc updated in commit `b2cd5954` before implementation.

`responses.regency_confirmed` is NOT written by this PR.

## AC #3 reinterpretation
"Decline" = "absence of confirmation entry". The append-only API has no un-confirm affordance, and the predicate already maps absence→false correctly. If a regent confirms then changes their mind, that's a future API-extension issue (file separately if it bites in practice).

## Multi-territory disposition
**Single-block UI** — `findRegentTerritory()` (`public/js/data/helpers.js:153`) uses `find()` (singular) and returns one territory. All consumers (`player.js`, `admin.js`, `app.js`, `downtime-form.js`, `regency-tab.js`, `export-character.js`) treat it as singular. The codebase **structurally** assumes one regent → one territory; multi-territory regents don't surface anywhere today. Live DB count distribution wasn't checkable from the implementation session (API requires ST auth), but the structural answer is sufficient. AC #5 is satisfied by the single-block disposition.

## Implementation
- `public/js/tabs/downtime-form.js` (+82/-0):
  - New `renderRegencySection()` helper (returns `''` for non-regents → no DOM)
  - Render call inserted after `renderProjectSlots()`, before ADVANCED-only sections (matches MINIMAL_SECTIONS ordering: court → personal_story → territory → feeding → projects → regency)
  - Delegated click handler for `#dt-btn-confirm-regency` posts the territory's `feeding_rights[]` to `/confirm-feeding`, swaps `currentCycle` with the server response, re-renders
  - Tick rule in `updateSectionTicks` reads the predicate (source of truth, not a form field)
  - Dev-stub cycle (`location.hostname === 'localhost'` fallback) handled with a friendly "Dev preview — confirmation requires a live cycle." status message
- The static `if (section.key === 'regency') continue;` skip at line 1841 is preserved (the explicit render call is the canonical path; the loop continues to skip).

## Lesson #105 / drop-the-iteration
No legacy `regency_*` keys in the collect path required removal. `regency_action` (vamping section, ADVANCED-only) and `regent_territory` (gate metadata) are out of scope and not superseded by this story.

## Test plan
- [x] Static parse: `node --input-type=module --check < public/js/tabs/downtime-form.js` — PASS
- [x] Server tests: full suite 678/678 passing with changes applied (no server delta — UI-only)
- [x] Regent-gate tests specifically: 12/12 passing
- [ ] Browser smoke (DEFERRED per story Test Plan): regent character sees the section; non-regent does not; confirm flow round-trips and reflects "Confirmed [date]" on re-render; tick appears next to "Regency" header
- [ ] Browser smoke (DEFERRED): MINIMAL banner / completeness state flips correctly from "regency not confirmed" to confirmed via predicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)