### PR TITLE
fix(dt-form.48): sync feed_violence on load — banner false-positive (#113)

### DIFF
--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -1296,6 +1296,13 @@ export async function renderDowntimeTab(targetEl, char, territories, options = {
     feedCustomAttr = responseDoc.responses['_feed_custom_attr'] || '';
     feedCustomSkill = responseDoc.responses['_feed_custom_skill'] || '';
     feedCustomDisc = responseDoc.responses['_feed_custom_disc'] || '';
+    // fix.48: sync violence default so the render-path completeness check
+    // (isMinimalComplete(saved, ctx) line 1719) agrees with the visual pre-select.
+    // Only backfills when feed_violence is absent and the method has a default;
+    // stalking/other have null defaults and are intentionally left for explicit pick.
+    if (!responseDoc.responses.feed_violence && feedMethodId && FEED_VIOLENCE_DEFAULTS[feedMethodId]) {
+      responseDoc.responses.feed_violence = FEED_VIOLENCE_DEFAULTS[feedMethodId];
+    }
   } else {
     feedMethodId = ''; feedDiscName = ''; feedSpecName = ''; feedCustomAttr = ''; feedCustomSkill = ''; feedCustomDisc = '';
   }

--- a/specs/stories/fix.48.dt-form-feed-card-violence-sync.story.md
+++ b/specs/stories/fix.48.dt-form-feed-card-violence-sync.story.md
@@ -1,0 +1,251 @@
+---
+id: fix.48
+task: 48
+issue: 113
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/113
+branch: morningstar-issue-113-feed-card-highlight-sync
+epic: epic-dt-form-mvp-redesign
+status: review
+priority: high
+---
+
+# Story fix.48 — DT form: feeding method card highlights without registering as selected
+
+As a player whose prior submission included a feeding method,
+When I open the downtime form in ADVANCED mode,
+The method card should be highlighted AND validation should pass — not show "Feeding: choose Kiss or Violent" as missing.
+
+## Context
+
+**The visual/validation split.** Two separate systems drive feeding state:
+
+1. **Visual highlight** — driven by the in-memory variable `feedMethodId`. On load,
+   `feedMethodId` is restored from `responseDoc.responses['_feed_method']` (line 1293),
+   so the correct card appears highlighted.
+
+2. **Violence toggle pre-select** — driven by
+   `FEED_VIOLENCE_DEFAULTS[feedMethodId]` in the HTML render (line 5748). This is
+   visual-only: it does not write to `responseDoc.responses.feed_violence`.
+
+3. **Completeness banner** — `renderForm()` calls `isMinimalComplete(saved, ctx)` at
+   line 1719, where `saved = responseDoc.responses` (raw stored object). It reads
+   `saved.feed_violence` directly. If that field is empty (common for submissions that
+   predated DTFP-5 or where the player never explicitly clicked the violence toggle),
+   `_hasFeedingViolence()` fails → banner shows "Feeding: choose Kiss or Violent".
+
+**Net result:** method card visually highlighted (good), violence button visually
+pre-selected (good), but `responseDoc.responses.feed_violence` is empty (bad) → banner
+lies to the player.
+
+This is different from the SAVE path (line 952), where `collectResponses()` IS called
+and does backfill `feed_violence` from `FEED_VIOLENCE_DEFAULTS`. So the state heals
+after the first auto-save cycle — but the player sees a false error before that.
+
+## Root Cause
+
+Initialization block at lines 1291–1301 in `downtime-form.js`:
+
+```javascript
+if (responseDoc?.responses) {
+  feedMethodId = responseDoc.responses['_feed_method'] || '';
+  feedDiscName = responseDoc.responses['_feed_disc'] || '';
+  // ...
+  // ← feed_violence is never backfilled here
+}
+```
+
+`feed_violence` in `responseDoc.responses` remains whatever was last saved (possibly
+empty). The visual default (`FEED_VIOLENCE_DEFAULTS`) is only applied at render time
+for display — it is never written back to `responseDoc.responses` on load.
+
+## Files in Scope
+
+- `public/js/tabs/downtime-form.js` — 2–3 line addition in the feeding restore block
+  (~line 1298, immediately after `feedDiscName` etc. assignments)
+- `tests/fix-48-feed-card-violence-sync.spec.js` — new: 3 Playwright tests
+
+## Files NOT in Scope
+
+- `public/js/data/dt-completeness.js` — no logic change; root cause is upstream
+- `public/js/tabs/downtime-data.js` — `FEED_VIOLENCE_DEFAULTS` is correct as-is
+- `public/js/data/feeding-pool.js` — not involved
+- Any server file
+
+## Acceptance Criteria
+
+**AC-1 — Prior method saved, violence not saved → banner correct on load**
+Given a character has a saved submission with `_feed_method = 'seduction'` (or any
+method that has a non-null default violence in `FEED_VIOLENCE_DEFAULTS`)
+And `feed_violence` is absent or empty in the saved responses
+When the ADVANCED feeding section renders
+Then the method card IS visually highlighted
+And the completeness banner does NOT show "Feeding: choose Kiss or Violent"
+
+**AC-2 — No prior method → no card highlighted, banner requires selection**
+Given a character has no saved feeding method
+When the feeding section renders in ADVANCED mode
+Then no method card is highlighted
+And the completeness banner includes the feeding violence requirement
+
+**AC-3 — Clicking any method card immediately satisfies violence (for default methods)**
+Given the feeding section is open in ADVANCED mode
+When the player clicks a method card whose method has a default violence
+Then the card highlights AND the violence toggle highlights AND the banner no longer
+reports "choose Kiss or Violent"
+
+**AC-4 — Null-default methods (stalking, other) still require explicit violence pick**
+Given the player selects 'stalking' or 'other' (both have `null` in
+`FEED_VIOLENCE_DEFAULTS`)
+When the method card is clicked
+Then the card highlights AND the violence toggle shows no pre-selection
+And the banner still reports "choose Kiss or Violent" until the player explicitly
+clicks a violence button
+
+**AC-5 — MINIMAL mode feeding is unaffected**
+Given the form is in MINIMAL mode
+The feeding section change produces no regressions (no new banner errors)
+
+## Implementation Notes
+
+### The fix — one location, 3 lines
+
+In the feeding state restore block (~line 1298), after the `feedDiscName` etc.
+assignments, add:
+
+```javascript
+if (responseDoc?.responses) {
+  feedMethodId = responseDoc.responses['_feed_method'] || '';
+  feedDiscName = responseDoc.responses['_feed_disc'] || '';
+  feedSpecName = responseDoc.responses['_feed_spec'] || '';
+  feedCustomAttr = responseDoc.responses['_feed_custom_attr'] || '';
+  feedCustomSkill = responseDoc.responses['_feed_custom_skill'] || '';
+  feedCustomDisc = responseDoc.responses['_feed_custom_disc'] || '';
+  // fix.48: sync violence default into stored responses so the render-path
+  // completeness check (isMinimalComplete(saved, ctx) at line 1719) agrees with
+  // the visual pre-select. Only backfill if not already explicitly saved.
+  if (!responseDoc.responses.feed_violence && feedMethodId && FEED_VIOLENCE_DEFAULTS[feedMethodId]) {
+    responseDoc.responses.feed_violence = FEED_VIOLENCE_DEFAULTS[feedMethodId];
+  }
+}
+```
+
+**Why this is safe:**
+- Only applies when `feed_violence` is empty/absent — never overrides an explicit player
+  choice.
+- Only applies when `FEED_VIOLENCE_DEFAULTS[feedMethodId]` is truthy — `stalking` and
+  `other` both have `null`, so those methods are untouched (player must still pick
+  explicitly).
+- `FEED_VIOLENCE_DEFAULTS` is already imported at line 16 — no new import needed.
+- The save path (`collectResponses()` → `scheduleSave()`) already does equivalent logic
+  at lines 393–396. This brings the load path into parity.
+
+### Why "clicking again may or may not fix it" per the issue
+
+For methods with a default (`seduction` → kiss, `force` → violent, etc.):
+- Clicking the card triggers `collectResponses()` which backfills `feed_violence` from
+  the default, then `renderForm()` picks it up → banner heals on click.
+
+For methods with `null` default (`stalking`, `other`):
+- Clicking the card calls `collectResponses()` but `_defaultViolence` is null → nothing
+  is backfilled → banner still reports violence missing → player must click a violence
+  button explicitly. This is intentional UX.
+
+### Why Cyrus triggers it, Cazz doesn't
+
+Cyrus: prior submission saved `_feed_method` but `feed_violence` was never written (e.g.,
+submission predates DTFP-5, or player closed the form before the auto-save cycle ran).
+
+Cazz: either has no prior submission (fresh form, no highlights at all) or has a
+submission where `feed_violence` was explicitly clicked and saved.
+
+### Do NOT touch
+
+- The `collectResponses()` logic at lines 393–396 — it is correct and handles the save
+  path already.
+- `_hasFeedingViolence()` in `dt-completeness.js` — reads the right field (`feed_violence`).
+- `renderForm()` completeness evaluation at line 1719 — `isMinimalComplete(saved, ctx)`
+  is correct; this story aligns the data, not the check.
+- FEED_VIOLENCE_DEFAULTS definition in `downtime-data.js` — already correct.
+
+### Test approach
+
+Use the Playwright harness from `tests/fix-47-minimal-feeding-advanced-hint.spec.js`
+(`setupSuite`, `openDowntimeForm`, `switchToAdvanced`, `expandFeedingSection`).
+
+For AC-1: inject a responseDoc with `_feed_method: 'seduction'` and no `feed_violence`
+into the sandbox before render. After render, check that `.dt-feed-min-pool__advanced-hint`
+is absent from the banner's missing list (or more precisely, confirm the completeness
+banner does NOT contain "Kiss or Violent"). The simplest way:
+
+```javascript
+await page.evaluate(async (c) => {
+  // ... set up sandbox ...
+  const mod = await import('/js/tabs/downtime-form.js');
+  // Provide a saved submission that has _feed_method but no feed_violence
+  await mod.renderDowntimeTab(sandbox, c, [], {
+    responses: { _feed_method: 'seduction' }
+  });
+}, char);
+```
+
+Then check the completeness banner text. If `renderDowntimeTab` does not accept a
+responses override parameter, inject via `localStorage` or mock the submissions API
+to return a document with those responses.
+
+The mock approach (more reliable): in `setupSuite`, return a saved submission from
+`GET /api/downtime_submissions?...` with `{ _feed_method: 'seduction' }` in responses
+(and no `feed_violence`). After `openDowntimeForm`, expand the feeding section and
+assert the banner's missing-items list does not include violence text.
+
+**Banner selector:** The completeness banner is rendered inside `#dt-sandbox`. Find the
+missing-items text — look for a `<ul>` or list of missing pieces near the banner. The
+exact selector can be derived by searching for `dt-banner` or `qf-minimum-bar` in
+`downtime-form.js`.
+
+For AC-4 (null default): inject `{ _feed_method: 'stalking' }` with no `feed_violence`.
+After render, confirm the banner still shows the violence requirement.
+
+For AC-5 (MINIMAL regression): stay in MINIMAL mode (don't call `switchToAdvanced`),
+confirm no new banner errors appear.
+
+## Test Plan
+
+1. `npx playwright test tests/fix-48-feed-card-violence-sync.spec.js` — all tests green.
+2. `npx playwright test tests/fix-47-minimal-feeding-advanced-hint.spec.js` — no regressions.
+3. `npx playwright test tests/fix-45-feeding-validation-false-block.spec.js` — no regressions.
+4. Manual smoke: Open DT form for Cyrus in ADVANCED mode → confirm "choose Kiss or Violent"
+   no longer appears in banner when method card is pre-highlighted.
+
+## Definition of Done
+
+- [x] `public/js/tabs/downtime-form.js` — 3-line backfill in feeding restore block
+- [x] AC-1: default-violence methods load without banner violence error
+- [x] AC-2: no prior method → no highlight, banner requires selection
+- [x] AC-3: clicking default-violence method card clears violence error immediately
+- [x] AC-4: stalking/other still require explicit violence click
+- [x] AC-5: MINIMAL mode unaffected (fix.47 + fix.45 regression suites green)
+- [x] `tests/fix-48-feed-card-violence-sync.spec.js` created with 4 passing tests
+- [x] No regressions in fix-47, fix-45 test suites
+
+## Dev Agent Record
+
+**Agent:** Claude (Morningstar)
+**Date:** 2026-05-07
+
+### File List
+
+**Modified**
+- `public/js/tabs/downtime-form.js`
+
+**Added**
+- `tests/fix-48-feed-card-violence-sync.spec.js`
+
+### Change Log
+
+| Date | Author | Change |
+|---|---|---|
+| 2026-05-07 | Claude (Morningstar) | 3-line backfill in feeding restore block (~line 1298): if `feed_violence` absent and method has a non-null default, write default into `responseDoc.responses.feed_violence`. 4 Playwright tests passing. No regressions. |
+
+### Completion Notes
+
+The render-path completeness check (`isMinimalComplete(saved, ctx)` line 1719) reads `responseDoc.responses` directly. On load, `feed_violence` was absent for prior submissions that predated DTFP-5 or where the player never explicitly clicked the toggle. The visual pre-select via `FEED_VIOLENCE_DEFAULTS` was display-only and never wrote to `responseDoc.responses`. Fix brings the stored state into parity with the visual state at restore time. Methods with `null` defaults (stalking, other) are intentionally excluded — player must still pick explicitly.

--- a/tests/fix-48-feed-card-violence-sync.spec.js
+++ b/tests/fix-48-feed-card-violence-sync.spec.js
@@ -1,0 +1,214 @@
+/**
+ * Regression tests for fix.48 — feeding method card highlights without violence registering
+ *
+ * Root cause: on load, responseDoc.responses.feed_violence is empty even when a method with
+ * a default violence is saved. The render-path completeness check reads saved responses
+ * directly (not collectResponses()), so the banner falsely shows "choose Kiss or Violent".
+ *
+ * Fix: backfill feed_violence from FEED_VIOLENCE_DEFAULTS on restore when absent.
+ *
+ * AC-1: method with default violence saved, no feed_violence → banner does NOT show violence error
+ * AC-2: no prior method → banner DOES show violence error
+ * AC-3: clicking a default-violence card immediately clears the violence error
+ * AC-4: null-default methods (stalking, other) still require explicit violence pick
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const PLAYER_USER = {
+  id: '777000048', username: 'test_player48', global_name: 'Test Player 48',
+  avatar: null, role: 'player', player_id: 'p-fix48',
+  character_ids: ['char-fix48'], is_dual_role: false,
+};
+
+const ACTIVE_CYCLE = {
+  _id: 'cycle-fix48', status: 'active', label: 'Test Cycle FIX48',
+  feeding_rights_confirmed: true, is_chapter_finale: false,
+  created_at: '2026-05-07T00:00:00.000Z',
+};
+
+function buildChar() {
+  return {
+    _id: 'char-fix48', name: 'Violence Sync Tester', moniker: null, honorific: null,
+    clan: 'Daeva', covenant: 'Carthian Movement', player: 'Test Player',
+    blood_potency: 1, humanity: 7, humanity_base: 7, court_title: null, retired: false,
+    status: { city: 0, clan: 0, covenant: {} },
+    attributes: {
+      Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+      Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+      Presence: { dots: 3, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+    },
+    skills: {
+      Persuasion: { dots: 2, bonus: 0, specs: [], nine_again: false },
+    },
+    disciplines: {}, merits: [], ordeals: [], powers: [],
+  };
+}
+
+function buildSavedSubmission(char, responses = {}) {
+  return {
+    _id: 'sub-fix48',
+    cycle_id: ACTIVE_CYCLE._id,
+    character_id: char._id,
+    status: 'draft',
+    responses,
+  };
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+async function setupSuite(page, char, savedResponses = null) {
+  await page.addInitScript((u) => {
+    localStorage.removeItem('tm-mode');
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 36000000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(u));
+  }, PLAYER_USER);
+
+  const savedSub = savedResponses !== null
+    ? buildSavedSubmission(char, savedResponses)
+    : null;
+
+  await page.route('**/api/**', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.route('**/api/auth/me', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(PLAYER_USER) })
+  );
+  await page.route(new RegExp(`/api/characters/${char._id}$`), r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(char) })
+  );
+  await page.route(/\/api\/characters$/, r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([char]) })
+  );
+  await page.route('**/api/characters/names', r =>
+    r.fulfill({ status: 200, contentType: 'application/json',
+      body: JSON.stringify([{ _id: char._id, name: char.name }]) })
+  );
+  await page.route('**/api/downtime_cycles', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([ACTIVE_CYCLE]) })
+  );
+  await page.route(/\/api\/downtime_submissions/, r => {
+    const method = r.request().method();
+    if (method === 'GET') {
+      const body = savedSub ? JSON.stringify([savedSub]) : '[]';
+      return r.fulfill({ status: 200, contentType: 'application/json', body });
+    }
+    // POST / PUT — echo back a draft document
+    const reqBody = JSON.parse(r.request().postData() || '{}');
+    return r.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify({
+        _id: 'sub-fix48', cycle_id: ACTIVE_CYCLE._id, character_id: char._id,
+        status: 'draft', responses: reqBody.responses || {},
+      }),
+    });
+  });
+
+  await page.goto('/');
+  await page.waitForSelector('#app', { state: 'visible', timeout: 15000 });
+}
+
+async function openDowntimeForm(page, char) {
+  await page.evaluate(async (c) => {
+    const sandbox = document.createElement('div');
+    sandbox.id = 'dt-sandbox';
+    sandbox.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;background:#1a1208;z-index:99999;overflow:auto;';
+    document.body.appendChild(sandbox);
+    const mod = await import('/js/tabs/downtime-form.js');
+    await mod.renderDowntimeTab(sandbox, c, []);
+  }, char);
+  await page.waitForSelector('#dt-sandbox #dt-btn-submit', { timeout: 10000 });
+}
+
+async function switchToAdvanced(page) {
+  await page.locator('#dt-sandbox [data-dt-mode="advanced"]').click();
+  await page.waitForSelector('#dt-sandbox [data-dt-mode="advanced"][aria-pressed="true"]', { timeout: 5000 });
+}
+
+async function expandFeedingSection(page) {
+  const titleSel = '#dt-sandbox [data-section-key="feeding"] .qf-section-title';
+  await page.locator(titleSel).click();
+  await page.waitForFunction(() => {
+    const el = document.querySelector('#dt-sandbox [data-section-key="feeding"]');
+    return el && !el.classList.contains('collapsed');
+  }, { timeout: 5000 });
+}
+
+/** Returns the text content of the minimum-complete banner, or null if not shown. */
+async function getBannerText(page) {
+  const banner = page.locator('#dt-sandbox .dt-min-banner');
+  const count = await banner.count();
+  if (!count) return null;
+  return banner.textContent();
+}
+
+const VIOLENCE_ERROR = 'choose Kiss or Violent';
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('fix.48: feeding method card violence sync on load', () => {
+
+  test('AC-1: seduction saved (default kiss), no feed_violence → banner omits violence error', async ({ page }) => {
+    const char = buildChar();
+    // Saved submission: method selected, violence not saved (pre-DTFP-5 style)
+    await setupSuite(page, char, { _feed_method: 'seduction' });
+    await openDowntimeForm(page, char);
+
+    const bannerText = await getBannerText(page);
+    if (bannerText) {
+      expect(bannerText).not.toContain(VIOLENCE_ERROR);
+    }
+    // If banner is absent entirely, form is fully complete — also passes.
+  });
+
+  test('AC-2: no prior method → banner includes violence error', async ({ page }) => {
+    const char = buildChar();
+    // No saved submission at all → fresh form, method and violence both absent
+    await setupSuite(page, char, null);
+    await openDowntimeForm(page, char);
+
+    const bannerText = await getBannerText(page);
+    // Banner must be present (form is below minimum) and must include violence requirement
+    expect(bannerText).toBeTruthy();
+    expect(bannerText).toContain(VIOLENCE_ERROR);
+  });
+
+  test('AC-3: clicking a default-violence method card immediately clears violence error', async ({ page }) => {
+    const char = buildChar();
+    // Start fresh (no saved method)
+    await setupSuite(page, char, null);
+    await openDowntimeForm(page, char);
+    await switchToAdvanced(page);
+    await expandFeedingSection(page);
+
+    // Before click: violence error should be present
+    const before = await getBannerText(page);
+    expect(before).toContain(VIOLENCE_ERROR);
+
+    // Click the 'force' card (default: violent) — any non-null-default method works
+    await page.locator('#dt-sandbox [data-feed-method="force"]').click();
+    // Re-render happens synchronously after click; wait briefly for DOM update
+    await page.waitForTimeout(500);
+
+    const after = await getBannerText(page);
+    if (after) {
+      expect(after).not.toContain(VIOLENCE_ERROR);
+    }
+  });
+
+  test('AC-4: stalking (null default) still requires explicit violence pick', async ({ page }) => {
+    const char = buildChar();
+    // stalking method saved, no feed_violence — fix.48 must NOT backfill (null default)
+    await setupSuite(page, char, { _feed_method: 'stalking' });
+    await openDowntimeForm(page, char);
+
+    const bannerText = await getBannerText(page);
+    // Banner must still show violence as required
+    expect(bannerText).toBeTruthy();
+    expect(bannerText).toContain(VIOLENCE_ERROR);
+  });
+
+});


### PR DESCRIPTION
## Summary

- Feeding method card could appear visually highlighted with violence pre-selected on load, yet the completeness banner still reported "choose Kiss or Violent" — because the render-path check reads `responseDoc.responses` directly and `feed_violence` was never written there on load
- Fix: 3-line backfill in the feeding restore block — if `feed_violence` is absent and the method has a non-null default in `FEED_VIOLENCE_DEFAULTS`, write the default into `responseDoc.responses` on load
- Methods with null defaults (`stalking`, `other`) are intentionally excluded; those still require an explicit player click

## Closes

- Closes #113

## Story

- specs/stories/fix.48.dt-form-feed-card-violence-sync.story.md

## Test plan

- [x] `npx playwright test tests/fix-48-feed-card-violence-sync.spec.js` — 4 tests green
- [x] `npx playwright test tests/fix-47-minimal-feeding-advanced-hint.spec.js tests/fix-45-feeding-validation-false-block.spec.js` — 6 tests green (no regressions)
- [ ] CI green
- [ ] Manual: open DT form for Cyrus in ADVANCED mode → confirm "choose Kiss or Violent" no longer appears in banner when method card is pre-highlighted

## Branch flow

- From: `morningstar-issue-113-feed-card-highlight-sync`
- Into: `dev`