### PR TITLE
feat(dt-form): Mentor + Staff actions (dt-form.28)

### DIFF
--- a/public/js/data/dt-action-summary.js
+++ b/public/js/data/dt-action-summary.js
@@ -38,6 +38,8 @@ function _nonEmpty(v) {
  * @param {number} totals.statusSlots
  * @param {number} totals.contactSlots
  * @param {number} totals.retainerSlots
+ * @param {number} totals.mentorSlots
+ * @param {number} totals.staffSlots
  * @param {number} totals.acquisitionSlots
  * @param {number} totals.sorcerySlots
  * @param {number} totals.equipmentSlots
@@ -50,6 +52,8 @@ export function actionSpentSummary(responses, totals = {}) {
     statusSlots:      totals.statusSlots      ?? 0,
     contactSlots:     totals.contactSlots     ?? 0,
     retainerSlots:    totals.retainerSlots    ?? 0,
+    mentorSlots:      totals.mentorSlots      ?? 0,
+    staffSlots:       totals.staffSlots       ?? 0,
     acquisitionSlots: totals.acquisitionSlots ?? 1,
     sorcerySlots:     totals.sorcerySlots     ?? 0,
     equipmentSlots:   totals.equipmentSlots   ?? 0,
@@ -85,6 +89,16 @@ export function actionSpentSummary(responses, totals = {}) {
     if (_nonEmpty(r[`retainer_${n}_task`]) || _nonEmpty(r[`retainer_${n}_type`])) retainersUsed++;
   }
 
+  let mentorsUsed = 0;
+  for (let n = 1; n <= t.mentorSlots; n++) {
+    if (_nonEmpty(r[`mentor_${n}_task`]) || _nonEmpty(r[`mentor_${n}_target`])) mentorsUsed++;
+  }
+
+  let staffUsed = 0;
+  for (let n = 1; n <= t.staffSlots; n++) {
+    if (_nonEmpty(r[`staff_${n}_task`]) || _nonEmpty(r[`staff_${n}_target`])) staffUsed++;
+  }
+
   let acquisitionsUsed = 0;
   for (let n = 1; n <= t.acquisitionSlots; n++) {
     if (_nonEmpty(r[`acq_${n}_description`])) acquisitionsUsed++;
@@ -108,6 +122,8 @@ export function actionSpentSummary(responses, totals = {}) {
     status_actions:    { used: statusUsed,       total: t.statusSlots      },
     contact_actions:   { used: contactsUsed,     total: t.contactSlots     },
     retainer_actions:  { used: retainersUsed,    total: t.retainerSlots    },
+    mentor_actions:    { used: mentorsUsed,      total: t.mentorSlots      },
+    staff_actions:     { used: staffUsed,        total: t.staffSlots       },
     acquisition_slots: { used: acquisitionsUsed, total: t.acquisitionSlots },
     sorcery_slots:     { used: sorceriesUsed,    total: t.sorcerySlots     },
     equipment_slots:   { used: equipmentUsed,    total: t.equipmentSlots   },
@@ -127,6 +143,8 @@ export function formatActionSpentSummary(summary) {
     status_actions:    'Status actions',
     contact_actions:   'Contact actions',
     retainer_actions:  'Retainer actions',
+    mentor_actions:    'Mentor actions',
+    staff_actions:     'Staff actions',
     acquisition_slots: 'Acquisition slots',
     sorcery_slots:     'Blood Sorcery slots',
     equipment_slots:   'Equipment items',

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -116,7 +116,7 @@ let priorPublishedLabel = null; // label of most recent published cycle other th
 let _allSubmissions = []; // DTUI-13: all submissions for the current cycle, for free-slot detection
 
 // Merits detected from the character sheet, grouped by type
-let detectedMerits = { spheres: [], contacts: [], retainers: [], status: [] };
+let detectedMerits = { spheres: [], contacts: [], retainers: [], status: [], mentors: [], staff: [] };
 
 
 // Characters who attended last game (for shoutout picks)
@@ -308,6 +308,15 @@ function detectMerits() {
   // expandedInfluence so any benefit_grants-sourced Retainer is picked up.
   detectedMerits.retainers = deduplicateMerits(expandedInfluence.filter(m =>
     m.category === 'influence' && (m.name === 'Retainer' || m.name?.startsWith('Attaché ('))
+  ));
+  // dt-form.28: Mentor (per-merit, like Retainer) and Staff (per-dot, like
+  // Contacts) — same expandedInfluence walk so granted instances surface
+  // (hotfix #45 pattern).
+  detectedMerits.mentors = deduplicateMerits(expandedInfluence.filter(m =>
+    m.category === 'influence' && m.name === 'Mentor'
+  ));
+  detectedMerits.staff = deduplicateMerits(expandedInfluence.filter(m =>
+    m.category === 'influence' && m.name === 'Staff'
   ));
 
   gateValues.has_sorcery = (discDots(currentChar, 'Cruac') > 0 || discDots(currentChar, 'Theban') > 0) ? 'yes' : 'no';
@@ -778,6 +787,33 @@ function collectResponses() {
     // Backwards compat: combined value in old key
     const combined = [responses[`retainer_${n}_type`], responses[`retainer_${n}_task`]].filter(Boolean).join('\n');
     responses[`retainer_${n}`] = combined;
+  }
+
+  // dt-form.28: Mentor fields (per-merit, mirrors Retainer pattern).
+  // Hidden charPicker target id is auto-written by the picker's onChange;
+  // we read it here for canonical persistence on collect.
+  const maxMentors = detectedMerits.mentors.length;
+  for (let n = 1; n <= maxMentors; n++) {
+    const targetEl = document.getElementById(`dt-mentor_${n}_target`);
+    const taskEl = document.getElementById(`dt-mentor_${n}_task`);
+    const meritEl = document.getElementById(`dt-mentor_${n}_merit`);
+    responses[`mentor_${n}_target`] = targetEl ? targetEl.value : '';
+    responses[`mentor_${n}_task`] = taskEl ? taskEl.value : '';
+    responses[`mentor_${n}_merit`] = meritEl ? meritEl.value : '';
+  }
+
+  // dt-form.28: Staff fields (per-dot, mirrors Contacts per-slot pattern).
+  // Total slots = sum of effective ratings across all detected Staff merits.
+  const totalStaffDots = detectedMerits.staff.reduce(
+    (s, m) => s + (meritEffectiveRating(currentChar, m) || 0), 0
+  );
+  for (let n = 1; n <= totalStaffDots; n++) {
+    const targetEl = document.getElementById(`dt-staff_${n}_target`);
+    const taskEl = document.getElementById(`dt-staff_${n}_task`);
+    const meritEl = document.getElementById(`dt-staff_${n}_merit`);
+    responses[`staff_${n}_target`] = targetEl ? targetEl.value : '';
+    responses[`staff_${n}_task`] = taskEl ? taskEl.value : '';
+    responses[`staff_${n}_merit`] = meritEl ? meritEl.value : '';
   }
 
   // dt-form.29: structured-row collect for the redesigned Acquisitions
@@ -1595,6 +1631,10 @@ function openSubmitFinalModal(container) {
     statusSlots:      Math.min((detectedMerits.status || []).length, 5),
     contactSlots:     Math.min((detectedMerits.contacts || []).length, 5),
     retainerSlots:    (detectedMerits.retainers || []).length,
+    mentorSlots:      (detectedMerits.mentors || []).length,
+    staffSlots:       (detectedMerits.staff || []).reduce(
+                        (s, m) => s + (meritEffectiveRating(currentChar, m) || 0), 0
+                      ),
     acquisitionSlots: parseInt(saved.acq_slot_count || '1', 10) || 1,
     sorcerySlots:     parseInt(saved.sorcery_slot_count || '0', 10) || 0,
     equipmentSlots:   parseInt(saved.equipment_slot_count || '0', 10) || 0,
@@ -2211,6 +2251,52 @@ function renderForm(container) {
       scheduleSave();
       return;
     }
+    // dt-form.28: Mentor row toggle
+    const mentorToggle = e.target.closest('[data-mentor-toggle]');
+    if (mentorToggle && !e.target.closest('[data-mentor-clear]')) {
+      const n = mentorToggle.dataset.mentorToggle;
+      const panel = container.querySelector(`[data-mentor-panel="${n}"]`);
+      if (panel) panel.classList.toggle('dt-contact-panel-hidden');
+      return;
+    }
+    // dt-form.28: Mentor clear button
+    const mentorClear = e.target.closest('[data-mentor-clear]');
+    if (mentorClear) {
+      const n = mentorClear.dataset.mentorClear;
+      const targetEl = document.getElementById(`dt-mentor_${n}_target`);
+      const taskEl = document.getElementById(`dt-mentor_${n}_task`);
+      if (targetEl) targetEl.value = '';
+      if (taskEl) taskEl.value = '';
+      const responses = collectResponses();
+      if (responseDoc) responseDoc.responses = responses;
+      else responseDoc = { responses };
+      renderForm(container);
+      scheduleSave();
+      return;
+    }
+    // dt-form.28: Staff row toggle
+    const staffToggle = e.target.closest('[data-staff-toggle]');
+    if (staffToggle && !e.target.closest('[data-staff-clear]')) {
+      const n = staffToggle.dataset.staffToggle;
+      const panel = container.querySelector(`[data-staff-panel="${n}"]`);
+      if (panel) panel.classList.toggle('dt-contact-panel-hidden');
+      return;
+    }
+    // dt-form.28: Staff clear button
+    const staffClear = e.target.closest('[data-staff-clear]');
+    if (staffClear) {
+      const n = staffClear.dataset.staffClear;
+      const targetEl = document.getElementById(`dt-staff_${n}_target`);
+      const taskEl = document.getElementById(`dt-staff_${n}_task`);
+      if (targetEl) targetEl.value = '';
+      if (taskEl) taskEl.value = '';
+      const responses = collectResponses();
+      if (responseDoc) responseDoc.responses = responses;
+      else responseDoc = { responses };
+      renderForm(container);
+      scheduleSave();
+      return;
+    }
     // Cast picker modal
     const castBtn = e.target.closest('[data-cast-open]');
     if (castBtn) {
@@ -2300,6 +2386,33 @@ function renderForm(container) {
         const typeEl = document.getElementById(`dt-retainer_${n}_type`);
         const taskEl = document.getElementById(`dt-retainer_${n}_task`);
         const hasContent = (typeEl && typeEl.value.trim()) || (taskEl && taskEl.value.trim());
+        row.classList.toggle('dt-contact-used', !!hasContent);
+        const badge = row.querySelector('.dt-contact-status');
+        if (badge) badge.textContent = hasContent ? 'Tasked' : 'Idle';
+      }
+    }
+    // dt-form.28: live status update for Mentor / Staff rows.
+    const mentorPanel = e.target.closest('[data-mentor-panel]');
+    if (mentorPanel) {
+      const n = mentorPanel.dataset.mentorPanel;
+      const row = container.querySelector(`[data-mentor-row="${n}"]`);
+      if (row) {
+        const targetEl = document.getElementById(`dt-mentor_${n}_target`);
+        const taskEl = document.getElementById(`dt-mentor_${n}_task`);
+        const hasContent = (targetEl && targetEl.value.trim()) || (taskEl && taskEl.value.trim());
+        row.classList.toggle('dt-contact-used', !!hasContent);
+        const badge = row.querySelector('.dt-contact-status');
+        if (badge) badge.textContent = hasContent ? 'Asked' : 'Idle';
+      }
+    }
+    const staffPanel = e.target.closest('[data-staff-panel]');
+    if (staffPanel) {
+      const n = staffPanel.dataset.staffPanel;
+      const row = container.querySelector(`[data-staff-row="${n}"]`);
+      if (row) {
+        const targetEl = document.getElementById(`dt-staff_${n}_target`);
+        const taskEl = document.getElementById(`dt-staff_${n}_task`);
+        const hasContent = (targetEl && targetEl.value.trim()) || (taskEl && taskEl.value.trim());
         row.classList.toggle('dt-contact-used', !!hasContent);
         const badge = row.querySelector('.dt-contact-status');
         if (badge) badge.textContent = hasContent ? 'Tasked' : 'Idle';
@@ -5272,6 +5385,11 @@ function renderMeritToggles(saved) {
   const hasContacts = detectedMerits.contacts.length > 0;
   const hasRetainers = detectedMerits.retainers.length > 0;
   const hasStatus = detectedMerits.status.length > 0;
+  const hasMentors = detectedMerits.mentors.length > 0;
+  const totalStaffDots = detectedMerits.staff.reduce(
+    (s, m) => s + (meritEffectiveRating(currentChar, m) || 0), 0
+  );
+  const hasStaff = totalStaffDots > 0;
   const charMerits = (currentChar.merits || []).filter(m =>
     m.category === 'general' || m.category === 'influence' || m.category === 'standing'
   );
@@ -5282,7 +5400,7 @@ function renderMeritToggles(saved) {
     m.category === 'standing' || (m.category === 'influence' && m.name === 'Status')
   );
 
-  if (!hasSpheres && !hasContacts && !hasRetainers && !hasStatus) return '';
+  if (!hasSpheres && !hasContacts && !hasRetainers && !hasStatus && !hasMentors && !hasStaff) return '';
 
   // ── Spheres of Influence (tabbed, max 5) ──
   if (hasSpheres) {
@@ -5512,6 +5630,123 @@ function renderMeritToggles(saved) {
     h += '</div></div>';
   }
 
+  // ── Mentor (per-merit, mirrors Retainer pattern) ──
+  // dt-form.28: one row per Mentor merit on the character (granted instances
+  // included via the expandedInfluence walk in detectMerits — same pattern as
+  // hotfix #45). Each row carries a free-text query type, a description
+  // textarea, and an optional universal char picker for a target person.
+  if (hasMentors) {
+    const maxMentors = detectedMerits.mentors.length;
+    h += '<div class="qf-section collapsed" data-section-key="mentors">';
+    h += '<h4 class="qf-section-title">Mentor: Counsel<span class="qf-section-tick">✔</span></h4>';
+    h += '<div class="qf-section-body">';
+    h += '<p class="qf-section-intro">Click a mentor to expand and ask a question or request guidance for this Downtime.</p>';
+
+    h += '<div class="dt-contacts-table">';
+    for (let n = 1; n <= maxMentors; n++) {
+      const m = detectedMerits.mentors[n - 1];
+      const area = m.area || m.qualifier || 'Mentor';
+      const dots = '●'.repeat(meritEffectiveRating(currentChar, m) || 1);
+      const savedTarget = saved[`mentor_${n}_target`] || '';
+      const savedTask = saved[`mentor_${n}_task`] || '';
+
+      const isUsed = !!(savedTarget || savedTask);
+      const expanded = isUsed;
+
+      h += `<div class="dt-contact-row${isUsed ? ' dt-contact-used' : ''}" data-mentor-row="${n}">`;
+      h += `<div class="dt-contact-header" data-mentor-toggle="${n}">`;
+      h += `<span class="dt-contact-area">${esc(area)}</span>`;
+      h += `<span class="dt-contact-dots">${dots}</span>`;
+      h += `<span class="dt-contact-status">${isUsed ? 'Asked' : 'Idle'}</span>`;
+      if (isUsed) {
+        h += `<button type="button" class="dt-contact-clear" data-mentor-clear="${n}" title="Clear and close">✕</button>`;
+      }
+      h += '</div>';
+
+      h += `<div class="dt-contact-panel${expanded ? '' : ' dt-contact-panel-hidden'}" data-mentor-panel="${n}">`;
+      // Optional target — universal char picker (ADR-003 §Q6); excludes self.
+      const initialJson = esc(JSON.stringify(savedTarget ? String(savedTarget) : ''));
+      const excludeJson = esc(JSON.stringify(currentChar?._id ? [String(currentChar._id)] : []));
+      h += '<div class="qf-field">';
+      h += `<label class="qf-label" for="dt-mentor_${n}_target">Person involved (optional)</label>`;
+      h += `<input type="hidden" id="dt-mentor_${n}_target" value="${esc(savedTarget)}">`;
+      h += `<div data-cp-mount data-cp-site="mentor-target"`
+         + ` data-cp-scope="all" data-cp-cardinality="single"`
+         + ` data-cp-hidden="dt-mentor_${n}_target"`
+         + ` data-cp-initial="${initialJson}"`
+         + ` data-cp-exclude="${excludeJson}"`
+         + ` data-cp-placeholder="Pick a target character"></div>`;
+      h += '</div>';
+      h += '<div class="qf-field">';
+      h += `<label class="qf-label" for="dt-mentor_${n}_task">What are you asking your mentor?</label>`;
+      h += `<textarea id="dt-mentor_${n}_task" class="qf-textarea" rows="3" placeholder="Question, advice sought, or guidance you want from this mentor.">${esc(savedTask)}</textarea>`;
+      h += '</div>';
+      h += `<input type="hidden" id="dt-mentor_${n}_merit" value="${esc(meritLabel(m))}">`;
+      h += '</div>'; // panel
+      h += '</div>'; // row
+    }
+    h += '</div>';
+
+    h += '</div></div>';
+  }
+
+  // ── Staff (per-dot, mirrors Contacts per-slot pattern) ──
+  // dt-form.28: one row per dot of Staff (summed across all Staff merits;
+  // granted instances included via the expandedInfluence walk). Each row
+  // carries an optional target char picker and a task-description textarea.
+  if (hasStaff) {
+    const primaryStaff = detectedMerits.staff[0];
+    const meritLabelText = primaryStaff
+      ? (primaryStaff.area || primaryStaff.qualifier || 'Staff')
+      : 'Staff';
+    h += '<div class="qf-section collapsed" data-section-key="staff">';
+    h += '<h4 class="qf-section-title">Staff: Tasks<span class="qf-section-tick">✔</span></h4>';
+    h += '<div class="qf-section-body">';
+    h += '<p class="qf-section-intro">Click a staff slot to expand and assign a task. One slot per dot of Staff.</p>';
+
+    h += '<div class="dt-contacts-table">';
+    for (let n = 1; n <= totalStaffDots; n++) {
+      const savedTarget = saved[`staff_${n}_target`] || '';
+      const savedTask = saved[`staff_${n}_task`] || '';
+      const isUsed = !!(savedTarget || savedTask);
+      const expanded = isUsed;
+
+      h += `<div class="dt-contact-row${isUsed ? ' dt-contact-used' : ''}" data-staff-row="${n}">`;
+      h += `<div class="dt-contact-header" data-staff-toggle="${n}">`;
+      h += `<span class="dt-contact-area">${esc(meritLabelText)} — Slot ${n}</span>`;
+      h += `<span class="dt-contact-dots">●</span>`;
+      h += `<span class="dt-contact-status">${isUsed ? 'Tasked' : 'Idle'}</span>`;
+      if (isUsed) {
+        h += `<button type="button" class="dt-contact-clear" data-staff-clear="${n}" title="Clear and close">✕</button>`;
+      }
+      h += '</div>';
+
+      h += `<div class="dt-contact-panel${expanded ? '' : ' dt-contact-panel-hidden'}" data-staff-panel="${n}">`;
+      const initialJson = esc(JSON.stringify(savedTarget ? String(savedTarget) : ''));
+      const excludeJson = esc(JSON.stringify(currentChar?._id ? [String(currentChar._id)] : []));
+      h += '<div class="qf-field">';
+      h += `<label class="qf-label" for="dt-staff_${n}_target">Person involved (optional)</label>`;
+      h += `<input type="hidden" id="dt-staff_${n}_target" value="${esc(savedTarget)}">`;
+      h += `<div data-cp-mount data-cp-site="staff-target"`
+         + ` data-cp-scope="all" data-cp-cardinality="single"`
+         + ` data-cp-hidden="dt-staff_${n}_target"`
+         + ` data-cp-initial="${initialJson}"`
+         + ` data-cp-exclude="${excludeJson}"`
+         + ` data-cp-placeholder="Pick a target character"></div>`;
+      h += '</div>';
+      h += '<div class="qf-field">';
+      h += `<label class="qf-label" for="dt-staff_${n}_task">Task description</label>`;
+      h += `<textarea id="dt-staff_${n}_task" class="qf-textarea" rows="3" placeholder="What do you want this staff slot to do?">${esc(savedTask)}</textarea>`;
+      h += '</div>';
+      h += `<input type="hidden" id="dt-staff_${n}_merit" value="${esc(primaryStaff ? meritLabel(primaryStaff) : 'Staff')}">`;
+      h += '</div>'; // panel
+      h += '</div>'; // row
+    }
+    h += '</div>';
+
+    h += '</div></div>';
+  }
+
   return h;
 }
 
@@ -5554,6 +5789,34 @@ function updateSectionTicks(container) {
         const info = document.getElementById(`dt-contact_${n}_info`);
         const req = document.getElementById(`dt-contact_${n}_request`);
         if ((info && info.value.trim()) || (req && req.value.trim())) { anyUsed = true; break; }
+      }
+      tick.classList.toggle('visible', anyUsed);
+      return;
+    }
+
+    // dt-form.28: Mentors tick when any mentor row has target or task
+    if (key === 'mentors') {
+      const maxM = detectedMerits.mentors.length;
+      let anyUsed = false;
+      for (let n = 1; n <= maxM; n++) {
+        const tg = document.getElementById(`dt-mentor_${n}_target`);
+        const tk = document.getElementById(`dt-mentor_${n}_task`);
+        if ((tg && tg.value.trim()) || (tk && tk.value.trim())) { anyUsed = true; break; }
+      }
+      tick.classList.toggle('visible', anyUsed);
+      return;
+    }
+
+    // dt-form.28: Staff tick when any staff slot has target or task
+    if (key === 'staff') {
+      const maxS = detectedMerits.staff.reduce(
+        (s, m) => s + (meritEffectiveRating(currentChar, m) || 0), 0
+      );
+      let anyUsed = false;
+      for (let n = 1; n <= maxS; n++) {
+        const tg = document.getElementById(`dt-staff_${n}_target`);
+        const tk = document.getElementById(`dt-staff_${n}_task`);
+        if ((tg && tg.value.trim()) || (tk && tk.value.trim())) { anyUsed = true; break; }
       }
       tick.classList.toggle('visible', anyUsed);
       return;

--- a/specs/stories/dt-form.28-mentor-staff-actions.story.md
+++ b/specs/stories/dt-form.28-mentor-staff-actions.story.md
@@ -75,10 +75,10 @@ Detection walk: hotfix #45 establishes that granted merits should be detected by
 
 ## Definition of Done
 
-- [ ] Mentor action: one per Mentor merit (like Retainer)
-- [ ] Staff action: one per dot of Staff (like Contacts)
-- [ ] Character pickers use `charPicker` (#16)
-- [ ] Merit detection follows hotfix #45 walk
+- [x] Mentor action: one per Mentor merit (like Retainer)
+- [x] Staff action: one per dot of Staff (like Contacts)
+- [x] Character pickers use `charPicker` (#16)
+- [x] Merit detection follows hotfix #45 walk
 - [ ] PR opened into `dev`
 
 ## Dependencies
@@ -86,3 +86,39 @@ Detection walk: hotfix #45 establishes that granted merits should be detected by
 - **Upstream**: #16 (picker); #17 (lifecycle); **hotfix #45** (granted-merit detection walk — must land first via hotfix lane)
 - **Downstream**: none
 - **Cross-reference**: GitHub issue #45 establishes the merit-detection walk; #28's detection follows that pattern.
+
+## Dev Agent Record
+
+### Agent Model Used
+claude-opus-4-7 (Ptah / James persona, BMAD dev)
+
+### Survey findings
+- **Hotfix #45 walk helper** is `detectMerits()` at `public/js/tabs/downtime-form.js:249`, where `expandedInfluence` is built by walking each merit's `benefit_grants[]` (lines 262-274) and merging non-duplicate granted entries into the influence pool. Mentor/Staff detection extends this same function — no re-implementation, no divergence.
+- **Retainer template**: per-merit, persistence keys `retainer_${n}_type`, `retainer_${n}_task`, `retainer_${n}_merit` (collect at lines 766-789, render at 5466-5513). No charPicker today.
+- **Contacts template**: per-sphere (sphere is the per-dot unit for Contacts via `m.spheres[]` expansion in detection), persistence keys `contact_${n}_info`, `contact_${n}_request`, `contact_${n}_merit` (collect at lines 752-771, render at 5415-5463). No charPicker today.
+- **Persistence-key convention divergence**: Retainer uses `_type`/`_task`/`_merit`; Contacts uses `_info`/`_request`/`_merit`. Different field names but identical structure (`<merit>_${n}_<field>`). Mentor mirrors Retainer's row pattern; Staff mirrors Contacts' per-slot pattern.
+- **No legacy `mentor_*` / `staff_*` keys** exist anywhere in `public/` or `server/` — Lesson #105 drop-the-iteration doesn't apply (clean greenfield).
+- **Mentor and Staff merits**: both `category: 'influence'` with `m.area` carrying the human-readable name/area (per `public/js/editor/sheet.js:899-903`).
+
+### Persistence shape (chosen)
+- **Mentor**: `mentor_${n}_target` (charPicker hidden id), `mentor_${n}_task` (textarea), `mentor_${n}_merit` (hidden meritLabel ref). Mirrors Retainer's `<merit>_${n}_<field>` shape with the addition of `_target` for the optional charPicker.
+- **Staff**: `staff_${n}_target`, `staff_${n}_task`, `staff_${n}_merit`. Same shape; `n` indexes total Staff dots summed across detected Staff merits.
+
+### Completion Notes
+- Detection extends `detectMerits()` at downtime-form.js:309-318: `detectedMerits.mentors` (per-merit) and `detectedMerits.staff` (per-merit list, dot count summed at render time). Both filtered from `expandedInfluence` so granted instances (e.g. via Patron / MCI grants) surface — same #45 walk pattern, no parallel implementation.
+- Render extends `renderMeritToggles()`: Mentor block (per-merit, mirrors Retainer chrome), Staff block (per-dot total summed across detected Staff merits, mirrors Contacts per-slot chrome). Both reuse `dt-contacts-table` / `dt-contact-row` / `dt-contact-panel` classes for visual consistency.
+- charPicker (#16) used for an OPTIONAL "Person involved" target in both Mentor and Staff rows. `excludeIds: [currentChar._id]` so the player can't target themselves. Each picker site has a stable hidden mirror input that the picker's `onChange` writes to (`dt-mentor_${n}_target` / `dt-staff_${n}_target`).
+- Click handlers + live row-status badge updates follow the existing Retainer/Contacts pattern verbatim (toggle, clear button, input-driven badge flip).
+- Tick rules added to `updateSectionTicks` for `mentors` and `staff` keys; both flip when any row has either a target or task.
+- Action-spent summary (`public/js/data/dt-action-summary.js`) extended with `mentor_actions` / `staff_actions` cells so the Submit Final modal renders Mentor/Staff counts alongside Contacts/Retainer when the character has those merits. Wired through `openSubmitFinalModal()` totals at downtime-form.js:1632-1636.
+- No HALT-DARs encountered. Persistence convention divergence between Retainer (`_type`/_task`) and Contacts (`_info`/`_request`) is preserved — mirrored field-by-field rather than normalised; the broader "row keyed `<merit>_${n}_<field>`" structure is the actual shared convention.
+- Server tests baseline preserved: 678/678 passing on full suite with changes applied.
+
+### File List
+- Modified: `public/js/tabs/downtime-form.js` (Mentor/Staff detection in `detectMerits`; collect loops; render blocks in `renderMeritToggles`; click handlers; live row-status updates; tick rules; modal totals)
+- Modified: `public/js/data/dt-action-summary.js` (`mentorSlots`/`staffSlots` totals; `mentor_actions`/`staff_actions` summary cells; labels)
+
+### Change Log
+| Date | Change | Notes |
+|---|---|---|
+| 2026-05-07 | Mentor + Staff actions implemented in DT form (per-merit / per-dot mirrors of Retainer / Contacts) | downtime-form.js + dt-action-summary.js |

--- a/specs/stories/dt-form.28-mentor-staff-actions.story.md
+++ b/specs/stories/dt-form.28-mentor-staff-actions.story.md
@@ -4,7 +4,7 @@ task: 28
 issue: 86
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/86
 epic: epic-dt-form-mvp-redesign
-status: Draft
+status: Ready for Dev
 priority: medium
 depends_on: ['dt-form.16', 'dt-form.17']
 hotfix_predecessor: 'GitHub issue #45'


### PR DESCRIPTION
## Summary
Adds **Mentor** (per-merit, mirrors Retainer pattern) and **Staff** (per-dot, mirrors Contacts per-slot pattern) action surfaces to the downtime form, alongside the existing Retainer / Contacts blocks. Detection reuses the hotfix #45 `expandedInfluence` walk so granted Mentor / Staff (e.g. via Patron, MCI grants) surface alongside direct merits — same walk, no parallel implementation.

Closes #86

## Survey: Retainer/Contacts pattern mirror
- **Retainer template** (per-merit): one row per Retainer merit, persistence `retainer_${n}_type` / `_task` / `_merit`. Mentor mirrors this row pattern, swapping `_type` for `_target` (universal char picker target) and `_task` (textarea description).
- **Contacts template** (per-sphere, effectively per-dot via `m.spheres[]` expansion at detection time): one row per sphere, persistence `contact_${n}_info` / `_request` / `_merit`. Staff mirrors this per-slot pattern, where slots = total dots summed across all Staff merits the character holds.

## Persistence-key convention (discovered)
| Surface | Keys | Per | Notes |
|---|---|---|---|
| Retainer | `retainer_${n}_type`, `_task`, `_merit` | merit | Free-text type input + textarea |
| Contacts | `contact_${n}_info`, `_request`, `_merit` | sphere/dot | Input + textarea |
| **Mentor** (new) | `mentor_${n}_target`, `_task`, `_merit` | merit | charPicker target + textarea |
| **Staff** (new) | `staff_${n}_target`, `_task`, `_merit` | dot | charPicker target + textarea |

The actual shared convention is the structural shape (`<merit>_${n}_<field>`); the field names (`_type`/`_task`/`_info`/`_request`) diverge between Retainer and Contacts today. No HALT-DAR — preserved both existing surfaces unchanged; new surfaces follow the structural convention.

## #45 walk pattern reuse
Detection extended in-place at `public/js/tabs/downtime-form.js:309-318`:
```js
detectedMerits.mentors = deduplicateMerits(expandedInfluence.filter(m =>
  m.category === 'influence' && m.name === 'Mentor'
));
detectedMerits.staff = deduplicateMerits(expandedInfluence.filter(m =>
  m.category === 'influence' && m.name === 'Staff'
));
```
Same `expandedInfluence` source the existing Retainer/Contacts/Allies detection uses. The `benefit_grants` traversal at lines 262-274 (the actual #45 walk) feeds Mentor/Staff identically — granted instances are picked up automatically. No helper-lifting required; the helper is the function itself.

## charPicker (#16) usage
Both Mentor and Staff action rows include an OPTIONAL "Person involved" target picker:
```html
<div data-cp-mount data-cp-site="mentor-target"
     data-cp-scope="all" data-cp-cardinality="single"
     data-cp-hidden="dt-mentor_${n}_target"
     data-cp-initial="..."
     data-cp-exclude='["<currentChar._id>"]'
     data-cp-placeholder="Pick a target character"></div>
```
`excludeIds` carries `[currentChar._id]` per AC #3 so the player can't target themselves.

## Symmetry: Submit Final modal
Extended `public/js/data/dt-action-summary.js` with `mentor_actions` / `staff_actions` cells so the modal lists Mentor/Staff counts alongside Contacts/Retainer when the character has those merits. Consistency with how the modal already covers every per-merit action section.

## Lesson #105 / drop-the-iteration
No legacy `mentor_*` / `staff_*` keys exist anywhere in `public/` or `server/` — clean greenfield, nothing to remove from the collect path.

## File list
- `public/js/tabs/downtime-form.js` (+260) — detection (`detectMerits`); collect loops; render blocks in `renderMeritToggles` (Mentor + Staff after Retainers); click handlers (toggle + clear); live row-status badge updates; tick rules; Submit Final modal totals
- `public/js/data/dt-action-summary.js` (+18) — `mentorSlots` / `staffSlots` totals; `mentor_actions` / `staff_actions` summary cells; labels

## Test plan
- [x] Static parse: both modified files pass `node --input-type=module --check`
- [x] Server tests: full suite **678/678** passing with changes applied (no server delta)
- [ ] Browser smoke (DEFERRED per story Test Plan): a character with Mentor and/or Staff sees the rendered sections; granted Mentor (via Patron/MCI) surfaces correctly through the #45 walk; charPicker mounts and excludes self; selections persist to `mentor_${n}_*` / `staff_${n}_*` keys; ticks flip when rows have content; Submit Final modal lists Mentor/Staff counts when present; non-Mentor/non-Staff characters see no extra sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)