### PR TITLE
fix(territory): tighten territorySchema to reject unknown properties

### DIFF
--- a/public/js/admin/data-portability-import.js
+++ b/public/js/admin/data-portability-import.js
@@ -76,11 +76,13 @@ export async function writeRow(collection, row) {
 async function writeTerritoryRow(r) {
   // Post-ADR-002: insert (no _id) creates a new doc with a generated _id;
   // slug carries the legacy id value as a label.
+  // Issue #33 (2026-05-07): territorySchema is now strict — `regent_name`
+  // dropped from the body. It was a derived display cache, never persisted
+  // on real territory docs, and is not in the canonical fieldset.
   await apiPost('/api/territories', {
     slug: r.id || undefined,
     name: r.name || undefined,
     regent_id: r.regent_id || undefined,
-    regent_name: r.regent_name || undefined,
     ambience: r.ambience || undefined,
     feeding_rights: r.feeding_rights ? r.feeding_rights.split(';').map(s => s.trim()).filter(Boolean) : [],
   });

--- a/server/schemas/territory.schema.js
+++ b/server/schemas/territory.schema.js
@@ -4,6 +4,16 @@
  *
  * ADR-002 contract: _id is the canonical FK. The legacy `id` field is renamed
  * to `slug` and demoted to a non-required, non-unique human-readable label.
+ *
+ * Strict cutover (issue #33, 2026-05-07): `additionalProperties: false`. Any
+ * body containing fields outside this canonical set is rejected with
+ * `VALIDATION_ERROR`. This closes the silent-accept window that produced 5
+ * duplicate territories on 2026-05-05 when a stale browser session posted
+ * bodies carrying the retired `id` field.
+ *
+ * Canonical post-ADR-002 fieldset (per issue #33 spec):
+ *   _id, slug, name, ambience, ambienceMod, regent_id, lieutenant_id,
+ *   feeding_rights, updated_at
  */
 
 export const territorySchema = {
@@ -13,12 +23,14 @@ export const territorySchema = {
   // No universally-required field. The route layer enforces what it needs per
   // endpoint (POST without _id requires an insert; POST with _id requires the
   // doc to exist).
-  additionalProperties: true,
+  additionalProperties: false,
 
   properties: {
+    _id:             { type: 'string', minLength: 1 },
     slug:            { type: 'string', minLength: 1 },
     name:            { type: 'string' },
     ambience:        { type: 'string' },
+    ambienceMod:     { type: 'number' },
     regent_id:       { type: ['string', 'null'] },
     lieutenant_id:   { type: ['string', 'null'] },
     feeding_rights:  { type: 'array', items: { type: 'string' } },

--- a/server/tests/api-territories.test.js
+++ b/server/tests/api-territories.test.js
@@ -126,6 +126,67 @@ describe('POST /api/territories', () => {
       .send(testTerritory('test_territory_quinn_player'));
     expect(res.status).toBe(403);
   });
+
+  // Issue #33 — defence-in-depth: schema rejects the retired legacy `id` field
+  // so a stale browser session cannot silently insert a duplicate document.
+  // Reproduces the 2026-05-05 incident pattern (5 dupes via apiPost with `id`).
+  it('POST with legacy `id` field returns 400 VALIDATION_ERROR', async () => {
+    const res = await request(app)
+      .post('/api/territories')
+      .set('X-Test-User', stUser())
+      .send({
+        id: 'test_territory_quinn_legacy_id',
+        name: 'Legacy ID Reject',
+        ambience: 'Settled',
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('VALIDATION_ERROR');
+    expect(res.body.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ property: 'id' }),
+      ]),
+    );
+  });
+
+  // Issue #33 — strict schema also rejects other unknown fields (e.g. legacy
+  // `regent_name` cache that one importer used to send).
+  it('POST with unknown field returns 400 VALIDATION_ERROR', async () => {
+    const res = await request(app)
+      .post('/api/territories')
+      .set('X-Test-User', stUser())
+      .send({
+        slug: 'test_territory_quinn_unknown',
+        name: 'Unknown Field Reject',
+        regent_name: 'Legacy Display Cache',
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('VALIDATION_ERROR');
+    expect(res.body.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ property: 'regent_name' }),
+      ]),
+    );
+  });
+
+  // Issue #33 — sanity check: every field in the canonical post-ADR-002
+  // contract round-trips cleanly through the strict schema.
+  it('POST with full canonical fieldset round-trips (no rejection)', async () => {
+    const res = await request(app)
+      .post('/api/territories')
+      .set('X-Test-User', stUser())
+      .send({
+        slug: 'test_territory_quinn_canonical',
+        name: 'Canonical Round-Trip',
+        ambience: 'Curated',
+        ambienceMod: 3,
+        regent_id: null,
+        lieutenant_id: null,
+        feeding_rights: [],
+      });
+    expect(res.status).toBe(201);
+    expect(res.body.slug).toBe('test_territory_quinn_canonical');
+    expect(res.body.ambienceMod).toBe(3);
+  });
 });
 
 // ── PUT /:id ──────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Tightens `server/schemas/territory.schema.js` to **strict mode** (`additionalProperties: false`) so the server rejects any territory body containing fields outside the canonical post-ADR-002 contract. Closes the silent-accept vulnerability that produced 5 duplicate territory documents on 2026-05-05 when a stale browser session posted bodies carrying the retired legacy `id` field.

Closes #33

## Survey: every territory writer audited
| Writer | Body fields | Canonical? |
|---|---|---|
| `city-views.js:596` | `_id, name, feeding_rights` | ✓ |
| `city-views.js:661` | `_id, name, ambience, ambienceMod` | ✓ |
| `city-views.js:688` | `_id, name, regent_id, lieutenant_id` | ✓ |
| `downtime-views.js:10059` | `slug, name, ambience` | ✓ |
| `downtime-views.js:10078` | `slug, name, ambience` | ✓ |
| `data-portability-import.js:79` | `slug, name, regent_id, regent_name, ambience, feeding_rights` | ⚠ `regent_name` non-canonical |
| `data-portability.js:525` | spread of import body (with `id` already stripped before POST) | ✓ structurally |

`regent_name` is NOT in the issue's canonical list, NOT in current schema `properties`, and NOT present on any real territory document (verified via the 2026-05-05 migration backup at `server/scripts/_backups/territory-fk-migration-2026-05-05T05-36-59-765Z.json` — 0 occurrences; only `ambienceMod` and the canonical fields appear). It was a stale derived display cache used by one rarely-exercised admin importer.

## Decision: Option A (strict) — chosen
- Every legitimate writer sends only canonical fields once `regent_name` is dropped from the lone exception.
- Strict mode gives full defense-in-depth: any future stale-tab or new-bug pattern introducing unknown fields is rejected at the API boundary.
- Option B (targeted `id`-only reject) would leave the door open for the next unknown-field accident — strictly weaker.

## Lesson #105 / drop-the-iteration applied
Rather than gating the write in the schema and leaving the legacy collect path to silently send a non-canonical key, the legacy `regent_name` field is dropped from `data-portability-import.js`. The schema doesn't need to whitelist it; the writer doesn't send it.

## `territoryResidencySchema` (AC #2)
Not applicable. The residency schema was removed when the `territory_residency` collection was retired — see `server/scripts/retire-territory-residency.js:20`:
> `server/schemas/territory.schema.js (territoryResidencySchema removed)`
There is no live schema to tighten.

## File list
- `server/schemas/territory.schema.js` — `additionalProperties: false`; properties extended with `_id` (string) and `ambienceMod` (number) so canonical bodies validate
- `public/js/admin/data-portability-import.js` — drops `regent_name` from the territory POST body
- `server/tests/api-territories.test.js` — 3 new tests:
  - POST with legacy `id` returns 400 VALIDATION_ERROR (literal reproduction of the May-5 incident)
  - POST with unknown `regent_name` returns 400 VALIDATION_ERROR (defense-in-depth)
  - POST with full canonical fieldset round-trips cleanly (no false rejections)

## Out of scope (noted for follow-up)
PUT `/api/territories/:id` does not have `validate()` middleware (route at `server/routes/territories.js:53`). The issue's AC #3 specifically targets POST and the May-5 incident was a POST. PUT could get the same defense-in-depth as a follow-up if it bites in practice; not done here to keep the surface area at exactly what the issue asks for.

## Test plan
- [x] Server tests: full suite **681/681** passing (was 678 baseline; +3 new tests)
- [x] `api-territories.test.js` specifically: 15/15 passing (was 12; +3 new)
- [x] Static review: every existing canonical writer has its body fields covered by the new properties block; only the legacy `regent_name` writer needed adjustment
- [ ] Browser smoke (DEFERRED — admin-only path, no player-facing surface): admin City tab edit operations (rename/regent/lieutenant/feeding-rights/ambience) continue to round-trip; admin data-portability JSON-import path with a clean canonical territory doc inserts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)