### PR TITLE
feat(rules-view): 'Held by' column + retire stored `selected` boolean

### DIFF
--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -3941,6 +3941,9 @@ body {
 .rules-td-dim { color: var(--txt2, #aaa); font-size: 12px; }
 .rules-td-dots { color: var(--accent); font-size: 11px; letter-spacing: 1px; white-space: nowrap; }
 .rules-td-prereq { font-size: 11px; color: var(--txt3, #777); max-width: 180px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.rules-td-held { font-family: var(--fl); font-size: 12px; color: var(--txt2); text-align: center; cursor: help; min-width: 56px; }
+.rules-td-held:empty { color: var(--txt3); }
+.rules-th-held { cursor: help; }
 .rules-td-empty { text-align: center; color: var(--txt3); padding: 24px; }
 .rules-cat-tag { font-size: 10px; text-transform: uppercase; letter-spacing: .5px; padding: 1px 6px; border-radius: 3px; background: var(--accent-a8); color: var(--accent); }
 .rules-edit-btn { background: none; border: none; color: var(--txt3, #777); font-size: 16px; cursor: pointer; padding: 2px 6px; line-height: 1; }

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -205,7 +205,7 @@ function switchDomain(domain) {
   if (domain === 'ordeals') initOrdealsAdminView(chars);
   if (domain === 'documents') initPrimerAdmin(document.getElementById('documents-content'));
   if (domain === 'tickets') initTicketsView(document.getElementById('tickets-admin-content'));
-  if (domain === 'rules') initRulesView(document.getElementById('rules-content'));
+  if (domain === 'rules') initRulesView(document.getElementById('rules-content'), chars);
   if (domain === 'rde') initRulesDataView(document.getElementById('rde-content'));
 }
 

--- a/public/js/admin/rules-view.js
+++ b/public/js/admin/rules-view.js
@@ -4,13 +4,14 @@
  */
 
 import { apiGet, apiPut, apiPost, apiDelete } from '../data/api.js';
-import { esc } from '../data/helpers.js';
+import { esc, displayName, sortName } from '../data/helpers.js';
 import { invalidateRulesCache } from '../data/loader.js';
 import { prereqLabel } from '../data/prereq.js';
 
 // ── State ──
 
 let _container = null;
+let _chars = [];
 let activeCategory = '';
 let searchQuery = '';
 let currentPage = 1;
@@ -28,9 +29,10 @@ const CATEGORY_ENUM = ['attribute', 'skill', 'discipline', 'merit', 'devotion', 
 
 // ── Init ──
 
-export async function initRulesView(container) {
+export async function initRulesView(container, chars) {
   if (!container) return;
   _container = container;
+  _chars = Array.isArray(chars) ? chars : [];
   container.innerHTML = '<p class="placeholder-msg">Loading rules\u2026</p>';
   await fetchAndRender();
   wireEvents();
@@ -70,6 +72,46 @@ function truncate(str, max) {
   return str.slice(0, max) + '\u2026';
 }
 
+// Issue #5: holder detection per category. Living-only filter (`!c.retired`)
+// is applied by the caller. Match key is the rule's canonical `name`; storage
+// shape per category is documented inline.
+function _isPowerHeld(c, rule) {
+  switch (rule.category) {
+    case 'merit':
+      // c.merits[].name; require some non-zero contribution so a hollow entry
+      // (e.g. dropdown picked but no rating set) is not counted.
+      return (c.merits || []).some(m =>
+        m.name === rule.name && ((m.rating || 0) > 0 || (m.cp || 0) > 0 || (m.xp || 0) > 0)
+      );
+    case 'discipline':
+      // c.disciplines is keyed by name; sanitiseChar already strips 0-dot entries.
+      return ((c.disciplines || {})[rule.name]?.dots || 0) > 0;
+    case 'devotion':
+      return (c.powers || []).some(p => p.category === 'devotion' && p.name === rule.name);
+    case 'rite':
+      return (c.powers || []).some(p => p.category === 'rite' && p.name === rule.name);
+    case 'manoeuvre':
+      return (c.fighting_picks || []).some(pk =>
+        (typeof pk === 'string' ? pk : pk?.manoeuvre) === rule.name
+      );
+    default:
+      // attribute / skill: universal traits, not "held" semantically.
+      return false;
+  }
+}
+
+// Issue #5: count + sorted display-name list of living characters who hold a
+// rule. Computed at render time from `_chars`; the stored `selected` boolean
+// on `purchasable_power` documents is retired (no longer read or written).
+function holdersForRule(rule) {
+  const matches = (_chars || []).filter(c => !c.retired && _isPowerHeld(c, rule));
+  matches.sort((a, b) => sortName(a).localeCompare(sortName(b)));
+  return {
+    count: matches.length,
+    names: matches.map(displayName),
+  };
+}
+
 function render(data) {
   let h = '';
 
@@ -102,10 +144,15 @@ function render(data) {
     const arrow = active ? (sortOrder === 'asc' ? ' \u25B2' : ' \u25BC') : '';
     h += `<th class="rules-th-sort${active ? ' rules-th-active' : ''}" data-sort="${col.key}">${col.label}${arrow}</th>`;
   }
-  h += '<th>Prereqs</th><th></th>';
+  h += '<th>Prereqs</th><th class="rules-th-held" title="Living characters who currently hold this power">Held by</th><th></th>';
   h += '</tr></thead><tbody>';
   for (const rule of data) {
     const pq = rule.prereq ? truncate(prereqLabel(rule.prereq), 40) : '';
+    const holders = holdersForRule(rule);
+    const heldTitle = holders.count
+      ? 'Held by: ' + holders.names.join(', ')
+      : 'Not currently held by any living character';
+    const heldCell = holders.count ? String(holders.count) : '';
     h += '<tr>';
     h += `<td class="rules-td-name">${esc(rule.name)}</td>`;
     h += `<td><span class="rules-cat-tag">${esc(rule.category)}</span></td>`;
@@ -114,11 +161,12 @@ function render(data) {
     h += `<td class="rules-td-dim">${rule.rating_range ? rule.rating_range[0] + '\u2013' + rule.rating_range[1] : ''}</td>`;
     h += `<td class="rules-td-dim">${rule.xp_fixed != null ? rule.xp_fixed : ''}</td>`;
     h += `<td class="rules-td-prereq" title="${esc(rule.prereq ? prereqLabel(rule.prereq) : '')}">${esc(pq)}</td>`;
+    h += `<td class="rules-td-held" title="${esc(heldTitle)}">${esc(heldCell)}</td>`;
     h += `<td><button class="rules-edit-btn" data-edit-key="${esc(rule.key)}" title="Edit">&#9998;</button><button class="rules-del-btn" data-del-key="${esc(rule.key)}" data-del-name="${esc(rule.name)}" title="Delete">&#128465;</button></td>`;
     h += '</tr>';
   }
   if (!data.length) {
-    h += '<tr><td colspan="8" class="rules-td-empty">No rules match your filters.</td></tr>';
+    h += '<tr><td colspan="9" class="rules-td-empty">No rules match your filters.</td></tr>';
   }
   h += '</tbody></table></div>';
 

--- a/server/schemas/purchasable_power.schema.js
+++ b/server/schemas/purchasable_power.schema.js
@@ -127,8 +127,12 @@ export const purchasablePowerSchema = {
     offering:  { type: ['string', 'null'] },
     cult:      { type: ['string', 'null'] },
 
-    // Tracking flags — not consumed by game logic yet
-    selected:    { type: 'boolean' },   // power is actively chosen by at least one character
+    // Tracking flag — not consumed by game logic yet.
+    // Issue #5 (2026-05-07): the legacy `selected` boolean was retired. Holder
+    // count is now computed at render time from the live character set
+    // (admin Rule Data table 'Held by' column). The migration script at
+    // server/scripts/strip-selected-from-purchasable-powers.js $unsets the
+    // field across existing documents.
     implemented: { type: 'boolean' },   // all rules/prereqs/mechanics verified correct in backend
   },
 };

--- a/server/scripts/strip-selected-from-purchasable-powers.js
+++ b/server/scripts/strip-selected-from-purchasable-powers.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * One-off retirement: $unset the legacy `selected` boolean from every
+ * document in tm_suite.purchasable_powers.
+ *
+ * Background (issue #5, 2026-05-07):
+ *   The Rule Data table now derives the 'Held by' count at render time from
+ *   the live character set (admin → Rule Data column). The stored `selected`
+ *   flag drifted out of sync with reality and is no longer read or written
+ *   anywhere in the codebase; the schema field has been removed in the same
+ *   PR. This script clears the dormant key from existing documents so the
+ *   on-disk shape matches the new schema.
+ *
+ * Behaviour:
+ *   - DRY-RUN by default: counts and prints the documents that carry the
+ *     field. Exits 0 without touching MongoDB.
+ *   - --apply: writes a JSON backup of every targeted document
+ *     (full body) to server/scripts/_backups/strip-selected-<ISO>.json
+ *     BEFORE issuing the $unset. If the backup write throws, the unset
+ *     never runs.
+ *   - Idempotent: re-running after success matches zero documents and
+ *     writes no backup.
+ *
+ * Usage:
+ *   cd server && node scripts/strip-selected-from-purchasable-powers.js
+ *   cd server && node scripts/strip-selected-from-purchasable-powers.js --apply
+ *
+ * Companion changes (this PR):
+ *   - server/schemas/purchasable_power.schema.js — `selected` removed from
+ *     properties; with `additionalProperties: false`, future POSTs that
+ *     include the field will fail validation
+ *   - public/js/admin/rules-view.js — 'Held by' column derives count from
+ *     live characters, never reads `selected`
+ */
+
+import 'dotenv/config';
+import { MongoClient } from 'mongodb';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const APPLY = process.argv.includes('--apply');
+const HELP = process.argv.includes('--help') || process.argv.includes('-h');
+
+if (HELP) {
+  console.log('Usage: node scripts/strip-selected-from-purchasable-powers.js [--apply]');
+  console.log('  Default is DRY-RUN. --apply writes a backup then $unsets `selected` across the collection.');
+  process.exit(0);
+}
+
+const URI = process.env.MONGODB_URI;
+if (!URI) {
+  console.error('MONGODB_URI missing — populate server/.env before running.');
+  process.exit(1);
+}
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const BACKUP_DIR = join(__dirname, '_backups');
+
+const client = new MongoClient(URI);
+
+async function main() {
+  await client.connect();
+  const db = client.db('tm_suite');
+  const col = db.collection('purchasable_powers');
+
+  // Match docs that carry the legacy field. Using $exists rather than
+  // matching on value so we catch both `selected: true` and `selected: false`.
+  const filter = { selected: { $exists: true } };
+  const matches = await col.find(filter).toArray();
+
+  console.log('Mode:    ' + (APPLY ? 'APPLY (will backup + unset)' : 'DRY-RUN'));
+  console.log('Matched: ' + matches.length + ' documents with `selected` field');
+
+  if (!matches.length) {
+    console.log('already-clean: true   updated: 0');
+    await client.close();
+    process.exit(0);
+  }
+
+  if (!APPLY) {
+    // Print a sample so the operator can sanity-check before --apply.
+    const sample = matches.slice(0, 5).map(d => ({ key: d.key, name: d.name, selected: d.selected }));
+    console.log('Sample (first 5):');
+    for (const s of sample) console.log('  - ' + s.key + ' (' + s.name + ') selected=' + s.selected);
+    if (matches.length > 5) console.log('  ... and ' + (matches.length - 5) + ' more');
+    console.log('Run with --apply to back up and unset.');
+    await client.close();
+    process.exit(0);
+  }
+
+  // Apply path: backup first, then unset.
+  mkdirSync(BACKUP_DIR, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const backupPath = join(BACKUP_DIR, 'strip-selected-' + stamp + '.json');
+  writeFileSync(backupPath, JSON.stringify(matches, null, 2));
+  console.log('Backup written: ' + backupPath);
+
+  const result = await col.updateMany(filter, { $unset: { selected: '' } });
+  console.log('updated:       ' + result.modifiedCount);
+
+  // Verify post-state.
+  const remaining = await col.countDocuments(filter);
+  console.log('remaining:     ' + remaining + ' (expected 0)');
+  if (remaining !== 0) {
+    console.error('SAFETY: residual documents with `selected` after $unset. Investigate before re-running.');
+    await client.close();
+    process.exit(2);
+  }
+
+  await client.close();
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error('ERROR:', err.message);
+  process.exit(1);
+});

--- a/server/tests/api-rules-offering.test.js
+++ b/server/tests/api-rules-offering.test.js
@@ -159,3 +159,55 @@ describe('POST /api/rules — sub_category enum relaxed (rites.3)', () => {
     expect(res.body.sub_category).toBe('general');
   });
 });
+
+// Issue #5: the legacy `selected` boolean was removed from the schema. POST
+// without the field continues to succeed; POST WITH the field is rejected
+// (additionalProperties: false catches the unknown key).
+describe('POST /api/rules — `selected` field retired (issue #5)', () => {
+  const retiredKeys = [];
+
+  afterAll(async () => {
+    const col = getCollection('purchasable_powers');
+    await col.deleteMany({ key: { $in: retiredKeys } });
+  });
+
+  it('POST without `selected` succeeds (no regression)', async () => {
+    const key = 'rite-selected-retired-baseline';
+    retiredKeys.push(key);
+    const res = await request(app)
+      .post('/api/rules')
+      .set('X-Test-User', stUser())
+      .send({
+        key,
+        name: 'Selected Retired Baseline',
+        category: 'rite',
+        parent: 'Theban',
+        rank: 1,
+        cost: '1 WP',
+      });
+    expect(res.status).toBe(201);
+    expect(res.body).not.toHaveProperty('selected');
+  });
+
+  it('POST with `selected: true` returns 400 VALIDATION_ERROR', async () => {
+    const res = await request(app)
+      .post('/api/rules')
+      .set('X-Test-User', stUser())
+      .send({
+        key: 'rite-selected-retired-reject',
+        name: 'Selected Retired Reject',
+        category: 'rite',
+        parent: 'Theban',
+        rank: 1,
+        cost: '1 WP',
+        selected: true,
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('VALIDATION_ERROR');
+    expect(res.body.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ property: 'selected' }),
+      ]),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Adds a 'Held by' column to the admin Rule Data table showing the count of living characters who currently hold each power, with an HTML-native `title=` tooltip listing those holders by `displayName(c)`. Computed at render time from the loaded character set; the stored `selected` boolean on `purchasable_power` documents is retired (no longer read or written, and removed from the schema).

Closes #5

## Survey findings
- **Only consumer of `selected`**: just `server/schemas/purchasable_power.schema.js:131`. Verified via grep across `public/js/admin/`, `public/js/data/`, `server/`. No client or server code reads or writes the field. Drop-the-iteration straight removal — Lesson #105 satisfied at the schema layer.
- **Character cache**: `chars` array in `admin.js`, already passed to peer init functions (`initDowntimeView`, `initNpcRegister`, `initDataPortabilityView`, etc.). Same pattern reused for `initRulesView(container, chars)`.
- **Storage shapes per category** (verified against character documents in production):
  | Category | Storage | Match logic |
  |---|---|---|
  | `merit` | `c.merits[].name` | require non-zero `rating`/`cp`/`xp` so a hollow entry doesn't count |
  | `discipline` | `c.disciplines[Name].dots` | `> 0` (sanitiseChar already strips 0-dot) |
  | `devotion` | `c.powers[]` where `category === 'devotion'` | name match |
  | `rite` | `c.powers[]` where `category === 'rite'` | name match |
  | `manoeuvre` | `c.fighting_picks[].manoeuvre` (or string form) | name match either shape |
  | `attribute` / `skill` | universal traits | not "held" semantically — cell empty |

## Performance decision: eager compute (PROCEED-WITH-NOTICE)
Budget: 50 rows × ~30 living characters × small constant per category lookup ≈ 1500 cheap predicate checks per render. Hover-list strings sorted on the same pass. Using HTML-native `title=` keeps tooltip behaviour zero-JS. Eager wins on simplicity over on-demand hover-handler attachment; flagged here per Khepri's brief.

## Schema migration: silent-leave on existing docs (PROCEED-WITH-NOTICE)
The migration script is in scope (per issue AC #7) but the field's removal alone doesn't break anything immediately:
- POST route uses `validate(purchasablePowerSchema)` — with `additionalProperties: false` already in place, removing `selected` from `properties` means future POSTs that include the field now 400 (defense-in-depth on top of the retirement).
- PUT route uses `UPDATABLE_FIELDS` allowlist (`server/routes/rules.js:70`). `selected` was not in it — PUT never wrote the field.
- Existing documents on disk with `selected: <bool>` continue to GET cleanly until the migration `$unset`s the key.

## File list
- `public/js/admin/rules-view.js` (+50): `_isPowerHeld(c, rule)` predicate, `holdersForRule(rule)` helper using `_chars` module-local cache, new 'Held by' column header, count cell + `title=` tooltip, colspan bumped from 8 to 9 on the empty row, `initRulesView(container, chars)` signature extension
- `public/js/admin.js` (+1/-1): pass `chars` to `initRulesView`
- `public/css/admin-layout.css` (+3): `.rules-td-held` (centered, help cursor, dim when empty), `.rules-th-held` (help cursor)
- `server/schemas/purchasable_power.schema.js`: `selected` removed from `properties`; replaced with a comment pointing at the rendered count + the migration script
- `server/scripts/strip-selected-from-purchasable-powers.js` (new): one-off migration following the project's dry-run-by-default + backup-before-write pattern (matches `cleanup-territory-id-dupes.js`); idempotent
- `server/tests/api-rules-offering.test.js` (+2 tests): regression test (POST without `selected` succeeds) + defense-in-depth (POST with `selected: true` returns 400 VALIDATION_ERROR)

## Test plan
- [x] Static parse: all four modified JS files + migration script pass `node --check`
- [x] Server tests: full suite **683/683** passing (681 baseline + 2 new). `api-rules-offering.test.js` specifically: 11/11
- [ ] Migration script smoke (DEFERRED — production-only operation): `node scripts/strip-selected-from-purchasable-powers.js` (dry-run, prints sample) → `--apply` (writes JSON backup, then `$unset`s); re-run to confirm idempotency
- [ ] Browser smoke (DEFERRED per project convention): admin Rule Data tab renders with the new 'Held by' column populated; tooltip on the count cell lists holders' display names sorted alphabetically; retired characters excluded from both count and list; column populated correctly across categories (merit, discipline, devotion, rite, manoeuvre); attribute and skill rows show empty cells; pagination/category-filter/search continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)