### PR TITLE
fix(defense-in-depth): PUT territory schema gate + Contacts prune in resync

### DIFF
--- a/public/js/admin/data-portability.js
+++ b/public/js/admin/data-portability.js
@@ -516,13 +516,17 @@ async function writeJsonDoc(collection, doc) {
 
     case 'territories': {
       // Post-ADR-002: territories use MongoDB _id as canonical FK; slug is a label.
-      // For import, prefer the doc's stored _id when present; fall back to insert.
-      if (id) return apiPut(`/api/territories/${id}`, body);
-      // No _id: insert. Carry slug forward as a label if present in source data.
-      const insertBody = { ...body };
-      if (doc.slug || doc.id) insertBody.slug = doc.slug || doc.id;
-      delete insertBody.id;
-      return apiPost('/api/territories', insertBody);
+      // Issue #141 (2026-05-07): PUT is now schema-validated like POST. Apply
+      // the same body-shaping to BOTH paths so legacy export JSON (which may
+      // carry the retired `id` and `regent_name` fields) imports cleanly under
+      // strict mode. Lesson #105 — drop the legacy keys at the writer rather
+      // than gate them on the schema.
+      const cleanBody = { ...body };
+      if (doc.slug || doc.id) cleanBody.slug = doc.slug || doc.id;
+      delete cleanBody.id;
+      delete cleanBody.regent_name;
+      if (id) return apiPut(`/api/territories/${id}`, cleanBody);
+      return apiPost('/api/territories', cleanBody);
     }
 
     case 'game_sessions':

--- a/public/js/editor/mci.js
+++ b/public/js/editor/mci.js
@@ -5,7 +5,7 @@
  */
 
 import { addMerit, ensureMeritSync } from './merits.js';
-import { syncMeritRating } from './domain.js';
+import { syncMeritRating, pruneContactsSpheres } from './domain.js';
 import { getRulesBySource, getRulesCache } from './rule_engine/load-rules.js';
 import { applyPTRulesFromDb } from './rule_engine/pt-evaluator.js';
 import { applyMCIRulesFromDb } from './rule_engine/mci-evaluator.js';
@@ -94,6 +94,12 @@ export function applyDerivedMerits(c, allChars = []) {
     if (m.name === 'Mystery Cult Initiation' || m.name === 'Professional Training' || m.name === 'Mandragora Garden') return;
     const total = syncMeritRating(m);
     if (total > 0) m.rating = total;
+    // Issue #144: cascade scenario — a free_* grant clearing here (e.g. MCI
+    // removed → free_mci on Contacts drops to 0) lowers the effective rating
+    // without going through the user-edit chokepoints (#143). Prune the
+    // spheres array on the auto-resync path too so the DT-form picker doesn't
+    // surface stale options the character no longer holds.
+    pruneContactsSpheres(m);
   });
 }
 

--- a/server/routes/territories.js
+++ b/server/routes/territories.js
@@ -50,7 +50,12 @@ router.post('/', requireST, validate(territorySchema), async (req, res) => {
 });
 
 // PUT /api/territories/:id — update one by _id (ST only)
-router.put('/:id', requireST, async (req, res) => {
+// Issue #141 (2026-05-07): defense-in-depth — same `validate(territorySchema)`
+// gate as POST. Closes the parallel attack vector PR #140 left open: a stale
+// browser session calling PUT with a legacy `id` body would have been
+// silently accepted and persisted unknown fields against the strict schema's
+// intent.
+router.put('/:id', requireST, validate(territorySchema), async (req, res) => {
   const oid = parseId(req.params.id);
   if (!oid) return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid territory ID format' });
 

--- a/server/tests/api-territories.test.js
+++ b/server/tests/api-territories.test.js
@@ -225,6 +225,34 @@ describe('PUT /api/territories/:id', () => {
     expect(res.body.error).toBe('VALIDATION_ERROR');
   });
 
+  // Issue #141 — defense-in-depth follow-up to #33: PUT now carries the same
+  // strict-schema gate as POST. A stale browser session posting the retired
+  // legacy `id` field via PUT must be rejected, mirroring the POST path's
+  // literal May-5 incident reproduction.
+  it('PUT with legacy `id` body field returns 400 VALIDATION_ERROR', async () => {
+    const create = await request(app)
+      .post('/api/territories')
+      .set('X-Test-User', stUser())
+      .send(testTerritory('test_territory_quinn_put_legacy_id'));
+    const mongoId = create.body._id;
+
+    const res = await request(app)
+      .put(`/api/territories/${mongoId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        id: 'test_territory_quinn_put_legacy_id',
+        name: 'Legacy ID Reject (PUT)',
+        ambience: 'Settled',
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('VALIDATION_ERROR');
+    expect(res.body.errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ property: 'id' }),
+      ]),
+    );
+  });
+
   it('player is blocked from updating', async () => {
     const create = await request(app)
       .post('/api/territories')


### PR DESCRIPTION
## Summary
Two micro-fixes bundled. Both close symmetric gaps from PRs that landed earlier in this session.

Closes #141
Closes #144

## #141 — PUT /api/territories/:id strict-schema gate

Defense-in-depth follow-up to #33 (PR #140). PR #140 added `validate(territorySchema)` to POST but PUT was left ungated — same body shape that triggered the May-5 dupes via POST would have been silently accepted via PUT.

**Server fix (1 line):** `server/routes/territories.js:53` — adds `validate(territorySchema)` middleware to the PUT route, mirroring POST.

**Test (+1):** `server/tests/api-territories.test.js` — PUT with legacy `id` body returns 400 + VALIDATION_ERROR (literal May-5 incident reproduction, parallel to PR #140's POST-side test).

## Pre-implementation audit of PUT writers — Lesson #105 applied
Two callers found in `public/`:
| Caller | Body shape | Canonical? |
|---|---|---|
| `downtime-views.js:10075` | `{ ambience: r.projStep }` | ✓ no change needed |
| `data-portability.js:520` | spread of `{ ...doc }` from import JSON | ⚠ at risk: legacy export files may carry retired `id` and `regent_name` fields |

`data-portability.js`: extracted the body-cleaning that the POST path already did (slug-fallback from `doc.slug || doc.id`, then `delete cleanBody.id`) into a shared block applied to BOTH paths, plus `delete cleanBody.regent_name` to mirror the importer cleanup PR #140 made at `data-portability-import.js`. Both POST and PUT now share identical pre-flight body shaping; legacy export JSON imports cleanly under strict mode.

## #144 — `pruneContactsSpheres` on the `applyDerivedMerits` resync path

Cascade scenario flagged by Ma'at on PR #143: a `free_*` grant clearing on the auto-resync path (e.g. MCI removed → `free_mci` on Contacts drops to 0) lowers the effective rating without going through the three user-edit chokepoints PR #143 wired (`shEditMeritPt`, `shStepMeritRating`, `shEditInflMerit`). Result: spheres array stays stale, DT-form picker surfaces options the character no longer holds.

**Client fix (2 lines):** `public/js/editor/mci.js`
- Imports `pruneContactsSpheres` alongside the existing `syncMeritRating` import (sibling helper, same module).
- Calls `pruneContactsSpheres(m)` inside the `applyDerivedMerits` resync forEach right after `m.rating = total`, closing the fourth rating-mutation path.

No new test — the helper itself is already covered by PR #143's chokepoint tests; the issue was a call-site gap, not helper logic.

## File list
- `server/routes/territories.js` (+1) — PUT validate middleware
- `server/tests/api-territories.test.js` (+1 test, ~28 lines) — PUT-id-reject regression
- `public/js/admin/data-portability.js` (+11/-7) — shared body-cleaning across POST and PUT paths
- `public/js/editor/mci.js` (+2) — pruneContactsSpheres call in the resync forEach

## Tests
- [x] Server tests: full suite **684/684** passing (683 baseline + 1 new for #141)
- [x] Static parse: all four modified files pass `node --input-type=module --check`
- [ ] Browser smoke (DEFERRED per project Test Plan):
  - Admin City tab edits (rename/regent/lieutenant/feeding-rights/ambience) continue to round-trip via PUT
  - Admin data-portability JSON-import path with a legacy export carrying `id` field imports cleanly (POST or PUT)
  - Cascade test for #144: character with Contacts 5 (5 spheres assigned) and `free_mci` from MCI; remove the MCI merit; confirm `c.merits[].spheres.length` truncated to match the new rating after `applyDerivedMerits` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)