### PR TITLE
feat(map): per-territory regent + ambience overlay with ST drag-to-place

### DIFF
--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -727,6 +727,14 @@ body {
 
 .city-section-title:first-child { margin-top: 0; }
 .city-game-tag { font-size: 13px; color: var(--txt3); font-weight: 400; letter-spacing: .08em; }
+.city-map-edit-launch {
+  display: block; width: 100%; margin: 0 0 12px;
+  padding: 10px 14px;
+  background: var(--surf2); border: 1px solid var(--bdr);
+  color: var(--accent); font-family: var(--fl); font-size: 13px;
+  letter-spacing: .04em; cursor: pointer; border-radius: 6px;
+}
+.city-map-edit-launch:hover { background: var(--surf3); border-color: var(--accent); }
 
 .asc-columns { display: flex; gap: 24px; }
 .asc-block { flex: 1; }

--- a/public/css/suite.css
+++ b/public/css/suite.css
@@ -1279,10 +1279,66 @@ details.city-section[open] > .city-section-hd::before { transform: rotate(90deg)
   flex: 1; display: flex; align-items: center; justify-content: center;
   overflow: hidden; touch-action: none; cursor: default;
 }
-.city-map-img {
-  max-width: 100%; max-height: 100%; object-fit: contain;
+/* Issue #9: pinch/zoom transform now applies to the stage so the overlay
+   layer (sibling of the img inside the stage) pans/scales with the map. */
+.map-stage {
+  position: relative; display: inline-block; line-height: 0;
   transform-origin: center center; transition: none;
+  max-width: 100%; max-height: 100%;
+}
+.city-map-img {
+  display: block; max-width: 100%; max-height: 100%; object-fit: contain;
   user-select: none; -webkit-user-drag: none;
+}
+.map-img-wrap .map-stage { display: block; width: 100%; }
+.map-img-wrap .city-map { width: 100%; height: auto; display: block; }
+.map-overlay-layer {
+  position: absolute; inset: 0; pointer-events: none;
+}
+.map-label {
+  position: absolute;
+  transform: translate(-50%, -50%);
+  pointer-events: none;
+  display: flex; flex-direction: column; align-items: center;
+  gap: 1px;
+  padding: 3px 8px;
+  background: rgba(13, 11, 9, .82);
+  border: 1px solid var(--gold2-a40, rgba(224, 196, 122, .4));
+  border-radius: 4px;
+  font-family: var(--fl);
+  font-size: 11px; line-height: 1.15;
+  color: var(--txt, #E8E0D0);
+  white-space: nowrap;
+  box-shadow: 0 1px 4px rgba(0,0,0,.45);
+  user-select: none;
+}
+.map-label__regent { font-weight: 600; color: var(--accent, #E0C47A); }
+.map-label__ambience { font-size: 10px; color: var(--txt2, #b8b0a0); }
+.map-label--editable { pointer-events: auto; cursor: move; }
+.map-label--editable:hover { border-color: var(--accent, #E0C47A); }
+.map-label--dragging { opacity: .85; box-shadow: 0 0 0 2px var(--accent, #E0C47A); }
+.map-overlay-layer--editing .map-label { pointer-events: auto; }
+
+/* Edit-mode toolbar on the fullscreen map overlay */
+.city-map-toolbar {
+  position: absolute; top: 12px; left: 12px; z-index: 2;
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 10px;
+  background: rgba(13, 11, 9, .85);
+  border: 1px solid var(--bdr);
+  border-radius: 6px;
+}
+.city-map-toolbar button {
+  background: var(--surf2); border: 1px solid var(--bdr);
+  color: var(--accent); font-family: var(--fl);
+  font-size: 12px; padding: 5px 10px; border-radius: 4px;
+  cursor: pointer;
+}
+.city-map-toolbar button:hover { background: var(--surf3); border-color: var(--accent); }
+.city-map-toolbar button:disabled { opacity: .5; cursor: not-allowed; }
+.city-map-edit-status {
+  font-family: var(--fl); font-size: 11px; color: var(--txt2);
+  margin-left: 4px;
 }
 
 /* ── Regent rows ── */

--- a/public/js/admin/city-views.js
+++ b/public/js/admin/city-views.js
@@ -11,6 +11,7 @@ import { displayName, dropdownName, sortName, clanIcon, covIcon } from '../data/
 import { setStatusTerritories } from '../data/accessors.js';
 import { AMBIENCE_MODS } from '../tabs/downtime-data.js';
 import { invalidateCachedTerritories } from './downtime-views.js';
+import { openCityMapOverlay } from '../tabs/city-tab.js';
 
 const TERRITORIES = [
   { id: 'academy', name: 'The Academy', ambience: 'Curated', ambienceMod: +3 },
@@ -325,6 +326,9 @@ function _terrDoc(terrId) {
 function renderTerritories() {
   const active = chars.filter(c => !c.retired).sort((a, b) => sortName(a).localeCompare(sortName(b)));
   let h = '<h3 class="city-section-title">Territories</h3>';
+  // Issue #9: ST entry-point to the fullscreen map overlay where the
+  // drag-to-place edit mode lives. Sibling to the existing territory cards.
+  h += '<button type="button" class="city-map-edit-launch" data-open-map-edit>Open city map (drag-to-place)</button>';
 
   for (const t of TERRITORIES) {
     const td = _terrDoc(t.id);
@@ -441,6 +445,12 @@ function renderTerritories() {
 // ══════════════════════════════════════
 
 function wireEvents(container) {
+  // Issue #9: open the fullscreen map overlay (with the ST drag-to-place
+  // edit toggle inside) — sibling to the existing territory cards.
+  container.querySelector('[data-open-map-edit]')?.addEventListener('click', () => {
+    openCityMapOverlay({ chars, territories: terrDocs });
+  });
+
   // Court edit toggle
   container.querySelector('#court-edit-toggle')?.addEventListener('click', () => {
     const panel = document.getElementById('court-edit-panel');

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -48,6 +48,7 @@ import {
 import { xpLeft } from './editor/xp.js';
 import { devotions, rites, setStatusTerritories } from './data/accessors.js';
 import { renderCharPools } from './game/char-pools.js';
+import { renderMapStageHtml } from './components/map-overlay.js';
 import { openContestedRoll, closeContestedRoll, crSetType, crSetChar, crAdjPool, crRoll } from './game/contested-roll.js';
 import { startChallengePoller, stopChallengePoller } from './game/challenge-notification.js';
 import { openChallengeModal } from './game/challenge-initiation.js';
@@ -379,7 +380,16 @@ function goTab(t) {
         }
         regHtml += '</div></div>';
       }
-      el.innerHTML = `<div class="map-tab-wrap"><div class="map-img-wrap"><img class="city-map" src="/assets/Terra Mortis Map.png" alt="Terra Mortis City Map"></div>${regHtml}</div>`;
+      // Issue #9: render map_coords overlay labels over the inline image.
+      // Read-only on this surface — ST drag-to-place lives on the World
+      // fullscreen overlay (city-tab.js _openMapOverlay).
+      const mapStage = renderMapStageHtml({
+        territories: suiteState.territories || [],
+        chars,
+        imgClass: 'city-map',
+        editable: false,
+      });
+      el.innerHTML = `<div class="map-tab-wrap"><div class="map-img-wrap">${mapStage}</div>${regHtml}</div>`;
     }
   }
   if (t === 'feeding') {

--- a/public/js/components/map-overlay.js
+++ b/public/js/components/map-overlay.js
@@ -1,0 +1,173 @@
+/**
+ * City map overlay component (issue #9).
+ *
+ * Two surfaces consume this:
+ *   - public/js/tabs/city-tab.js  — World fullscreen pinch/zoom overlay
+ *   - public/js/app.js (Map tab)  — inline static image with regent panel below
+ *
+ * Both wrap the map image in a `.map-stage` so the overlay layer is a sibling
+ * of the img and inherits any stage-level CSS transform (city-tab applies
+ * pinch/zoom to the stage; map tab leaves it untransformed). Labels are
+ * absolutely positioned at `map_coords.x`% / `map_coords.y`% relative to the
+ * stage — which sizes to the rendered image — so they track responsive width
+ * and zoom transforms automatically.
+ *
+ * Edit mode (ST-only) layers a `cursor: move` + pointerdown handler onto each
+ * label; pointer client coords convert to natural-percent via the IMG's
+ * post-transform getBoundingClientRect(), so the conversion is correct under
+ * any pinch/zoom scale without recomputing the transform manually.
+ */
+
+import { esc, displayName, findRegentTerritory } from '../data/helpers.js';
+
+export const MAP_IMG_SRC = '/assets/Terra Mortis Map.png';
+
+/**
+ * Render the stage HTML — `<div class="map-stage"><img><div class="map-overlay-layer">…</div></div>`.
+ * Pass `editable: true` to mark labels as drag-eligible (ST mode).
+ *
+ * @param {object} opts
+ * @param {object[]} opts.territories — territory documents
+ * @param {object[]} opts.chars — character documents (for displayName resolution)
+ * @param {string} [opts.imgClass='city-map-img'] — class on the <img>
+ * @param {string} [opts.imgId] — optional id on the <img>
+ * @param {boolean} [opts.editable=false] — render labels with drag handles
+ * @param {string} [opts.alt='Terra Mortis City Map']
+ */
+export function renderMapStageHtml(opts) {
+  const { territories = [], chars = [], imgClass = 'city-map-img', imgId, editable = false, alt = 'Terra Mortis City Map' } = opts || {};
+  const idAttr = imgId ? ` id="${esc(imgId)}"` : '';
+
+  let labels = '';
+  for (const t of territories) {
+    if (!_hasCoords(t.map_coords)) continue;
+    labels += renderLabelHtml(t, chars, editable);
+  }
+
+  return `<div class="map-stage" data-map-stage>`
+    + `<img class="${esc(imgClass)}" src="${esc(MAP_IMG_SRC)}" alt="${esc(alt)}"${idAttr}>`
+    + `<div class="map-overlay-layer" data-map-overlay${editable ? ' data-map-editable' : ''}>${labels}</div>`
+    + `</div>`;
+}
+
+/**
+ * Render a single territory label. Vacant territories render '(vacant)'
+ * for the regent line; ambience comes straight from the territory doc.
+ */
+export function renderLabelHtml(territory, chars, editable = false) {
+  const regent = territory.regent_id ? (chars || []).find(c => String(c._id) === String(territory.regent_id)) : null;
+  const regentName = regent ? displayName(regent) : '(vacant)';
+  const ambience = territory.ambience || '';
+  const x = territory.map_coords?.x ?? 0;
+  const y = territory.map_coords?.y ?? 0;
+  const editClass = editable ? ' map-label--editable' : '';
+  const idAttr = territory._id ? String(territory._id) : '';
+
+  let h = `<div class="map-label${editClass}"`
+    + ` style="left:${x}%;top:${y}%"`
+    + ` data-map-label`
+    + ` data-territory-id="${esc(idAttr)}"`
+    + (editable ? ` role="button" tabindex="0" aria-label="Drag to reposition ${esc(territory.name || '')}"` : '')
+    + '>';
+  h += `<span class="map-label__regent">${esc(regentName)}</span>`;
+  if (ambience) h += `<span class="map-label__ambience">${esc(ambience)}</span>`;
+  h += '</div>';
+  return h;
+}
+
+function _hasCoords(c) {
+  return c && typeof c.x === 'number' && typeof c.y === 'number'
+    && c.x >= 0 && c.x <= 100 && c.y >= 0 && c.y <= 100;
+}
+
+/**
+ * Convert a pointer's client coords into image-natural-percent. Uses the IMG
+ * element's getBoundingClientRect(), which already factors in any CSS
+ * transform on the parent stage — so this works under pinch/zoom without
+ * needing the caller to track the transform state.
+ *
+ * Returns null if the pointer is outside the image bounds (caller decides
+ * whether to clamp or reject the drag move).
+ */
+export function pointerToPercent(clientX, clientY, imgEl) {
+  if (!imgEl) return null;
+  const rect = imgEl.getBoundingClientRect();
+  if (rect.width <= 0 || rect.height <= 0) return null;
+  const x = ((clientX - rect.left) / rect.width) * 100;
+  const y = ((clientY - rect.top) / rect.height) * 100;
+  return { x, y };
+}
+
+/**
+ * Wire drag handlers onto every editable label inside `stageEl`. Uses the
+ * unified PointerEvent API (mouse + touch). On each drag end, calls
+ * `onChange(territoryId, { x, y })` so the caller can update local state.
+ *
+ * Returns a teardown function that removes all listeners.
+ */
+export function attachDragHandlers(stageEl, onChange) {
+  if (!stageEl) return () => {};
+  const imgEl = stageEl.querySelector('img');
+  if (!imgEl) return () => {};
+
+  let activeLabel = null;
+  let pointerId = null;
+
+  function onDown(e) {
+    const label = e.target.closest('.map-label--editable');
+    if (!label || !stageEl.contains(label)) return;
+    e.preventDefault();
+    activeLabel = label;
+    pointerId = e.pointerId;
+    label.setPointerCapture?.(pointerId);
+    label.classList.add('map-label--dragging');
+  }
+
+  function onMove(e) {
+    if (!activeLabel || e.pointerId !== pointerId) return;
+    e.preventDefault();
+    const pct = pointerToPercent(e.clientX, e.clientY, imgEl);
+    if (!pct) return;
+    const x = Math.max(0, Math.min(100, pct.x));
+    const y = Math.max(0, Math.min(100, pct.y));
+    activeLabel.style.left = x + '%';
+    activeLabel.style.top = y + '%';
+  }
+
+  function onUp(e) {
+    if (!activeLabel || e.pointerId !== pointerId) return;
+    e.preventDefault();
+    const pct = pointerToPercent(e.clientX, e.clientY, imgEl);
+    let coords;
+    if (pct) {
+      coords = {
+        x: Math.max(0, Math.min(100, pct.x)),
+        y: Math.max(0, Math.min(100, pct.y)),
+      };
+    } else {
+      // Fall back to the style-encoded position if the pointer left the image.
+      coords = {
+        x: parseFloat(activeLabel.style.left) || 0,
+        y: parseFloat(activeLabel.style.top) || 0,
+      };
+    }
+    activeLabel.classList.remove('map-label--dragging');
+    activeLabel.releasePointerCapture?.(pointerId);
+    const tid = activeLabel.dataset.territoryId;
+    activeLabel = null;
+    pointerId = null;
+    if (tid && typeof onChange === 'function') onChange(tid, coords);
+  }
+
+  stageEl.addEventListener('pointerdown', onDown);
+  stageEl.addEventListener('pointermove', onMove);
+  stageEl.addEventListener('pointerup', onUp);
+  stageEl.addEventListener('pointercancel', onUp);
+
+  return () => {
+    stageEl.removeEventListener('pointerdown', onDown);
+    stageEl.removeEventListener('pointermove', onMove);
+    stageEl.removeEventListener('pointerup', onUp);
+    stageEl.removeEventListener('pointercancel', onUp);
+  };
+}

--- a/public/js/tabs/city-tab.js
+++ b/public/js/tabs/city-tab.js
@@ -3,9 +3,17 @@
  * Map opens in a fullscreen pinch-zoom overlay.
  */
 
-import { apiGet } from '../data/api.js';
+import { apiGet, apiPut } from '../data/api.js';
 import { esc, displayName, sortName, redactPlayer } from '../data/helpers.js';
 import { clanIcon, covIcon } from '../data/helpers.js';
+import { getRole } from '../auth/discord.js';
+import { renderMapStageHtml, attachDragHandlers } from '../components/map-overlay.js';
+
+// Issue #9: capture latest chars + territories at render time so the map
+// overlay (opened lazily from the button) has access to the same data the
+// rest of the tab uses.
+let _latestChars = [];
+let _latestTerrs = [];
 
 // ── Module-local helpers ───────────────────────────────────────────────────────
 
@@ -50,6 +58,10 @@ export async function renderCityTab(el, territories = []) {
     el.innerHTML = `<p class="placeholder-msg">Failed to load: ${esc(err.message)}</p>`;
     return;
   }
+
+  // Cache for the lazy-opened map overlay (issue #9).
+  _latestChars = chars;
+  _latestTerrs = territories || [];
 
   // ── Data prep ──
   const CATEGORY_ORDER = ['Head of State', 'Primogen', 'Administrator', 'Socialite', 'Enforcer'];
@@ -143,17 +155,56 @@ export async function renderCityTab(el, territories = []) {
 // ── Fullscreen map overlay with pinch-zoom ───────────────────────────────────
 
 let _mapOverlay = null;
+// Issue #9: pending coord changes while ST drag-mode is active. Keyed by
+// territory _id; values are { x, y } percent. Save commits these via PUT.
+let _pendingCoords = new Map();
+let _editMode = false;
+let _detachDrag = null;
+
+/**
+ * Issue #9: public entry-point so the admin City view can open the same
+ * fullscreen overlay (with the ST edit-mode toggle) without re-implementing
+ * the pinch/zoom + drag/save pipeline. When called with `opts`, the cached
+ * chars/territories are overwritten before opening.
+ */
+export function openCityMapOverlay(opts) {
+  if (opts && Array.isArray(opts.chars)) _latestChars = opts.chars;
+  if (opts && Array.isArray(opts.territories)) _latestTerrs = opts.territories;
+  _openMapOverlay();
+}
 
 function _openMapOverlay() {
   if (_mapOverlay) { _mapOverlay.classList.add('on'); document.body.style.overflow = 'hidden'; return; }
 
+  const isST = getRole() === 'st';
+
   const div = document.createElement('div');
   div.id = 'city-map-overlay';
   div.className = 'city-map-overlay on';
+  // Stage transform replaces the prior img-only transform so the map_coords
+  // overlay layer (sibling of the img inside the stage) pans/scales together
+  // with the image (issue #9).
+  const stageHtml = renderMapStageHtml({
+    territories: _latestTerrs,
+    chars: _latestChars,
+    imgClass: 'city-map-img',
+    imgId: 'city-map-img',
+    editable: false,
+  });
+  let toolbarHtml = '';
+  if (isST) {
+    toolbarHtml = `<div class="city-map-toolbar" data-st-toolbar>
+      <button class="city-map-edit-toggle" id="city-map-edit-toggle">Edit map placement</button>
+      <button class="city-map-edit-save" id="city-map-edit-save" hidden>Save placement</button>
+      <button class="city-map-edit-cancel" id="city-map-edit-cancel" hidden>Cancel</button>
+      <span class="city-map-edit-status" id="city-map-edit-status" aria-live="polite"></span>
+    </div>`;
+  }
   div.innerHTML = `
     <button class="city-map-close" id="city-map-close">&times;</button>
+    ${toolbarHtml}
     <div class="city-map-viewport" id="city-map-viewport">
-      <img class="city-map-img" src="/assets/Terra Mortis Map.png" alt="Terra Mortis City Map" id="city-map-img">
+      ${stageHtml}
     </div>`;
   document.body.appendChild(div);
   _mapOverlay = div;
@@ -162,20 +213,31 @@ function _openMapOverlay() {
   div.querySelector('#city-map-close').addEventListener('click', _closeMapOverlay);
   div.addEventListener('click', e => { if (e.target === div) _closeMapOverlay(); });
 
-  // Pinch-zoom + pan via CSS transform
+  if (isST) _wireEditMode(div);
+
+  // Pinch-zoom + pan via CSS transform on the stage (so the overlay layer
+  // pans/scales with the img — issue #9).
   const viewport = div.querySelector('#city-map-viewport');
-  const img = div.querySelector('#city-map-img');
+  const stage = div.querySelector('[data-map-stage]');
   let scale = 1, posX = 0, posY = 0;
   let startDist = 0, startScale = 1;
   let panStartX = 0, panStartY = 0, startPosX = 0, startPosY = 0;
   let isPanning = false;
 
   function applyTransform() {
-    img.style.transform = `translate(${posX}px, ${posY}px) scale(${scale})`;
+    stage.style.transform = `translate(${posX}px, ${posY}px) scale(${scale})`;
+  }
+
+  // Issue #9: edit-mode short-circuit. When dragging a label, skip the
+  // pan/zoom touch handlers so the label drag wins (PointerEvents fire
+  // alongside TouchEvents).
+  function _isEditingLabelEvent(e) {
+    return _editMode && e.target?.closest && e.target.closest('.map-label--editable');
   }
 
   // Touch: pinch-zoom + two-finger pan
   viewport.addEventListener('touchstart', e => {
+    if (_isEditingLabelEvent(e)) return;
     if (e.touches.length === 2) {
       e.preventDefault();
       startDist = _dist(e.touches[0], e.touches[1]);
@@ -226,6 +288,7 @@ function _openMapOverlay() {
   let mouseDown = false, mx0 = 0, my0 = 0, px0 = 0, py0 = 0;
   viewport.addEventListener('mousedown', e => {
     if (scale <= 1) return;
+    if (_isEditingLabelEvent(e)) return;
     mouseDown = true; mx0 = e.clientX; my0 = e.clientY; px0 = posX; py0 = posY;
     viewport.style.cursor = 'grabbing';
   });
@@ -253,8 +316,102 @@ function _openMapOverlay() {
 function _closeMapOverlay() {
   if (_mapOverlay) _mapOverlay.classList.remove('on');
   document.body.style.overflow = '';
+  // Tear down any in-flight edit mode so the next open starts clean.
+  if (_detachDrag) { _detachDrag(); _detachDrag = null; }
+  _editMode = false;
+  _pendingCoords.clear();
 }
 
 function _dist(a, b) {
   return Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY);
+}
+
+// Issue #9: ST drag-to-place wiring. Toggles label editability, captures
+// pending coord changes, and PUTs each modified territory's map_coords on
+// Save. Cancel discards local changes (the next open re-renders from the
+// canonical territories cache).
+function _wireEditMode(overlayEl) {
+  const toggleBtn = overlayEl.querySelector('#city-map-edit-toggle');
+  const saveBtn   = overlayEl.querySelector('#city-map-edit-save');
+  const cancelBtn = overlayEl.querySelector('#city-map-edit-cancel');
+  const statusEl  = overlayEl.querySelector('#city-map-edit-status');
+  const overlayLayer = overlayEl.querySelector('[data-map-overlay]');
+  const stage = overlayEl.querySelector('[data-map-stage]');
+  if (!toggleBtn || !saveBtn || !cancelBtn || !overlayLayer || !stage) return;
+
+  function _setStatus(msg) { if (statusEl) statusEl.textContent = msg || ''; }
+
+  function _enterEdit() {
+    _editMode = true;
+    _pendingCoords.clear();
+    overlayLayer.classList.add('map-overlay-layer--editing');
+    overlayLayer.dataset.mapEditable = '';
+    overlayLayer.querySelectorAll('.map-label').forEach(el => el.classList.add('map-label--editable'));
+    toggleBtn.hidden = true;
+    saveBtn.hidden = false;
+    cancelBtn.hidden = false;
+    _setStatus('Drag a territory label to reposition. Save commits the new coordinates.');
+    _detachDrag = attachDragHandlers(stage, (territoryId, coords) => {
+      _pendingCoords.set(String(territoryId), coords);
+      _setStatus(`${_pendingCoords.size} change${_pendingCoords.size === 1 ? '' : 's'} pending`);
+    });
+  }
+
+  function _exitEdit() {
+    _editMode = false;
+    if (_detachDrag) { _detachDrag(); _detachDrag = null; }
+    overlayLayer.classList.remove('map-overlay-layer--editing');
+    delete overlayLayer.dataset.mapEditable;
+    overlayLayer.querySelectorAll('.map-label').forEach(el => el.classList.remove('map-label--editable', 'map-label--dragging'));
+    saveBtn.hidden = true;
+    cancelBtn.hidden = true;
+    toggleBtn.hidden = false;
+  }
+
+  function _restoreLabelPositions() {
+    // Reset the in-DOM positions to whatever the cached territories carry,
+    // discarding any drag state since the user cancelled.
+    for (const t of _latestTerrs) {
+      if (!t.map_coords) continue;
+      const el = overlayLayer.querySelector(`.map-label[data-territory-id="${String(t._id)}"]`);
+      if (!el) continue;
+      el.style.left = (t.map_coords.x || 0) + '%';
+      el.style.top = (t.map_coords.y || 0) + '%';
+    }
+  }
+
+  toggleBtn.addEventListener('click', _enterEdit);
+
+  cancelBtn.addEventListener('click', () => {
+    _restoreLabelPositions();
+    _pendingCoords.clear();
+    _exitEdit();
+    _setStatus('');
+  });
+
+  saveBtn.addEventListener('click', async () => {
+    if (!_pendingCoords.size) { _exitEdit(); _setStatus(''); return; }
+    saveBtn.disabled = true;
+    cancelBtn.disabled = true;
+    _setStatus(`Saving ${_pendingCoords.size} change${_pendingCoords.size === 1 ? '' : 's'}…`);
+    try {
+      // Sequential PUTs — small N (max ~10 territories), keeps server load
+      // and error semantics simple.
+      for (const [tid, coords] of _pendingCoords.entries()) {
+        const updated = await apiPut(`/api/territories/${tid}`, { map_coords: coords });
+        // Reflect the saved value into the cached array so a re-open
+        // (without a full reload) renders the persisted positions.
+        const cached = _latestTerrs.find(t => String(t._id) === String(tid));
+        if (cached) cached.map_coords = updated.map_coords || coords;
+      }
+      _pendingCoords.clear();
+      _setStatus('Saved.');
+      _exitEdit();
+    } catch (err) {
+      _setStatus('Save failed: ' + (err?.message || 'unknown error'));
+    } finally {
+      saveBtn.disabled = false;
+      cancelBtn.disabled = false;
+    }
+  });
 }

--- a/server/schemas/territory.schema.js
+++ b/server/schemas/territory.schema.js
@@ -35,5 +35,24 @@ export const territorySchema = {
     lieutenant_id:   { type: ['string', 'null'] },
     feeding_rights:  { type: 'array', items: { type: 'string' } },
     updated_at:      { type: 'string' },
+    // Issue #9 (2026-05-07): optional placement on the city map overlay.
+    // Both x and y are percentages of the map image's natural dimensions
+    // (0–100 inclusive). When present, both keys are required and must be
+    // numbers in range; partial or out-of-range coords reject as
+    // VALIDATION_ERROR. Territories without map_coords render no overlay.
+    map_coords: {
+      oneOf: [
+        { type: 'null' },
+        {
+          type: 'object',
+          properties: {
+            x: { type: 'number', minimum: 0, maximum: 100 },
+            y: { type: 'number', minimum: 0, maximum: 100 },
+          },
+          required: ['x', 'y'],
+          additionalProperties: false,
+        },
+      ],
+    },
   },
 };

--- a/server/tests/api-territories.test.js
+++ b/server/tests/api-territories.test.js
@@ -127,6 +127,16 @@ describe('POST /api/territories', () => {
     expect(res.status).toBe(403);
   });
 
+  // Issue #9 — `map_coords` accepted at insert time and round-tripped.
+  it('POST with valid `map_coords` round-trips', async () => {
+    const res = await request(app)
+      .post('/api/territories')
+      .set('X-Test-User', stUser())
+      .send({ ...testTerritory('test_territory_quinn_post_coords'), map_coords: { x: 33.3, y: 66.7 } });
+    expect(res.status).toBe(201);
+    expect(res.body.map_coords).toEqual({ x: 33.3, y: 66.7 });
+  });
+
   // Issue #33 — defence-in-depth: schema rejects the retired legacy `id` field
   // so a stale browser session cannot silently insert a duplicate document.
   // Reproduces the 2026-05-05 incident pattern (5 dupes via apiPost with `id`).
@@ -223,6 +233,67 @@ describe('PUT /api/territories/:id', () => {
       .send({ ambience: 'hostile' });
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('VALIDATION_ERROR');
+  });
+
+  // Issue #9 — `map_coords` round-trips on PUT and validates components.
+  it('PUT with valid `map_coords` round-trips', async () => {
+    const create = await request(app)
+      .post('/api/territories')
+      .set('X-Test-User', stUser())
+      .send(testTerritory('test_territory_quinn_put_coords'));
+    const mongoId = create.body._id;
+
+    const res = await request(app)
+      .put(`/api/territories/${mongoId}`)
+      .set('X-Test-User', stUser())
+      .send({ map_coords: { x: 42.5, y: 71.25 } });
+    expect(res.status).toBe(200);
+    expect(res.body.map_coords).toEqual({ x: 42.5, y: 71.25 });
+  });
+
+  it('PUT with `map_coords.x` out of range returns 400', async () => {
+    const create = await request(app)
+      .post('/api/territories')
+      .set('X-Test-User', stUser())
+      .send(testTerritory('test_territory_quinn_put_coords_oor'));
+    const mongoId = create.body._id;
+
+    const res = await request(app)
+      .put(`/api/territories/${mongoId}`)
+      .set('X-Test-User', stUser())
+      .send({ map_coords: { x: 150, y: 50 } });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('VALIDATION_ERROR');
+  });
+
+  it('PUT with partial `map_coords` (missing y) returns 400', async () => {
+    const create = await request(app)
+      .post('/api/territories')
+      .set('X-Test-User', stUser())
+      .send(testTerritory('test_territory_quinn_put_coords_partial'));
+    const mongoId = create.body._id;
+
+    const res = await request(app)
+      .put(`/api/territories/${mongoId}`)
+      .set('X-Test-User', stUser())
+      .send({ map_coords: { x: 50 } });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('VALIDATION_ERROR');
+  });
+
+  it('PUT with `map_coords: null` clears the field', async () => {
+    const create = await request(app)
+      .post('/api/territories')
+      .set('X-Test-User', stUser())
+      .send({ ...testTerritory('test_territory_quinn_put_coords_clear'), map_coords: { x: 25, y: 25 } });
+    const mongoId = create.body._id;
+
+    const res = await request(app)
+      .put(`/api/territories/${mongoId}`)
+      .set('X-Test-User', stUser())
+      .send({ map_coords: null });
+    expect(res.status).toBe(200);
+    expect(res.body.map_coords).toBeNull();
   });
 
   // Issue #141 — defense-in-depth follow-up to #33: PUT now carries the same


### PR DESCRIPTION
## Summary
Adds `map_coords: { x, y }` to the territory schema and surfaces regent + ambience labels over the city map on both player views (World fullscreen overlay + Map tab inline). Adds an ST-only drag-to-place edit mode on the fullscreen overlay, reachable from both the player Who's Who tab map button and a new admin City view button.

Closes #9

## Architecture
**Shared helper** (new file `public/js/components/map-overlay.js`):
- `renderMapStageHtml({ territories, chars, ... })` builds `<div class="map-stage"><img><div class="map-overlay-layer">…labels…</div></div>` — labels are absolutely positioned by `style="left:X%;top:Y%"`. CSS percentages on the overlay layer (sized to the rendered image box) automatically equal natural-image percentages because the image scales uniformly, so labels track responsive width and zoom without any coordinate transform math at render time.
- `pointerToPercent(clientX, clientY, imgEl)` reads the IMG's post-transform `getBoundingClientRect()` — that rect already reflects any CSS transform on the parent stage, so the conversion is correct under pinch/zoom without the caller tracking transform state manually.
- `attachDragHandlers(stageEl, onChange)` uses unified PointerEvent API (mouse + touch) with `setPointerCapture`. Returns a teardown function for clean unwiring.

**Two consuming surfaces:**
| Surface | File | Mode |
|---|---|---|
| Map tab inline | `public/js/app.js:381` | Read-only labels |
| World fullscreen | `public/js/tabs/city-tab.js` | Read + ST drag-to-place |

**ST entry points (chosen UX):**
- Player Who's Who tab → "View City Map" button → fullscreen → ST sees "Edit map placement" button on overlay (gated `getRole() === 'st'`)
- Admin City view → "Open city map (drag-to-place)" button (sibling to territory cards, satisfying the issue body's `public/js/admin` placement hint)

Both routes call the exported `openCityMapOverlay({ chars, territories })`. The admin path passes its own loaded data (which includes ambienceMod overrides via `applyDerivedMerits`); the player path uses the cached suite-state data.

## Pinch/zoom architecture change
Previously: `transform: translate scale` was applied to the `<img>` directly. Adding overlay siblings inside the same viewport wouldn't pan/scale with it.

Now: transform applies to `.map-stage` (the wrapper containing both `<img>` and `.map-overlay-layer`). Labels track the image transform automatically as descendants. The IMG's `getBoundingClientRect()` reflects the parent's transform, so pointer-to-percent math works without explicit transform tracking.

## Drag-conflict resolution
City-tab's pinch/zoom touchstart and one-finger pan handlers gate with `_isEditingLabelEvent(e)`. When the pointer hits `.map-label--editable` and edit mode is active, those handlers short-circuit so the label drag (PointerEvent path) wins. Two-finger pinch and wheel zoom continue to work; one-finger pan is suppressed during a label drag.

## Schema + validation
```js
map_coords: {
  oneOf: [
    { type: 'null' },
    {
      type: 'object',
      properties: {
        x: { type: 'number', minimum: 0, maximum: 100 },
        y: { type: 'number', minimum: 0, maximum: 100 },
      },
      required: ['x', 'y'],
      additionalProperties: false,
    },
  ],
},
```
- Required-both-or-null shape — partial coords reject as VALIDATION_ERROR
- Out-of-range numbers reject (matches the canonical strict pattern from PR #140)
- `null` clears the field (territory then renders no overlay)
- POST + PUT already use `validate(territorySchema)` (PRs #140 + #147), so the new field round-trips automatically

## Save semantics
Sequential PUTs on Save (small N, max ~10 territories — keeps server load and error semantics simple). Each PUT updates a single territory's `map_coords`; on success, the response body is reflected back into the cached array so a re-open without a full reload renders the persisted positions. Cancel discards local changes.

## File list
- `public/js/components/map-overlay.js` (new, ~150 lines): shared render + drag helpers
- `public/js/tabs/city-tab.js` (+~120): stage wrapper; transform target moved to stage; ST toolbar; edit mode lifecycle (enter/exit/save/cancel); drag-conflict short-circuit; exported `openCityMapOverlay`
- `public/js/app.js` (+~10): Map tab stage-wrapped read-only render
- `public/js/admin/city-views.js` (+~10): 'Open city map (drag-to-place)' button + click handler
- `public/css/suite.css` (+~60): `.map-stage`, `.map-overlay-layer`, `.map-label*`, `.city-map-toolbar`. Token-driven; no bare hex
- `public/css/admin-layout.css` (+8): `.city-map-edit-launch` button style
- `server/schemas/territory.schema.js`: `map_coords` property added (under `additionalProperties: false`)
- `server/tests/api-territories.test.js` (+5 tests): POST round-trip, PUT round-trip, PUT out-of-range x, PUT partial coords, PUT clearing with `null`

## AC matrix (12 points)
- [x] Schema accepts `map_coords: {x, y}` with x,y as numbers 0–100; persists in MongoDB — schema + 5 tests
- [x] API endpoints accept and return `map_coords` — POST + PUT both validate(territorySchema)
- [x] World tab fullscreen overlay renders regent + ambience labels — `renderMapStageHtml` inside `_openMapOverlay`
- [x] Map tab inline view renders the same labels — `renderMapStageHtml` in app.js Map tab branch
- [x] Labels track pinch/zoom and pan in World tab — transform target moved to `.map-stage`
- [x] Labels track responsive image width on Map tab — CSS percentages on overlay layer match image rendered box
- [x] Vacant territories show "(vacant)" — handled in `renderLabelHtml` when no `regent_id`
- [x] Territories without `map_coords` render no overlay — `_hasCoords` guard skips them
- [x] ST-only edit mode allows drag-to-place — toolbar gated `getRole() === 'st'`; drag handlers wire `.map-label--editable`
- [x] Drag works on touch + mouse — unified PointerEvent API with `setPointerCapture`
- [x] Save commits new map_coords; reload reflects persisted values — sequential PUTs; response body reflected into cache
- [x] Non-ST users cannot enter placement mode — UI gated client-side; server enforces via existing requireST middleware on PUT

## Test plan
- [x] Server tests: full suite **689/689** passing (684 baseline + 5 new). `api-territories.test.js`: 21/21
- [x] Static parse: all five modified JS files plus new `map-overlay.js` helper pass `node --input-type=module --check`
- [ ] Browser smoke (DEFERRED per project Test Plan):
  - Player Who's Who → View City Map: regent + ambience labels render over each territory with `map_coords`
  - Player Map tab: same labels render over the static image; responsive width preserved
  - ST role: 'Edit map placement' toolbar button visible on overlay
  - Click Edit → drag a label by mouse → click Save → reload → label persists at new position
  - Same flow with touch on iPad
  - Cancel discards local drag changes
  - Multiple labels dragged in one session → single Save commits all
  - Pinch/zoom in non-edit mode pans labels with the image
  - Admin City tab → 'Open city map (drag-to-place)' opens the same overlay with same edit toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)