### PR TITLE
chore(npcs): remove orphaned /api/npcs/for-character/:characterId route

### DIFF
--- a/server/routes/npcs.js
+++ b/server/routes/npcs.js
@@ -116,27 +116,12 @@ router.get('/directory', async (req, res) => {
   res.json(docs);
 });
 
-// DTOSL.2: player-readable endpoint (must register BEFORE the ST-only
-// router.use below). Returns NPCs linked to the given character. The
-// caller must own the character (character_ids contains the id). ST
-// bypasses the ownership check.
-router.get('/for-character/:characterId', async (req, res) => {
-  const { characterId } = req.params;
-  const userCharIds = (req.user?.character_ids || []).map(String);
-  const isSt = req.user?.role === 'st' || req.user?.role === 'dev';
-  if (!isSt && !userCharIds.includes(String(characterId))) {
-    return res.status(403).json({ error: 'FORBIDDEN', message: 'Not your character' });
-  }
-  const filter = {
-    linked_character_ids: String(characterId),
-    status: { $in: ['active', 'pending'] },
-  };
-  if (req.query.is_correspondent === 'true') {
-    filter.is_correspondent = true;
-  }
-  const docs = await col().find(filter).sort({ name: 1 }).toArray();
-  res.json(docs);
-});
+// Issue #108 (2026-05-08): the player-readable
+// `GET /api/npcs/for-character/:characterId` route (formerly DTOSL.2) was
+// removed. After PR #107 (closes #84, dt-form.33 NPC selector removal),
+// no client code calls it anywhere in `public/`. The companion
+// `/api/relationships/for-character/:characterId` route (NPCR.6) is
+// independently consumed by `relationships-tab.js` and is unaffected.
 
 // NPCP-1: list endpoint is now player-readable but scoped at the Mongo
 // query level to NPCs linked to the caller's characters. ST/dev see the


### PR DESCRIPTION
## Summary
PR #107 (closes #84, dt-form.33 NPC selector removal) eliminated every client caller of `/api/npcs/for-character/`. A grep across `public/` / `server/` confirmed zero live consumers — only doc/comment references remain. The route was harmless dead code on the server but added maintenance surface (auth posture, future schema migrations, route tests).

Closes #108

## Audit
- `grep -rn '/api/npcs/for-character' public/` → zero hits in live code (only a deletion-receipt comment at `downtime-form.js:1216`)
- `grep -rn '/api/npcs/for-character' server/` → zero hits outside the route definition itself
- `grep -rn 'for-character' server/tests/` → only `api-relationships-for-character.test.js` (the relationship variant, NPCR.6, NOT this route)
- `specs/` / `specs/stories/` references are historical (DTOSL.2 / NPCR.6 stories) — no live spec dependency

The companion `GET /api/relationships/for-character/:characterId` (NPCR.6) is independently consumed by `public/js/tabs/relationships-tab.js:266` and is **not** affected by this change.

## Diff
- `server/routes/npcs.js:123-139` — route handler removed; replaced with a deletion-receipt comment pointing at PR #107

## Test plan
- [x] Server tests: full suite **689/689** passing (no regression — the removed route had no tests)
- [ ] Browser smoke (DEFERRED — admin-only path, no player-facing surface): admin NPC views continue to work via `GET /api/npcs` (the player-readable list endpoint that supersedes this one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)