### PR TITLE
fix(admin): canonical ambience-action dispatch across form + CSV paths

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -140,6 +140,31 @@ const ALL_ACTION_TYPES = [
   'block', 'rumour', 'grow', 'acquisition',
 ];
 
+// Issue #129 (2026-05-08): canonical ambience action dispatcher.
+// The DT form (post-#79) persists `project_${n}_action === 'ambience_change'`
+// + `responses.project_${n}_ambience_direction` ('improve' | 'degrade').
+// Legacy CSV-imported submissions in the DB carry `'ambience_increase'` /
+// `'ambience_decrease'` (pre-canonicalisation parser output). Both shapes
+// must dispatch correctly here. The helper accepts any of the three action
+// type strings; direction is derived from the type itself for legacy or
+// from the responses bag for canonical.
+const _AMBIENCE_ACTION_TYPES = new Set(['ambience_change', 'ambience_increase', 'ambience_decrease']);
+function _isAmbienceAction(actionType) {
+  return _AMBIENCE_ACTION_TYPES.has(actionType);
+}
+function _ambienceDirection(actionType, projN, responses) {
+  if (actionType === 'ambience_increase') return 'increase';
+  if (actionType === 'ambience_decrease') return 'decrease';
+  if (actionType === 'ambience_change' && responses) {
+    const dir = responses[`project_${projN}_ambience_direction`]
+      || responses[`project_${projN}_ambience_dir`]
+      || '';
+    if (dir === 'improve') return 'increase';
+    if (dir === 'degrade') return 'decrease';
+  }
+  return null;
+}
+
 const FEED_METHOD_LABELS_MAP = {
   seduction: 'Seduction', stalking: 'Stalking', force: 'By Force',
   familiar: 'Familiar Face', intimidation: 'Intimidation', other: 'Other',
@@ -2875,7 +2900,8 @@ async function recomputeDisciplineProfile() {
       if (!proj?.pool_validated) continue;
       if (proj.pool_status !== 'validated') continue;
       const actionType = proj.action_type_override || proj.action_type;
-      const isAmbience = actionType === 'ambience_increase' || actionType === 'ambience_decrease';
+      // Issue #129: accept canonical 'ambience_change' alongside legacy aliases.
+      const isAmbience = _isAmbienceAction(actionType);
       const isRoteFeed = actionType === 'feed';
       if (!isAmbience && !isRoteFeed) continue;
       const territory = _resolveProjectTerritory(sub, pIdx);
@@ -2944,7 +2970,7 @@ async function saveEntryReview(entry, patch) {
     sub.projects_resolved = resolved;
     // Recompute discipline profile when ambience actions are validated
     if (('pool_status' in patch || 'pool_validated' in patch) &&
-        (entry.actionType === 'ambience_increase' || entry.actionType === 'ambience_decrease')) {
+        _isAmbienceAction(entry.actionType)) {
       recomputeDisciplineProfile(); // fire-and-forget
     }
   } else if (entry.source === 'merit') {
@@ -3135,8 +3161,10 @@ function _gatherProjectAmbience(subs) {
       const resolved = (sub.projects_resolved || [])[idx] || {};
       // Effective action type: ST override takes priority over player submission
       const effectiveType = resolved.action_type_override || proj.action_type || resp[`project_${n}_action`] || '';
-      const isIncrease = effectiveType === 'ambience_increase';
-      const isDecrease = effectiveType === 'ambience_decrease';
+      // Issue #129: dispatch on canonical + legacy ambience shapes.
+      const dir = _ambienceDirection(effectiveType, n, resp);
+      const isIncrease = dir === 'increase';
+      const isDecrease = dir === 'decrease';
       if (!isIncrease && !isDecrease) continue;
       // Pending: not yet rolled (pool_status is never updated on project roll, so use roll presence)
       if (!resolved.roll) { pendingCount++; continue; }
@@ -7153,7 +7181,10 @@ function renderActionPanel(entry, review) {
   const playerFacingNote  = rev.player_facing_note  || '';
   const isSorcery        = entry.source === 'sorcery'
                         || (entry.source === 'st_created' && entry.actionType === 'sorcery');
-  const isAmbienceMerit  = entry.source === 'merit' && (entry.actionType === 'ambience_increase' || entry.actionType === 'ambience_decrease');
+  // Issue #129: defensive symmetry. Form sphere/status collect (downtime-form.js:717-718,761-762)
+  // already normalises 'ambience_change' to legacy here, so this stays
+  // legacy-only in practice — but the helper handles all three shapes.
+  const isAmbienceMerit  = entry.source === 'merit' && _isAmbienceAction(entry.actionType);
 
   // Single character lookup — resolved once for all source types
   const entrySub  = submissions.find(s => s._id === entry.subId) || null;

--- a/public/js/downtime/db.js
+++ b/public/js/downtime/db.js
@@ -270,6 +270,11 @@ export function mapRawToResponses(parsed, characters) {
   projects.forEach((p, i) => {
     const n = i + 1;
     if (p.action_type) r[`project_${n}_action`] = p.action_type;
+    // Issue #129: canonicalise CSV-imported ambience actions. Parser now
+    // emits `action_type: 'ambience_change'` + `ambience_direction:
+    // 'improve' | 'degrade'`. Write the direction into the canonical
+    // responses key the live form uses so the admin tally sees one shape.
+    if (p.ambience_direction) r[`project_${n}_ambience_direction`] = p.ambience_direction;
     if (p.project_name) r[`project_${n}_title`] = p.project_name;
     if (p.desired_outcome) r[`project_${n}_outcome`] = p.desired_outcome;
     if (p.detail || p.description) r[`project_${n}_description`] = p.detail || p.description;

--- a/public/js/downtime/parser.js
+++ b/public/js/downtime/parser.js
@@ -100,14 +100,21 @@ function feedingStatus(v) {
 /**
  * Extract the canonical action type from the composite Google Forms value.
  * e.g. "XP Spend: Grow your character 🌱" → "xp_spend"
- *      "Ambience Change (Increase): Make a Territory delicious 😄" → "ambience_increase"
+ *      "Ambience Change (Increase): Make a Territory delicious 😄" → "ambience_change"
+ *
+ * Issue #129 (2026-05-08): legacy 'ambience_increase' / 'ambience_decrease'
+ * action types unified into the canonical 'ambience_change' shape that the
+ * live DT form persists post-#79. Direction is captured separately via
+ * `extractAmbienceDirection()` so the project's collect path can write
+ * `responses[\`project_${n}_ambience_direction\`]`. One canonical shape
+ * across CSV-import and live-form paths; one dispatcher.
  */
 function normaliseActionType(raw) {
   if (!raw) return null;
   const s = raw.trim();
   if (/^xp spend/i.test(s))                    return 'xp_spend';
-  if (/^ambience.*increase/i.test(s))           return 'ambience_increase';
-  if (/^ambience.*decrease/i.test(s))           return 'ambience_decrease';
+  if (/^ambience.*increase/i.test(s))           return 'ambience_change';
+  if (/^ambience.*decrease/i.test(s))           return 'ambience_change';
   if (/^attack/i.test(s))                       return 'attack';
   if (/^feed/i.test(s))                         return 'feed';
   if (/^hide|^protect/i.test(s))                return 'hide_protect';
@@ -117,6 +124,20 @@ function normaliseActionType(raw) {
   if (/^misc/i.test(s))                          return 'misc';
   if (/^no action/i.test(s))                     return null;
   return s.split(':')[0].trim().toLowerCase().replace(/\s+/g, '_');
+}
+
+/**
+ * Issue #129: extract the ambience direction from the raw composite value
+ * for canonical-shape persistence. Returns 'improve', 'degrade', or null.
+ * Mirrors the live form's direction value space so mapRawToResponses can
+ * write `responses.project_${n}_ambience_direction` directly.
+ */
+function extractAmbienceDirection(raw) {
+  if (!raw) return null;
+  const s = raw.trim();
+  if (/^ambience.*increase/i.test(s)) return 'improve';
+  if (/^ambience.*decrease/i.test(s)) return 'degrade';
+  return null;
 }
 
 /**
@@ -175,6 +196,10 @@ function parseProject(cols, offset) {
   return {
     action_type: normaliseActionType(actionTypeRaw),
     action_type_raw: actionTypeRaw,
+    // Issue #129: ambience direction extracted alongside the canonical
+    // 'ambience_change' action_type. mapRawToResponses writes this into
+    // `responses.project_${n}_ambience_direction`.
+    ambience_direction: extractAmbienceDirection(actionTypeRaw),
     primary_pool: parseDicePool(cols[offset + 1]),
     secondary_pool: parseDicePool(cols[offset + 2]),
     desired_outcome: str(cols[offset + 3]) || '',


### PR DESCRIPTION
## Summary
The DT form (post-#79) persists ambience actions as `project_${n}_action === 'ambience_change'` + `responses.project_${n}_ambience_direction` ('improve' | 'degrade'). The admin tally / discipline-profile dispatchers expected the legacy `'ambience_increase'` / `'ambience_decrease'` strings — neither branch fired for any form-saved submission, so the tally returned wrong results for live-form ambience actions. CSV-imported submissions (which the parser produced in legacy enum shape) tallied correctly; live-form submissions did not.

Closes #129

## Approach: one canonical shape, polymorphic dispatcher

The fix pushes both paths to the canonical shape (`'ambience_change'` + direction key) AND keeps the dispatcher tolerant of the legacy aliases for pre-canonicalisation CSV imports already in the DB. No data migration required.

### Parser canonicalisation (`public/js/downtime/parser.js`)
- `normaliseActionType` maps both "Ambience Change (Increase): …" and "Ambience Change (Decrease): …" raw values to `'ambience_change'`, matching the live form
- New `extractAmbienceDirection` returns `'improve'` | `'degrade'` | `null` from the same raw input
- `parseProject` returns `{ action_type, ambience_direction, ... }` so downstream consumers see canonical shape

### Response-bag mapping (`public/js/downtime/db.js` `mapRawToResponses`)
- Writes `r[\`project_${n}_ambience_direction\`] = p.ambience_direction` alongside the action_type, so CSV-imported and live-form submissions carry the same response-bag shape

### Polymorphic dispatcher (`public/js/admin/downtime-views.js`)
New helpers:
```js
const _AMBIENCE_ACTION_TYPES = new Set(['ambience_change', 'ambience_increase', 'ambience_decrease']);
function _isAmbienceAction(actionType) { ... }
function _ambienceDirection(actionType, projN, responses) {
  if (actionType === 'ambience_increase') return 'increase';
  if (actionType === 'ambience_decrease') return 'decrease';
  if (actionType === 'ambience_change' && responses) {
    const dir = responses[\`project_${projN}_ambience_direction\`]
      || responses[\`project_${projN}_ambience_dir\`]  // legacy fallback
      || '';
    if (dir === 'improve') return 'increase';
    if (dir === 'degrade') return 'decrease';
  }
  return null;
}
```

Four call sites updated:
- **Discipline-profile recompute scan** (line 2877+) — `_isAmbienceAction(actionType)` for the gate
- **saveEntryReview discipline-profile-recompute trigger** (line 2941+) — `_isAmbienceAction(entry.actionType)`
- **Project ambience tally** (line 3137+) — load-bearing `isIncrease` / `isDecrease` derived from `_ambienceDirection(...)`; reads the canonical key plus a legacy `_ambience_dir` fallback
- **Merit-side `isAmbienceMerit` UI gate** (line 7184) — defensive symmetry; sphere/status form collect already normalises to legacy here so this stays legacy-only in practice

## Pre-canonicalisation CSV imports already in the DB
Submissions imported BEFORE this PR continue to dispatch correctly because the helper accepts all three action-type strings. New imports use the canonical shape.

## File list
- `public/js/admin/downtime-views.js` (+33/-8): helpers + four call-site updates
- `public/js/downtime/parser.js` (+28/-3): canonical action_type + extractAmbienceDirection + emit on parseProject
- `public/js/downtime/db.js` (+5): mapRawToResponses writes _ambience_direction

## Test plan
- [x] Static parse: all three modified JS files pass `node --input-type=module --check`
- [x] Server tests: full suite **689/689** passing (no server delta — admin + parser are client-side modules)
- [ ] Browser smoke (DEFERRED per project Test Plan):
  - **Form path**: live-form submission with ambience_change + direction='improve' → admin tally counts as increase under the right territory
  - **CSV path**: import a legacy "Ambience Change (Increase): ..." row → submission stored with `_action='ambience_change'` + `_ambience_direction='improve'` → tally counts correctly
  - **Pre-canonicalisation CSV path**: existing DB submission with `_action='ambience_increase'` → tally still counts correctly via the legacy alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)