### PR TITLE
fix(touchstone): remove DB-relational NPC picker from edit mode (#162, cycle-blocker)

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -19,9 +19,9 @@ import { loadDB, saveDB, saveAll, syncToSuite, downloadCSV, registerCallbacks as
 import {
   editFromSheet, shEdit, shEditStatus,
   shEditBaneName, shEditBaneEffect, shRemoveBane, shAddBane,
-  shEnsureTouchstoneData,
+  // Issue #162 (2026-05-08): shEnsureTouchstoneData / shTouchstonePickerToggleCharacter
+  // / shTouchstonePickerSetMode dropped alongside the suppressed NPC picker UI.
   shTouchstoneStartAdd, shTouchstoneStartEdit, shTouchstonePickerClose, shTouchstonePickerDraft,
-  shTouchstonePickerToggleCharacter, shTouchstonePickerSetMode,
   shTouchstoneSaveAdd, shTouchstoneSaveEdit, shTouchstoneRemove,
   shEditBP, shEditBPCreation, shEditBPXP, shEditBPLost, shEditHumanity, shEditHumanityXP, shEditHumanityLost,
   shStatusUp, shStatusDown,
@@ -1040,13 +1040,10 @@ Object.assign(window, {
   shEditBaneEffect,
   shRemoveBane,
   shAddBane,
-  shEnsureTouchstoneData,
   shTouchstoneStartAdd,
   shTouchstoneStartEdit,
   shTouchstonePickerClose,
   shTouchstonePickerDraft,
-  shTouchstonePickerToggleCharacter,
-  shTouchstonePickerSetMode,
   shTouchstoneSaveAdd,
   shTouchstoneSaveEdit,
   shTouchstoneRemove,

--- a/public/js/editor/edit.js
+++ b/public/js/editor/edit.js
@@ -152,38 +152,21 @@ export function anchorFor(c) {
 
 function _tsCap() { return 6; }
 
-export async function shEnsureTouchstoneData() {
-  if (state.editIdx < 0) return;
-  const c = state.chars[state.editIdx];
-  if (c._ts_loaded === true || c._ts_loaded === 'loading') return;
-  c._ts_loaded = 'loading';
-  try {
-    const npcs = await apiGet('/api/npcs');
-    c._ts_npcs = Array.isArray(npcs) ? npcs : [];
-    c._ts_loaded = true;
-  } catch (err) {
-    console.error('[touchstone] load error:', err);
-    c._ts_npcs = [];
-    c._ts_loaded = 'error';
-    c._ts_load_error = String(err?.message || err);
-  }
-  _renderSheet(c);
-}
+// Issue #162 (2026-05-08): shEnsureTouchstoneData removed. The Touchstone
+// editor no longer exposes the DB-relational NPC picker (broader NPC
+// suppression policy, Piatra 2026-05-06), so the /api/npcs preload that
+// fed `c._ts_npcs` / `c._ts_loaded` is dead. The export was previously
+// imported by sheet.js to kick off the load on every render-edit pass.
 
 export function shTouchstoneStartAdd() {
   if (state.editIdx < 0) return;
   const c = state.chars[state.editIdx];
+  // Issue #162: draft slimmed to free-text shape only (Name + Description).
+  // The legacy is_character / pick_existing / npc_id / new_npc_* fields
+  // were tied to the suppressed NPC picker and are no longer initialised.
   c._ts_picker = {
     mode: 'add',
-    draft: {
-      is_character: false,
-      pick_existing: true,
-      name: '',
-      desc: '',
-      npc_id: '',
-      new_npc_name: '',
-      new_npc_desc: '',
-    },
+    draft: { name: '', desc: '' },
   };
   _tsClearError(c);
   _renderSheet(c);
@@ -217,21 +200,10 @@ export function shTouchstonePickerDraft(field, value) {
   c._ts_picker.draft[field] = value;
 }
 
-export function shTouchstonePickerToggleCharacter(on) {
-  if (state.editIdx < 0) return;
-  const c = state.chars[state.editIdx];
-  if (!c._ts_picker) return;
-  c._ts_picker.draft.is_character = !!on;
-  _renderSheet(c);
-}
-
-export function shTouchstonePickerSetMode(mode) {
-  if (state.editIdx < 0) return;
-  const c = state.chars[state.editIdx];
-  if (!c._ts_picker) return;
-  c._ts_picker.draft.pick_existing = mode === 'existing';
-  _renderSheet(c);
-}
+// Issue #162 (2026-05-08): shTouchstonePickerToggleCharacter and
+// shTouchstonePickerSetMode removed alongside the NPC picker UI they
+// drove. The picker no longer has an is_character toggle or
+// existing/create mode chips.
 
 export async function shTouchstoneSaveAdd() {
   if (state.editIdx < 0) return;
@@ -246,60 +218,19 @@ export async function shTouchstoneSaveAdd() {
   const draft = picker.draft;
   const charId = String(c._id);
 
-  let newEntry;
-  let newEdge = null;
-  let newNpc = null;
+  // Issue #162: NPC picker branch dropped — Touchstone is free-text only.
+  // The legacy DB-relational path (POST /api/npcs + POST /api/relationships)
+  // returned 4xx under the broader NPC suppression and blocked sheet save.
+  // Free-text shape: { humanity, name, desc }. Legacy entries with edge_id
+  // continue to render and edit; their edges sit dormant in relationships.
+  const name = String(draft.name || '').trim();
+  if (!name) { _tsSetError(c, 'Name is required.'); return; }
+  const newEntry = { humanity, name, desc: String(draft.desc || '') };
 
   try {
-    if (draft.is_character) {
-      let npcId, npcName;
-      if (draft.pick_existing) {
-        if (!draft.npc_id) { _tsSetError(c, 'Pick an NPC.'); return; }
-        npcId = String(draft.npc_id);
-        const npc = (c._ts_npcs || []).find(n => String(n._id) === npcId);
-        npcName = String(draft.name || npc?.name || '').trim();
-        if (!npcName) npcName = npc?.name || '(unnamed)';
-      } else {
-        const rawName = String(draft.new_npc_name || draft.name || '').trim();
-        if (!rawName) { _tsSetError(c, 'NPC name is required.'); return; }
-        newNpc = await apiPost('/api/npcs', {
-          name: rawName,
-          description: String(draft.new_npc_desc || '').trim(),
-          status: 'active',
-        });
-        c._ts_npcs = (c._ts_npcs || []).concat(newNpc);
-        npcId = String(newNpc._id);
-        npcName = rawName;
-      }
-
-      newEdge = await apiPost('/api/relationships', {
-        a: { type: 'pc', id: charId },
-        b: { type: 'npc', id: npcId },
-        kind: 'touchstone',
-        direction: 'a_to_b',
-        state: String(draft.desc || ''),
-        st_hidden: false,
-        touchstone_meta: { humanity },
-      });
-
-      newEntry = {
-        humanity,
-        name: npcName,
-        desc: String(draft.desc || ''),
-        edge_id: String(newEdge._id),
-      };
-    } else {
-      const name = String(draft.name || '').trim();
-      if (!name) { _tsSetError(c, 'Name is required.'); return; }
-      newEntry = { humanity, name, desc: String(draft.desc || '') };
-    }
-
     const nextTouchstones = existing.concat([newEntry]);
     await apiPut('/api/characters/' + charId, { touchstones: nextTouchstones });
     c.touchstones = nextTouchstones;
-    // Surface the resolved name client-side so the slot renders immediately
-    // without waiting for the next GET enrichment.
-    if (newEntry.edge_id) newEntry._npc_name = newEntry.name;
     delete c._ts_picker;
     _renderSheet(c);
   } catch (err) {

--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -14,7 +14,9 @@ import { getRulesByCategory, getRuleByKey } from '../data/loader.js';
 import { applyDerivedMerits, getPoolTotal, getPoolUsed, getPoolsForCategory, mciPoolTotal, getMCIPoolUsed } from './mci.js';
 import { domMeritTotal, domMeritAccess, domMeritContrib, domMeritShareable, calcTotalInfluence, influenceBreakdown, calcContactsInfluence, calcMeritInfluence, hasHoneyWithVinegar, hasViralMythology, vmUsed, ssjHerdBonus, flockHerdBonus, hasLorekeeper, lorekeeperUsed, hasOHM, ohmUsed, hasInvested, investedPool, investedUsed, effectiveInvictusStatus, attacheBonusDots, meritFreeSum, syncMeritRating, meritEffectiveRating, domKey } from './domain.js';
 import { auditCharacter } from '../data/audit.js';
-import { shEnsureTouchstoneData } from './edit.js';
+// Issue #162 (2026-05-08): shEnsureTouchstoneData import dropped — the
+// Touchstone editor no longer needs the NPC list (DB-relational picker
+// removed; free-text Name + Description only).
 import { powersForDisc } from '../suite/sheet-helpers.js';
 
 // Build legacy-format shims from rules cache for remaining deep consumers.
@@ -272,10 +274,9 @@ export function renderTouchstones(c, editMode) {
     return expRow('touchstones', 'Touchstones', '', rows);
   }
 
-  // Edit mode — kick off NPC load (used by Add-picker).
-  if (c._ts_loaded !== true && c._ts_loaded !== 'error' && c._ts_loaded !== 'loading') {
-    shEnsureTouchstoneData();
-  }
+  // Issue #162: NPC pre-load dropped — Touchstone editor no longer
+  // exposes the DB-relational NPC picker. Free-text Name + Description
+  // only.
 
   const picker = c._ts_picker;
   let h = '<div class="sh-touchstones-edit">';
@@ -331,65 +332,26 @@ export function renderTouchstones(c, editMode) {
 function renderTouchstoneAddForm(c, anchor, existingCount) {
   const draft = c._ts_picker.draft;
   const humanity = anchor - existingCount;
-  const npcsLoading = c._ts_loaded !== true;
-  const linkedNpcIds = new Set(
-    (c.touchstones || []).map(t => t.edge_id ? String(t._npc_id || '') : null).filter(Boolean)
-  );
-  const npcs = (c._ts_npcs || [])
-    .filter(n => n.status === 'active' || n.status === 'pending')
-    .filter(n => !linkedNpcIds.has(String(n._id)))
-    .sort((a, b) => String(a.name || '').localeCompare(String(b.name || ''), undefined, { sensitivity: 'base' }));
 
+  // Issue #162 (2026-05-08): NPC selector removed from the Touchstone editor
+  // per the broader NPC-suppression policy (Piatra 2026-05-06). The
+  // 'is_character' branch (Pick existing NPC / Create new NPC) was a
+  // DB-relational picker that POSTed to /api/relationships to create an
+  // edge — that endpoint flow no longer round-trips cleanly under the
+  // suppression sweep, returning 4xx and blocking sheet save. Touchstone
+  // is now free-text only (Name + optional Description), categorically a
+  // typed-string input — same shape dt-form.18 used for the Personal
+  // Story person field. Legacy touchstones carrying `edge_id` continue
+  // to render and edit by name + desc; their edges sit dormant in the
+  // relationships collection (silent-leave per A1 precedent).
   let h = '<div class="sh-ts-picker">';
   h += '<div class="sh-ts-picker-head">New touchstone · Humanity ' + humanity + '</div>';
-
-  h += '<label class="sh-ts-picker-check">';
-  h += '<input type="checkbox"' + (draft.is_character ? ' checked' : '')
-    + ' onchange="shTouchstonePickerToggleCharacter(this.checked)"> ';
-  h += '<span>This touchstone is a character (link or create an NPC)</span>';
-  h += '</label>';
-
-  if (!draft.is_character) {
-    h += '<label class="sh-ts-picker-field"><span>Name *</span>'
-      + '<input class="sh-edit-input" placeholder="e.g., Grandfather&#39;s pocket watch" value="'
-      + esc(draft.name || '') + '" oninput="shTouchstonePickerDraft(&#39;name&#39;, this.value)"></label>';
-    h += '<label class="sh-ts-picker-field"><span>Description (optional)</span>'
-      + '<input class="sh-edit-input" placeholder="Why it matters" value="'
-      + esc(draft.desc || '') + '" oninput="shTouchstonePickerDraft(&#39;desc&#39;, this.value)"></label>';
-  } else {
-    h += '<div class="sh-ts-picker-mode-chips">';
-    h += '<button type="button" class="sh-ts-slot-btn' + (draft.pick_existing ? ' primary' : '')
-      + '" onclick="shTouchstonePickerSetMode(&#39;existing&#39;)">Pick existing NPC</button>';
-    h += '<button type="button" class="sh-ts-slot-btn' + (!draft.pick_existing ? ' primary' : '')
-      + '" onclick="shTouchstonePickerSetMode(&#39;create&#39;)">Create new NPC</button>';
-    h += '</div>';
-
-    if (draft.pick_existing) {
-      if (npcsLoading) {
-        h += '<div class="sh-ts-picker-loading">Loading NPCs…</div>';
-      } else {
-        const opts = npcs.map(n => '<option value="' + esc(String(n._id)) + '"'
-          + (String(draft.npc_id || '') === String(n._id) ? ' selected' : '') + '>'
-          + esc(n.name || '(unnamed)') + '</option>').join('');
-        h += '<label class="sh-ts-picker-field"><span>NPC *</span>'
-          + '<select class="sh-edit-select" onchange="shTouchstonePickerDraft(&#39;npc_id&#39;, this.value)">'
-          + '<option value="">(pick an NPC)</option>' + opts + '</select></label>';
-      }
-      h += '<label class="sh-ts-picker-field"><span>Touchstone description (optional)</span>'
-        + '<input class="sh-edit-input" placeholder="How they anchor the character" value="'
-        + esc(draft.desc || '') + '" oninput="shTouchstonePickerDraft(&#39;desc&#39;, this.value)"></label>';
-    } else {
-      h += '<label class="sh-ts-picker-field"><span>NPC name *</span>'
-        + '<input class="sh-edit-input" placeholder="Full NPC name" value="'
-        + esc(draft.new_npc_name || '') + '" oninput="shTouchstonePickerDraft(&#39;new_npc_name&#39;, this.value)"></label>';
-      h += '<label class="sh-ts-picker-field"><span>NPC description (for the register)</span>'
-        + '<input class="sh-edit-input" placeholder="Short description" value="'
-        + esc(draft.new_npc_desc || '') + '" oninput="shTouchstonePickerDraft(&#39;new_npc_desc&#39;, this.value)"></label>';
-      h += '<label class="sh-ts-picker-field"><span>Touchstone description (optional)</span>'
-        + '<input class="sh-edit-input" placeholder="How they anchor the character" value="'
-        + esc(draft.desc || '') + '" oninput="shTouchstonePickerDraft(&#39;desc&#39;, this.value)"></label>';
-    }
-  }
+  h += '<label class="sh-ts-picker-field"><span>Name *</span>'
+    + '<input class="sh-edit-input" placeholder="e.g., Grandfather&#39;s pocket watch or person&#39;s name" value="'
+    + esc(draft.name || '') + '" oninput="shTouchstonePickerDraft(&#39;name&#39;, this.value)"></label>';
+  h += '<label class="sh-ts-picker-field"><span>Description (optional)</span>'
+    + '<input class="sh-edit-input" placeholder="Why it matters" value="'
+    + esc(draft.desc || '') + '" oninput="shTouchstonePickerDraft(&#39;desc&#39;, this.value)"></label>';
 
   h += '<div class="sh-ts-picker-actions">';
   h += '<button class="sh-ts-slot-btn primary" onclick="shTouchstoneSaveAdd()">Save</button>';


### PR DESCRIPTION
## Summary
The ST-side Character Panel > Edit mode > Touchstone editor still exposed the NPC picker affordance ('Pick existing NPC' / 'Create new NPC') after the broader NPC suppression sweep (Piatra 2026-05-06). Selecting an NPC POSTed to `/api/relationships` to create a touchstone edge — that endpoint flow no longer round-trips cleanly under the suppression and returned 4xx, blocking sheet save.

Closes #162

## Survey findings
The Touchstone editor at `public/js/editor/sheet.js:331` (`renderTouchstoneAddForm`) had two branches gated by an `is_character` checkbox:
- **Non-character (free-text)**: `Name *` + `Description (optional)` — already a typed-string shape, no DB lookup. Matches the dt-form.18 Personal Story person field pattern exactly.
- **is_character (DB-relational picker)**: 'Pick existing NPC' (select from preloaded `c._ts_npcs`) OR 'Create new NPC' (POST `/api/npcs`). Either path then POSTed `/api/relationships` to create a touchstone edge with `{ a: pc, b: npc, kind: 'touchstone' }`.

The 4xx originates from the `/api/relationships` POST in the DB-relational branch (`shTouchstoneSaveAdd:275-283` in the pre-fix code). Other touchstone consumers (renderer, edit-existing flow, remove flow) read only `t.name` / `t.desc` and don't touch the NPC list.

## Path A chosen — pure removal
The non-character branch was already the suppression-compatible shape; deleting the DB-relational branch needs no replacement. Exactly mirrors dt-form.18 option Y.

**Touchstone semantics preserved:** the renderer at `sheet.js:255` (`renderTouchstones`) iterates `t.name` / `t.desc` per slot. No NPC reference required for game-state consumers.

## Legacy data: silent-leave per A1
Characters with `edge_id`-bearing legacy touchstone entries continue to load and edit normally — the renderer reads `t.name` / `t.desc` (both populated for legacy entries by the pre-fix save path). Their edges sit dormant in the `relationships` collection. The edit flow at `shTouchstoneSaveEdit` continues to mirror the description back to the legacy edge if `t.edge_id` is present (kept as-is for round-trip correctness).

## Lesson #105 / drop-the-iteration applied
The legacy draft fields (`is_character`, `pick_existing`, `npc_id`, `new_npc_name`, `new_npc_desc`) are dropped from the initialiser entirely rather than gated. Spread base preserves any in-flight legacy values silently. The two suppressed UI handlers (`shTouchstonePickerToggleCharacter`, `shTouchstonePickerSetMode`) are deleted; their window registrations are removed from `app.js`.

## File list
- `public/js/editor/sheet.js` (-50): `renderTouchstoneAddForm` collapsed to free-text Name + Description + Save/Cancel; `shEnsureTouchstoneData` import + call dropped
- `public/js/editor/edit.js` (-65): `shEnsureTouchstoneData` deleted; `shTouchstoneStartAdd` draft slimmed to `{ name: '', desc: '' }`; `shTouchstoneSaveAdd` collapsed to the free-text write; `shTouchstonePickerToggleCharacter` + `shTouchstonePickerSetMode` deleted
- `public/js/app.js` (-3): dead exports / window registrations dropped

## Test plan
- [x] Static parse: all three modified JS files pass `node --input-type=module --check`
- [x] Server tests: full suite **689/689** passing (no server delta — all changes are client-side)
- [ ] Browser smoke (DEFERRED per project Test Plan):
  - ST opens any character's edit panel → Touchstone section: only Name + Description + Save/Cancel visible (no NPC checkbox / mode chips / NPC select / create-NPC fields)
  - Save a fresh touchstone → 200 OK, no 4xx, the slot renders with the typed name
  - Open an existing character carrying a legacy `edge_id`-bearing touchstone → loads cleanly, edit-name path round-trips
  - Remove a legacy edge_id touchstone → confirm modal still works; the edge retire path at `shTouchstoneRemove` is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)