### PR TITLE
fix(dt-form): speciality bonus flows through pool + ROTE inherits it (#164, #166)

### DIFF
--- a/public/js/data/feeding-pool.js
+++ b/public/js/data/feeding-pool.js
@@ -27,8 +27,19 @@
 import { FEED_METHODS, TERRITORY_DATA } from '../tabs/downtime-data.js';
 import { SKILLS_MENTAL } from './constants.js';
 import { getAttrTotal, skTotal, discDots } from './accessors.js';
+import { hasAoE } from './helpers.js';
 
-export function computeBestFeedingPool({ char, methodId, territorySlug } = {}) {
+/**
+ * Issue #166 (2026-05-08): the optional `spec` parameter folds the
+ * primary feeding's active speciality bonus into the inherited pool
+ * total. Without it, ROTE's read-only annotation showed a value lower
+ * than the primary feeding's actual pool — the speciality contribution
+ * wasn't flowing through. The bonus is +2 if the speciality is an Area
+ * of Expertise (`hasAoE`) or the picked skill has nine_again, else +1.
+ * Matches the bonus shape `renderFeedPoolSelector` already computes for
+ * the ADVANCED primary readout (downtime-form.js:4750).
+ */
+export function computeBestFeedingPool({ char, methodId, territorySlug, spec = '' } = {}) {
   if (!char || !methodId) return null;
   const method = FEED_METHODS.find(m => m.id === methodId);
   if (!method) return null;
@@ -74,9 +85,22 @@ export function computeBestFeedingPool({ char, methodId, territorySlug } = {}) {
     ? (method.skills.some(s => !SKILLS_MENTAL.includes(s)) ? -1 : -3)
     : 0;
 
+  // Issue #166: speciality bonus. Adds +1 (or +2 for Area-of-Expertise /
+  // nine_again skills) when an active speciality is supplied. Match shape
+  // mirrors `renderFeedPoolSelector` so the ROTE inherited annotation
+  // agrees with the ADVANCED primary readout 1:1.
+  let specBonus = 0;
+  if (spec && bestSkillName) {
+    const sk = char.skills?.[bestSkillName];
+    const skillSpecs = sk?.specs || [];
+    if (skillSpecs.includes(spec) || hasAoE(char, spec)) {
+      specBonus = (sk?.nine_again || hasAoE(char, spec)) ? 2 : 1;
+    }
+  }
+
   const total = Math.max(
     0,
-    bestAttrVal + bestSkillVal + bestDiscVal + ambMod + unskilled
+    bestAttrVal + bestSkillVal + bestDiscVal + ambMod + unskilled + specBonus
   );
 
   return {
@@ -85,6 +109,7 @@ export function computeBestFeedingPool({ char, methodId, territorySlug } = {}) {
     skill: { name: bestSkillName, val: bestSkillVal, specs: bestSkillSpecs },
     disc:  { name: bestDiscName,  val: bestDiscVal  },
     ambience: { mod: ambMod, label: ambLabel, territorySlug: territorySlug || '', name: ambName },
+    spec: spec ? { name: spec, bonus: specBonus } : { name: '', bonus: 0 },
     unskilled,
   };
 }

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -2615,16 +2615,28 @@ function renderForm(container) {
       return;
     }
     // Project dice pool spec chip — toggle selection and re-render
+    // Issue #164 (2026-05-08): hardened. Toggle now mutates responseDoc.responses
+    // directly (canonical state) AND mirrors to the hidden DOM input as a
+    // belt-and-braces measure for any consumer that reads the input directly.
+    // Then collect+render so the dice-pool total span re-renders with the
+    // bonus included via renderDicePool's spec branch.
     const poolSpecChip = e.target.closest('[data-pool-spec]');
     if (poolSpecChip) {
       const prefix = poolSpecChip.dataset.poolSpec;
-      const specName = poolSpecChip.dataset.specName;
+      const specName = poolSpecChip.dataset.specName || '';
+      const key = `${prefix}_spec`;
+      const baseResponses = (responseDoc && responseDoc.responses) || {};
+      const cur = baseResponses[key] || '';
+      const next = cur === specName ? '' : specName;
+      // Canonical write — guarantees the spec state persists across renders
+      // even if the hidden input wasn't found or its value diverged.
+      const nextResponses = { ...baseResponses, [key]: next };
       const hidden = document.getElementById(`dt-${prefix}_spec`);
-      if (hidden) hidden.value = hidden.value === specName ? '' : specName;
-      const responses = collectResponses();
-      if (responseDoc) responseDoc.responses = responses;
-      else responseDoc = { responses };
+      if (hidden) hidden.value = next;
+      if (responseDoc) responseDoc.responses = nextResponses;
+      else responseDoc = { responses: nextResponses };
       renderForm(container);
+      scheduleSave();
       return;
     }
     // XP category/item change — collect current state and re-render
@@ -3618,10 +3630,15 @@ function renderProjectSlots(saved, mode = 'advanced') {
         return td?.slug || '';
       };
       const roteSlug = slugFromGrid(saved.feeding_territories_rote || '');
+      // Issue #166 (2026-05-08): pass the primary feeding's active spec
+      // so the inherited ROTE pool matches the ADVANCED primary readout
+      // 1:1. Without this, ROTE under-counted by the +1 / +2 speciality
+      // bonus.
       const inheritedPool = computeBestFeedingPool({
         char: currentChar,
         methodId: feedMethodId,
         territorySlug: roteSlug || slugFromGrid(saved.feeding_territories || ''),
+        spec: feedSpecName || '',
       });
       h += '<div class="qf-field dt-proj-rote-pool">';
       if (!feedMethodId) {
@@ -3635,6 +3652,7 @@ function renderProjectSlots(saved, mode = 'advanced') {
         else if (inheritedPool.unskilled) parts.push(`${inheritedPool.unskilled} unskilled`);
         if (inheritedPool.disc.name) parts.push(`${inheritedPool.disc.val} ${esc(inheritedPool.disc.name)}`);
         if (inheritedPool.ambience.mod) parts.push(`${inheritedPool.ambience.mod > 0 ? '+' : ''}${inheritedPool.ambience.mod} ambience`);
+        if (inheritedPool.spec?.bonus) parts.push(`+${inheritedPool.spec.bonus} ${esc(inheritedPool.spec.name)}`);
         h += `<label class="qf-label">Pool: <strong>${inheritedPool.total}</strong> <span class="qf-desc" style="font-weight:normal">(inherited from primary hunt)</span></label>`;
         h += `<p class="qf-desc">${parts.join(' &middot; ')}</p>`;
       }
@@ -3694,13 +3712,16 @@ function renderDicePool(slotNum, poolKey, label, attrs, skills, discs, saved) {
   h += '</select>';
 
   // Skill dropdown
+  // Issue #164 (2026-05-08): dropdown label is plain `Skill (dots)`. The
+  // `[spec1, spec2]` suffix was redundant with the speciality chip strip
+  // below and made the label noisy. The chips ARE the speciality affordance
+  // — clicking one toggles the +1 / +2 bonus into the pool total.
   h += `<select id="dt-${prefix}_skill" class="qf-select dt-pool-select" data-pool-prefix="${prefix}">`;
   h += '<option value="">Skill</option>';
   for (const s of skills) {
     const dots = skTotal(currentChar, s);
-    const specs = currentChar.skills?.[s]?.specs?.length ? ` [${currentChar.skills[s].specs.join(', ')}]` : '';
     const sel = savedSkill === s ? ' selected' : '';
-    h += `<option value="${esc(s)}"${sel}>${esc(s)} (${dots})${esc(specs)}</option>`;
+    h += `<option value="${esc(s)}"${sel}>${esc(s)} (${dots})</option>`;
   }
   h += '</select>';
 
@@ -6103,7 +6124,15 @@ function renderQuestion(q, value) {
           return td?.slug || '';
         };
         const territorySlug = slugFromGrid(responseDoc?.responses?.feeding_territories);
-        const pool = computeBestFeedingPool({ char: c, methodId: feedMethodId, territorySlug });
+        // Issue #166: pass the active speciality so the MINIMAL primary
+        // readout includes the bonus when one is set (e.g. carried over
+        // from a prior ADVANCED-mode toggle).
+        const pool = computeBestFeedingPool({
+          char: c,
+          methodId: feedMethodId,
+          territorySlug,
+          spec: feedSpecName || '',
+        });
         h += '<div class="qf-field dt-feed-min-pool">';
         if (!feedMethodId) {
           h += '<p class="qf-desc">Pick a method above to see your auto-derived hunt pool.</p>';
@@ -6116,6 +6145,7 @@ function renderQuestion(q, value) {
           else if (pool.unskilled) parts.push(`${pool.unskilled} unskilled`);
           if (pool.disc.name) parts.push(`${pool.disc.val} ${esc(pool.disc.name)}`);
           if (pool.ambience.mod) parts.push(`${pool.ambience.mod > 0 ? '+' : ''}${pool.ambience.mod} ambience`);
+          if (pool.spec?.bonus) parts.push(`+${pool.spec.bonus} ${esc(pool.spec.name)}`);
           h += `<label class="qf-label">Pool: <strong>${pool.total}</strong></label>`;
           h += `<p class="qf-desc">${parts.join(' &middot; ')} (auto-picked from your sheet)</p>`;
         }


### PR DESCRIPTION
## Summary
Two related bugs from speciality-bonus pool flow. Same general territory (speciality bonus into dice pools) but two distinct root causes — kept separate in the diff.

Closes #164
Closes #166

## Survey: distinct root causes confirmed

The Khepri brief flagged a shared-root-cause hypothesis. After tracing both ends:

| | #164 | #166 |
|---|---|---|
| Surface | Personal Action dice pool | ROTE inherited pool |
| Path | `renderDicePool` (downtime-form.js:3664) + chip handler at :2618 | `computeBestFeedingPool` (feeding-pool.js:31) + ROTE call site at :3621 |
| Root | Dropdown label noise + DOM-routed toggle | Pool helper omits the spec channel entirely |
| Bonus shape consumed | `bestSpecs.includes(savedSpec)` then +1/+2 | None — `attr + skill + disc + amb + unskilled` only |
| Code already existed | Yes — `renderDicePool:3677-3680` does compute it | No — nothing in feeding-pool.js touches spec |

The two are NOT a shared root cause. #164 is a UI/state-routing concern in the project pool; #166 is a pure helper-side omission that affects any consumer of `computeBestFeedingPool` (currently MINIMAL primary feeding readout + ROTE inherited pool). Both addressed in one PR per Khepri's bundle plan.

## #164 — Personal-action skill dropdown noise + chip toggle hardening

**Dropdown label cleanup** (`renderDicePool`): the skill dropdown options embedded `[spec1, spec2]` after the dot count, redundant with the chip strip below the row. Stripped — dropdown is now plain `Skill (dots)`. The chip strip is the canonical speciality affordance.

**Chip click handler hardening**: the previous implementation routed the spec toggle through a hidden DOM input and `collectResponses()`. Hardened to mutate `responseDoc.responses` directly (canonical state) and mirror to the hidden input as a belt-and-braces measure. The toggle now also calls `scheduleSave` so the new state persists immediately. After the toggle, `renderForm` recomputes the dice-pool total via `renderDicePool`'s spec branch — which already correctly checks `bestSpecs.includes(savedSpec)` and adds +1 / +2 (nine_again / Area-of-Expertise → +2).

## #166 — ROTE inherited pool omits primary feeding's speciality

`computeBestFeedingPool` computed total as `attr + skill + disc + ambience + unskilled` — no speciality channel. The ADVANCED primary feeding readout (`renderFeedPoolSelector` at downtime-form.js:4750) DOES include the spec bonus, so the two readouts disagreed by +1/+2 whenever the primary feeding had an active speciality.

**Helper extension** (`feeding-pool.js`):
- `computeBestFeedingPool({ char, methodId, territorySlug, spec })` now takes an optional `spec` parameter
- When `spec` matches `bestSkillName`'s `c.skills[name].specs` (or is an Area-of-Expertise via `hasAoE`), adds +1 (or +2 for AoE / nine_again) to the total — same shape as `renderFeedPoolSelector`
- Returns `pool.spec = { name, bonus }` so consumers can render the contribution in their breakdown

**Call sites updated**:
- ROTE inherited pool readout (downtime-form.js:3621): passes `feedSpecName` (the active primary speciality)
- MINIMAL primary feeding readout (downtime-form.js:6106): also passes `feedSpecName` so a spec carried over from a prior ADVANCED toggle reflects in the MINIMAL readout consistently
- Both readouts append `+N <spec>` to the breakdown line when a bonus is contributed

## File list
- `public/js/data/feeding-pool.js` (+27/-2): `spec` parameter + bonus computation + return-shape extension
- `public/js/tabs/downtime-form.js` (+38/-8): dropdown label strip in renderDicePool; hardened chip handler; spec passthrough at both call sites + breakdown line

## Test plan
- [x] Static parse: both modified files pass `node --input-type=module --check`
- [x] Server tests: full suite **689/689** passing (no server delta — client-side helpers + UI)
- [ ] Browser smoke (DEFERRED per project Test Plan):
  - **#164**: Personal Action of any type → skill dropdown shows `Skill (dots)` only (no `[spec]`); pick a skill with multiple specs → chip strip renders; click a chip → `dt-feed-spec-on` class flips, dice-pool total span jumps by +1 (or +2 if AoE / nine_again); click again → toggles off, total drops back; refresh page → spec persists in saved state
  - **#166**: ADVANCED primary feeding with a speciality active → primary readout shows `Pool: X` with `+N <spec>` in breakdown; pick ROTE on a project slot → ROTE inherited pool shows the SAME X (no longer X−1); breakdown line shows `+N <spec>` matching primary; toggle the spec off on primary → both readouts drop together on next render

🤖 Generated with [Claude Code](https://claude.com/claude-code)