### PR TITLE
fix(dt-form): sibling-slot exclusions for ROTE + maintenance (#170, #167)

### DIFF
--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -625,12 +625,18 @@ function collectResponses() {
     // Target zone (unified: attack, hide_protect, investigate, patrol_scout, misc)
     const targetTypeRadio = document.querySelector(`input[name="dt-project_${n}_target_type"]:checked`);
     responses[`project_${n}_target_type`] = targetTypeRadio ? targetTypeRadio.value : '';
+    // Issue #170 (2026-05-08): gate target_* writes on element presence
+    // (Lesson #105 silent-leave). When a slot's action doesn't render the
+    // target_* hidden inputs (e.g. action changed away from maintenance),
+    // the prior value persists on the spread base instead of being clobbered
+    // with empty. Action-change handlers that DO need to clear targets can
+    // do so explicitly via the canonical-first state write pattern.
     const targetValueEl = document.getElementById(`dt-project_${n}_target_value`);
-    responses[`project_${n}_target_value`] = targetValueEl ? targetValueEl.value : '';
+    if (targetValueEl) responses[`project_${n}_target_value`] = targetValueEl.value;
     const targetTerrEl = document.getElementById(`dt-project_${n}_target_terr`);
-    responses[`project_${n}_target_terr`] = targetTerrEl ? targetTerrEl.value : '';
+    if (targetTerrEl) responses[`project_${n}_target_terr`] = targetTerrEl.value;
     const targetOtherEl = document.getElementById(`dt-project_${n}_target_other`);
-    responses[`project_${n}_target_other`] = targetOtherEl ? targetOtherEl.value : '';
+    if (targetOtherEl) responses[`project_${n}_target_other`] = targetOtherEl.value;
     // dt-form.25: legacy `_ambience_dir` radio collect dropped (drop-the-
     // iteration shape per Ma'at #127 praise). The new row-table writes
     // `_ambience_target` + `_ambience_direction` directly via the hidden
@@ -2799,21 +2805,30 @@ function renderForm(container) {
     // [data-npc-pick] is rendered anywhere now.
     // dt-form.16: target character chip handler removed — universal charPicker
     // mounted in renderTargetCharOrOther handles its own selection lifecycle.
-    // Maintenance merit chip — single-select, writes to hidden target_value input
+    // Maintenance merit chip — single-select, writes to hidden target_value input.
+    // Issue #170 (2026-05-08): hardened with canonical-first state writes +
+    // re-render so SIBLING slots' chip availability re-evaluates immediately.
+    // Previously the handler only mutated the local DOM; sibling slots couldn't
+    // see the new selection until something else triggered a render, leaving
+    // their disabled-chip state stale across add/remove/re-add cycles.
     const maintChip = e.target.closest('[data-maintenance-target]');
     if (maintChip && !maintChip.disabled) {
       const slotNum = maintChip.dataset.maintenanceTarget;
       const mPrefix = maintChip.dataset.maintenancePrefix || 'project';
       const targetId = maintChip.dataset.targetId;
+      const key = `${mPrefix}_${slotNum}_target_value`;
+      const baseResponses = (responseDoc && responseDoc.responses) || {};
+      const wasSelected = baseResponses[key] === targetId;
+      const next = wasSelected ? '' : targetId;
+      // Canonical-first write — mirrors the spec-chip pattern (#164) and
+      // mode-pill / ambience-arrow handlers. Sibling slots reading
+      // `responses.project_*_target_value` see the new state on re-render.
+      const nextResponses = { ...baseResponses, [key]: next };
       const hidden = document.getElementById(`dt-${mPrefix}_${slotNum}_target_value`);
-      const wasSelected = maintChip.classList.contains('dt-chip--selected');
-      container.querySelectorAll(`[data-maintenance-target="${slotNum}"]`).forEach(c => c.classList.remove('dt-chip--selected'));
-      if (!wasSelected) {
-        maintChip.classList.add('dt-chip--selected');
-        if (hidden) hidden.value = targetId;
-      } else {
-        if (hidden) hidden.value = '';
-      }
+      if (hidden) hidden.value = next;
+      if (responseDoc) responseDoc.responses = nextResponses;
+      else responseDoc = { responses: nextResponses };
+      renderForm(container);
       scheduleSave();
       return;
     }
@@ -3417,10 +3432,20 @@ function renderProjectSlots(saved, mode = 'advanced') {
     h += '<div class="dt-action-block">';
 
     // Action type selector — always visible
+    // Issue #167 (2026-05-08): ROTE is single-instance per cycle. If any
+    // sibling slot already holds 'rote', filter it out of THIS slot's
+    // dropdown (unless this slot itself is currently 'rote', so the user
+    // can still see + change/clear their existing selection). Legacy
+    // submissions with multiple ROTE entries continue to load — each slot
+    // showing 'rote' keeps it as a selectable option, but no new slot can
+    // pick a fresh 'rote' while one already exists.
+    const slotActions = siblingHasAction(saved, n, 'rote') && actionVal !== 'rote'
+      ? availableActions.filter(opt => opt.value !== 'rote')
+      : availableActions;
     h += '<div class="qf-field">';
     h += `<label class="qf-label" for="dt-project_${n}_action">Action Type ${n === 1 ? '<span class="qf-req">*</span>' : ''}</label>`;
     h += `<select id="dt-project_${n}_action" class="qf-select" data-project-action="${n}">`;
-    for (const opt of availableActions) {
+    for (const opt of slotActions) {
       const sel = actionVal === opt.value ? ' selected' : '';
       h += `<option value="${esc(opt.value)}"${sel}>${esc(opt.label)}</option>`;
     }
@@ -4930,6 +4955,26 @@ function getAlreadyMaintainedTargets(n, saved, maxSlots) {
     }
   }
   return maintained;
+}
+
+/**
+ * Issue #167 + #170 (2026-05-08): walk sibling project slots and report
+ * which actions are claimed elsewhere. Used by:
+ *   - #167 ROTE single-instance — `siblingHasAction(saved, n, 'rote')`
+ *     filters 'rote' out of the action-type dropdown
+ *   - #170 Maintenance pill exclusion — `getAlreadyMaintainedTargets`
+ *     above already does this for maintenance specifically; this helper
+ *     gives consumers a general way to ask "does any sibling slot have
+ *     action X?" without re-walking the slot map.
+ *
+ * Reads from the canonical `responses` object — no DOM dependency.
+ */
+function siblingHasAction(saved, currentSlot, action, maxSlots = 4) {
+  for (let k = 1; k <= maxSlots; k++) {
+    if (k === currentSlot) continue;
+    if (saved[`project_${k}_action`] === action) return true;
+  }
+  return false;
 }
 
 /** Returns a Set of chip ids that maintenance_audit says are already done this chapter (dtui-50). */


### PR DESCRIPTION
## Summary
Genuine shared-concern bundle — both bugs reduce to "form needs to walk sibling project slots before populating this slot's picker options". Implemented via a small `siblingHasAction(saved, n, action)` helper alongside the existing `getAlreadyMaintainedTargets` (which already walks for maintenance specifically).

Closes #167
Closes #170

## #167 — ROTE single-instance constraint

ROTE was selectable in every project slot independently because the action-type dropdown's `availableActions` (downtime-form.js:3357) was computed once across all slots. Per dt-form.22's design (#73), ROTE is single-instance per cycle.

**Fix**: build `slotActions` per-slot. When a sibling holds `action === 'rote'` AND the current slot isn't already 'rote' itself, filter 'rote' out of the dropdown options. Legacy submissions with multiple ROTE entries continue to load — each existing ROTE slot keeps the option visible (so it can be cleared / changed) but no new slot can pick a fresh 'rote' while one already exists. Silent-leave per A1.

## #170 — Maintenance pill exclusions don't refresh on selection change

Root cause: the maintenance chip click handler at downtime-form.js:2803 mutated local DOM only — chip class + hidden input value + scheduleSave. **No re-render**. Sibling slots' chip availability is computed at render time from `responses.project_*_target_value`, but without an explicit re-render, sibling slots' chips kept their stale disabled state across add/remove/re-add cycles.

**Fix**: hardened the chip click handler with the **canonical-first state pattern** (matches mode-pill, ambience-arrow, spec-chip from #164):
1. Read current state from `responseDoc.responses[key]` (canonical source of truth)
2. Compute next state (toggle on/off)
3. Spread + write to `responseDoc.responses` (canonical write)
4. Mirror to the hidden DOM input as belt-and-braces
5. `renderForm(container)` so SIBLING slots' chip availability re-evaluates immediately
6. `scheduleSave` for persistence

## Bonus: Lesson #105 fix at the project collect path

Closed an asymmetric-guard surface at line 629: `responses.project_${n}_target_*` were written unconditionally even when no `target_*` hidden input was rendered for the slot, clobbering legacy values on the spread base across action changes. Gated on element presence — when the slot's action doesn't render the target hidden inputs, the prior value silent-leaves instead. Same shape as the #105 fix earlier today.

## Helper

```js
function siblingHasAction(saved, currentSlot, action, maxSlots = 4) {
  for (let k = 1; k <= maxSlots; k++) {
    if (k === currentSlot) continue;
    if (saved[`project_${k}_action`] === action) return true;
  }
  return false;
}
```

Reads canonical `responses` only — no DOM dependency. Sits next to `getAlreadyMaintainedTargets` (the maintenance-specific equivalent that returns the Set of claimed target ids for disabled-chip rendering).

## Note on the canonical-first state pattern

This bundle is the third PR this session that explicitly uses the canonical-first pattern (after #164 spec-chip and #129 ambience dispatch). Pattern shape: `responseDoc.responses` is the source of truth; DOM mirrors are belt-and-braces; `renderForm` triggers sibling re-evaluation. Established convention now spans mode-pill, ambience-arrow, acquisitions add/remove, spec-chip, maintenance-chip — worth carrying forward as a documented pattern.

## Test plan
- [x] Static parse: `node --input-type=module --check < public/js/tabs/downtime-form.js` — PASS
- [x] Server tests: full suite **689/689** passing (no server delta — all changes are client-side render + handler logic)
- [ ] Browser smoke (DEFERRED per project Test Plan):
  - **#170**: PT + MCI character → MA #1 selects PT → MA #2's PT chip greys out → select MCI in MA #2 → remove MA #2 (clear chip OR change action) → re-add MA #2 → PT chip STILL greyed out (no longer falsely available); change MA #1 to clear PT → both chips available again in any maintenance slot
  - **#167**: pick ROTE in slot 1 → slots 2/3/4 dropdowns no longer offer ROTE; clear slot 1's ROTE → ROTE re-appears in other slots' dropdowns; legacy submission with multiple ROTE entries loads cleanly, each existing slot can still clear its own ROTE
  - Sibling chip exclusions now refresh in real-time across selection changes (single chip click, not just action-dropdown changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)