### PR TITLE
fix(dt-form): move ambience arrow + spec chip handlers from change to click listener (#165)

### DIFF
--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -2544,42 +2544,11 @@ function renderForm(container) {
       scheduleSave();
       return;
     }
-    // dt-form.25: Ambience row-table arrow click. Single-target state
-    // machine per the 6 ACs:
-    //   - new row click           → switch to (newRow, clickedDir)
-    //   - opposite arrow same row → switch direction, retain row
-    //   - same arrow same row     → toggle off (clear both)
-    const ambArrow = e.target.closest('[data-amb-arrow]');
-    if (ambArrow) {
-      e.preventDefault();
-      const slot     = ambArrow.dataset.ambSlot;
-      const target   = ambArrow.dataset.ambTarget;
-      const dirClick = ambArrow.dataset.ambArrow; // 'up' | 'down'
-      const targetEl = document.getElementById(`dt-project_${slot}_ambience_target`);
-      const dirEl    = document.getElementById(`dt-project_${slot}_ambience_direction`);
-      const curTarget = targetEl ? targetEl.value : '';
-      const curDir    = dirEl    ? dirEl.value    : '';
-      let nextTarget = '';
-      let nextDir    = '';
-      if (curTarget === target && curDir === dirClick) {
-        // same arrow same row → toggle off
-        nextTarget = '';
-        nextDir    = '';
-      } else {
-        // new row OR opposite arrow same row → set to clicked
-        nextTarget = target;
-        nextDir    = dirClick;
-      }
-      if (targetEl) targetEl.value = nextTarget;
-      if (dirEl)    dirEl.value    = nextDir;
-      activeProjectTab = parseInt(slot, 10) || activeProjectTab;
-      const responses = collectResponses();
-      if (responseDoc) responseDoc.responses = responses;
-      else responseDoc = { responses };
-      renderForm(container);
-      scheduleSave();
-      return;
-    }
+    // Issue #165 (2026-05-08): the dt-form.25 ambience-arrow handler used
+    // to live here in the `change` listener — but `<button>` clicks fire
+    // `click`, not `change`, so this never executed. Moved to the click
+    // listener below, where the maintenance-chip / feeding-card / blood-type
+    // button handlers live.
     // dt-form.25: legacy improve/degrade ticker handler retained for
     // sphere-side ambience_change (sphere keeps the legacy radio). Project
     // side no longer emits `[data-proj-ambience-dir]` after the row-table
@@ -2620,31 +2589,13 @@ function renderForm(container) {
       renderForm(container);
       return;
     }
-    // Project dice pool spec chip — toggle selection and re-render
-    // Issue #164 (2026-05-08): hardened. Toggle now mutates responseDoc.responses
-    // directly (canonical state) AND mirrors to the hidden DOM input as a
-    // belt-and-braces measure for any consumer that reads the input directly.
-    // Then collect+render so the dice-pool total span re-renders with the
-    // bonus included via renderDicePool's spec branch.
-    const poolSpecChip = e.target.closest('[data-pool-spec]');
-    if (poolSpecChip) {
-      const prefix = poolSpecChip.dataset.poolSpec;
-      const specName = poolSpecChip.dataset.specName || '';
-      const key = `${prefix}_spec`;
-      const baseResponses = (responseDoc && responseDoc.responses) || {};
-      const cur = baseResponses[key] || '';
-      const next = cur === specName ? '' : specName;
-      // Canonical write — guarantees the spec state persists across renders
-      // even if the hidden input wasn't found or its value diverged.
-      const nextResponses = { ...baseResponses, [key]: next };
-      const hidden = document.getElementById(`dt-${prefix}_spec`);
-      if (hidden) hidden.value = next;
-      if (responseDoc) responseDoc.responses = nextResponses;
-      else responseDoc = { responses: nextResponses };
-      renderForm(container);
-      scheduleSave();
-      return;
-    }
+    // Issue #165 (2026-05-08): the spec-chip handler used to live here in
+    // the `change` listener — same root cause as the ambience-arrow bug.
+    // `<button>` clicks fire `click`, not `change`. Moved to the click
+    // listener below. (My earlier #164 fix landed the canonical-first
+    // writes correctly but the handler itself was never firing — only
+    // the dropdown-label cleanup actually shipped a user-visible change.
+    // This PR restores the chip toggle behaviour the issue spec asked for.)
     // XP category/item change — collect current state and re-render
     const xpCat = e.target.closest('[data-xp-cat]');
     const xpItem = e.target.closest('[data-xp-item]');
@@ -2710,6 +2661,74 @@ function renderForm(container) {
       if (responseDoc) responseDoc.responses = responses;
       else responseDoc = { responses };
       renderForm(container);
+      return;
+    }
+
+    // Issue #165 (2026-05-08): dt-form.25 Ambience row-table arrow click.
+    // Single-target state machine per the dt-form.25 ACs:
+    //   - new row click           → switch to (newRow, clickedDir)
+    //   - opposite arrow same row → switch direction, retain row
+    //   - same arrow same row     → toggle off (clear both)
+    // Originally placed in the `change` listener which never fires for
+    // `<button>` clicks; moved here so the chip click actually executes
+    // the state machine. Uses canonical-first state pattern (writes
+    // `responseDoc.responses` first, mirrors to DOM, then renders).
+    const ambArrow = e.target.closest('[data-amb-arrow]');
+    if (ambArrow) {
+      e.preventDefault();
+      const slot     = ambArrow.dataset.ambSlot;
+      const target   = ambArrow.dataset.ambTarget;
+      const dirClick = ambArrow.dataset.ambArrow; // 'up' | 'down'
+      const targetKey = `project_${slot}_ambience_target`;
+      const dirKey    = `project_${slot}_ambience_direction`;
+      const baseResponses = (responseDoc && responseDoc.responses) || {};
+      const curTarget = baseResponses[targetKey] || '';
+      const curDir    = baseResponses[dirKey]    || '';
+      let nextTarget;
+      let nextDir;
+      if (curTarget === target && curDir === dirClick) {
+        // same arrow same row → toggle off
+        nextTarget = '';
+        nextDir    = '';
+      } else {
+        // new row OR opposite arrow same row → set to clicked
+        nextTarget = target;
+        nextDir    = dirClick;
+      }
+      // Canonical-first: spread + write to responseDoc.responses BEFORE
+      // mirroring to DOM, so renderForm reads the new state cleanly.
+      const nextResponses = { ...baseResponses, [targetKey]: nextTarget, [dirKey]: nextDir };
+      const targetEl = document.getElementById(`dt-project_${slot}_ambience_target`);
+      const dirEl    = document.getElementById(`dt-project_${slot}_ambience_direction`);
+      if (targetEl) targetEl.value = nextTarget;
+      if (dirEl)    dirEl.value    = nextDir;
+      activeProjectTab = parseInt(slot, 10) || activeProjectTab;
+      if (responseDoc) responseDoc.responses = nextResponses;
+      else responseDoc = { responses: nextResponses };
+      renderForm(container);
+      scheduleSave();
+      return;
+    }
+
+    // Issue #165 (2026-05-08): Project dice pool spec chip — toggle selection
+    // and re-render. Same root-cause story as ambience-arrow above: the
+    // handler was misplaced in the `change` listener and never fired for
+    // button clicks. Moved here. Canonical-first state pattern.
+    const poolSpecChip = e.target.closest('[data-pool-spec]');
+    if (poolSpecChip) {
+      const prefix = poolSpecChip.dataset.poolSpec;
+      const specName = poolSpecChip.dataset.specName || '';
+      const key = `${prefix}_spec`;
+      const baseResponses = (responseDoc && responseDoc.responses) || {};
+      const cur = baseResponses[key] || '';
+      const next = cur === specName ? '' : specName;
+      const nextResponses = { ...baseResponses, [key]: next };
+      const hidden = document.getElementById(`dt-${prefix}_spec`);
+      if (hidden) hidden.value = next;
+      if (responseDoc) responseDoc.responses = nextResponses;
+      else responseDoc = { responses: nextResponses };
+      renderForm(container);
+      scheduleSave();
       return;
     }
     // Blood type toggle — single-select pill buttons


### PR DESCRIPTION
## Summary
Root cause identified: the dt-form.25 ambience-arrow handler at line 2552 lived inside `container.addEventListener('change', ...)`, but `<button>` clicks fire `click`, not `change`. The handler never executed — and no console errors because nothing matched, the listener just silently didn't run.

Closes #165

## Listener layout in downtime-form.js
| Lines | Listener | Purpose |
|---|---|---|
| 2052-2371 | click #1 | General click delegation (mode-pill, project-tab, section toggle, etc.) |
| 2373-2441 | input | Live keystroke updates |
| 2443-2700 | change | `<select>` and radio changes — `[data-project-action]`, `[data-pool-prefix]`, `[data-sphere-action]`, `[data-flex-type]`, `[data-feed-terr]`, etc. ✓ |
| 2702-... | click #2 | Button-shaped affordances — feeding-method cards, blood-type pills, maintenance chips |

`[data-amb-arrow]` (line 2552) and `[data-pool-spec]` (line 2629) are both `<button>` elements but were placed inside the change listener. Buttons don't fire change → handlers never ran.

## What this PR fixes

**`[data-amb-arrow]`** — moved to click listener 2. After the move, clicking an up/down chip executes the dt-form.25 state machine:
- new row click          → switch to (newRow, clickedDir)
- opposite arrow same row → switch direction, retain row
- same arrow same row    → toggle off (clear both)

Persistence captures `responses.project_${n}_ambience_target` (slug) and `_ambience_direction` ('up' | 'down'). The backward-compat legacy seed (`_target_terr` + `_ambience_dir` → ambience_target/_direction) at downtime-form.js:3597+ continues to work (it's render-side, no handler dependency).

**`[data-pool-spec]`** — also moved to click listener 2. PR #175 (#164) landed the canonical-first writes inside this handler, but the handler was sitting in the change listener and never firing. The `<select>` skill dropdown's `[spec]` suffix cleanup that ALSO landed in #175 IS user-visible (it's a render change) — but the chip toggle PR #175 was supposed to fix never actually worked. This PR completes #164's fix by relocating the handler so it runs on click.

This explains the user-reported regression: the AC body said "static review PASSed cleanly; browser smoke was DEFERRED" — the misplaced handler couldn't be caught by static review because the call sites (chip emission + handler block) were both syntactically valid; the routing-via-wrong-listener bug only manifests at runtime.

## Implementation

Both handlers re-implemented in click listener 2 with the canonical-first state pattern (matches mode-pill / acquisitions / now-corrected spec-chip / maintenance-chip):

1. Read current state from `responseDoc.responses[key]` (canonical source of truth)
2. Compute next state per the state machine
3. Spread + write to `responseDoc.responses` (canonical write)
4. Mirror to DOM hidden inputs (belt-and-braces)
5. `renderForm(container)` so sibling chips / total visuals update immediately
6. `scheduleSave` for persistence

The misplaced handler blocks in the change listener are removed and replaced with deletion-receipt comments pointing at the new location.

## File scope
- `public/js/tabs/downtime-form.js` (+80/-61 net): two handler blocks moved listener-to-listener; both rewritten with canonical-first state pattern + replaced placeholder comments at the old sites

## Test plan
- [x] Static parse: `node --input-type=module --check < public/js/tabs/downtime-form.js` — PASS
- [x] Server tests: full suite **689/689** passing (no server delta — pure handler placement)
- [ ] Browser smoke (DEFERRED per project Test Plan):
  - **#165 ambience arrow**: pick `ambience_change` action → row-table renders → click any row's down arrow → red selected, target+direction persists; click same row's up arrow → switches to up, target preserved; click another row's arrow → switches target+direction; click same arrow on same selected row → toggles off (clear both)
  - **#164 spec chip retro-fix**: Personal Action with skill picker → click a spec chip → `dt-feed-spec-on` flips; dice-pool total jumps by +1 (or +2 for AoE / nine_again); click again → toggles off, total drops back; refresh page → spec persists in saved state
  - Regression check: `<select>` change events that ARE in the change listener (action type dropdowns, pool selects) still work — the change listener still has all the `<select>` and radio matchers untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)