### PR TITLE
fix(merit-data): grant Mandragora Garden the shared quality (#160, errata)

### DIFF
--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -951,8 +951,15 @@ export function shRenderDomainMerits(c, editMode) {
       h += _derivedNotes(m);
       if (m.name === 'Herd') { const ssjB = ssjHerdBonus(c); if (ssjB) h += '<div class="derived-note">SSJ Bonus: +' + ssjB + ' dots (' + shDots(ssjB) + ') \u2014 equals MCI dots</div>'; }
       if (m.name === 'Herd') { const flockB = flockHerdBonus(c); if (flockB) h += '<div class="derived-note">Flock Bonus: +' + flockB + ' dots (' + shDots(flockB) + ') \u2014 equals Flock rating, can exceed 5</div>'; }
-      // Haven and Mandragora Garden excluded from partner sharing (sharing is at the Safe Place level)
-      const _noShare = ['Herd', 'Feeding Grounds', 'Haven', 'Mandragora Garden'];
+      // Issue #160 (2026-05-08): Mandragora Garden gains the shared quality
+      // per published errata — direct partner sharing on the Mandragora
+      // instance, semantically identical to Safe Place's existing treatment.
+      // Removed from _noShare here. The attached-to-Safe-Place cap stays
+      // (CAP_DOMAIN in editor/domain.js); per-instance shared_with sums
+      // partner contributions through the existing domMeritShareable path.
+      // Haven still excluded — its shared treatment is via the Safe Place
+      // it attaches to, NOT a direct shared quality on the Haven itself.
+      const _noShare = ['Herd', 'Feeding Grounds', 'Haven'];
       if (!_noShare.includes(m.name) && parts.length) { h += '<div class="dom-partners-row">'; parts.forEach(pN => { const p = chars.find(ch => ch.name === pN), pD = p ? domMeritShareable(p, m.name) : 0; h += '<span class="dom-partner-tag">' + esc(pN) + (pD ? ' ' + shDots(pD) : ' \u25CB') + '<button class="dom-partner-rm" onclick="shRemoveDomainPartner(' + di + ',\'' + pN.replace(/'/g, "\\'") + '\')">\u00D7</button></span>'; }); h += '</div>'; }
       if (!_noShare.includes(m.name) && avP.length) h += '<div class="dom-add-partner-row"><select class="dom-partner-sel" onchange="if(this.value){shAddDomainPartner(' + di + ',this.value);this.value=\'\';}"><option value="">+ Add shared partner\u2026</option>' + avP.map(p => '<option value="' + esc(p.name) + '">' + esc(dropdownName(p)) + '</option>').join('') + '</select></div>';
       h += '</div>';


### PR DESCRIPTION
## Summary
Per published errata, Mandragora Garden carries the shared quality alongside Safe Place — multiple residents can be associated with a single instance via the existing per-instance `shared_with` array.

Closes #160

## Survey: shared semantics already exist for any domain merit

Sharing is implemented per-instance via `m.shared_with`:
- `shAddDomainPartner` / `shRemoveDomainPartner` (`edit-domain.js:356+`) are merit-name-agnostic
- `domMeritContrib` / `domMeritShareable` (`domain.js:96+`) sum per-instance contributions through `shared_with` for any merit name

The only gate excluding Mandragora was the UI allowlist:
```js
// editor/sheet.js:954-955 (before this PR)
// Haven and Mandragora Garden excluded from partner sharing (sharing is at the Safe Place level)
const _noShare = ['Herd', 'Feeding Grounds', 'Haven', 'Mandragora Garden'];
```

Removed `'Mandragora Garden'` from the list. The partner-add UI now renders for Mandragora Garden instances, identical to Safe Place's treatment.

## Haven stays in `_noShare`

Haven's shared treatment is via the Safe Place it attaches to (per the comment), NOT a direct shared quality on the Haven itself. Mandragora Garden gains the direct shared quality per the errata; Haven does not. Comment updated to clarify the distinction.

## Cap interaction preserved

Mandragora Garden's rating is capped at the attached Safe Place's effective rating (`CAP_DOMAIN` set in `domain.js:17`). The cap applies per Mandragora instance regardless of partner sharing. Existing characters with attached Mandragora entries continue to load with correct effective ratings — sharing simply layers partner contributions on top through the same `domMeritShareable` path Safe Place already uses.

## File scope
- `public/js/editor/sheet.js` (+8/-2): drop `'Mandragora Garden'` from `_noShare` allowlist + comment block clarifying the distinction from Haven

## Test plan
- [x] Static parse: `node --input-type=module --check < public/js/editor/sheet.js` — PASS
- [x] Server tests: full suite **689/689** passing (no server delta — pure client-side UI gate)
- [ ] Browser smoke (DEFERRED per project Test Plan):
  - Character with a Mandragora Garden merit instance → admin edit panel renders the "+ Add shared partner" picker (was hidden before this PR)
  - Add a partner → both characters' Mandragora Garden instances carry matching `shared_with` arrays
  - Partner contribution sums correctly into the effective rating breakdown
  - Cap to attached Safe Place rating still applies (no overflow past the cap when partners contribute)
  - Haven instances still hide the partner picker (sharing-via-Safe-Place semantics preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)