### PR TITLE
fix(regency): cap is a soft warning, not a hard gate (#159)

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -2323,7 +2323,9 @@ html:not([data-theme="dark"]) .sk-spec-row  span { color: var(--crim) !important
   background: var(--surf);
 }
 .dt-residency-row.dt-over-cap {
-  background: rgba(139, 0, 0, 0.25);
+  /* Issue #159: cap is a soft warning surface — token-driven crimson
+     wash so the over-cap row reads as "warning" without being aggressive. */
+  background: var(--crim-a25);
   border: 1px solid var(--crim);
 }
 .dt-residency-label {

--- a/public/js/tabs/regency-tab.js
+++ b/public/js/tabs/regency-tab.js
@@ -141,8 +141,18 @@ function render(container) {
     id => id !== regentId && (!ltId || id !== ltId)
   );
 
-  // Render slots from loopStart; show any existing over-cap entries too
-  const loopEnd = Math.max(cap, loopStart + additionalRights.length - 1);
+  // Issue #159 (2026-05-08): cap is a SOFT warning, not a hard gate. Per
+  // the rules, exceeding the cap is permitted with a mechanical penalty
+  // surfaced via the existing `.dt-over-cap` row treatment + 'Over
+  // capacity' chip. The render must always provide a trailing empty slot
+  // beyond the current filled count so the regent can add a fresh
+  // resident — including past the cap into over-capacity territory.
+  // Cap-allowed slots within cap stay visible (so the regent sees the
+  // unfilled cap slots even before any rights are added).
+  const filledCount = additionalRights.length;
+  const minWithinCap = Math.max(0, cap - (loopStart - 1));
+  const desiredAdditionals = Math.max(minWithinCap, filledCount + 1);
+  const loopEnd = Math.min(loopStart + desiredAdditionals - 1, MAX_FEEDING_POSITION);
 
   // dt-form.16: publish source list to the universal char picker (ADR-003 §Q6).
   setCharPickerSources({
@@ -175,7 +185,7 @@ function render(container) {
 
   h += `<h3 class="regency-title">Regency: ${esc(terrName)}</h3>`;
   h += `<p class="regency-meta">Ambience: ${esc(ambience)} — Feeding rights cap: ${cap}</p>`;
-  h += `<p class="regency-desc">Grant feeding rights for your territory. Slots beyond the cap are highlighted as over-capacity.</p>`;
+  h += `<p class="regency-desc">Grant feeding rights for your territory. The cap is a soft warning — you can grant rights beyond it, but residents in over-capacity slots feed under a mechanical penalty per the rules. The ST adjudicates the penalty when feeding rolls resolve.</p>`;
 
   h += '<div class="dt-residency-grid">';
 
@@ -223,7 +233,7 @@ function render(container) {
          + ` data-cp-initial="${initialJson}"`
          + ` data-cp-placeholder="Pick a feeding right"></div>`;
     }
-    if (overCap) h += '<span class="dt-over-cap-warn">Over capacity</span>';
+    if (overCap) h += '<span class="dt-over-cap-warn" title="This slot exceeds the territory feeding-rights cap. The resident feeds under a mechanical penalty (ST adjudicates).">Over cap — penalty applies</span>';
     h += '</div>';
   }
 


### PR DESCRIPTION
## Summary
Per the rules, exceeding the feeding-rights cap is permitted with a mechanical penalty — the system should allow the assignment and surface the penalty rather than block. The "block" was purely client-side via the rendered slot count: the loop only emitted slots up to `cap`, so a regent at the cap had no empty trailing slot to pick a new resident into.

Closes #159

## Survey: server has no cap enforcement
Verified: `server/routes/territories.js` PATCH `/api/territories/:id/feeding-rights` endpoint has no cap validation. The `AMBIENCE_CAP` table is purely client-side (`downtime-data.js:70+`). Over-cap saves round-trip cleanly through the existing schema. Pure client-side fix.

## Changes (`public/js/tabs/regency-tab.js`)

**`loopEnd` calc extended to always render a trailing empty slot.**

Before:
```js
const loopEnd = Math.max(cap, loopStart + additionalRights.length - 1);
```

After:
```js
const filledCount = additionalRights.length;
const minWithinCap = Math.max(0, cap - (loopStart - 1));
const desiredAdditionals = Math.max(minWithinCap, filledCount + 1);
const loopEnd = Math.min(loopStart + desiredAdditionals - 1, MAX_FEEDING_POSITION);
```

| State | Before behaviour | After behaviour |
|---|---|---|
| 0 filled, cap=6, loopStart=3 | slots 3..6 (4 empty) | slots 3..6 (4 empty) — unchanged |
| 4 filled, cap=6, loopStart=3 | slots 3..6 (all filled, no empty) | slots 3..7 (4 filled + 1 trailing empty over-cap) |
| 8 filled, cap=6, loopStart=3 | slots 3..10 (all filled, no empty) | slots 3..11 (8 filled + 1 trailing) |

Empty within-cap slots stay visible (regent sees unfilled cap slots). One trailing empty slot beyond filled count always renders, giving the affordance to grow into over-cap territory. Capped at `MAX_FEEDING_POSITION = 12`.

**Description copy** updated to explain soft-warning semantics directly: cap is a soft warning, residents in over-cap slots feed under a mechanical penalty per the rules, ST adjudicates the penalty.

**Over-cap chip** wording: `Over capacity` → `Over cap — penalty applies`, with an explanatory `title=` tooltip.

## Bonus token fix (`public/css/components.css`)

`.dt-residency-row.dt-over-cap` previously had a bare-hex `background: rgba(139, 0, 0, 0.25)` — violates the no-bare-hex CSS standard from CLAUDE.md. Replaced with `var(--crim-a25)`, the existing crimson-with-25%-alpha token already defined in theme.css. Same visual intensity; token-driven.

## File scope
- `public/js/tabs/regency-tab.js` (+13/-3 net): loopEnd calc, description copy, over-cap chip wording
- `public/css/components.css` (+3/-1): bare-hex → token

## Test plan
- [x] Static parse: `node --input-type=module --check < public/js/tabs/regency-tab.js` — PASS
- [x] Server tests: full suite **689/689** passing (no server delta — client-side render + copy only)
- [ ] Browser smoke (DEFERRED per project Test Plan):
  - **Cap-allowed slots**: regent at 0 filled, cap=6 → 4 empty additional slots visible (unchanged)
  - **Add to cap**: fill all 4 cap-allowed slots → save → reload → regent sees 4 filled + 1 empty trailing slot (NEW)
  - **Add over-cap**: pick a 5th resident in the trailing empty slot → row gets `dt-over-cap` styling (crimson wash) + `Over cap — penalty applies` chip + tooltip explaining ST adjudicates
  - **Save over-cap**: PATCH `/api/territories/:id/feeding-rights` → 200 OK; reload page → over-cap residents persist; row styling re-applies
  - **Remove**: clear an over-cap slot → row stays as empty trailing slot until removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)