### PR TITLE
fix(dt-form): preserve _gameXP across the fresh-char fetch (#184, cycle-blocker)

### DIFF
--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -1188,7 +1188,15 @@ export async function renderDowntimeTab(targetEl, char, territories, options = {
   currentChar = char;
   try {
     const fresh = await apiGet(`/api/characters/${encodeURIComponent(String(char._id))}`);
-    currentChar = fresh;
+    // Issue #184 (2026-05-08): merge server data over the cached `char`
+    // object instead of replacing the reference wholesale. `_gameXP` (set
+    // by loadGameXP() before the form opens) and any other underscore-
+    // prefixed ephemeral state are NOT persisted to MongoDB, so the fresh
+    // API response doesn't carry them — wholesale `currentChar = fresh`
+    // would silently zero out xpGame() and short xpEarned()/xpLeft() by
+    // the full game-XP total. Mirrors the existing admin.js:548 pattern.
+    Object.assign(char, fresh);
+    currentChar = char;
   } catch { /* silent — stale char is better than a broken form */ }
   if (currentChar) applyDerivedMerits(currentChar);
   _territories = territories || [];


### PR DESCRIPTION
## Summary
`renderDowntimeTab` assigned `currentChar = fresh` wholesale, clobbering the client-side `_gameXP` cache that `loadGameXP()` sets on the parent `char` object before the form opens. `_gameXP` is not persisted to MongoDB, so the fresh API response carries none of it — post-assignment, `xpGame()` returned 0 forever, and `xpEarned()` / `xpLeft()` shorted by the entire game-XP total.

Closes #184

## Blast radius — single fix at load cures all consumers
Every consumer of `xpLeft(currentChar)` saw a budget too small by the full game-XP. Four sites:
- `:1101` submit-final budget gate
- `:3510` per-slot xp_spend grid render
- `:4124` action-spent accounting
- `:6554` Submit Final summary

Single fix at the load site (downtime-form.js:1187+) cures all four consumers.

## Fix
Mirrored the established pattern at `public/js/admin.js:545-552`: merge server data over the cached object via `Object.assign(char, fresh)` and keep the same reference, so any underscore-prefixed ephemeral properties on the cached `char` survive. The admin.js comment at :548 literally documents this:

> Merge server data over cached object; _-prefixed ephemeral props (e.g. _gameXP) are not on `fresh` so they survive.

```diff
 try {
   const fresh = await apiGet(`/api/characters/${...}`);
-  currentChar = fresh;
+  Object.assign(char, fresh);
+  currentChar = char;
 } catch { /* silent — stale char is better than a broken form */ }
```

## File scope
- `public/js/tabs/downtime-form.js` (+9/-1): two-line fix + reference comment

## Test plan
- [x] Static parse: `node --input-type=module --check < public/js/tabs/downtime-form.js` — PASS
- [x] Server tests: full suite **689/689** passing (no server delta — client-side cache-preservation only)
- [ ] Browser smoke (REQUIRED per issue body):
  1. Open DT form for a character with non-zero game XP (e.g. 6 from prior games) → XP-available matches player sheet's XP-Left
  2. Submit-final crossing the minimum threshold; reload form → +1 downtime XP reflected
  3. Over-budget toast at `:1101` fires only at the true XP cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)