### PR TITLE
fix(dt-form): harmonise XP Spend merit picker with sheet's eligibility filters (#188)

### DIFF
--- a/public/js/editor/merits.js
+++ b/public/js/editor/merits.js
@@ -13,10 +13,11 @@ import { getRulesByCategory, getRuleByKey, getRulesDB } from '../data/loader.js'
 // Re-export the new prereq engine for direct use by consumers
 export { _meetsPrereq as meetsPrereq, _prereqLabel as prereqLabel };
 
-/** Check if a merit is excluded by a merit the character already owns. */
-function _isExcluded(c, meritName) {
-  const owned = (c.merits || []).map(m => m.name.toLowerCase());
-  // Check if any owned merit's exclusive list includes this candidate
+/** Check if a merit is excluded by a merit the character already owns.
+ *  Issue #188 (2026-05-08): exposed as `isMeritExcluded` so the DT form's
+ *  XP Spend picker can apply the same exclusion logic the sheet's Merit
+ *  Add picker uses, without duplicating the rule walk. */
+export function isMeritExcluded(c, meritName) {
   for (const m of (c.merits || [])) {
     const rule = getRuleByKey(m.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''));
     if (!rule || !rule.exclusive) continue;
@@ -25,6 +26,10 @@ function _isExcluded(c, meritName) {
   }
   return null;
 }
+// Local alias preserved so the existing internal callers (buildMeritOptions
+// / buildSubCategoryMeritOptions / buildMCIGrantOptions) don't need to be
+// touched.
+const _isExcluded = isMeritExcluded;
 
 /* ══════════════════════════════════════════════════════
    Merit string helpers

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -20,7 +20,7 @@ import { ALL_ATTRS, ALL_SKILLS, CLAN_DISCS, BLOODLINE_DISCS, CORE_DISCS, RITUAL_
 import { calcTotalInfluence, domMeritTotal, attacheBonusDots, effectiveInvictusStatus, ssjHerdBonus, flockHerdBonus, meritEffectiveRating, influenceBreakdown } from '../editor/domain.js';
 import { calcVitaeMax, skTotal, skNineAgain, riteCost, skillAcqPoolStr, getAttrEffective, getAttrTotal, discDots } from '../data/accessors.js';
 import { xpLeft } from '../editor/xp.js';
-import { meetsPrereq } from '../editor/merits.js';
+import { meetsPrereq, isMeritExcluded } from '../editor/merits.js';
 import { getRuleByKey, getRulesByCategory } from '../data/loader.js';
 import { getRole, isSTRole } from '../auth/discord.js';
 import { FAMILIES, kindByCode } from '../data/relationship-kinds.js';
@@ -3929,10 +3929,28 @@ function getItemsForCategory(category) {
         return found.length ? Math.max(...found.map(m => meritEffectiveRating(c, m))) : 0;
       }
 
-      // Try rules cache first, fallback to MERITS_DB
+      // Try rules cache first, fallback to MERITS_DB.
+      // Issue #188 (2026-05-08): harmonised with the sheet's Merit Add
+      // picker (`buildMeritOptions` in editor/merits.js:271). The XP Spend
+      // picker previously called `meetsPrereq` only — the prereq filter
+      // was honoured but the picker still surfaced merits the player
+      // can't directly XP-purchase:
+      //   - Standing-subcategory merits (MCI / PT — gained via IC events,
+      //     not XP per dot)
+      //   - Structural sub-system merits (Style / Invictus Oath /
+      //     Carthian Law parents — bought via the fighting-style pool /
+      //     sub-system enrollment paths)
+      //   - Clan/covenant-excluded merits (via `isMeritExcluded`)
+      // Influence and domain merits ARE XP-purchasable directly per
+      // VtR 2e, so they REMAIN in the picker (they were correctly there).
+      // Already-owned merits that are now clan/covenant-excluded continue
+      // to surface for raising existing dots — silent-leave on legacy
+      // owned data, parallels `buildMeritOptions`'s allow-current escape.
       const meritRules = getRulesByCategory('merit');
       if (meritRules.length) {
         for (const rule of meritRules) {
+          if (rule.parent && ['Style', 'Invictus Oath', 'Carthian Law'].includes(rule.parent)) continue;
+          if (rule.sub_category === 'standing') continue;
           if (!meetsPrereq(c, rule.prereq)) continue;
           const name = rule.name;
           const rr = rule.rating_range;
@@ -3940,6 +3958,9 @@ function getItemsForCategory(category) {
           const max = rr ? rr[1] : 1;
           const currentDots = currentMeritDots(name);
           if (currentDots >= max) continue;
+          // Skip clan/covenant-excluded merits UNLESS the character already
+          // owns the merit (allow raising existing legacy dots).
+          if (isMeritExcluded(c, name) && currentDots === 0) continue;
 
           if (min === max) {
             items.push({


### PR DESCRIPTION
## Summary
The XP Spend merit picker ALREADY called `meetsPrereq` — the user-visible "unfiltered" report was the picker surfacing merits the player can't directly XP-purchase (standing merits, structural sub-system merits, clan/covenant-excluded merits). Harmonised with the sheet's `buildMeritOptions` exclusion shape.

Closes #188

## Survey result — prereq filter was already in place

Static read of `getItemsForCategory('merit')` (downtime-form.js:3922) confirmed `meetsPrereq(c, rule.prereq)` is called at line 3936. Prereq filtering works. The "unfiltered" perception is from three OTHER classes of merit that were leaking through:

| Class | Why it shouldn't be XP-purchasable | Sheet picker excludes it? |
|---|---|---|
| Standing merits (MCI, PT) | Gained via IC events (joining cult / enrolling), not XP-per-dot | Yes (sub_category check) |
| Structural sub-system merits (Style, Invictus Oath, Carthian Law) | Bought via fighting-style pool or sub-system enrollment | Yes (parent check) |
| Clan/covenant-excluded merits | Conflicts with an owned merit per `rule.exclusive` | Yes (`_isExcluded` check) |

Influence and domain merits (Allies, Contacts, Safe Place, Herd etc.) ARE XP-purchasable per VtR 2e and stay in the picker.

## Fix

`public/js/editor/merits.js`:
- Promoted private `_isExcluded` helper to exported `isMeritExcluded` so the DT form picker can apply the same exclusion logic the sheet's Merit Add picker uses, without duplicating the rule walk. Local alias preserved so internal callers (`buildMeritOptions`, `buildSubCategoryMeritOptions`, `buildMCIGrantOptions`) don't need to change.

`public/js/tabs/downtime-form.js`:
- Imported `isMeritExcluded` alongside the existing `meetsPrereq`
- Added three exclusion checks to the merit picker loop:
  ```js
  if (rule.parent && ['Style', 'Invictus Oath', 'Carthian Law'].includes(rule.parent)) continue;
  if (rule.sub_category === 'standing') continue;
  if (isMeritExcluded(c, name) && currentDots === 0) continue;
  ```

The third check uses an **allow-current escape**: clan/covenant-conflicting merits stay visible if the character already owns the merit (`currentDots > 0`), so legacy data with a now-conflicting merit can still be raised. Mirrors `buildMeritOptions`'s `excl && rule.name.toLowerCase() !== currentName.toLowerCase()` pattern.

## Notes
- **Already-owned merits**: max-dots check at line 3942 was already in place and is preserved
- **Graduated merits**: existing flat-vs-grad branching at line 3944-3957 untouched — supports both adding new and raising existing
- **No HALT-DAR**: XP Spend's intent (per the existing graduated-raising path) matches sheet's Merit Add semantics for the general/influence/domain categories. Standing and structural sub-system merits aren't part of the XP Spend lane

## File scope
- `public/js/editor/merits.js` (+8/-4): export `isMeritExcluded`; preserve local alias
- `public/js/tabs/downtime-form.js` (+24/-2): import; three exclusion checks; documentation comment

## Test plan
- [x] Static parse: both modified files pass `node --input-type=module --check`
- [x] Server tests: full suite **689/689** passing on second run (first run hit a pre-existing pool-state flake unrelated to this PR)
- [ ] Browser smoke (REQUIRED per issue):
  - Char with low Dex → no Dex-prereq merits visible (prereq still works)
  - Char with the prereq merit → dependent merit appears
  - Char at max dots for a flat merit → that merit hidden
  - Char with a graduated merit at < max → appears with "raise to N" path
  - Char with an MCI / PT merit → those entries no longer appear in the XP Spend picker (was leaking)
  - Char where a clan-excluded merit is owned (legacy) → the merit appears for dot-raising but no NEW conflicting merit can be picked
  - Cross-check vs sheet's Merit Add picker: general-merit visibility is now consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)