### PR TITLE
fix(dt-form): mirror project pool into _pool_expr (audit #198)

### DIFF
--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -557,10 +557,41 @@ function collectResponses() {
       const skillEl = document.getElementById(`dt-${prefix}_skill`);
       const discEl = document.getElementById(`dt-${prefix}_disc`);
       const specEl = document.getElementById(`dt-${prefix}_spec`);
-      responses[`${prefix}_attr`] = attrEl ? attrEl.value : '';
-      responses[`${prefix}_skill`] = skillEl ? skillEl.value : '';
-      responses[`${prefix}_disc`] = discEl ? discEl.value : '';
-      responses[`${prefix}_spec`] = specEl ? specEl.value : '';
+      const attrName  = attrEl  ? attrEl.value  : '';
+      const skillName = skillEl ? skillEl.value : '';
+      const discName  = discEl  ? discEl.value  : '';
+      const specName  = specEl  ? specEl.value  : '';
+      responses[`${prefix}_attr`]  = attrName;
+      responses[`${prefix}_skill`] = skillName;
+      responses[`${prefix}_disc`]  = discName;
+      responses[`${prefix}_spec`]  = specName;
+      // Audit #198 — compose the human-readable pool expression admin's
+      // action-queue renderer reads (downtime-views.js:2524, 2585, 2624,
+      // 10240). Form previously wrote only the components; admin's
+      // `_pool_expr` reads always fell back to '' so the project's
+      // Player's Pool column rendered empty. Mirror the components into a
+      // single expression string + numeric total so ST sees what the
+      // player picked at a glance. Skipped silently when no component is
+      // selected, so empty rows don't pollute the queue.
+      if (attrName || skillName || discName) {
+        const validSpec = !!(specName && skillName
+          && (currentChar.skills?.[skillName]?.specs || []).includes(specName));
+        const specBonus = validSpec
+          ? ((skNineAgain(currentChar, skillName) || hasAoE(currentChar, specName)) ? 2 : 1)
+          : 0;
+        let total = 0;
+        if (attrName)  total += getAttrEffective(currentChar, attrName);
+        if (skillName) total += skTotal(currentChar, skillName);
+        if (discName)  total += discDots(currentChar, discName);
+        total += specBonus;
+        const parts = [attrName, skillName, discName].filter(Boolean);
+        let expr = parts.join(' + ');
+        if (validSpec) expr += ` (+${specBonus} ${specName})`;
+        if (expr) expr += ` = ${total}`;
+        responses[`${prefix}_expr`] = expr;
+      } else {
+        responses[`${prefix}_expr`] = '';
+      }
     }
     const outcomeEl = document.getElementById(`dt-project_${n}_outcome`);
     const outcomeRadio = document.querySelector(`input[name="dt-project_${n}_outcome"]:checked`);


### PR DESCRIPTION
## Summary

First fix landing from the audit on #198. Resolves the highest-severity Type B gap: form writes `project_${n}_pool_attr/skill/disc/spec` per slot, but admin reads `project_${n}_pool_expr` (a composed expression string). The form never wrote that key, so admin's Player's Pool column rendered empty for every project row.

Compose the expression alongside the existing component writes in `collectResponses`:

```
Wits + Investigation + Auspex (+1 Stakeouts) = 7
```

Spec bonus respects nine-again / Area-of-Expertise (matches `renderDicePool`'s total math at line 3766). Empty rows write `''` so the action queue isn't polluted with stub entries.

## Why this scope

- Single mirror block — surgical, no surrounding refactor.
- Schema unchanged: `additionalProperties: true` at `downtime_submission.schema.js:175` permits the new key.
- Sphere and sorcery `_pool_expr` admin reads remain orphaned, but those surfaces have **no form-side pool builder** (`renderDicePool` is invoked only for projects). Those gaps need either form UI (new feature) or admin read-removal — separate scope per the audit punch list.

## Cross-refs

- Audit: https://github.com/angelusvmorningstar/TerraMortis/issues/198#issuecomment-4403966947
- Admin reads: `public/js/admin/downtime-views.js:2524, 2585, 2624, 10240` (`primary_pool` build) + `7391` (render)

## Test plan

- [ ] Player picks attr + skill + disc on a project row, saves; admin DT portal shows the expression in Player's Pool.
- [ ] Add a speciality the player owns → expression includes `(+1 SpecName)` (or `+2` for AoE / 9-again skills).
- [ ] Empty project row → no pool string surfaces.
- [ ] Server tests pass: 53 files / 689 tests (verified locally).

## Branch

`dev` (not `main`) per house rule. After merge, manually close #198 (GitHub's `Closes` keyword auto-close only fires on default-branch merges).