### PR TITLE
fix(dt-form): Status block detects MCI under canonical merit name (#194)

### DIFF
--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -276,9 +276,16 @@ function detectMerits() {
   detectedMerits.spheres = deduplicateMerits(expandedInfluence.filter(m =>
     m.category === 'influence' && m.name === 'Allies'
   ));
+  // Issue #194 (2026-05-08): the standing-merit name is canonically
+  // 'Mystery Cult Initiation' across the codebase (sheet, editor, admin,
+  // audit). Filtering on 'MCI' here meant any character whose MCI was
+  // stored under the canonical name (i.e. all of them) had an empty
+  // detectedMerits.status array, so the Status block never rendered and
+  // the 'Grow' action — required to raise Status above 3 dots — was
+  // unreachable. Reproduced for Keeper.
   detectedMerits.status = deduplicateMerits(merits.filter(m =>
     m.category === 'influence' && m.name === 'Status'
-  )).concat(merits.filter(m => m.category === 'standing' && m.name === 'MCI'));
+  )).concat(merits.filter(m => m.category === 'standing' && m.name === 'Mystery Cult Initiation'));
   // Contacts: expand spheres array into individual entries for toggle rendering
   const rawContacts = deduplicateMerits(expandedInfluence.filter(m =>
     m.category === 'influence' && m.name === 'Contacts'
@@ -5699,7 +5706,7 @@ function renderMeritToggles(saved) {
       const label = actionVal ? (ACTION_SHORT[actionVal] || actionVal) : 'No Action';
       const active = n === 1 ? ' dt-proj-tab-active' : '';
       const noAction = !actionVal ? ' dt-proj-tab-empty' : '';
-      const baseLabel = m.name === 'MCI' ? `MCI${m.cult_name ? ` (${m.cult_name})` : ''}` :
+      const baseLabel = m.name === 'Mystery Cult Initiation' ? `MCI${m.cult_name ? ` (${m.cult_name})` : ''}` :
         (m.qualifier || m.area ? `Status (${m.qualifier || m.area})` : 'Broad Status');
       // Issue #190 (2026-05-08): append the character's dot rating so the
       // tab title reads "MCI ●●●" / "Status (Police) ●●●●". Uses the


### PR DESCRIPTION
## Summary

Closes #194 — Status block now renders for characters whose only standing merit is MCI, surfacing the 'Grow' action required to raise Status above 3 dots.

## Root cause

The standing-merit name is canonically `'Mystery Cult Initiation'` across the codebase — 17 references in sheet.js, editor/edit-domain.js, admin/downtime-views.js, data/audit.js, editor/csv-format.js. Two sites in `public/js/tabs/downtime-form.js` used the abbreviated `'MCI'`:

- **Line 281** (`detectMerits`): filtered `detectedMerits.status` on the abbreviation. Every character's MCI is stored under the canonical full name, so the filter never matched. `detectedMerits.status` was empty for any character whose only standing merit was MCI → `renderMeritToggles()` Status block never rendered → 'Grow' unreachable.
- **Line 5702** (tab label): same abbreviation in the tab-label fallback. Even if the filter had matched, the tab title would have fallen through to 'Broad Status' instead of rendering `MCI (Cult Name) ●●●`.

Reproduced for **Keeper** — fixture has `category: 'standing', name: 'Mystery Cult Initiation', cult_name: 'The Remembrance of the Lidless Eye', rating: 5`. Pre-fix: empty Status block. Post-fix: one tab labelled `MCI (The Remembrance of the Lidless Eye) ●●●●●`, dropdown surfaces all sphere actions including Grow.

## Mirror of Allies

The dropdown filter at line 5736 already includes Grow for the Status block — `SPHERE_ACTIONS.filter(o => o.value !== 'ambience_change')` excludes only ambience_change, so all other sphere actions (including 'grow') are present. The bug was in the upstream merit-detection that gated whether the Status block rendered at all. No additional action-shape changes needed — once `detectedMerits.status` populates, Grow flows through the existing handler and persists via `status_${n}_grow_target` (line 5378), matching Allies' shape exactly.

## Cross-spheres regression check

- **Influence Status merits** (`category: 'influence', name: 'Status'`) — unchanged. Filter at line 280 untouched.
- **Allies** — separate code path (`detectedMerits.spheres`), untouched.
- **PT** — not in `.status` (correctly: PT is Maintenance, not Standing-as-Status). Untouched.
- **MCI tab label** — line 5702 fix is now consistent with line 281; both recognise the canonical name.

## Test plan

- [ ] As Keeper, open DT form → Status: Social Standing block renders with MCI tab.
- [ ] Action dropdown surfaces 'Grow: Attempt to acquire Allies or Status 4 or 5'.
- [ ] Select Grow, save, reload — `status_1_action === 'grow'`, `status_1_grow_target` persists.
- [ ] Other characters with `category: 'influence', name: 'Status'` merits unaffected (e.g. anyone with Status (Police), Status (Underworld) tabs continue to surface Grow).
- [ ] Server tests pass: 53 files / 689 tests (verified locally).

## HALT-DAR check

Not triggered. Pure mirror-of-Allies — single string match correction, no schema change, no new action shape.

## Branch

`dev` per house rule. Manually close #194 after merge (auto-close gap on dev merges).