### PR TITLE
feat(admin): surface Mentor + Staff in DT action queue (#202)

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -2757,6 +2757,67 @@ function buildProcessingQueue(subs) {
       meritFlatIdx++;
     });
 
+    // Audit #198 / Issue #202 — Mentor + Staff surfaces (PR #137 / dt-form.28)
+    // were entirely invisible on the admin side. Mirror the per-slot loop the
+    // contacts + retainers blocks use, reading the form's mentor_${n}_* and
+    // staff_${n}_* response keys. Mentor mirrors Retainer (per-merit, directed
+    // action — phase 12); Staff mirrors Contacts (per-dot, tasked action —
+    // phase 11). Description composes the merit label + resolved target name +
+    // task so the ST sees who the action is directed at without drilling into
+    // the raw response. Bound to 10 / 20 slots to cover any realistic dot
+    // total.
+    const _resolveTargetName = (id) => {
+      if (!id) return '';
+      const c = characters.find(ch => String(ch._id) === String(id));
+      return c ? displayName(c) : '';
+    };
+    const _composeDirectedDesc = (meritLabel, targetName, task) => {
+      const head = [meritLabel, targetName].filter(Boolean).join(' — ');
+      return [head, task].filter(Boolean).join(': ');
+    };
+    for (let n = 1; n <= 10; n++) {
+      const task    = resp[`mentor_${n}_task`];
+      const target  = resp[`mentor_${n}_target`];
+      const meritLb = resp[`mentor_${n}_merit`];
+      if (!task && !target) continue;
+      queue.push({
+        key: `${sub._id}:merit:${meritFlatIdx}`,
+        subId: sub._id,
+        charName,
+        phase: PHASE_NUM_TO_LABEL[12],
+        phaseNum: 12,
+        actionType: 'resources_retainers',
+        label: 'Mentor: Directed Action',
+        description: _composeDirectedDesc(meritLb, _resolveTargetName(target), task || ''),
+        source: 'merit',
+        meritCategory: 'mentor',
+        actionIdx: meritFlatIdx,
+        poolPlayer: '',
+      });
+      meritFlatIdx++;
+    }
+    for (let n = 1; n <= 20; n++) {
+      const task    = resp[`staff_${n}_task`];
+      const target  = resp[`staff_${n}_target`];
+      const meritLb = resp[`staff_${n}_merit`];
+      if (!task && !target) continue;
+      queue.push({
+        key: `${sub._id}:merit:${meritFlatIdx}`,
+        subId: sub._id,
+        charName,
+        phase: PHASE_NUM_TO_LABEL[11],
+        phaseNum: 11,
+        actionType: 'contacts',
+        label: 'Staff: Tasked Action',
+        description: _composeDirectedDesc(meritLb, _resolveTargetName(target), task || ''),
+        source: 'merit',
+        meritCategory: 'staff',
+        actionIdx: meritFlatIdx,
+        poolPlayer: '',
+      });
+      meritFlatIdx++;
+    }
+
     // ── Acquisitions (resource and skill, from raw.acquisitions form section) ──
     const resAcq   = (raw.acquisitions?.resource_acquisitions || '').trim();
     const skillAcq = (raw.acquisitions?.skill_acquisitions   || '').trim();


### PR DESCRIPTION
## Summary

Closes #202 — Mentor + Staff downtime actions (PR #137 / dt-form.28) now appear in the admin DT portal's action queue.

## Root cause

Form-side `collectResponses` (downtime-form.js:810–831) writes:

- `mentor_${n}_target` (charpicker `_id`), `mentor_${n}_task` (text), `mentor_${n}_merit` (display label)
- `staff_${n}_target`, `staff_${n}_task`, `staff_${n}_merit`

Admin's `buildActionQueue` iterated spheres → contacts → retainers → acquisitions, but never the new mentor/staff response keys. ST sees nothing for those rows on a submission.

## Shape of the fix

Add two per-slot loops right after the retainers iteration in `buildActionQueue`, mirroring the contacts + retainers shapes already in place:

- **Mentor → phase 12 / 'Retainers' label / 'Mentor: Directed Action' row label.** Per-merit, mirrors Retainer's directed-action shape.
- **Staff → phase 11 / 'Contacts' label / 'Staff: Tasked Action' row label.** Per-dot, mirrors Contacts' tasked-action shape.

Description composes: `<stored merit label> — <resolved target name>: <task>`. Target name lookup uses the existing `characters` array (same pattern as `downtime-views.js:1289` for the rp_shoutout JSON parser).

Empty rows are skipped (no `task` and no `target` → continue), so unused slots don't pollute the queue.

Slot bounds: 10 mentors / 20 staff — comfortably above any realistic in-game dot total.

## Why phase labels stay 'Retainers' / 'Contacts'

dt-form.28's design intent (per the story file): mentor is per-merit like Retainer, staff is per-dot like Contacts. Phase headers reuse the parallel phases so the queue reads naturally — within the 'Retainers' phase the ST sees both `Retainer: Directed Action` and `Mentor: Directed Action` rows; within the 'Contacts' phase both `Contacts: Gather Info` and `Staff: Tasked Action`. Adding new phases would have meant editing `PHASE_NUM_TO_LABEL` / `PHASE_LABELS` plus all consumers — out of the surgical-fix scope Khepri set.

## Regression check

- **Retainers existing flow** (`raw.retainer_actions?.actions`): untouched, runs before the new mentor loop, indexes via the same `meritFlatIdx` counter.
- **Contacts existing flow** (`raw.contact_actions?.requests` + `contact_${n}_request` fallback): untouched.
- **Spheres iteration** (allies/status/etc.): untouched.
- **`merit_actions_resolved` flat index alignment**: new entries use the same incrementing `meritFlatIdx`, so any ST resolution the merit_actions_resolved array already tracks for retainer/contacts indices stays correctly aligned.

## Test plan

- [ ] Submission with `mentor_1_target` + `mentor_1_task` populated → 'Mentor: Directed Action' row appears under Retainers phase header.
- [ ] Submission with `staff_1_target` + `staff_1_task` populated → 'Staff: Tasked Action' row appears under Contacts phase header.
- [ ] Description renders `<merit label> — <target name>: <task>` (target name resolved from `_id`).
- [ ] Empty mentor/staff slots: no spurious rows.
- [ ] Existing Retainer / Contacts rows unchanged (no regression).
- [ ] Server tests pass: 53 files / 689 tests (verified locally).

## HALT-DAR check

Not triggered. Pure additive block insertion; no changes to phase labels, schema, or existing consumers.

## Branch

`dev` per house rule. Manually close #202 after merge (auto-close gap on dev merges).