### PR TITLE
fix(admin): normalise project ambience to canonical enum (#196)

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -2595,7 +2595,19 @@ function buildProcessingQueue(subs) {
 
       // ST recategorisation override — changes phase and label without altering player data
       const projReview = (sub.projects_resolved || [])[idx] || {};
-      const effectiveActionType = projReview.action_type_override || actionType;
+      let effectiveActionType = projReview.action_type_override || actionType;
+
+      // Issue #196 — dt-form.25's project ambience redesign keeps action
+      // = 'ambience_change' and persists direction in `_ambience_direction`
+      // ('up' | 'down'). Normalise to the canonical enum so phase routing,
+      // ACTION_TYPE_LABELS, and downstream tally + render code match. The
+      // ST override (if set) was already applied above, so this only
+      // touches the player-submitted shape.
+      if (effectiveActionType === 'ambience_change') {
+        const projDir = resp[`project_${slot}_ambience_direction`] || resp[`project_${slot}_ambience_dir`] || '';
+        if (projDir === 'up' || projDir === 'improve') effectiveActionType = 'ambience_increase';
+        else if (projDir === 'down' || projDir === 'degrade') effectiveActionType = 'ambience_decrease';
+      }
 
       let phaseNum = PHASE_ORDER[effectiveActionType] ?? 7;
       let phaseKey = PHASE_NUM_TO_LABEL[phaseNum];
@@ -2607,6 +2619,15 @@ function buildProcessingQueue(subs) {
         phaseNum = PHASE_JOINT;
         phaseKey = PHASE_NUM_TO_LABEL[PHASE_JOINT];
       }
+
+      // Issue #196 — for ambience-change projects, dt-form.25 writes the
+      // territory to `_ambience_target` instead of `_territory`. Prefer
+      // the new key, fall back to legacy for pre-redesign drafts.
+      const _isProjAmb = effectiveActionType === 'ambience_increase'
+                      || effectiveActionType === 'ambience_decrease';
+      const _projTerritory = _isProjAmb
+        ? (resp[`project_${slot}_ambience_target`] || resp[`project_${slot}_territory`] || '')
+        : (resp[`project_${slot}_territory`] || '');
 
       queue.push({
         key: `${sub._id}:proj:${idx}`,
@@ -2627,7 +2648,7 @@ function buildProcessingQueue(subs) {
         projDescription,
         projCast:        projCastResolved,
         projMerits:      projMeritsResolved,
-        projTerritory:   resp[`project_${slot}_territory`] || '',
+        projTerritory:   _projTerritory,
         // JDT-5: joint membership — populated when the slot belongs to a joint.
         joint_id:        _jointInfo?.joint?._id || null,
         joint_role:      _jointInfo?.role || null,
@@ -3134,14 +3155,29 @@ function _gatherProjectAmbience(subs) {
       const n = idx + 1;
       const resolved = (sub.projects_resolved || [])[idx] || {};
       // Effective action type: ST override takes priority over player submission
-      const effectiveType = resolved.action_type_override || proj.action_type || resp[`project_${n}_action`] || '';
+      let effectiveType = resolved.action_type_override || proj.action_type || resp[`project_${n}_action`] || '';
+      // Issue #196 — dt-form.25's project ambience redesign keeps the raw
+      // action `'ambience_change'` and persists direction in
+      // `_ambience_direction` ('up' | 'down'). Sphere-side normalises to
+      // ambience_increase / _decrease at form-write time; project-side does
+      // not. Map at admin read so the existing tally branches still match.
+      if (effectiveType === 'ambience_change') {
+        const dir = resp[`project_${n}_ambience_direction`] || resp[`project_${n}_ambience_dir`] || '';
+        if (dir === 'up' || dir === 'improve') effectiveType = 'ambience_increase';
+        else if (dir === 'down' || dir === 'degrade') effectiveType = 'ambience_decrease';
+      }
       const isIncrease = effectiveType === 'ambience_increase';
       const isDecrease = effectiveType === 'ambience_decrease';
       if (!isIncrease && !isDecrease) continue;
       // Pending: not yet rolled (pool_status is never updated on project roll, so use roll presence)
       if (!resolved.roll) { pendingCount++; continue; }
       const terrOverride = resolveTerrId(sub.st_review?.territory_overrides?.[String(idx)] || '');
-      const terrRaw = resp[`project_${n}_territory`] || '';
+      // Issue #196 — dt-form.25 writes `_ambience_target` (territory slug)
+      // for ambience-change actions; the legacy `_territory` key is no
+      // longer set on those rows. Prefer the new key, fall back for
+      // pre-redesign drafts and non-ambience action types that still
+      // carry `_territory`.
+      const terrRaw = resp[`project_${n}_ambience_target`] || resp[`project_${n}_territory`] || '';
       const desc    = resp[`project_${n}_description`] || proj.detail || '';
       const outcome = proj.desired_outcome || resp[`project_${n}_outcome`] || '';
       const tid = terrOverride || resolveTerrId(terrRaw) || extractTerritoryFromText(desc) || extractTerritoryFromText(outcome);


### PR DESCRIPTION
## Summary

Closes #196 (Ambience Increase action: territory not displaying on admin DT portal).

dt-form.25's project ambience redesign keeps the raw action string `'ambience_change'` and persists direction in `_ambience_direction` (`'up'` | `'down'`). Sphere-side **does** normalise `'ambience_change'` → `'ambience_increase'` / `'_decrease'` at form-write time (`downtime-form.js:723-725, 767-768`) so admin's tally + render code matches; project-side intentionally does **not** normalise (per the dt-form.25 commit body), leaving the parallel-state-system gap the audit on #198 flagged as HIGH Type A.

## Two consequences pre-fix

| Site | Pre-fix behaviour |
|---|---|
| `_gatherProjectAmbience` (line 3119) | Tested `effectiveType === 'ambience_increase'` / `'_decrease'`. Project rows kept the raw `'ambience_change'` value → `isIncrease` and `isDecrease` both false → loop skipped every project ambience row. Cycle ambience tally never reflected project contributions. |
| Project queue.push (line ~2630) | `projTerritory = resp[\`project_${slot}_territory\`]`. dt-form.25 writes territory to `project_${slot}_ambience_target`, so the legacy key was empty for ambience-change projects → action card rendered no territory. |

## Fix shape — additive admin normalisation

Mirror the sphere-side normalisation the form already performs, but at the admin read boundary:

1. At the project queue.push (~line 2611): if `effectiveActionType === 'ambience_change'`, look at `_ambience_direction` and map → `'ambience_increase'` (`'up'` | `'improve'`) or `'ambience_decrease'` (`'down'` | `'degrade'`). Phase routing, ACTION_TYPE_LABELS, and every downstream consumer of `entry.actionType` now match the sphere shape automatically.
2. At the same site: if the resulting actionType is ambience_increase/decrease, prefer `_ambience_target` for the territory cell (fall back to `_territory` for pre-redesign drafts and for non-ambience action types that still carry it).
3. In `_gatherProjectAmbience` (line 3119): same normalisation; same territory read fallback.

The legacy `_ambience_dir` (`'improve'` | `'degrade'`) is honoured as a back-compat fallback for pre-dt-form.25 drafts that may still exist in the dev DB.

## HALT-DAR resolution

The audit's two-parallel-state-systems caveat assumed structural reconciliation might be needed between `cycle.confirmed_ambience` (territory-`_id`-keyed, ST-confirmed final state) and per-submission `_ambience_target` writes (player intent). This fix takes the additive path: keep both systems, just teach the admin surface to read the player intent it was previously silently dropping. No schema change, no form-side touch.

## Regression check

- ST `action_type_override`: applied before the normalisation branch, so an ST recategorisation to anything other than `ambience_change` skips the new mapping path entirely.
- Sphere-side ambience: untouched (form already normalises the shape, admin code unchanged).
- Non-ambience projects (attack / hide_protect / investigate / etc.): the new branch only fires when `effectiveActionType === 'ambience_change'`, and `projTerritory` reads `_territory` as before for non-ambience rows.
- Pre-dt-form.25 drafts using `_ambience_dir = 'improve'` / `'degrade'`: covered by the OR-fallback in both sites.

## Test plan

- [ ] Submission with `project_1_action='ambience_change'`, `_ambience_target='academy'`, `_ambience_direction='up'`:
  - Action card shows label **Ambience Increase**.
  - Territory cell shows **academy**.
  - Cycle tally counts the contribution to `projPos` once the roll resolves with successes.
- [ ] Same with `direction='down'` → label **Ambience Decrease**, contribution to `projNeg`.
- [ ] Pre-redesign draft with `_ambience_dir='improve'` (legacy key): still maps via the fallback branch.
- [ ] Non-ambience projects: untouched.
- [ ] Sphere-side ambience: untouched.
- [ ] Server tests pass: 53 files / 689 tests (verified locally).

## Branch

`dev` per house rule. Manually close #196 after merge.