### PR TITLE
feat(admin): surface project target picker on action card (#210)

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -2758,6 +2758,43 @@ function buildProcessingQueue(subs) {
         ? (resp[`project_${slot}_ambience_target`] || resp[`project_${slot}_territory`] || '')
         : (resp[`project_${slot}_territory`] || '');
 
+      // Issue #210 — resolve the player's target picker selection into a
+      // human-readable string. Form's structured shape (downtime-form.js
+      // renderTargetCharOrOther:5215+) writes:
+      //   _target_type:  'character' | 'territory' | 'own_merit' | 'other'
+      //   _target_value: charId (when type=character) | merit_key
+      //                  ('Name|qualifier', when type=own_merit) | ''
+      //   _target_terr:  territory slug (when type=territory)
+      //   _target_other: free-text description (when type=other)
+      // Pre-fix all four were silently dropped on the admin floor.
+      const _targetType  = resp[`project_${slot}_target_type`]  || '';
+      const _targetValue = resp[`project_${slot}_target_value`] || '';
+      const _targetTerr  = resp[`project_${slot}_target_terr`]  || '';
+      const _targetOther = resp[`project_${slot}_target_other`] || '';
+      let _projTarget = '';
+      if (_targetType === 'character' && _targetValue) {
+        // Backward-compat: pre-DTFP-6 drafts stored char IDs as JSON arrays.
+        let charId = _targetValue;
+        if (charId.startsWith('[')) {
+          try {
+            const arr = JSON.parse(charId);
+            charId = Array.isArray(arr) && arr.length ? String(arr[0]) : '';
+          } catch { charId = ''; }
+        }
+        if (charId) {
+          const c = characters.find(ch => String(ch._id) === String(charId));
+          _projTarget = c ? `Character: ${displayName(c)}` : `Character: ${charId} (unresolved)`;
+        }
+      } else if (_targetType === 'territory' && _targetTerr) {
+        _projTarget = `Territory: ${_targetTerr}`;
+      } else if (_targetType === 'own_merit' && _targetValue) {
+        // merit_key is `'Name|qualifier'` — split for readability.
+        const [mName, mQual] = _targetValue.split('|');
+        _projTarget = `Own merit: ${mQual ? `${mName} (${mQual})` : mName}`;
+      } else if (_targetType === 'other' && _targetOther) {
+        _projTarget = `Other: ${_targetOther}`;
+      }
+
       queue.push({
         key: `${sub._id}:proj:${idx}`,
         subId: sub._id,
@@ -2778,6 +2815,7 @@ function buildProcessingQueue(subs) {
         projCast:        projCastResolved,
         projMerits:      projMeritsResolved,
         projTerritory:   _projTerritory,
+        projTarget:      _projTarget,
         // JDT-5: joint membership — populated when the slot belongs to a joint.
         joint_id:        _jointInfo?.joint?._id || null,
         joint_role:      _jointInfo?.role || null,
@@ -7485,6 +7523,7 @@ function renderActionPanel(entry, review) {
       if (titleVal)      h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Title</span> ${esc(titleVal)}</div>`;
       if (outcomeVal)    h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Desired Outcome</span> ${esc(outcomeVal)}</div>`;
       if (descVal)       h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Description</span> ${esc(descVal)}</div>`;
+      if (entry.projTarget) h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Target</span> ${esc(entry.projTarget)}</div>`;
       if (playerPoolVal) h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Player's Pool</span> ${esc(playerPoolVal)}</div>`;
       if (meritsVal)     h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Merits &amp; Bonuses</span> ${esc(meritsVal)}</div>`;
       if (!titleVal && !outcomeVal && !descVal) h += `<div class="proc-proj-field proc-feed-desc-empty">\u2014 No details recorded</div>`;


### PR DESCRIPTION
## Summary

Closes #210 (audit HIGH Type A — project target picker invisible to ST).

Form's structured target picker (DTFP-6, `downtime-form.js` `renderTargetCharOrOther` from line 5215) writes four keys per project slot when the action is `attack` / `hide_protect` / `investigate` / `misc`:

| Key | Value |
|---|---|
| `project_${n}_target_type` | `'character'` \| `'territory'` \| `'own_merit'` \| `'other'` |
| `project_${n}_target_value` | charId (type=character) \| merit_key `'Name\|qualifier'` (type=own_merit) \| `''` |
| `project_${n}_target_terr` | territory slug (type=territory) |
| `project_${n}_target_other` | free-text description (type=other) |

**All four were silently dropped** on the admin floor. STs adjudicating an attack / hide_protect / investigate / misc action saw no indication of who or what the player was targeting.

## Resolution at queue-build

Compose a human-readable `projTarget` string per type at `downtime-views.js:2611+` project queue.push:

- `'character'`: resolve charId via the existing module-scope `characters` array (same pattern as the `rp_shoutout` JSON parser at line 1289 and PR #203's mentor/staff target resolver). Graceful fallback for unresolved IDs (deleted / hard-deleted characters): show raw ID with `(unresolved)` suffix.
- `'territory'`: prefix with `Territory:` + slug.
- `'own_merit'`: split the `'Name|qualifier'` merit_key for readability.
- `'other'`: prefix with `Other:` + free text.

Backward-compat: pre-DTFP-6 drafts stored char IDs as JSON arrays (`'[\"<id>\"]'`); same defensive parse the form's own `renderTargetZone` does at `downtime-form.js:5174`.

## Render

Added a 'Target' row in the project card View mode at `downtime-views.js:7261`, between Description and Player's Pool. Only renders when `projTarget` is non-empty, so unused slots and action types that don't take a target picker (ambience, patrol_scout, maintenance, xp_spend, rote) don't pollute the card.

## Regression check

- **Action types without target picker** (ambience_change, patrol_scout, maintenance, xp_spend, rote): no `_target_type` in responses → composer leaves `projTarget` empty → no Target row.
- **ST `territory_overrides`** (`st_review.territory_overrides[idx]`): unrelated channel for ST adjudication corrections; untouched.
- **Existing project card fields** (Title / Outcome / Description / Player's Pool / Merits): rendered before/after the new Target row in the same View mode block; unchanged.
- **No new edit-mode field** — target is set by the player via the form picker. ST adjudication corrections continue to use `action_type_override` + `territory_overrides`.

## HALT-DAR check

Not triggered. Pure additive read at queue-build + one new render row. Standard ID resolution per dispatch.

## Test plan

- [ ] `attack` + `_target_type='character'` + `_target_value=<charId>`: action card 'Target' row reads `Character: <displayName>`.
- [ ] Same with deleted character: `Character: <id> (unresolved)`.
- [ ] `_target_type='other'`, `_target_other='The conspiracy itself'`: `Target` row reads `Other: The conspiracy itself`.
- [ ] `_target_type='own_merit'`, `_target_value='Resources|'`: `Target` row reads `Own merit: Resources`.
- [ ] Action without target picker (`ambience_change` / `maintenance`): no Target row.
- [ ] Server tests pass: 53 files / 689 tests (verified locally).

## Branch

`dev` per house rule. Manually close #210 after merge.