### PR TITLE
feat(admin): surface sphere territory on merit action card (#212)

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -2798,6 +2798,12 @@ function buildProcessingQueue(subs) {
           desired_outcome: resp[`sphere_${n}_outcome`]     || '',
           description:     resp[`sphere_${n}_description`] || '',
           primary_pool:    resp[`sphere_${n}_pool_expr`] ? { expression: resp[`sphere_${n}_pool_expr`] } : null,
+          // Issue #212 — surface the player's territory pick. Form writes
+          // `sphere_${n}_territory` (territory slug, populated by the
+          // generic suffix loop at downtime-form.js:752 — same shape as
+          // the project per-slot territory). Pre-fix this key was never
+          // read; sphere action cards rendered no territory cell.
+          territory:       resp[`sphere_${n}_territory`]   || '',
         }];
       }
     }
@@ -2849,6 +2855,17 @@ function buildProcessingQueue(subs) {
         phaseNum = PHASE_ORDER[actionType] ?? 13;
       }
       const phaseKey = PHASE_NUM_TO_LABEL[phaseNum];
+      // Issue #212 — carry the player's sphere territory pick onto the
+      // queue entry. `action.territory` is set by the response-keys
+      // fallback above (form-shape submissions); legacy
+      // `raw.sphere_actions[]` may also include it. Falls back to
+      // `resp[\`sphere_${idx+1}_territory\`]` so submissions whose
+      // sphere_actions array lacks a territory field still surface
+      // the player's pick.
+      const meritTerritory = action.territory
+                          || resp[`sphere_${idx + 1}_territory`]
+                          || '';
+
       queue.push({
         key: `${sub._id}:merit:${meritFlatIdx}`,
         subId: sub._id,
@@ -2868,6 +2885,7 @@ function buildProcessingQueue(subs) {
         meritDots,
         meritQualifier,
         meritDesiredOutcome: action.desired_outcome || '',
+        meritTerritory,
       });
       meritFlatIdx++;
     });
@@ -7452,7 +7470,8 @@ function renderActionPanel(entry, review) {
       h += `<div class="proc-feed-desc-view">`;
       if (outcomeVal) h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Desired Outcome</span> ${esc(outcomeVal)}</div>`;
       if (descVal)    h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Description</span> ${esc(descVal)}</div>`;
-      if (!outcomeVal && !descVal) h += `<div class="proc-proj-field proc-feed-desc-empty">\u2014 No details recorded</div>`;
+      if (entry.meritTerritory) h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Territory</span> ${esc(entry.meritTerritory)}</div>`;
+      if (!outcomeVal && !descVal && !entry.meritTerritory) h += `<div class="proc-proj-field proc-feed-desc-empty">\u2014 No details recorded</div>`;
       h += `</div>`;
       h += `<div class="proc-feed-desc-edit" style="display:none">`;
       h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Desired Outcome</span><input type="text" class="proc-detail-input proc-merit-outcome-input" data-proc-key="${esc(entry.key)}" value="${esc(outcomeVal)}"></div>`;


### PR DESCRIPTION
## Summary

Closes #212 (audit HIGH Type A — sphere territory invisible to ST).

Form persists sphere territory via the generic suffix loop at `downtime-form.js:752` — `sphere_${n}_territory` carries a territory slug (same shape as project per-slot territory; `renderTerritoryPills` writes the slug as the hidden input value at line 5274).

Pre-fix, the admin sphere queue-build at `downtime-views.js:2789-2802` read merit_type / action_type / desired_outcome / description / primary_pool from the response keys but **never** `sphere_${n}_territory`. The queue entry shape carried no territory field; merit cards rendered no territory cell. ST adjudicating a sphere action saw the merit, the action type, the description — but not which territory the player was acting in.

## Three additive sites

| Site | Change |
|---|---|
| Spheres array build (line 2795-2802) | Added `territory: resp[\`sphere_${n}_territory\`]` to the action-object literal so form-shape submissions carry the territory through. |
| Queue.push (line 2852+) | Composed `meritTerritory` from `action.territory` with a fallback to `resp[\`sphere_${idx + 1}_territory\`]`. |
| Merit View-mode card (line 7453+) | New 'Territory' row when `entry.meritTerritory` is non-empty. 'No details recorded' fallback now also requires meritTerritory to be empty. |

## Display convention

Renders the slug as-is (e.g., `Territory: academy`), matching the existing convention from PR #206 (project ambience territory) and PR #211 (project target territory). A future helper to map slug → display name (`The Academy`) would benefit all three sites uniformly — flagging as session-end follow-up.

## Regression check

- **Empty sphere territory**: `meritTerritory === ''` → no Territory row.
- **Legacy `raw.sphere_actions[]` with `territory` field**: `action.territory` flows through unchanged.
- **Sphere actions without territory pickers** (e.g. block, hide_protect with `target_own_merit`): no `_territory` key in responses → no Territory row.
- **Other merit categories** (allies / status / retainers / contacts / staff): they enter the same loop, but none write `sphere_${n}_territory` → no impact.
- **No edit-mode field added** — territory is set by the player. ST adjudication corrections continue via `territory_overrides`.

## HALT-DAR check

Not triggered. Standard slug resolution. Persistence shape is single slug (not multi-territory array, not name string) — confirmed via `downtime-form.js:752` (suffix loop) and `renderTerritoryPills` at line 5267-5276.

## Test plan

- [ ] Submission with `sphere_1_action='investigate'`, `sphere_1_territory='harbour'`: merit card 'Territory' row reads `harbour`.
- [ ] Sphere action without territory: no Territory row.
- [ ] Other merit cards (allies/status etc.) unaffected.
- [ ] Server tests pass: 53 files / 689 tests (verified locally).

## Branch

`dev` per house rule. Manually close #212 after merge.