### PR TITLE
feat(admin): multi-row + app-form acquisitions visibility (#214)

### DIFF
--- a/public/js/admin/downtime-story.js
+++ b/public/js/admin/downtime-story.js
@@ -1703,8 +1703,32 @@ function buildMeritActions(sub) {
   // ── Resource / skill acquisitions ──
   // Stored separately from sphere actions — appended last so flat indices for
   // spheres/contacts/retainers above are not disturbed.
+  // Issue #214 — read the canonical JSON-array shape
+  // (`acq_resource_rows` / `acq_skill_rows`, downtime-form.js:907-908)
+  // first so multi-row acquisitions surface as one action per row. Pre-fix
+  // this only emitted a single combined entry from the slot-1 mirror
+  // (`acq_description` / `acq_merits`) or the joined blob — slots ≥ 2
+  // were structurally invisible.
   const resAcqBlob = raw.acquisitions?.resource_acquisitions || resp['resources_acquisitions'] || '';
-  if (resAcqBlob.trim()) {
+  let pushedStructuredRes = false;
+  try {
+    const rRows = JSON.parse(resp['acq_resource_rows'] || '[]');
+    if (Array.isArray(rRows) && rRows.length) {
+      rRows.forEach((row, i) => {
+        const merits = Array.isArray(row.merits) ? row.merits.join(', ') : '';
+        const desc   = row.description || '';
+        if (!desc && !merits) return;
+        actions.push({
+          merit_type:      rRows.length > 1 ? `Resources (Row ${i + 1})` : 'Resources',
+          action_type:     'acquisition',
+          desired_outcome: merits,
+          description:     desc,
+        });
+      });
+      pushedStructuredRes = true;
+    }
+  } catch { /* malformed JSON — fall through to blob */ }
+  if (!pushedStructuredRes && resAcqBlob.trim()) {
     const desc = resp['acq_description'] || resAcqBlob;
     let meritsLabel = '';
     try {
@@ -1719,8 +1743,29 @@ function buildMeritActions(sub) {
     });
   }
 
+  // Skill acquisitions: form's PR #187 collapsed skill_acq to a single
+  // fixed row, so `acq_skill_rows` always has length ≤ 1 in current
+  // submissions. Still preferred over the blob for structured access.
   const skillAcqBlob = raw.acquisitions?.skill_acquisitions || resp['skill_acquisitions'] || '';
-  if (skillAcqBlob.trim()) {
+  let pushedStructuredSkill = false;
+  try {
+    const sRows = JSON.parse(resp['acq_skill_rows'] || '[]');
+    if (Array.isArray(sRows) && sRows.length) {
+      sRows.forEach((row) => {
+        const merits = Array.isArray(row.merits) ? row.merits.join(', ') : '';
+        const desc   = row.description || '';
+        if (!desc && !merits) return;
+        actions.push({
+          merit_type:      'Skill Acquisition',
+          action_type:     'acquisition',
+          desired_outcome: merits,
+          description:     desc,
+        });
+      });
+      pushedStructuredSkill = true;
+    }
+  } catch { /* malformed JSON — fall through to blob */ }
+  if (!pushedStructuredSkill && skillAcqBlob.trim()) {
     actions.push({
       merit_type:      'Skill Acquisition',
       action_type:     'acquisition',

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -3007,14 +3007,53 @@ function buildProcessingQueue(subs) {
     }
 
     // ── Acquisitions (resource and skill, from raw.acquisitions form section) ──
-    const resAcq   = (raw.acquisitions?.resource_acquisitions || '').trim();
-    const skillAcq = (raw.acquisitions?.skill_acquisitions   || '').trim();
+    // Issue #214 — pre-fix this block read ONLY `raw.acquisitions?.*`,
+    // which is populated by the CSV import path (server schema:478, _raw
+    // is the CSV-structured-data slot). For app-form submissions `raw`
+    // is `{}` and both branches were skipped — Resources and Skill
+    // Acquisitions phases of the action queue were entirely empty for
+    // every submission entered through the player form. Fall back to
+    // the canonical response-key blobs (form writes both at
+    // downtime-form.js:953 and :967 alongside the structured JSON-array
+    // sources of truth at :907-908).
+    const resAcq   = (raw.acquisitions?.resource_acquisitions || resp['resources_acquisitions'] || '').trim();
+    const skillAcq = (raw.acquisitions?.skill_acquisitions   || resp['skill_acquisitions']    || '').trim();
     /** Extract the first "Description: ..." value from an acquisitions blob for the row summary. */
     function _acqRowSummary(text) {
       const m = text.match(/description[:\s]+([^\n]+)/i);
       if (m) return m[1].trim();
       // Fall back to first non-empty line
       return text.split('\n').map(l => l.trim()).find(l => l) || text;
+    }
+    /**
+     * Issue #214 — compose a multi-row description from the canonical
+     * `acq_resource_rows` / `acq_skill_rows` JSON arrays (form-side
+     * single source of truth, downtime-form.js:907-908). Pre-fix only
+     * slot 1 (via `acq_description` mirror) was visible in any
+     * structured form; rows 2..N were either entirely dropped (for
+     * app-form submissions, see the resp fallback above) or
+     * concatenated as a free-text blob with no per-row delimiter.
+     * When the JSON array is present, build a per-row summary with
+     * `Row N: <description> | <merits>` so the ST sees the structure
+     * the player entered. Falls back to the blob's first-line summary
+     * (existing behaviour) when no JSON array is present.
+     */
+    function _multiRowSummary(jsonStr, blob) {
+      try {
+        const rows = JSON.parse(jsonStr || '[]');
+        if (Array.isArray(rows) && rows.length > 1) {
+          return rows.map((r, i) => {
+            const merits = Array.isArray(r.merits) && r.merits.length ? ` | ${r.merits.join(', ')}` : '';
+            const desc   = r.description || '';
+            return `Row ${i + 1}: ${desc}${merits}`;
+          }).join(' — ');
+        }
+        if (Array.isArray(rows) && rows.length === 1) {
+          // Single row — show description directly (matches blob summary shape).
+          return rows[0].description || _acqRowSummary(blob);
+        }
+      } catch { /* malformed JSON — fall through to blob */ }
+      return _acqRowSummary(blob);
     }
     if (resAcq) {
       queue.push({
@@ -3025,7 +3064,7 @@ function buildProcessingQueue(subs) {
         phaseNum: 14,
         actionType: 'resources_acquisitions',
         label: 'Resources Acquisitions',
-        description: _acqRowSummary(resAcq),
+        description: _multiRowSummary(resp['acq_resource_rows'], resAcq),
         acqNotes: resAcq,
         source: 'acquisition',
         actionIdx: 0,
@@ -3046,7 +3085,7 @@ function buildProcessingQueue(subs) {
         phaseNum: 7,
         actionType: 'skill_acquisitions',
         label: 'Skill Acquisitions',
-        description: _acqRowSummary(skillAcq),
+        description: _multiRowSummary(resp['acq_skill_rows'], skillAcq),
         acqNotes: skillAcq,
         source: 'acquisition',
         actionIdx: 1,


### PR DESCRIPTION
## Summary

Closes #214 (audit HIGH Type A bundle — multi-row resources, multi-slot acquisitions, structured skill_acq).

Three sub-findings shared the acquisitions render-block surface, so landing as one bundled PR per dispatch scope.

## Discovery during survey

Form-side single source of truth (PR #187 / dt-form.29) is the canonical JSON-array shape:

```js
responses.acq_resource_rows = [{ description, availability, merits[] }, …]
responses.acq_skill_rows    = [{ description, availability, merits[], skill, spec }, …]  // length ≤ 1 post-#187
```

The form mirrors the legacy surface alongside (`acq_slot_count`, `acq_${N}_*`, `acq_*` slot-1 alias, `resources_acquisitions` blob, `skill_acq_*` row-0 mirror, `skill_acquisitions` blob — `downtime-form.js:907-973`). All keys are written; admin can read any. **No HALT-DAR needed** — JSON arrays are canonical, mirror keys are back-compat.

## Two compounding bugs found

### 1. Action queue empty for app-form submissions (HIGH)

`downtime-views.js:3010-3011` pre-fix:

```js
const resAcq   = (raw.acquisitions?.resource_acquisitions || '').trim();
const skillAcq = (raw.acquisitions?.skill_acquisitions   || '').trim();
```

`raw` is `sub._raw`, the CSV-import structured-data slot (server schema line 478). App-form submissions have no `_raw.acquisitions` → both reads empty → both `queue.push` branches skipped. **Resources Acquisitions and Skill Acquisitions phases of the action queue contained zero entries for every player who used the form.**

Fix: fall back to `resp['resources_acquisitions']` / `resp['skill_acquisitions']`.

### 2. Multi-row resources collapsed to single description

`downtime-story.js:1706-1719` + `downtime-views.js:3019-3033` pre-fix only emitted one combined entry from the slot-1 mirror or the blob's first-line summary. Rows 2..N were structurally invisible — concatenated into the blob with no per-row delimiter the renderer could split on.

## Resolution

| Site | Change |
|---|---|
| Action queue (`downtime-views.js:3010+`) | New `_multiRowSummary()` helper parses the JSON array. When `length > 1`, description reads `Row 1: <desc> \| <merits> — Row 2: …`. Single-row falls through to the existing blob summary shape. |
| `downtime-story.js` per-character actions (line 1703+) | Replaced slot-1-only `acq_description` read with JSON-array iteration. Emits one `Resources (Row N)` action per row when array length > 1, or one `Resources` action when single. Skill acquisitions same shape. Blob fallback retained for pre-redesign drafts and CSV imports without the JSON arrays. |

## Regression check

- **CSV-imported submissions**: `raw.acquisitions.resource_acquisitions` fires first (unchanged).
- **App-form submissions with no acquisitions**: blob empty → no queue entries.
- **Single-row resource acquisition**: `_multiRowSummary` returns `rows[0].description`, matches existing single-row blob summary shape.
- **Malformed JSON**: try/catch falls through to blob summary (existing behaviour preserved).
- **`renderPlayerResponses` summary panel**: blob render unchanged — content was already visible there, just not tabular. Out of scope for this HIGH severity fix; logging structured-table render as session-end follow-up.

## HALT-DAR check

Not triggered. Persistence shape is unambiguous post-#187: JSON arrays are canonical, mirror keys are back-compat. Admin reads arrays first, falls back to blob — additive, no design call needed.

## Test plan

- [ ] App-form submission with `acq_resource_rows` = 2 rows: action queue 'Resources Acquisitions' description shows `Row 1: <desc> | <merits> — Row 2: <desc> | <merits>`.
- [ ] Same submission: downtime-story per-character actions list shows two entries: 'Resources (Row 1)' + 'Resources (Row 2)'.
- [ ] Single-row resource acquisition: no `Row N` prefix; description reads as before.
- [ ] CSV-imported submission with `_raw.acquisitions`: unchanged behaviour.
- [ ] Skill acquisition: structured JSON read first, falls back to blob.
- [ ] Server tests pass: 53 files / 689 tests (verified locally).

## Branch

`dev` per house rule. Manually close #214 after merge.