### PR TITLE
feat(admin): project investigate lead + multi-row xp_spend (#219)

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -1424,8 +1424,30 @@ function renderPlayerResponses(s) {
     const actionLabel = action.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
     let desc = r[`project_${n}_description`] || r[`project_${n}_xp_trait`] || '';
     if (action === 'xp_spend') {
-      const cat = r[`project_${n}_xp_category`]; const item = r[`project_${n}_xp_item`];
-      if (cat && item) desc = `${cat}: ${item}`;
+      // Issue #219 — read multi-row `_xp_rows` JSON first; legacy
+      // single-row keys remain as fallback for pre-redesign drafts.
+      const rj = r[`project_${n}_xp_rows`] || '';
+      let multi = '';
+      if (rj) {
+        try {
+          const rows = JSON.parse(rj);
+          if (Array.isArray(rows) && rows.length) {
+            multi = rows
+              .filter(x => x && (x.category || x.item))
+              .map(x => {
+                const dots = x.dotsBuying ? ` (${x.dotsBuying} dot${x.dotsBuying === 1 ? '' : 's'})` : '';
+                return `${x.category || ''}: ${x.item || ''}${dots}`;
+              })
+              .join(' — ');
+          }
+        } catch { /* fall through */ }
+      }
+      if (multi) {
+        desc = multi;
+      } else {
+        const cat = r[`project_${n}_xp_category`]; const item = r[`project_${n}_xp_item`];
+        if (cat && item) desc = `${cat}: ${item}`;
+      }
     }
     projRows.push(`${n}. ${actionLabel}${desc ? ': ' + desc : ''}`);
   }
@@ -2795,6 +2817,41 @@ function buildProcessingQueue(subs) {
         _projTarget = `Other: ${_targetOther}`;
       }
 
+      // Issue #219 — investigate-lead chip + multi-row xp_spend breakdown.
+      // Form persists `project_${n}_investigate_lead` (free text, populated
+      // when action === 'investigate') and `project_${n}_xp_rows` (JSON
+      // array of `{category, item, dotsBuying}` from the per-slot xp grid,
+      // when action === 'xp_spend'). Pre-fix neither surfaced on the
+      // project card; admin's xp review table read the top-level
+      // `responses.xp_spend` mirror but the per-slot card showed only the
+      // legacy single-row keys.
+      const _projInvestigateLead = resp[`project_${slot}_investigate_lead`] || '';
+      let _projXpBreakdown = '';
+      if (effectiveActionType === 'xp_spend') {
+        const _rj = resp[`project_${slot}_xp_rows`] || '';
+        if (_rj) {
+          try {
+            const _xpRows = JSON.parse(_rj);
+            if (Array.isArray(_xpRows) && _xpRows.length) {
+              _projXpBreakdown = _xpRows
+                .filter(r => r && (r.category || r.item))
+                .map(r => {
+                  const _dots = r.dotsBuying ? ` (${r.dotsBuying} dot${r.dotsBuying === 1 ? '' : 's'})` : '';
+                  return `${r.category || ''}: ${r.item || ''}${_dots}`;
+                })
+                .join(' — ');
+            }
+          } catch { /* malformed — fall through to legacy single-row */ }
+        }
+        // Single-row fallback for pre-redesign drafts that never engaged
+        // the multi-row grid (legacy `_xp_category` / `_xp_item` only).
+        if (!_projXpBreakdown) {
+          const _cat  = resp[`project_${slot}_xp_category`] || '';
+          const _item = resp[`project_${slot}_xp_item`]     || '';
+          if (_cat && _item) _projXpBreakdown = `${_cat}: ${_item}`;
+        }
+      }
+
       queue.push({
         key: `${sub._id}:proj:${idx}`,
         subId: sub._id,
@@ -2816,6 +2873,8 @@ function buildProcessingQueue(subs) {
         projMerits:      projMeritsResolved,
         projTerritory:   _projTerritory,
         projTarget:      _projTarget,
+        projInvestigateLead: _projInvestigateLead,
+        projXpBreakdown: _projXpBreakdown,
         // JDT-5: joint membership — populated when the slot belongs to a joint.
         joint_id:        _jointInfo?.joint?._id || null,
         joint_role:      _jointInfo?.role || null,
@@ -7582,6 +7641,8 @@ function renderActionPanel(entry, review) {
       if (outcomeVal)    h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Desired Outcome</span> ${esc(outcomeVal)}</div>`;
       if (descVal)       h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Description</span> ${esc(descVal)}</div>`;
       if (entry.projTarget) h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Target</span> ${esc(entry.projTarget)}</div>`;
+      if (entry.projInvestigateLead) h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Lead</span> ${esc(entry.projInvestigateLead)}</div>`;
+      if (entry.projXpBreakdown) h += `<div class="proc-proj-field"><span class="proc-feed-lbl">XP Spend</span> ${esc(entry.projXpBreakdown)}</div>`;
       if (playerPoolVal) h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Player's Pool</span> ${esc(playerPoolVal)}</div>`;
       if (meritsVal)     h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Merits &amp; Bonuses</span> ${esc(meritsVal)}</div>`;
       if (!titleVal && !outcomeVal && !descVal) h += `<div class="proc-proj-field proc-feed-desc-empty">\u2014 No details recorded</div>`;


### PR DESCRIPTION
## Summary

Closes #219 (audit MEDIUM Type A bundle — project investigate_lead chip + multi-row xp_spend breakdown).

Two project-action surfaces dropped on the admin floor:

1. **`project_${n}_investigate_lead`** — populated when `action === 'investigate'` (`downtime-form.js:687-688`). Pre-fix never read in admin; the dedicated lead chip the player filled in was invisible. Admin's project card relied on `proj.detail` / `description` as fallback, so the lead's structured shape was lost.

2. **`project_${n}_xp_rows`** (JSON multi-row) — populated when `action === 'xp_spend'` from the per-slot xp grid (`downtime-form.js:632-645`). Pre-fix, the project card read single-row `_xp_category` / `_xp_item` only; multi-row breakdowns collapsed to the first row. **Note**: the XP review table at line 3938+ already reads the top-level `responses.xp_spend` mirror, so multi-row IS visible there. The gap was specifically on the per-slot project card and the player-summary panel.

## Resolution

Three additive read sites:

| Site | Change |
|---|---|
| Project queue.push (line 2833+) | Added `projInvestigateLead` (raw text from `_investigate_lead`) and `projXpBreakdown` (composed string from `_xp_rows` JSON, with single-row legacy fallback). Composer renders `'skill: Investigation (1 dot) — skill: Streetwise (1 dot)'`. |
| Project View-mode card (line 7621+) | Added `Lead` and `XP Spend` rows. Conditional on field being non-empty so non-investigate / non-xp_spend slots don't pollute the card. |
| `renderPlayerResponses` Projects summary (line 1419+) | When `action === 'xp_spend'`, read `_xp_rows` JSON first; fall back to single-row `_xp_category` / `_xp_item` for legacy drafts. |

## Helper not factored

PR #218 introduced a shared `_composeTargetString` for project + sphere target rendering. xp_rows shape (`{category, item, dotsBuying}`) differs from acquisitions' `{description, availability, merits}` (PR #215) and from sphere/project's target keys; no shared structure across them. Inline composer for now; factor when a third consumer arrives.

## Independence from PR #218

PR #218 introduced the `_composeTargetString` helper but isn't merged yet. This PR retains the existing inline project target composer (untouched) alongside the new fields. Both PRs can land independently — when #218 lands, the project's target line will already have switched to the helper; this PR's new fields are additive in a different part of the queue.push and don't conflict.

## Regression check

- **Single-row xp_spend** (legacy drafts with only `_xp_category`): fallback branch fires; pre-fix shape preserved.
- **Non-investigate / non-xp_spend project actions**: composer output is `''`; conditional rows skip → card unchanged.
- **Malformed `_xp_rows` JSON**: try/catch falls through to single-row legacy keys.
- **renderPlayerResponses Projects summary**: existing single-row output unchanged when no `_xp_rows` is present.

## HALT-DAR check

Not triggered. xp_rows JSON shape is `{category, item, dotsBuying}` — different keys than PR #215's `acq_resource_rows` shape, but the per-row iteration pattern is identical. No design call.

## Test plan

- [ ] `project_1_action='investigate'`, `_investigate_lead='Found a ledger'`: project card 'Lead' row reads `Found a ledger`.
- [ ] `project_1_action='xp_spend'`, `_xp_rows='[{"category":"skill","item":"Investigation","dotsBuying":1},…]'`: 'XP Spend' row shows multi-row breakdown.
- [ ] Pre-redesign single-row xp_spend: 'XP Spend' row reads `skill: Investigation`.
- [ ] Non-investigate / non-xp_spend slots: no Lead / XP Spend rows.
- [ ] Server tests pass: 53 files / 689 tests (verified locally).

## Branch

`dev` per house rule. Manually close #219 after merge.