### PR TITLE
feat(admin): standalone MEDIUM Type A bundle — slot count, regent, recount (#221)

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -1369,20 +1369,39 @@ function renderPlayerResponses(s) {
   }
 
   // ── Court ──
-  const courtKeys = ['travel', 'game_recount', 'rp_shoutout', 'correspondence'];
-  const courtLabels = { travel: 'Travel', game_recount: 'Game Recount', rp_shoutout: 'Shoutout', correspondence: 'Correspondence' };
-  const courtVals = courtKeys.filter(k => r[k] && r[k].trim());
+  // Issue #221 — read per-game `game_recount_${n}` slots first so the
+  // ST sees one row per game highlight (form persists per-slot via the
+  // structured highlight UI at downtime-form.js:6597; the joined
+  // top-level `game_recount` mirror at line 545 is kept for back-compat
+  // with legacy single-cell readers). Pre-fix the player summary read
+  // only the joined string, collapsing the structured shape into a
+  // single 'Game Recount' cell with numbered prefixes.
+  const gameRecountSlots = [];
+  for (let n = 1; n <= 5; n++) {
+    const txt = (r[`game_recount_${n}`] || '').trim();
+    if (txt) gameRecountSlots.push({ n, txt });
+  }
+  const courtKeysWithoutRecount = ['travel', 'rp_shoutout', 'correspondence'];
+  const courtLabels = { travel: 'Travel', rp_shoutout: 'Shoutout', correspondence: 'Correspondence' };
+  const courtVals = courtKeysWithoutRecount.filter(k => r[k] && r[k].trim());
   const aspLines = [1,2,3].map(n => {
     const t = r[`aspiration_${n}_type`]; const v = r[`aspiration_${n}_text`];
     return (t && v) ? `${t}: ${v}` : null;
   }).filter(Boolean);
-  const hasCourtContent = courtVals.length || aspLines.length || r['aspirations'];
+  const hasJoinedRecount = !gameRecountSlots.length && r['game_recount'] && r['game_recount'].trim();
+  const hasCourtContent = courtVals.length || gameRecountSlots.length || hasJoinedRecount || aspLines.length || r['aspirations'];
   if (hasCourtContent) {
     h += '<div class="dt-resp-section"><div class="dt-resp-section-title">Court</div>';
     for (const k of courtVals) {
       let val = r[k];
       if (k === 'rp_shoutout') { try { val = JSON.parse(val).filter(Boolean).map(id => { const ch = characters.find(c => String(c._id) === String(id)); return ch ? (ch.moniker || ch.name) : id; }).join(', '); } catch { /* ignore */ } }
       h += row(courtLabels[k] || k, val);
+    }
+    if (gameRecountSlots.length) {
+      for (const { n, txt } of gameRecountSlots) h += row(`Game ${n} Recount`, txt);
+    } else if (hasJoinedRecount) {
+      // Legacy / migrated drafts that have only the joined string.
+      h += row('Game Recount', r['game_recount']);
     }
     if (aspLines.length) {
       h += row('Aspirations', aspLines.join('\n'));
@@ -1483,6 +1502,13 @@ function renderPlayerResponses(s) {
     ['form_feedback', 'Form Feedback'],
   ];
   let miscH = '';
+  // Issue #221 — surface the structured `regent_territory` slug
+  // (downtime-form.js:377, written when gateValues.is_regent === 'yes')
+  // alongside the free-text `regency_action` blob. Pre-fix the slug
+  // was never read — the ST saw the regent's narrative description
+  // but no structured indication of which territory they were
+  // governing.
+  if (r['regent_territory']) miscH += row('Regent territory', r['regent_territory']);
   for (const [key, label] of miscFields) {
     if (!r[key] || !r[key].trim?.()) continue;
     if (key === 'xp_spend') {
@@ -1490,6 +1516,17 @@ function renderPlayerResponses(s) {
         const rows = JSON.parse(r[key]).filter(rw => rw.category && rw.item);
         if (rows.length) miscH += row(label, rows.map(rw => `${rw.item} (${rw.cost} XP)`).join(', '));
       } catch { /* ignore */ }
+    } else if (key === 'resources_acquisitions') {
+      // Issue #221 — annotate the blob with the structured slot count
+      // (form persists `acq_slot_count` at downtime-form.js:920) so the
+      // ST can see at a glance how many acquisitions the player split
+      // their declaration into. Slot count > 1 indicates a multi-row
+      // submission already structured-rendered by PR #215; this adds
+      // the count summary to the player-summary panel where only the
+      // blob was shown.
+      const slotCount = parseInt(r['acq_slot_count'] || '1', 10) || 1;
+      const labelWithCount = slotCount > 1 ? `${label} (${slotCount} slots)` : label;
+      miscH += row(labelWithCount, r[key]);
     } else {
       miscH += row(label, r[key]);
     }


### PR DESCRIPTION
## Summary

Closes #221 (audit MEDIUM Type A standalone bundle — 4 small fields + 1 internal-state survey).

## Three additive reads in `renderPlayerResponses`

| # | Key | Pre-fix | Post-fix |
|---|---|---|---|
| 1 | `game_recount_${n}` per-slot text | Court section read only the joined top-level `game_recount` mirror, collapsing 5 structured highlight slots into a single 'Game Recount' cell with numbered prefixes. | Iterates per-slot keys, emits one 'Game N Recount' row per populated slot. Falls back to joined string for legacy drafts. |
| 2 | `regent_territory` slug | Never read; ST saw narrative `regency_action` blob but no structured territory indication. | New 'Regent territory' row in Other section. |
| 3 | `acq_slot_count` | Never read structurally. | Annotated as a parenthesised count on 'Resources Acquisitions' label when count > 1 (e.g. `Resources Acquisitions (3 slots)`). |

## Items already closed (noted for audit completeness)

### `story_moment_note`

The audit's punch list referred to this as `story_moment_relationship_note`, but the actual form key is `story_moment_note` (`downtime-form.js:518`). Already surfaced in PR #209 / Issue #208 as the Personal Story section's 'Moment note' row (`downtime-views.js:1405`). **Audit punch-list entry was a key-name typo for an item already addressed.**

## Bonus survey: `_merit_${key}` toggle state semantic

Form persists `_merit_${key}` (`downtime-form.js:746`) as a `'yes'` / `'no'` value mirroring `gateValues[\`merit_${key}\`]`. Used at `downtime-form.js:1418-1419` to restore section visibility gates on form load. **Internal UI state** — the player toggles whether a merit's section is rendered (e.g., whether to fill in sphere actions for Allies). The actual merit-action data the player enters in those sections IS what flows to admin (sphere / status / contacts / retainers / mentor / staff blocks). The toggle itself is not separate independent player content; its consequences are visible via section data being populated or not.

**Verdict: not real player content. Audit punch-list entry can close as 'no fix needed — internal UI state.'**

## Regression check

- **Pre-redesign drafts** with only joined `game_recount` and no per-slot keys: `gameRecountSlots` is empty, falls through to joined-string render branch.
- **No regent**: `r['regent_territory']` falsy → no 'Regent territory' row.
- **Single-slot acquisition** (count = 1 or absent): label unchanged; no `(N slots)` suffix.
- **Empty submissions**: all three fields produce no rows.

## HALT-DAR check

Not triggered. All three persistence shapes are simple scalar / numeric / repeated keys — no structural divergence. Pure additive bundle.

## Branch hygiene incident

Caught a branch-hygiene issue mid-edit: the topic branch was created correctly, but a subsequent `git checkout dev` somewhere between branch creation and editing left me on `dev` while staging changes. Recovered via `git stash` + checkout topic branch + `git stash pop`. No commits to `dev` made; no force-push needed. Logging the recovery pattern as a session-end carry-forward note alongside the explicit-fetch discipline. Branch hygiene rule is now: **`git status | head -1` confirm IMMEDIATELY before staging, not just before commit** — gives one extra checkpoint to catch this class of mistake.

## Test plan

- [ ] Submission with 3 game_recount slots populated: Court section shows 'Game 1 Recount', 'Game 2 Recount', 'Game 3 Recount' as separate rows.
- [ ] Submission with `regent_territory='academy'`: Other section shows 'Regent territory: academy'.
- [ ] Submission with `acq_slot_count=3` + multi-row resources: `Resources Acquisitions (3 slots)` label.
- [ ] Submission with `acq_slot_count=1`: 'Resources Acquisitions' unchanged.
- [ ] Server tests pass: 53 files / 689 tests (verified locally).

## Branch

`dev` per house rule. Manually close #221 after merge.

## Audit status post-merge

After this PR lands, **MEDIUM Type A audit punch-list is fully cleared.** Only LOW tier (5 items, mostly by-design / harmless) + MEDIUM Type B (1 item, `_feed_rote`, already addressed by PR #204) remain.