### PR TITLE
fix(helpers): findRegentTerritory canonical-slug guard (closes #216)

### DIFF
--- a/public/js/data/helpers.js
+++ b/public/js/data/helpers.js
@@ -3,6 +3,7 @@
 import { ICONS } from './icons.js';
 import { ARCHETYPES_DB } from './constants.js';
 import { getRole } from '../auth/discord.js';
+import { TERRITORY_DATA } from '../tabs/downtime-data.js';
 
 /* ── Dev-mode redaction ────────────────────────────────────
    The 'dev' role has full ST-equivalent access but every character and
@@ -153,8 +154,13 @@ export function dropdownName(c) {
 export function findRegentTerritory(territories, c) {
   if (!territories || !c) return null;
   const cid = String(c._id);
-  const t = territories.find(t => t.regent_id === cid);
-  if (!t) return null;
+  // Prefer canonical territories over stale/orphaned duplicates (issue #216).
+  // If multiple docs match the same regent_id, the one whose slug appears in
+  // TERRITORY_DATA wins; otherwise the first match is used as a safe fallback.
+  const canonicalSlugs = new Set(TERRITORY_DATA.map(td => td.slug));
+  const matches = territories.filter(t => t.regent_id === cid);
+  if (!matches.length) return null;
+  const t = matches.find(m => canonicalSlugs.has(m.slug)) || matches[0];
   // territoryId is the canonical FK (Mongo _id, stringified) per ADR-002.
   // slug is exposed alongside for callers that need to match against legacy
   // slug-variant strings (e.g. submissions feeding_territories keys, Q4).

--- a/server/tests/find-regent-territory.test.js
+++ b/server/tests/find-regent-territory.test.js
@@ -1,0 +1,212 @@
+/**
+ * Unit tests — findRegentTerritory() in public/js/data/helpers.js
+ *
+ * Issue #216: function was hardened to prefer canonical-slug territories
+ * over stale/orphaned duplicates when multiple docs share the same regent_id.
+ *
+ * Browser-only imports (icons, constants, discord auth) are mocked so Vitest
+ * can import the frontend module without a DOM.  TERRITORY_DATA from
+ * downtime-data.js is NOT mocked — it is pure data with no browser deps and
+ * we want to test against the real canonical slug set.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock browser-only imports that helpers.js pulls in at module level.
+vi.mock('../../public/js/data/icons.js', () => ({ ICONS: {} }));
+vi.mock('../../public/js/data/constants.js', () => ({ ARCHETYPES_DB: {} }));
+vi.mock('../../public/js/auth/discord.js', () => ({
+  getRole: () => 'player',
+  isLoggedIn: () => true,
+  validateToken: () => true,
+  login: () => {},
+  logout: () => {},
+  getUser: () => null,
+  getPlayerInfo: () => null,
+  isSTRole: () => false,
+  handleCallback: () => {},
+}));
+
+const { findRegentTerritory } = await import('../../public/js/data/helpers.js');
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const ALICE_ID  = '69d73ea49162ece35897a47c';
+const RENE_ID   = '69d73ea49162ece35897a496';
+
+const northShore = {
+  _id: '69d9e54b00815d471503bea6',
+  slug: 'northshore',
+  name: 'The North Shore',
+  regent_id: ALICE_ID,
+  lieutenant_id: null,
+  ambience: 'Tended',
+};
+
+const dockyards = {
+  _id: '69d9e54c00815d471503bea9',
+  slug: 'dockyards',
+  name: 'The Dockyards',
+  regent_id: RENE_ID,
+  lieutenant_id: null,
+  ambience: 'Settled',
+};
+
+const academy = {
+  _id: '69d9e54b00815d471503bea7',
+  slug: 'academy',
+  name: 'The Academy',
+  regent_id: '69d9e54b00815d471503aaaa',
+  lieutenant_id: null,
+  ambience: 'Curated',
+};
+
+const ALL_TERRITORIES = [
+  { _id: '69d5dc6a00815d47150397c6', slug: 'harbour',     name: 'The Harbour',      regent_id: '69d5dc6a00815d47150397ff', lieutenant_id: null, ambience: 'Untended' },
+  northShore,
+  academy,
+  { _id: '69d9e54c00815d471503bea8', slug: 'secondcity',  name: 'The Second City',  regent_id: '69d9e54c00815d471503bbbb', lieutenant_id: null, ambience: 'Tended' },
+  dockyards,
+];
+
+const aliceChar = { _id: ALICE_ID };
+const reneChar  = { _id: RENE_ID };
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('findRegentTerritory', () => {
+
+  describe('normal operation — correct data', () => {
+    it('returns North Shore for Alice in a clean 5-territory array', () => {
+      const result = findRegentTerritory(ALL_TERRITORIES, aliceChar);
+      expect(result).not.toBeNull();
+      expect(result.territory).toBe('The North Shore');
+      expect(result.slug).toBe('northshore');
+      expect(result.territoryId).toBe(northShore._id);
+    });
+
+    it('returns Dockyards for Rene in a clean 5-territory array', () => {
+      const result = findRegentTerritory(ALL_TERRITORIES, reneChar);
+      expect(result).not.toBeNull();
+      expect(result.territory).toBe('The Dockyards');
+      expect(result.slug).toBe('dockyards');
+    });
+
+    it('returns null when the character has no regent territory', () => {
+      const nonRegent = { _id: 'ffffffffffffffffffffffff' };
+      expect(findRegentTerritory(ALL_TERRITORIES, nonRegent)).toBeNull();
+    });
+
+    it('returns null for null/undefined inputs', () => {
+      expect(findRegentTerritory(null, aliceChar)).toBeNull();
+      expect(findRegentTerritory(ALL_TERRITORIES, null)).toBeNull();
+      expect(findRegentTerritory(null, null)).toBeNull();
+    });
+
+    it('returns null for empty territories array', () => {
+      expect(findRegentTerritory([], aliceChar)).toBeNull();
+    });
+
+    it('exposes all required fields in the return value', () => {
+      const result = findRegentTerritory(ALL_TERRITORIES, aliceChar);
+      expect(result).toMatchObject({
+        territory:   expect.any(String),
+        territoryId: expect.any(String),
+        slug:        expect.any(String),
+        ambience:    expect.any(String),
+      });
+      // lieutenantId allowed to be null
+      expect('lieutenantId' in result).toBe(true);
+    });
+  });
+
+  describe('AC-4 — canonical-slug preference (issue #216 guard)', () => {
+    it('prefers canonical-slug doc over non-canonical doc with same regent_id', () => {
+      // Simulate a stale orphan: same regent_id as North Shore but no canonical slug.
+      const staleOrphan = {
+        _id: 'aaaaaaaaaaaaaaaaaaaaaaaa',
+        slug: null,        // no slug — not canonical
+        name: 'The Dockyards',  // confusingly named, same as Dockyards
+        regent_id: ALICE_ID,
+        lieutenant_id: null,
+        ambience: 'Settled',
+      };
+      // Orphan appears BEFORE the real North Shore in the array.
+      const territoriesWithOrphan = [staleOrphan, ...ALL_TERRITORIES];
+
+      const result = findRegentTerritory(territoriesWithOrphan, aliceChar);
+      expect(result.slug).toBe('northshore');
+      expect(result.territory).toBe('The North Shore');
+      expect(result.territoryId).toBe(northShore._id);
+    });
+
+    it('prefers canonical-slug doc when stale doc has a non-canonical slug', () => {
+      const staleDupe = {
+        _id: 'bbbbbbbbbbbbbbbbbbbbbbbb',
+        slug: 'old-dockyards-id',  // non-canonical slug
+        name: 'The Dockyards',
+        regent_id: ALICE_ID,
+        lieutenant_id: null,
+        ambience: 'Settled',
+      };
+      const territoriesWithDupe = [staleDupe, ...ALL_TERRITORIES];
+
+      const result = findRegentTerritory(territoriesWithDupe, aliceChar);
+      expect(result.slug).toBe('northshore');
+    });
+
+    it('falls back to first match when no canonical slug exists in matches', () => {
+      // Edge case: regent_id matches, but no match has a canonical slug.
+      const orphanA = { _id: 'cccccccccccccccccccccccc', slug: 'unknown-a', name: 'Unknown A', regent_id: ALICE_ID, lieutenant_id: null, ambience: null };
+      const orphanB = { _id: 'dddddddddddddddddddddddd', slug: 'unknown-b', name: 'Unknown B', regent_id: ALICE_ID, lieutenant_id: null, ambience: null };
+      // Neither matches canonical slugs — first should win as safe fallback.
+      const orphansOnly = [orphanA, orphanB];
+
+      const result = findRegentTerritory(orphansOnly, aliceChar);
+      expect(result).not.toBeNull();
+      expect(result.territoryId).toBe(orphanA._id);
+    });
+
+    it('does not affect Rene — Dockyards has canonical slug and remains correct', () => {
+      const staleOrphan = {
+        _id: 'eeeeeeeeeeeeeeeeeeeeeeee',
+        slug: null,
+        name: 'Some Territory',
+        regent_id: ALICE_ID,
+        lieutenant_id: null,
+        ambience: null,
+      };
+      const territoriesWithOrphan = [staleOrphan, ...ALL_TERRITORIES];
+
+      const result = findRegentTerritory(territoriesWithOrphan, reneChar);
+      expect(result.slug).toBe('dockyards');
+      expect(result.territory).toBe('The Dockyards');
+    });
+  });
+
+  describe('return value field behaviour', () => {
+    it('uses name over slug for territory display string', () => {
+      const result = findRegentTerritory(ALL_TERRITORIES, aliceChar);
+      // name = 'The North Shore', slug = 'northshore' — name wins
+      expect(result.territory).toBe('The North Shore');
+    });
+
+    it('falls back to slug when name is absent', () => {
+      const noNameTerritory = [{
+        _id: 'ffffffffffffffffffffffff',
+        slug: 'northshore',
+        name: '',
+        regent_id: ALICE_ID,
+        lieutenant_id: null,
+        ambience: 'Tended',
+      }];
+      const result = findRegentTerritory(noNameTerritory, aliceChar);
+      expect(result.territory).toBe('northshore');
+    });
+
+    it('stringifies territoryId even when _id is ObjectId-like', () => {
+      const result = findRegentTerritory(ALL_TERRITORIES, aliceChar);
+      expect(typeof result.territoryId).toBe('string');
+    });
+  });
+});

--- a/specs/stories/issue-216-alice-regent-territory.story.md
+++ b/specs/stories/issue-216-alice-regent-territory.story.md
@@ -1,0 +1,246 @@
+# Story issue-216: DT form shows Alice as regent of Dockyards instead of North Shore
+
+Status: review
+
+issue: 216
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/216
+branch: morningstar-issue-216-alice-regent-territory
+
+---
+
+## Story
+
+As Alice (a regent player),
+When I open my advanced downtime form,
+I should see "I am acting as Regent of **The North Shore**" in the Regency section,
+so that my feeding-rights confirmation applies to the correct territory.
+
+---
+
+## Background and Current State
+
+**What the regency display code does today:**
+
+`findRegentTerritory(territories, c)` in `public/js/data/helpers.js:153` determines which territory
+a character is regent of:
+
+```js
+export function findRegentTerritory(territories, c) {
+  if (!territories || !c) return null;
+  const cid = String(c._id);
+  const t = territories.find(t => t.regent_id === cid);
+  if (!t) return null;
+  return {
+    territory: t.name || t.slug,
+    territoryId: String(t._id),
+    slug: t.slug || null,
+    lieutenantId: t.lieutenant_id || null,
+    ambience: t.ambience || null,
+  };
+}
+```
+
+The `territories` array is freshly fetched from `/api/territories` on every DT form render
+(fix for issue #153 — `downtime-form.js:1200–1205`). The API does a plain `col().find().toArray()`
+with **no sorting** — results return in MongoDB natural (insertion) order.
+
+**The Admin City view uses the opposite lookup direction:**
+
+`public/js/admin/city-views.js:321–323`:
+```js
+function _terrDoc(terrId) {
+  return terrDocs.find(d => d.slug === terrId); // slug-keyed; finds first match
+}
+```
+
+For each canonical territory slug from `TERRITORY_DATA` (downtime-data.js), the city view finds
+the first document whose `slug` matches and then resolves `regent_id` → character name.
+These are two separate lookup directions that can diverge when duplicate territory documents exist.
+
+**Root cause hypothesis — duplicate territory documents:**
+
+On 2026-05-05 a stale browser session posted bodies with the retired `id` field, creating
+**5 duplicate territories** (noted in `territory.schema.js` header and fixed by issue #33).
+If a duplicate Dockyards document exists with `regent_id = alice_id`:
+
+- City view: `_terrDoc("dockyards")` returns the FIRST doc with `slug === "dockyards"`.
+  If the correct doc (regent_id = rene_id) appears first in insertion order → Rene shown ✓
+- DT form: `territories.find(t => t.regent_id === alice_id)` scans ALL docs and may hit the
+  stale Dockyards duplicate before it reaches the North Shore document → Dockyards shown ✗
+
+All other regents display correctly because they have no stale duplicates.
+
+---
+
+## Files in Scope
+
+**Investigation (run + delete):**
+- `server/scripts/diagnose-regent-216.js` — one-shot diagnostic; query and print territory docs
+
+**Data fix (the actual repair):**
+- MongoDB: delete the stale territory document (identified by the diagnostic)
+
+**Code guard (apply after data fix to prevent recurrence):**
+- `public/js/data/helpers.js` — tighten `findRegentTerritory` to prefer canonical slugs
+
+---
+
+## Files NOT in Scope
+
+- `public/js/tabs/downtime-form.js` — no change needed; territories are already refreshed on render
+- `public/js/admin/city-views.js` — display is correct; do not change
+- `server/routes/territories.js` — no change needed; deduplication is a data fix, not API-level
+- Any server schema — territory.schema.js already has `additionalProperties: false` to block future duplicates
+
+---
+
+## Dev Tasks
+
+### Step 1 — Diagnose (mandatory before data fix)
+
+Write and run `server/scripts/diagnose-regent-216.js` as a one-shot Node script.
+The script must:
+
+1. Connect to MongoDB `tm_suite` (reuse the existing `server/db.js` connection helper)
+2. Find Alice's character by name (search characters collection for `name: /Alice/i` or moniker)
+3. Print Alice's `_id` string
+4. Query ALL territory documents: `db.territories.find({}).toArray()`
+5. Print each territory doc's `{ _id, slug, name, regent_id }` — flagging any where `regent_id === alice._id`
+6. Flag any slug that appears more than once (duplicates)
+
+Run the script, capture output, and decide which fix path applies:
+- **Path A (data)**: One or more territory documents have `regent_id = alice_id` AND should not
+  (name/slug is Dockyards or a stale orphan) → delete those documents
+- **Path B (code)**: Data is unexpectedly correct and there's a type mismatch or ordering issue →
+  see code guard below
+
+### Step 2 — Data fix (Path A — expected)
+
+If the diagnostic reveals stale/duplicate territory documents:
+
+Write a second script `server/scripts/fix-regent-216.js` that:
+1. Identifies the stale document(s) by `_id` (printed in Step 1 output)
+2. Deletes them with `deleteOne({ _id: ObjectId(staleId) })`
+3. Prints confirmation
+
+**The user runs both scripts manually.** Do not automate execution in the story implementation.
+
+After running the fix, re-run the diagnostic to confirm zero territory docs have `regent_id = alice_id`
+except the canonical North Shore document.
+
+### Step 3 — Code guard (apply regardless of fix path)
+
+Harden `findRegentTerritory` in `public/js/data/helpers.js` to prefer territories that have
+a canonical slug when multiple docs match the same regent_id.
+
+Import `TERRITORY_DATA` from `../tabs/downtime-data.js` at the top of `helpers.js`:
+
+```js
+import { TERRITORY_DATA } from '../tabs/downtime-data.js';
+```
+
+Update `findRegentTerritory`:
+
+```js
+export function findRegentTerritory(territories, c) {
+  if (!territories || !c) return null;
+  const cid = String(c._id);
+  const canonicalSlugs = new Set(TERRITORY_DATA.map(td => td.slug));
+  // Prefer canonical territories over stale/orphaned duplicates.
+  const matches = territories.filter(t => t.regent_id === cid);
+  if (!matches.length) return null;
+  const t = matches.find(m => canonicalSlugs.has(m.slug)) || matches[0];
+  return {
+    territory: t.name || t.slug,
+    territoryId: String(t._id),
+    slug: t.slug || null,
+    lieutenantId: t.lieutenant_id || null,
+    ambience: t.ambience || null,
+  };
+}
+```
+
+This means even if a stale duplicate doc (non-canonical slug) appears first in the API response,
+the canonical territory always wins.
+
+### Step 4 — Delete diagnostic scripts
+
+After the data fix is confirmed, delete:
+- `server/scripts/diagnose-regent-216.js`
+- `server/scripts/fix-regent-216.js`
+
+Do not commit these to main.
+
+---
+
+## Acceptance Criteria
+
+**AC-1 — Alice's DT form shows North Shore**
+Given Alice's player opens the advanced downtime form for the current cycle,
+When the Regency section renders,
+Then it reads "I am acting as Regent of **The North Shore** for this cycle."
+
+**AC-2 — Rene's DT form unchanged**
+Given Rene ST Dominique's player opens the advanced downtime form,
+When the Regency section renders,
+Then it continues to read "I am acting as Regent of **The Dockyards** for this cycle."
+
+**AC-3 — No other regents affected**
+Given all other regent characters open their DT forms,
+When the Regency section renders,
+Then all display the same territory they displayed before this fix.
+
+**AC-4 — `findRegentTerritory` code guard in place**
+Given `helpers.js` is patched with the canonical-slug preference,
+When `findRegentTerritory` is called with a territories array containing both a canonical
+and a non-canonical doc sharing the same regent_id,
+Then it returns the canonical doc.
+
+---
+
+## Key Code Locations
+
+| Symbol | File | Line |
+|--------|------|------|
+| `findRegentTerritory` | `public/js/data/helpers.js` | 153 |
+| `TERRITORY_DATA` | `public/js/tabs/downtime-data.js` | 92 |
+| `_territories` freshened on render | `public/js/tabs/downtime-form.js` | 1200 |
+| `renderRegencySection` (uses `findRegentTerritory`) | `public/js/tabs/downtime-form.js` | 4140 |
+| `_terrDoc` (city view; slug-keyed) | `public/js/admin/city-views.js` | 321 |
+| Territory schema (duplicate-prevention note) | `server/schemas/territory.schema.js` | 1 |
+
+---
+
+## Scope Notes
+
+- **In scope**: Stale data diagnosis + deletion; `findRegentTerritory` canonical-slug guard
+- **Out of scope**: Changes to the territories API; changes to how the city view resolves regents;
+  any other regent display issues (all other regents confirmed correct)
+- **Do not**: Modify the territory documents' `regent_id` directly in the scripts — only delete
+  stale duplicate documents. The correct regent assignments are already in place.
+
+---
+
+## Dev Agent Record
+
+### Diagnostic findings (2026-05-08)
+
+Ran `diagnose-regent-216.js` against production `tm_suite`. Results:
+
+- Alice `_id`: `69d73ea49162ece35897a47c`
+- North Shore `regent_id = 69d73ea49162ece35897a47c` — **correct match**
+- Dockyards `regent_id = 69d73ea49162ece35897a496` — different character (Rene)
+- **Zero duplicate slugs** — the 2026-05-05 `cleanup-territory-id-dupes.js` run already resolved all 5 duplicates
+- All regent_id values are strings — no type mismatch
+
+The territory data was correct at the time of the diagnostic. The screenshot-visible bug was likely caused by a data state between the 2026-05-05 duplicate cleanup and the subsequent admin correction of regent assignments through the City view.
+
+**Steps taken:**
+- Step 1 (Diagnose): Run — data already correct, no stale documents
+- Step 2 (Data fix): Skipped — not needed
+- Step 3 (Code guard): Applied — `findRegentTerritory` in `public/js/data/helpers.js` now prefers canonical slugs over any stale/orphaned duplicates if they reappear
+- Step 4 (Cleanup): Diagnostic script deleted
+
+### Files changed
+
+- `public/js/data/helpers.js` — `findRegentTerritory` hardened with canonical-slug preference; `TERRITORY_DATA` import added

--- a/specs/stories/sprint-status.yaml
+++ b/specs/stories/sprint-status.yaml
@@ -754,3 +754,4 @@ development_status:
   # Picked up via tm-gh-issue-pickup skill; story files in specs/stories/issue-*.story.md
 
   issue-12-domain-multi-instance-descriptors: review            # Domain: multi-instance SP/FG, Haven/MG cap system
+  issue-216-alice-regent-territory: review                     # DT form shows Alice as regent of Dockyards (stale dup doc); data fix + findRegentTerritory guard


### PR DESCRIPTION
## Summary

- Harden `findRegentTerritory` to prefer canonical-slug territories when multiple docs share the same regent_id — defends against stale orphaned territory documents producing wrong regency display in the DT form
- Diagnostic confirmed production data was already correct at fix time; code guard prevents recurrence if duplicate territory docs appear again
- 13 unit tests added covering normal operation, AC-4 canonical preference, and fallback behaviour

## Closes

- Closes #216

## Story

- specs/stories/issue-216-alice-regent-territory.story.md

## Test plan

- [x] 13 Vitest unit tests pass (`server/tests/find-regent-territory.test.js`)
- [ ] CI green
- [ ] Manual: open Alice's advanced DT form and confirm Regency section reads "The North Shore"

## Branch flow

- From: `morningstar-issue-216-alice-regent-territory`
- Into: `dev`
- Note: branch was cut from `Morningstar` — this PR also brings in Piatra's merged bundles (#93, #85, #129, #108, #62/#138/#146, #102/#105/#120/#132, #162, #164/#166) and the #153 stale-territories fix already carried on Morningstar.