### PR TITLE
fix(prereq): 'same level' qualifier sentinel — Mandragora Garden hotfix (#239)

### DIFF
--- a/public/js/data/prereq.js
+++ b/public/js/data/prereq.js
@@ -64,6 +64,20 @@ export function meetsPrereq(char, node, opts = {}) {
 
     case 'merit': {
       const merits = char.merits || [];
+      // Issue #239: 'same level' is a semantic sentinel meaning "the
+      // prerequisite merit must be at the same (or higher) dot rating
+      // as the merit being purchased." Used by Mandragora Garden's
+      // Safe Place prereq (rules cache `mandragora-garden` rule). The
+      // per-rating cap is enforced at runtime via CAP_DOMAIN
+      // (editor/domain.js:17), so a static prereq check just needs
+      // presence of the named merit at the dots floor — treating
+      // 'same level' as a literal qualifier-name (the pre-fix
+      // behaviour) silently excluded Mandragora Garden from every
+      // character's XP-purchase picker because no real merit has
+      // qualifier === 'same level'.
+      if (node.qualifier === 'same level') {
+        return merits.some(m => m.name === node.name && (m.rating || 0) >= (dots || 1));
+      }
       const directMatch = merits.some(m => {
         if (m.name !== node.name) return false;
         if (node.qualifier && m.qualifier !== node.qualifier && m.area !== node.qualifier) return false;

--- a/server/tests/prereq-same-level-sentinel.test.js
+++ b/server/tests/prereq-same-level-sentinel.test.js
@@ -1,0 +1,80 @@
+/**
+ * Unit tests — `"same level"` qualifier sentinel in meetsPrereq (issue #239).
+ *
+ * The sentinel encodes Mandragora Garden's per-rating cap on Safe Place: the
+ * prereq Safe Place must be at the same (or higher) dot rating as the
+ * Mandragora Garden being purchased. Pre-fix the engine matched the sentinel
+ * literally against `m.qualifier` / `m.area`, silently excluding the merit
+ * from every character's XP-purchase picker.
+ */
+
+import { vi, describe, it, expect } from 'vitest';
+
+vi.mock('../../public/js/data/accessors.js', () => ({
+  getAttrVal: () => 0,
+  skDots: () => 0,
+}));
+
+import { meetsPrereq } from '../../public/js/data/prereq.js';
+
+const MANDRAGORA_PREREQ = {
+  type: 'merit',
+  name: 'Safe Place',
+  qualifier: 'same level',
+};
+
+describe('meetsPrereq — "same level" qualifier sentinel', () => {
+  it('passes when the named merit exists at >= 1 dot, regardless of its qualifier', () => {
+    const char = { merits: [{ name: 'Safe Place', rating: 1 }] };
+    expect(meetsPrereq(char, MANDRAGORA_PREREQ)).toBe(true);
+  });
+
+  it('passes when the named merit has a real qualifier set (not the sentinel literal)', () => {
+    const char = { merits: [{ name: 'Safe Place', rating: 3, qualifier: 'Penthouse Apartment' }] };
+    expect(meetsPrereq(char, MANDRAGORA_PREREQ)).toBe(true);
+  });
+
+  it('passes when the named merit has area set instead of qualifier', () => {
+    const char = { merits: [{ name: 'Safe Place', rating: 2, area: 'The Old Quarter' }] };
+    expect(meetsPrereq(char, MANDRAGORA_PREREQ)).toBe(true);
+  });
+
+  it('fails when the character has no instance of the named merit', () => {
+    const char = { merits: [{ name: 'Haven', rating: 3 }] };
+    expect(meetsPrereq(char, MANDRAGORA_PREREQ)).toBe(false);
+  });
+
+  it('fails when the character has the named merit at 0 dots', () => {
+    const char = { merits: [{ name: 'Safe Place', rating: 0 }] };
+    expect(meetsPrereq(char, MANDRAGORA_PREREQ)).toBe(false);
+  });
+
+  it('fails when the character has no merits array at all', () => {
+    expect(meetsPrereq({}, MANDRAGORA_PREREQ)).toBe(false);
+  });
+
+  it('honours an explicit dots floor in the prereq', () => {
+    const char = { merits: [{ name: 'Safe Place', rating: 2 }] };
+    const prereqWithFloor = { ...MANDRAGORA_PREREQ, dots: 3 };
+    expect(meetsPrereq(char, prereqWithFloor)).toBe(false);
+    const charHigher = { merits: [{ name: 'Safe Place', rating: 4 }] };
+    expect(meetsPrereq(charHigher, prereqWithFloor)).toBe(true);
+  });
+});
+
+describe('meetsPrereq — non-sentinel qualifiers still work as before (regression guard)', () => {
+  it('passes when qualifier matches m.qualifier', () => {
+    const char = { merits: [{ name: 'Allies', rating: 2, qualifier: 'Police' }] };
+    expect(meetsPrereq(char, { type: 'merit', name: 'Allies', qualifier: 'Police' })).toBe(true);
+  });
+
+  it('passes when qualifier matches m.area', () => {
+    const char = { merits: [{ name: 'Contacts', rating: 1, area: 'Media' }] };
+    expect(meetsPrereq(char, { type: 'merit', name: 'Contacts', qualifier: 'Media' })).toBe(true);
+  });
+
+  it('fails when qualifier does not match any character merit qualifier or area', () => {
+    const char = { merits: [{ name: 'Allies', rating: 2, qualifier: 'Police' }] };
+    expect(meetsPrereq(char, { type: 'merit', name: 'Allies', qualifier: 'High Society' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #239. **Hotfix candidate** — universal exclusion of Mandragora Garden from every character's XP-purchase UI (DT form + sheet) since the rule was authored.

## Root cause

Mandragora Garden's prereq encodes a per-rating cap on Safe Place via the qualifier sentinel `"same level"`:

```json
{ "type": "merit", "name": "Safe Place", "qualifier": "same level" }
```

`meetsPrereq` (`public/js/data/prereq.js:65-77`) matched the sentinel literally against `m.qualifier` / `m.area`. No real Safe Place instance has `qualifier === "same level"` (it's a sentinel, not a real qualifier value), so every character failed the prereq universally. Both consumers — the DT form's XP Spend picker (`downtime-form.js:3992`) and the sheet's Merit Add picker (`editor/merits.js` `buildMeritOptions`) — silently filtered Mandragora Garden out for every player. The runtime cap itself is enforced separately via `CAP_DOMAIN` in `editor/domain.js:17` regardless of whether the prereq path encodes it.

Reported via Brandy LaRoux (Gangrel, Circle of the Crone, Safe Place 1 ✓, Cruac 1 ✓) — fully qualified per rules but unable to see the merit.

## Fix shape

Surgical branch at the top of `meetsPrereq`'s `case 'merit'`: when `node.qualifier === 'same level'`, treat the prereq as "any instance of the named merit at the dots floor" and skip the literal-qualifier match. Behaviour for every other prereq path is unchanged.

```js
if (node.qualifier === 'same level') {
  return merits.some(m => m.name === node.name && (m.rating || 0) >= (dots || 1));
}
```

`grep` confirms Mandragora Garden is the **only** merit using the `"same level"` sentinel — bug and fix are isolated to this single merit's prereq path, not a wider engine semantic change.

## Tests

`server/tests/prereq-same-level-sentinel.test.js` — 10 new unit tests mirroring the `prereq-covenant-status` test pattern (hotfix #44):

- Sentinel passes when named merit exists at ≥ 1 dot
- Passes regardless of the merit's actual qualifier / area value
- Fails when the named merit is absent or at 0 dots
- Honours an explicit dots floor in the prereq
- Regression guards: non-sentinel qualifiers still work as before

All 10 pass. No mocks beyond the existing accessors stub used by the sibling test file.

## Pre-existing test failure (NOT caused by this fix)

The full server suite shows 2 failures in `tests/api-downtime-regent-gate.test.js` (`feeding_rights_confirmed` flow). Verified pre-existing on origin/dev **without** this PR's changes (via `git stash` + re-test). Completely unrelated to `prereq.js`; likely landed via one of the recent dev merges (#231, #233, or #236). **Flagging for separate handling — not a regression introduced by this PR.**

Test counts:
- This PR's new tests: 10 / 10 pass.
- Full server suite with this PR: 718 passing / 2 pre-existing failures.

## Test plan (browser smoke for the user)

- [ ] As Brandy LaRoux, open DT form → Personal Project → XP Spend. Verify Mandragora Garden appears in the merit picker.
- [ ] Pick Mandragora Garden, save, reload — persists.
- [ ] Verify a character without Safe Place still doesn't see it (the merit branch returns false when no instance of Safe Place exists).
- [ ] Verify a character without Cruac still doesn't see it (the `Crúac dots: 1` part of the `all` group still gates).
- [ ] Sheet Merit Add picker: Mandragora Garden also surfaces for qualified characters there (same `meetsPrereq` consumer).

## HALT-DAR check

Not triggered. Single-line semantic addition with full unit coverage; isolated to the one merit using the sentinel. No schema change, no breaking change to existing prereq shapes.

## Branch

`dev` per house rule. **Hotfix candidacy**: user flagged this may need rapid promotion to `main`. Awaiting explicit user authorisation per the CLAUDE.md hard rule before merging dev → main.