### PR TITLE
fix(test): isolate regent-gate suite from seeded territories (#241)

### DIFF
--- a/server/tests/api-downtime-regent-gate.test.js
+++ b/server/tests/api-downtime-regent-gate.test.js
@@ -25,9 +25,36 @@ const OTHER    = new ObjectId().toHexString();
 let insertedCycleIds = [];
 let insertedTerrIds = [];
 
+// Issue #241: tm_suite_test was populated with 5 production-like territories
+// carrying `regent_id` values by the regent-id migration script run on
+// 2026-05-05 (server/scripts/migrate-regent-to-id.js + backup at
+// scripts/_backups/territory-fk-migration-2026-05-05T05-36-59-765Z.json).
+// The confirm-feeding gate at routes/downtime.js:139 queries every
+// territory with `regent_id` set; pre-existing territories leak into the
+// query alongside the test's own inserts and force allConfirmed=false
+// because the test only confirms its single territory. Snapshot the
+// pre-existing regent_id values in beforeAll, null them out for the
+// suite's lifetime, restore in afterAll. The test DB is throwaway so
+// the temporary mutation is bounded to this suite's run; restoring
+// keeps the snapshot intact for subsequent test files in the same
+// vitest worker.
+let _seededRegentSnapshot = [];
+
 beforeAll(async () => {
   await setupDb();
   app = createTestApp();
+  const terrCol = getCollection('territories');
+  _seededRegentSnapshot = await terrCol
+    .find({ regent_id: { $exists: true, $ne: null } })
+    .project({ _id: 1, regent_id: 1, lieutenant_id: 1 })
+    .toArray();
+  if (_seededRegentSnapshot.length) {
+    const ids = _seededRegentSnapshot.map(d => d._id);
+    await terrCol.updateMany(
+      { _id: { $in: ids } },
+      { $set: { regent_id: null, lieutenant_id: null } }
+    );
+  }
 });
 
 afterEach(async () => {
@@ -40,6 +67,19 @@ afterEach(async () => {
 });
 
 afterAll(async () => {
+  // Restore any seeded territories' regent_id we nulled in beforeAll
+  // (issue #241) so subsequent test files in the same worker — and
+  // manual ST smoke runs against tm_suite_test — see the original
+  // state.
+  if (_seededRegentSnapshot.length) {
+    const terrCol = getCollection('territories');
+    for (const doc of _seededRegentSnapshot) {
+      await terrCol.updateOne(
+        { _id: doc._id },
+        { $set: { regent_id: doc.regent_id, lieutenant_id: doc.lieutenant_id ?? null } }
+      );
+    }
+  }
   await teardownDb();
 });
 


### PR DESCRIPTION
## Summary

Closes #241. **Root cause is in the test, not the route.** Khepri's culprit window (#231/#233/#236) was a red herring — the actual regression was introduced earlier by the 2026-05-05 regent-id migration, whose effects on `tm_suite_test` were never compensated for in the regent-gate test fixture.

## Diagnosis

The regent-gate route at `server/routes/downtime.js:139` queries every territory with `regent_id` populated:

```js
await terrCollection().find({ regent_id: { $exists: true, $ne: null } }).toArray();
```

Then asserts every result is in the cycle's confirmation set. The route logic is correct — every territory with a regent SHOULD have to confirm before the gate flips.

The test fixture never isolated itself from the territories collection's existing state. On 2026-05-05 someone ran `server/scripts/migrate-regent-to-id.js` against `tm_suite_test` (or the migration's effects leaked from `tm_suite` via shared seeds), populating `regent_id` on 5 production-like territory docs:

- `academy` / `harbour` / `dockyards` / `northshore` / `secondcity`

Verified via ObjectId timestamps (territories created 2026-04-08 / 2026-04-11) + matching backup at `scripts/_backups/territory-fk-migration-2026-05-05T05-36-59-765Z.json`.

After that migration ran, the route's gate query returned the test's own territory **plus the 5 seeded ones**. `allConfirmed` required all 6 to be in the cycle's confirmations; the test only confirmed its single territory → `allConfirmed = false` → assertion `expected true` failed every run for two of the test cases (`Gate becomes true...` and `Territory with no regent_id...`).

Consistent with Ptah's PR #240 verification (failures pre-existed, not introduced by his hotfix). Also strictly pre-dates #231/#233/#236 — none of those PRs touched the test or route.

## Fix

Test-side, not route-side. Snapshot pre-existing territories with `regent_id` in `beforeAll`, null them out for the suite's lifetime, restore in `afterAll`. Test DB is throwaway by design (per `setup-env.js` comment); the temporary mutation is bounded.

The restore is best-effort — verified that by the end of the full suite run, the 5 seeded territories no longer exist in `tm_suite_test` (deleted by sibling territory tests). The restore's `updateOne` is then a no-op `matchedCount: 0`, which is correct behaviour.

## Why this is the right boundary

1. **Route semantic is canonical** (per dtx.7 + ADR-002 strict cutover). Changing it would break the production contract STs depend on for feeding-rights distribution.
2. **Test responsibility**: it's the test's job to isolate itself from shared DB state. Vitest's `fileParallelism: false` + `singleFork: true` (per `vitest.config.js`) already guarantees serial test-file execution, so snapshot/restore is sufficient — no concurrent-test interference to worry about.
3. **Sibling territory tests** (`api-territories-regent-save.test.js`, etc.) don't depend on the seeded docs; they create their own and scope cleanup by slug regex. Snapshot/restore in this one suite leaves them unaffected.

## Verification

| Run | Result |
|---|---|
| `npx vitest run tests/api-downtime-regent-gate.test.js` (this suite alone) | 12/12 pass |
| `npm test` (full server suite) | 720/720 pass (was 718/720 with these 2 failing pre-fix) |
| Post-suite `tm_suite_test` territories | Either seeds restored, or absent because sibling tests deleted them. No collection corruption either way. |

## Severity

API behaviour was never broken; only the regression-suite was failing. Production users following the regent confirm-feeding flow on main get correct gate computation. End-user smoke remains advisable as common sense, but the route logic is unchanged by this PR.

## HALT-DAR check

Not triggered. Test-only change, no production impact, no new contract.

## Branch

`dev` per house rule. Manually close #241 after merge. User has the dev → main promotion call (per CLAUDE.md hard rule).