### PR TITLE
fix(dt-form): Ambience Change rule text + arrow verify (#174, partial)

### DIFF
--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -3635,7 +3635,15 @@ function renderProjectSlots(saved, mode = 'advanced') {
 
       h += '<div class="qf-field dt-amb-table-wrap">';
       h += '<label class="qf-label">Territory + Direction</label>';
-      h += '<p class="qf-desc">Pick one direction on one territory. Success is +/-2 influence change to territory, +/-4 on exceptional success.</p>';
+      // Issue #174 — pre-fix the rule text described a non-existent
+      // '+/-2 per success / +/-4 exceptional' mechanic. Per Damnation
+      // City §102 the Ambience Change personal project is a dice-roll
+      // action (Attribute + Skill + Discipline pool, rendered below):
+      // each success on that roll shifts the territory's ambience by
+      // ±1 in the chosen direction. Player UI exposes only the dice
+      // pool — there is no influence-spend channel on this action in
+      // the current form, so language stays focused on the roll.
+      h += '<p class="qf-desc">Pick one direction on one territory. Each success on the dice pool below shifts that territory’s ambience by ±1 in the chosen direction.</p>';
       h += `<div class="dt-amb-table" data-amb-table="${n}">`;
       for (const t of TERRITORY_DATA) {
         const isRow = String(savedTarget) === String(t.slug);


### PR DESCRIPTION
## Summary

Partial fix for #174. Lands defect 2 (rule text) + verifies defect 1 (already covered). **Defect 3 (influence tracker) HALT-DAR** — design call needed before implementing.

## Defect 1 — arrow selectors — ALREADY FIXED ✓

The `[data-amb-arrow]` handler at `downtime-form.js:2743-2780` is inside the `click` listener at line 2720 (verified via `awk` line scan that maps each `addEventListener('click'...)` / `('change'...)` line). PR #180 / issue #165 relocated the chip + arrow handlers from the `change` listener to the click listener as part of the listener-routing fix family.

The handler implements the dt-form.25 single-target state machine (new row → switch, opposite arrow → switch direction, same arrow → toggle off) per the comment block at lines 2734-2742.

**No code change in this PR for defect 1.** Browser smoke still advisable to confirm end-user behaviour.

## Defect 2 — incorrect rule text — FIXED

`downtime-form.js:3638` rendered:

> 'Pick one direction on one territory. Success is +/-2 influence change to territory, +/-4 on exceptional success.'

This describes a mechanic that **does not exist** in the form or in the published rules. Per `specs/reference/Damnation City.txt:102` the Ambience Change personal project is a dice-roll action (Attribute + Skill + Discipline pool, already rendered just below this text via `renderDicePool` at line 3613), where each success shifts the territory's ambience by ±1 in the chosen direction.

Replaced with text that matches Damnation City's actual mechanic and the form's existing dice-pool widget:

> 'Pick one direction on one territory. Each success on the dice pool below shifts that territory's ambience by ±1 in the chosen direction.'

## Defect 3 — influence tracker — HALT-DAR

The issue body's AC says *'each influence spent counts as +/-1'* but the **same body's open-questions section** flags this as unclear:

> 'Is the Ambience Change Personal Project a dice-roll action (+/-1 per success) or a pure influence-spend action (+/-1 per influence point committed), or both?'

The form's current implementation has **no influence-spend channel** for this action — only a dice pool (`renderDicePool`). Adding an influence tracker would either:

| Path | Risk |
|---|---|
| (a) Introduce a NEW spend mechanic for this action | Not supported by published rules (Damnation City §102 is roll-driven) |
| (b) Wire it to the existing per-territory influence budget | **Double-counts** against the Territory + Influence section's `'X / Y Influence remaining'` tracker at `downtime-form.js:6670` which already gates the monthly influence pool |

Both paths require ST design call. **Deferring defect 3 to a follow-up after design clarification**, per Khepri's PROCEED-WITH-NOTICE direction in the dispatch.

Once ST clarifies whether Ambience Change is dice-only / influence-only / both, the follow-up issue can be specced cleanly without ambiguity.

## Verification

- **Server tests**: 720/720 pass (no regressions).
- **Parse-check**: clean.
- **Listener routing**: `[data-amb-arrow]` confirmed inside click listener at line 2720.

## Test plan (browser smoke deferred to user)

- [ ] Click ▲ or ▼ on a territory row → row highlights, selection persists across save + reload.
- [ ] Click the same arrow again → toggles off (clears target + direction).
- [ ] Click a different row's arrow → switches to the new row.
- [ ] Rule text reads `Each success on the dice pool below shifts that territory's ambience by ±1 in the chosen direction.`
- [ ] Dice pool below the table is the action's mechanical channel (no influence tracker yet — pending design).

## Branch

`dev` per house rule. Per Khepri's process clarification, NOT auto-merging — pinging Khepri after this PR opens for Ma'at static review routing.