### PR TITLE
fix(schema): add 'maintenance' to projectActionEnum (#235)

### DIFF
--- a/server/schemas/downtime_submission.schema.js
+++ b/server/schemas/downtime_submission.schema.js
@@ -35,7 +35,18 @@ const projectActionEnum = [
   // (the legacy `ambience_increase` / `ambience_decrease` values are kept
   // for CSV-import back-compat reads only — admin/parser still consume
   // them; tracked under issue #129 for future canonical normalisation).
-  'ambience_change'
+  'ambience_change',
+  // Issue #235: dt-form.28 added 'maintenance' as a project action for
+  // Professional Training / Mystery Cult Initiation upkeep
+  // (`MAINTENANCE_MERITS` in tabs/downtime-data.js:113). Form writes it
+  // via the PROJECT_ACTIONS dropdown at downtime-data.js:20; the
+  // canonical action label is rendered with maintenance-specific
+  // sub-fields (`renderMaintenanceChips` at downtime-form.js:5207). The
+  // server schema enum was missed when the action shipped — latent
+  // validation landmine where a maintenance submission would 400 on
+  // POST /downtime_submissions if strict enum checking was on the
+  // request path.
+  'maintenance'
 ];
 
 const sphereActionEnum = [

--- a/server/tests/schema-project-action-enum.test.js
+++ b/server/tests/schema-project-action-enum.test.js
@@ -1,0 +1,69 @@
+/**
+ * Unit tests — project action enum coverage in downtime_submission schema (#235).
+ *
+ * Form-side `PROJECT_ACTIONS` (public/js/tabs/downtime-data.js:10-21) lists
+ * every action the player can pick. The server schema's `projectActionEnum`
+ * gates POST /api/downtime_submissions; missing values land in 400
+ * VALIDATION_ERROR. Pre-fix `'maintenance'` (added by dt-form.28) was missing
+ * from the enum — latent landmine for any submission with a maintenance
+ * project action.
+ *
+ * These tests compile the schema with AJV (same setup as the validate
+ * middleware) and assert the enum accepts every form-side action value.
+ */
+
+import { describe, it, expect } from 'vitest';
+import Ajv from 'ajv';
+
+import { downtimeSubmissionSchema } from '../schemas/downtime_submission.schema.js';
+
+const ajv = new Ajv({ allErrors: true, coerceTypes: false });
+const validate = ajv.compile(downtimeSubmissionSchema);
+
+// Mirrors public/js/tabs/downtime-data.js:10-21 (PROJECT_ACTIONS).
+// Update both when adding a new project action.
+const FORM_PROJECT_ACTIONS = [
+  '',
+  'ambience_change',
+  'attack',
+  'hide_protect',
+  'investigate',
+  'patrol_scout',
+  'rote',
+  'xp_spend',
+  'misc',
+  'maintenance',
+];
+
+function minimalSubmission(overrides = {}) {
+  return {
+    character_id: '69d4e1d6277e2b2144b6166c',
+    status: 'draft',
+    responses: {},
+    ...overrides,
+  };
+}
+
+describe('downtime_submission schema — projectActionEnum coverage (#235)', () => {
+  for (const action of FORM_PROJECT_ACTIONS) {
+    it(`accepts project_1_action='${action || '<empty>'}' as a valid project action`, () => {
+      const doc = minimalSubmission({
+        responses: { project_1_action: action },
+      });
+      const ok = validate(doc);
+      const errs = (validate.errors || []).filter(e => /project_1_action/.test(e.instancePath || ''));
+      expect(errs, JSON.stringify(errs)).toEqual([]);
+      expect(ok).toBe(true);
+    });
+  }
+
+  it('rejects an unknown project action value', () => {
+    const doc = minimalSubmission({
+      responses: { project_1_action: 'definitely_not_a_real_action' },
+    });
+    const ok = validate(doc);
+    expect(ok).toBe(false);
+    const enumErr = (validate.errors || []).find(e => e.keyword === 'enum' && /project_1_action/.test(e.instancePath || ''));
+    expect(enumErr).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #235. Single-line schema fix + 11 unit tests guarding against future enum drift.

## Diagnosis

Form-side `PROJECT_ACTIONS` (`public/js/tabs/downtime-data.js:20`) includes `'maintenance'` — added by dt-form.28 for Professional Training / MCI upkeep, with maintenance-specific sub-fields rendered via `renderMaintenanceChips` at `downtime-form.js:5207`.

The server schema's `projectActionEnum` (`server/schemas/downtime_submission.schema.js:27-39`) was missed when the action shipped, leaving a **latent validation landmine**: any submission with `responses.project_${n}_action === 'maintenance'` would fail `POST /api/downtime_submissions` with a 400 `VALIDATION_ERROR` via the AJV `validate` middleware (`server/middleware/validate.js`).

Verified pre-fix by compiling the schema and validating a minimal maintenance submission — AJV rejected with `enum` keyword error on `/responses/project_1_action`.

## Other enum gaps surveyed (none found)

Per Khepri's HALT-DAR clause asking whether other enum values were also missing:

| Enum | Form source | Status |
|---|---|---|
| `projectActionEnum` | `downtime-data.js:10-21` | **`maintenance` missing — fixed by this PR** |
| `sphereActionEnum` | `downtime-data.js:49-58` | Aligned (form normalises `ambience_change` → `ambience_increase` / `_decrease` at `downtime-form.js:761-763` before write, so server only receives normalised values which are in the enum) |
| `feedMethodEnum` | `downtime-data.js:117-123` | Aligned with the 5 stock methods + `'other'` |
| `status_${n}_action` | (no schema entry) | Permissive via `additionalProperties: true` — no enum gap |

**No other actionable gaps.** PROCEED-WITH-NOTICE per the dispatch — clean 1-line fix as expected.

## Tests

`server/tests/schema-project-action-enum.test.js` — 11 new unit tests:

- Compile the schema with AJV (same setup as the `validate` middleware)
- Assert each `PROJECT_ACTIONS` value validates as a project action
- Regression guard: reject a known-bad action value to confirm the enum is actually being checked

The `FORM_PROJECT_ACTIONS` mirror in the test file is documented 'Update both when adding a new project action' so future additions catch any schema-side gap immediately.

## Verification

- **Server tests**: 731/731 pass (was 720 pre-fix; +11 from this file).
- Pre-fix the maintenance test case would have failed with AJV's `enum` keyword error on `/responses/project_1_action` — confirmed via ad-hoc debug script during diagnosis.

## Test plan

- [ ] Player submits a project with `action='maintenance'` → server accepts the POST (no 400 on enum).
- [ ] Existing project actions (`attack` / `hide_protect` / etc.) continue to validate as before.
- [ ] Unknown action values still rejected (regression guard test passes).

## Branch

`dev` per house rule. Per process: NOT auto-merging — pinging Khepri after this opens for Ma'at static review routing.