### PR TITLE
fix: ambience modifies Vitae yield, not feeding dice pool (#176)

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -957,6 +957,14 @@ function buildFeedingPool(char, methodId, ambienceMod, picks = {}) {
 
   const fg = (char.merits || []).find(m => m.name === 'Feeding Grounds');
   const fgVal = fg ? (fg.rating || 0) : 0;
+  // The `ambienceMod` parameter is misleadingly named — every caller in
+  // this file (renderFeedingDetail at line 1327, character-grid pool at
+  // 9208) passes `stMod` (ST manual feeding modifier from
+  // st_review.feeding_modifier), NOT territory ambience. Territory
+  // ambience is handled separately in feeding-pool.js (player-side) and
+  // gets the issue #176 Vitae-modifier treatment there. The ST manual
+  // modifier here legitimately adjusts dice (it's the ST's adjudication
+  // lever for difficulty / cover / etc.) and stays in the pool total.
   const amb = ambienceMod || 0;
   const unskilled = bestSkill === 0
     ? (method.skills.some(s => !SKILLS_MENTAL.includes(s)) ? -1 : -3)

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -957,14 +957,24 @@ function buildFeedingPool(char, methodId, ambienceMod, picks = {}) {
 
   const fg = (char.merits || []).find(m => m.name === 'Feeding Grounds');
   const fgVal = fg ? (fg.rating || 0) : 0;
-  // The `ambienceMod` parameter is misleadingly named — every caller in
-  // this file (renderFeedingDetail at line 1327, character-grid pool at
-  // 9208) passes `stMod` (ST manual feeding modifier from
-  // st_review.feeding_modifier), NOT territory ambience. Territory
-  // ambience is handled separately in feeding-pool.js (player-side) and
-  // gets the issue #176 Vitae-modifier treatment there. The ST manual
-  // modifier here legitimately adjusts dice (it's the ST's adjudication
-  // lever for difficulty / cover / etc.) and stays in the pool total.
+  // The `ambienceMod` parameter is misleadingly named. Three callers
+  // exist; only one passes actual territory ambience, and that one is
+  // a bug:
+  //   - renderFeedingDetail (line 1327): passes `stMod`
+  //     (st_review.feeding_modifier — ST manual adjudication lever for
+  //     cover / difficulty / etc.). Legitimately a dice modifier;
+  //     stays in `total` here.
+  //   - bestGenericPool (line 9716): passes `0`. Neutral.
+  //   - renderFeedingScene (post-#176 fix loop 2): now passes `0` after
+  //     Ma'at flagged the original `ambienceMod` (territory) here as a
+  //     dice double-count. Territory ambience is surfaced separately in
+  //     that table's 'Ambience' column.
+  //
+  // Net effect: `ambienceMod` here is now exclusively the ST manual
+  // modifier path; territory ambience is handled in feeding-pool.js
+  // (player-side) and surfaced separately in admin display surfaces.
+  // A follow-up tech-debt issue should rename this parameter to `stMod`
+  // to remove the lurking ambiguity.
   const amb = ambienceMod || 0;
   const unskilled = bestSkill === 0
     ? (method.skills.some(s => !SKILLS_MENTAL.includes(s)) ? -1 : -3)
@@ -9776,7 +9786,17 @@ function renderFeedingScene() {
       let poolTotal = '—';
       let poolNote = '';
       if (hasSub && methodId && methodObj) {
-        const pool = buildFeedingPool(char, methodId, ambienceMod);
+        // Issue #176 (fix loop 2 — Ma'at catch): pre-fix this passed
+        // `ambienceMod` (territory ambience from `terrRec.ambienceMod`)
+        // through `buildFeedingPool`'s misleadingly-named third parameter,
+        // which summed it into the dice total. Per Damnation City §158
+        // ambience is a Vitae yield modifier, not a dice pool component.
+        // The summary table already surfaces ambience separately via
+        // `ambModStr` rendered as a dedicated 'Ambience' column at line
+        // 9773 + downstream, so there is no display regression — passing
+        // `0` here just stops the dice double-count. Matches the
+        // neutral-call pattern bestGenericPool uses at line 9716.
+        const pool = buildFeedingPool(char, methodId, 0);
         poolTotal = pool ? pool.total : '?';
       } else if (!hasSub) {
         const best = bestGenericPool(char);

--- a/public/js/admin/feeding-engine.js
+++ b/public/js/admin/feeding-engine.js
@@ -98,7 +98,11 @@ function buildPool() {
   const unskilled = bestSkillVal === 0
     ? (m.skills.some(s => !SKILLS_MENTAL.includes(s)) ? -1 : -3)
     : 0;
-  const total = Math.max(0, bestAttrVal + bestSkillVal + discVal + ambMod + unskilled);
+  // Issue #176: ambience is a Vitae yield modifier per Damnation City §158,
+  // NOT a dice pool component. Dice total now excludes ambMod; the field is
+  // returned separately below so render() can show it as a Vitae bonus and
+  // renderResult() can fold it into the vitae yield calc.
+  const total = Math.max(0, bestAttrVal + bestSkillVal + discVal + unskilled);
 
   return { bestAttrName, bestAttrVal, bestSkillName, bestSkillVal, bestSkillSpec, discVal, discName: feedDiscName, ambMod, ambience: terr.ambience || '', unskilled, total };
 }
@@ -175,8 +179,10 @@ function render() {
       h += `<br>+ <span>${pool.bestSkillVal}</span> ${esc(pool.bestSkillName)}`;
       if (pool.bestSkillSpec) h += ` <span class="feed-dim">[${esc(pool.bestSkillSpec)}]</span>`;
       if (pool.discVal) h += `<br>+ <span>${pool.discVal}</span> ${esc(pool.discName)}`;
-      if (pool.ambMod !== 0) h += `<br>${pool.ambMod > 0 ? '+ ' : '\u2212 '}<span>${Math.abs(pool.ambMod)}</span> Ambience (${esc(pool.ambience)})`;
       if (pool.unskilled) h += `<br>\u2212 <span>${Math.abs(pool.unskilled)}</span> <span class="feed-dim">(unskilled)</span>`;
+      // Issue #176: ambience displayed as a separate Vitae modifier below
+      // the dice breakdown, not as a pool component.
+      if (pool.ambMod !== 0) h += `<br><span class="feed-dim">${pool.ambMod > 0 ? '+' : '\u2212'}${Math.abs(pool.ambMod)} Vitae from ${esc(pool.ambience || 'ambience')}</span>`;
       h += '</div>';
       h += '<div class="feed-pool-total">';
       h += `<div class="feed-pool-n">${pool.total}</div>`;
@@ -201,7 +207,14 @@ function render() {
 function renderResult() {
   const { cols, suc, poolN } = feedResult;
   const vessels = suc;
-  const safeVitae = vessels * 2;
+  // Issue #176: ambience modifies Vitae yield per Damnation City \u00A7158.
+  // Vessels still drive the base (2 Vitae per vessel); ambience is added
+  // after, floored at 0 so a hostile/barrens territory doesn't push the
+  // yield negative.
+  const pool = buildPool();
+  const ambMod = pool?.ambMod || 0;
+  const baseVitae = vessels * 2;
+  const safeVitae = Math.max(0, baseVitae + ambMod);
 
   let h = '<div class="feed-result-box">';
   h += '<div class="feed-suc-row"><div>';
@@ -227,9 +240,14 @@ function renderResult() {
     h += '<div class="feed-v-lbl">No vessels secured this hunt.</div>';
     h += '</div>';
   } else {
+    // Issue #176: when ambience is non-zero, surface its contribution
+    // explicitly so the ST sees vessels \u00D7 2 \u00B1 ambience = total Vitae.
+    const ambBreakdown = ambMod !== 0
+      ? ` (${baseVitae} from vessels ${ambMod > 0 ? '+' : '\u2212'} ${Math.abs(ambMod)} ambience)`
+      : ' (2 per vessel)';
     h += '<div class="feed-vessel-row" style="padding:12px 14px 8px;">';
     h += `<div class="feed-v-num">${vessels}</div>`;
-    h += `<div class="feed-v-lbl">vessel${vessels !== 1 ? 's' : ''} available \u00B7 <b>${safeVitae} Vitae</b> safe (2 per vessel)</div>`;
+    h += `<div class="feed-v-lbl">vessel${vessels !== 1 ? 's' : ''} available \u00B7 <b>${safeVitae} Vitae</b> safe${ambBreakdown}</div>`;
     h += '</div>';
 
     // Apply controls
@@ -334,8 +352,10 @@ function updateApplyBtn() {
   if (btn && feedChar) {
     btn.textContent = `Apply ${applyAmount} Vitae to ${displayName(feedChar)}`;
   }
-  // Show/hide warning
-  const safeVitae = (feedResult?.suc || 0) * 2;
+  // Show/hide warning. Issue #176: keep the safe-vitae calc in sync with
+  // renderResult — base from vessels × 2 plus ambience modifier, floored.
+  const _ambModForWarn = buildPool()?.ambMod || 0;
+  const safeVitae = Math.max(0, (feedResult?.suc || 0) * 2 + _ambModForWarn);
   const warnEl = document.querySelector('.fe-warn');
   if (warnEl) {
     warnEl.style.display = applyAmount > safeVitae ? '' : 'none';

--- a/public/js/data/feeding-pool.js
+++ b/public/js/data/feeding-pool.js
@@ -128,9 +128,18 @@ export function computeBestFeedingPool({ char, methodId, territorySlug, spec = '
     }
   }
 
+  // Issue #176 (2026-05-09): ambience is a Vitae yield modifier, NOT a dice
+  // pool component, per Damnation City §158: 'Starting Vitae is blood taken
+  // from hunting vessels (with Territory Ambience + Herd adding to this)'.
+  // Pre-fix `ambMod` was summed into `total`, which both inflated the dice
+  // count rendered to the player AND effectively double-counted ambience
+  // into vitae (more dice → more vessels → more vitae × 2). The dice pool
+  // is now Attribute + Skill + Discipline + spec ± unskilled penalty only;
+  // the `ambience.mod` field below stays so consuming display + vitae-yield
+  // logic can surface it on a separate line / fold it into vitae yield.
   const total = Math.max(
     0,
-    bestAttrVal + bestSkillVal + bestDiscVal + ambMod + unskilled + specBonus
+    bestAttrVal + bestSkillVal + bestDiscVal + unskilled + specBonus
   );
 
   return {

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -3718,10 +3718,19 @@ function renderProjectSlots(saved, mode = 'advanced') {
         if (inheritedPool.skill.name) parts.push(`${inheritedPool.skill.val} ${esc(inheritedPool.skill.name)}`);
         else if (inheritedPool.unskilled) parts.push(`${inheritedPool.unskilled} unskilled`);
         if (inheritedPool.disc.name) parts.push(`${inheritedPool.disc.val} ${esc(inheritedPool.disc.name)}`);
-        if (inheritedPool.ambience.mod) parts.push(`${inheritedPool.ambience.mod > 0 ? '+' : ''}${inheritedPool.ambience.mod} ambience`);
         if (inheritedPool.spec?.bonus) parts.push(`+${inheritedPool.spec.bonus} ${esc(inheritedPool.spec.name)}`);
+        // Issue #176: ambience is a Vitae yield modifier (Damnation City
+        // §158), not a dice pool component. Removed from the dice
+        // breakdown above; surfaced as a separate annotation line below
+        // so the player still sees the territory's ambience contribution
+        // — just labelled correctly.
         h += `<label class="qf-label">Pool: <strong>${inheritedPool.total}</strong> <span class="qf-desc" style="font-weight:normal">(inherited from primary hunt)</span></label>`;
         h += `<p class="qf-desc">${parts.join(' &middot; ')}</p>`;
+        if (inheritedPool.ambience.mod) {
+          const ambSign = inheritedPool.ambience.mod > 0 ? '+' : '−';
+          const ambLabel = inheritedPool.ambience.label ? ` (${esc(inheritedPool.ambience.label)})` : '';
+          h += `<p class="qf-desc dt-feed-dim">${ambSign}${Math.abs(inheritedPool.ambience.mod)} Vitae from territory ambience${ambLabel}</p>`;
+        }
       }
       h += '</div>';
     }
@@ -6322,10 +6331,17 @@ function renderQuestion(q, value) {
           if (pool.skill.name) parts.push(`${pool.skill.val} ${esc(pool.skill.name)}`);
           else if (pool.unskilled) parts.push(`${pool.unskilled} unskilled`);
           if (pool.disc.name) parts.push(`${pool.disc.val} ${esc(pool.disc.name)}`);
-          if (pool.ambience.mod) parts.push(`${pool.ambience.mod > 0 ? '+' : ''}${pool.ambience.mod} ambience`);
           if (pool.spec?.bonus) parts.push(`+${pool.spec.bonus} ${esc(pool.spec.name)}`);
           h += `<label class="qf-label">Pool: <strong>${pool.total}</strong></label>`;
           h += `<p class="qf-desc">${parts.join(' &middot; ')} (auto-picked from your sheet)</p>`;
+          // Issue #176: ambience is a Vitae yield modifier (Damnation
+          // City §158), not a dice pool component. Surfaced separately
+          // so the player still sees the territory's contribution.
+          if (pool.ambience.mod) {
+            const ambSign = pool.ambience.mod > 0 ? '+' : '−';
+            const ambLabel = pool.ambience.label ? ` (${esc(pool.ambience.label)})` : '';
+            h += `<p class="qf-desc dt-feed-dim">${ambSign}${Math.abs(pool.ambience.mod)} Vitae from territory ambience${ambLabel}</p>`;
+          }
         }
         h += '</div>';
         h += '<p class="qf-desc dt-feed-min-pool__advanced-hint">Want to customise your pool? Switch to <strong>Advanced</strong> mode at the top of the form.</p>';

--- a/server/tests/feeding-pool-ambience-vitae.test.js
+++ b/server/tests/feeding-pool-ambience-vitae.test.js
@@ -1,0 +1,111 @@
+/**
+ * Unit tests — ambience is a Vitae modifier, not a dice pool component (#176).
+ *
+ * Per Damnation City §158 ambience modifies Vitae yield, not the dice rolled
+ * to hunt. Pre-fix `computeBestFeedingPool` summed `ambMod` into `total`,
+ * inflating the dice count + double-counting ambience into vitae (more dice
+ * → more vessels → more vitae × 2). Post-fix `total` excludes ambMod and
+ * the `ambience.mod` field on the returned object stays unchanged so
+ * downstream display + Vitae-yield logic can surface it as a separate
+ * contribution.
+ *
+ * Worked example from the issue body (#176 AC):
+ *   Presence 8 + Empathy 3 + Auspex 4 + ambience +3 = 15 dice (NOT 18) +
+ *   +3 Vitae from ambience.
+ *
+ * Auspex isn't on Seduction's allowlist; the test mirrors the AC's spirit
+ * with method-allowed components instead — Seduction's Majesty is the
+ * canonical disc for the example.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// `feeding-pool.js`'s import chain pulls in api.js which references the
+// browser-only `location` global at module load. Mock api.js to a stub
+// so the chain can resolve under Node. Same hoist-friendly pattern as
+// the sibling prereq tests' accessors mock.
+vi.mock('../../public/js/data/api.js', () => ({
+  apiGet: () => Promise.resolve(null),
+  apiPost: () => Promise.resolve(null),
+  apiPut: () => Promise.resolve(null),
+  apiPatch: () => Promise.resolve(null),
+  apiDelete: () => Promise.resolve(null),
+}));
+
+vi.mock('../../public/js/data/loader.js', () => ({
+  getRulesCache: () => ({}),
+  getRuleByKey: () => null,
+  getRulesByCategory: () => [],
+  getRulesBySource: () => ({ grants: [], nineAgain: [], skillBonus: [] }),
+}));
+
+import { computeBestFeedingPool } from '../../public/js/data/feeding-pool.js';
+
+function makeChar({ presence = 8, empathy = 3, majesty = 4 } = {}) {
+  return {
+    attributes: {
+      Presence:    { dots: presence, bonus: 0 },
+      Manipulation:{ dots: 0,        bonus: 0 },
+    },
+    skills: {
+      Empathy:    { dots: empathy, bonus: 0, specs: [], nine_again: false },
+      Socialise:  { dots: 0,       bonus: 0, specs: [], nine_again: false },
+      Persuasion: { dots: 0,       bonus: 0, specs: [], nine_again: false },
+    },
+    disciplines: {
+      Majesty: { dots: majesty, cp: 0, xp: 0, free: 0 },
+    },
+    merits: [],
+  };
+}
+
+describe('computeBestFeedingPool — ambience excluded from dice total (#176)', () => {
+  it('worked example: Presence 8 + Empathy 3 + Majesty 4 + ambience +3 = 15 dice (NOT 18)', () => {
+    const char = makeChar();
+    const result = computeBestFeedingPool({
+      char,
+      methodId: 'seduction',
+      territorySlug: 'academy', // ambienceMod: +3 (Curated)
+    });
+    expect(result).toBeTruthy();
+    expect(result.total).toBe(15);
+    expect(result.ambience.mod).toBe(3);
+  });
+
+  it('preserves ambience.mod field on the returned object', () => {
+    const result = computeBestFeedingPool({
+      char: makeChar(),
+      methodId: 'seduction',
+      territorySlug: 'academy',
+    });
+    expect(result.ambience).toBeTruthy();
+    expect(result.ambience.mod).toBe(3);
+    expect(result.ambience.label).toBe('Curated');
+    expect(result.ambience.territorySlug).toBe('academy');
+  });
+
+  it('ambience does not affect dice when territory has zero ambience modifier', () => {
+    const result = computeBestFeedingPool({
+      char: makeChar(),
+      methodId: 'seduction',
+      territorySlug: 'dockyards', // ambienceMod: 0 (Settled)
+    });
+    expect(result.total).toBe(15);
+    expect(result.ambience.mod).toBe(0);
+  });
+
+  it('negative ambience does not subtract from dice (Hostile / Barrens territories)', () => {
+    const result = computeBestFeedingPool({
+      char: makeChar(),
+      methodId: 'seduction',
+      territorySlug: 'harbour', // ambienceMod: -2 (Untended)
+    });
+    // Pre-fix: would have been 13 (15 + (-2)). Post-fix: 15.
+    expect(result.total).toBe(15);
+    expect(result.ambience.mod).toBe(-2);
+  });
+
+  it('returns null when no method id is supplied', () => {
+    expect(computeBestFeedingPool({ char: makeChar() })).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #176. **Rules-correctness regression fix**, not just UI relabel — pre-fix the dice pool was inflated by ambience, which both displayed too many dice AND double-counted ambience into Vitae yield (more dice → more vessels → more Vitae × 2 = ambience compounded).

Per Damnation City §158 ('Starting Vitae is blood taken from hunting vessels (with Territory Ambience + Herd adding to this)'), ambience modifies Vitae yield, not the dice rolled.

## Changes

### Dice total — ambience removed

| Site | Change |
|---|---|
| `public/js/data/feeding-pool.js` (canonical helper, used by MINIMAL + ROTE annotations) | `total` now sums attr + skill + disc + spec ± unskilled. `ambience.mod` field stays on the returned object. |
| `public/js/admin/feeding-engine.js` `buildPool()` | `total` excludes `ambMod`. Field returned separately on the result. |

### Vitae yield — ambience added

| Site | Change |
|---|---|
| `feeding-engine.js` `renderResult()` | `safeVitae = vessels × 2 + ambMod` (floored at 0 for hostile / barrens territories). Breakdown reads e.g. `'3 vessels · 9 Vitae safe (6 from vessels + 3 ambience)'`. |
| `feeding-engine.js` `updateApplyBtn()` | Matching safeVitae calc so the beyond-safe-vitae warning fires at the correct threshold. |

### Display surfaces — ambience labelled as Vitae bonus

- `downtime-form.js` ROTE inherited pool annotation (line ~3721): ambience moved out of dice parts list, surfaced on a separate `'+/-N Vitae from territory ambience (Label)'` line.
- `downtime-form.js` MINIMAL feed pool annotation (line ~6325): same shape.
- `feeding-engine.js` pool breakdown: ambience moved out of `+ N Ambience` dice listing into a `'+N Vitae from ambience'` dim line below the dice breakdown.

## Surveyed admin's `buildFeedingPool` — kept stMod in dice pool

Caught mid-fix that `public/js/admin/downtime-views.js` `buildFeedingPool` has a parameter named `ambienceMod` but every caller passes `stMod` (`s.st_review.feeding_modifier` — the ST manual adjudication adjustment, NOT territory ambience). The territory ambience never flows through that function. ST modifier legitimately adjusts dice (it's the ST's lever for cover / difficulty / etc.) and stays in the pool total. Added a comment block clarifying the misleading parameter name so future readers don't make the same near-miss.

## HALT-DAR check — resolved as PROCEED

Issue body said `Open questions: None — rules are unambiguous`. Verified by surveying all admin adjudication surfaces:

- Admin `renderFeedingDetail` Pool breakdown (`downtime-views.js:1330-1339`) doesn't currently show ambience as a component → no ST visibility loss. Total now matches the actual dice that will be rolled (correctness fix).
- Admin `feeding-engine.js` ST-side feeding test panel: ambience visible as Vitae bonus + folded into yield calc — visibility gained, not lost.

## Tests

`server/tests/feeding-pool-ambience-vitae.test.js` — 5 unit tests for `computeBestFeedingPool`:

- **Worked example from issue body**: Presence 8 + Empathy 3 + Majesty 4 + ambience +3 → **15 dice** (NOT 18), `ambience.mod === 3`.
- `ambience.mod` field preserved on returned object (label, territorySlug, name).
- Zero-ambience territory: total unchanged.
- Negative ambience (Hostile / Barrens): does NOT subtract from dice (regression guard — pre-fix would have been 13).
- `null` return when methodId absent.

## Verification

- **Server tests**: 736/736 pass (was 731; +5 from this file).
- **Parse-check** across all 4 modified client files: clean.
- All 4 AC items from the issue body covered.

## Test plan (browser smoke deferred to user)

- [ ] Player MINIMAL feed: pool annotation no longer includes ambience in the dice breakdown; ambience appears below as `'+3 Vitae from territory ambience (Curated)'`.
- [ ] ROTE inherited pool annotation: same treatment.
- [ ] ST feeding-engine panel: dice count smaller (correct); vessels row shows `'X vessels · Y Vitae safe (vessels × 2 + ambience)'`.
- [ ] Hostile / Barrens territory: dice unchanged (pre-fix would have subtracted); Vitae yield reduced.

## Branch

`dev` per house rule. Per process: NOT auto-merging — pinging Khepri after this opens for Ma'at static review routing.