### PR TITLE
fix(hotfix): null-cache guard prevents Contacts spheres data loss (#249)

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -1108,7 +1108,20 @@ async function init() {
   // MUST await — applyDerivedMerits below (via charAlerts in renderCharGrid)
   // calls getRulesBySource synchronously. Cache miss → engine bonuses skipped
   // → m.rating gets re-synced to (cp + xp), wiping the saved bonus on display.
-  await preloadRules().catch(() => {});
+  // Issue #249 (HOTFIX 2026-05-09): silent catch removed. Downstream
+  // applyDerivedMerits guard now prevents Contacts-spheres data loss
+  // from a null cache; explicit error surfaces the degraded state.
+  try {
+    await preloadRules();
+  } catch (err) {
+    console.error('[admin] preloadRules failed — derivations skipped until rules cache loads (issue #249):', err);
+    const banner = document.getElementById('app-status-banner');
+    if (banner) {
+      banner.textContent = 'Rules data failed to load — some derived merit values may be unavailable. Reload the page or check your connection.';
+      banner.classList.add('app-status-banner--error');
+      banner.style.display = '';
+    }
+  }
 
   try {
     chars = await apiGet('/api/characters');

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -501,7 +501,29 @@ async function loadAllData() {
   // and a missing cache means free_attache / free_fwb / free_pt etc. all
   // resolve to 0, then m.rating gets re-synced to (cp + xp), wiping the
   // bonus the editor had correctly saved.
-  await preloadRules().catch(() => {});
+  // Issue #249 (HOTFIX 2026-05-09): pre-fix this swallowed all errors
+  // silently — when the rules API call failed, _cache stayed null and
+  // applyDerivedMerits proceeded with broken derivation, causing
+  // permanent Contacts-spheres data loss for any character with PT/MCI-
+  // granted spheres (Yusuf canonical example). The downstream
+  // applyDerivedMerits null-cache guard now prevents the data loss,
+  // but failing silently is still wrong — surface the error so the
+  // user knows the app is in a degraded state (derivations skipped
+  // until cache loads).
+  try {
+    await preloadRules();
+  } catch (err) {
+    console.error('[app] preloadRules failed — derivations skipped until rules cache loads (issue #249):', err);
+    // Best-effort user-visible signal. The element may not exist on
+    // every page; failure to surface is non-fatal — the console error
+    // remains the canonical signal.
+    const banner = document.getElementById('app-status-banner');
+    if (banner) {
+      banner.textContent = 'Rules data failed to load — some derived merit values may be unavailable. Reload the page or check your connection.';
+      banner.classList.add('app-status-banner--error');
+      banner.style.display = '';
+    }
+  }
 
   // 1. Try API first — role-filtered server-side (player sees own, ST sees all)
   const apiChars = await loadCharsFromApi();

--- a/public/js/editor/domain.js
+++ b/public/js/editor/domain.js
@@ -5,6 +5,7 @@
 
 import { INFLUENCE_SPHERES } from '../data/constants.js';
 import state from '../data/state.js';
+import { getRulesCache } from './rule_engine/load-rules.js';
 
 /* ══════════════════════════════════════════════════════
    Multi-instance domain type sets
@@ -214,6 +215,19 @@ export function syncMeritRating(m) {
 export function pruneContactsSpheres(m) {
   if (!m || m.name !== 'Contacts') return;
   if (!Array.isArray(m.spheres)) return;
+  // Issue #249 (HOTFIX 2026-05-09): belt-and-braces guard — bail if the
+  // rules cache is null. The primary guard lives at the top of
+  // applyDerivedMerits (mci.js), so under normal call patterns this
+  // branch is dead code. It exists to protect any future caller of
+  // pruneContactsSpheres that bypasses applyDerivedMerits — without it,
+  // a null-cache call would compute `r` with PT/free_* contributions
+  // missing and physically truncate the spheres array (permanent data
+  // loss on next save). Truncate-only never silently destroys data
+  // again from this path.
+  if (!getRulesCache()) {
+    console.warn('pruneContactsSpheres: rules cache not loaded — skipping prune to avoid sphere data loss (issue #249)');
+    return;
+  }
   const r = (m.cp || 0) + (m.xp || 0) + meritFreeSum(m);
   if (m.spheres.length > r) m.spheres.length = r;
 }

--- a/public/js/editor/mci.js
+++ b/public/js/editor/mci.js
@@ -26,6 +26,28 @@ import { applyAutoBonusRulesFromDb } from './rule_engine/auto-bonus-evaluator.js
 export function applyDerivedMerits(c, allChars = []) {
   if (!c) return;
 
+  // Issue #249 (HOTFIX 2026-05-09): bail out when the rules cache is null.
+  // Pre-fix sequence:
+  //   1. line 42 below clears `m.free_pt = 0` on every merit
+  //   2. line 52 calls applyPTRulesFromDb → no-ops when cache is null
+  //      (getRulesBySource returns empty arrays per load-rules.js:43)
+  //   3. line 102 calls pruneContactsSpheres → computes
+  //      `r = cp + xp + meritFreeSum(m)` with PT contribution missing →
+  //      truncates `m.spheres.length` to the deflated rating →
+  //      PT-granted spheres physically deleted from the array
+  //   4. next save persists the truncated spheres → permanent data loss
+  //
+  // Triggers: preloadRules silent failure, save-cycle before preload
+  // resolves, admin Rules Data view re-preload race, etc.
+  //
+  // Affected: any character with PT- or MCI-granted Contacts spheres.
+  // Yusuf: rating 3 (1 MCI + 2 PT) collapsed to ['Legal'] when bug
+  // fired; Street + Underworld physically deleted.
+  if (!getRulesCache()) {
+    console.warn('applyDerivedMerits: rules cache not loaded — skipping derivation to avoid partial-state corruption (issue #249)');
+    return;
+  }
+
   // Clear ephemeral tracking
   c._pt_nine_again_skills = new Set();
   c._pt_dot4_bonus_skills = new Set();

--- a/public/js/player.js
+++ b/public/js/player.js
@@ -164,7 +164,20 @@ async function loadCharacters() {
   // unconditionally zeroes free_pt / free_mdb at start. Without rules in
   // cache, the evaluators can't re-apply them, so the displayed m.rating
   // collapses to (cp + xp) and any engine bonus disappears from the view.
-  await preloadRules().catch(() => {});
+  // Issue #249 (HOTFIX 2026-05-09): see app.js:504 — silent catch removed.
+  // Downstream applyDerivedMerits guard now prevents data loss from a
+  // null cache; explicit error surfaces the degraded state to the user.
+  try {
+    await preloadRules();
+  } catch (err) {
+    console.error('[player] preloadRules failed — derivations skipped until rules cache loads (issue #249):', err);
+    const banner = document.getElementById('app-status-banner');
+    if (banner) {
+      banner.textContent = 'Rules data failed to load — some derived merit values may be unavailable. Reload the page or check your connection.';
+      banner.classList.add('app-status-banner--error');
+      banner.style.display = '';
+    }
+  }
 
   try {
     chars = await apiGet(getRole() === 'st' ? '/api/characters' : '/api/characters?mine=1');

--- a/server/tests/apply-derived-merits-harness.test.js
+++ b/server/tests/apply-derived-merits-harness.test.js
@@ -39,7 +39,14 @@ vi.mock('../../public/js/data/loader.js', () => ({
 vi.mock('../../public/js/editor/rule_engine/load-rules.js', () => ({
   preloadRules: async () => {},
   invalidateRulesCache: () => {},
-  getRulesCache: () => null,
+  // Issue #249 (HOTFIX): applyDerivedMerits now bails out when
+  // getRulesCache() returns null to prevent Contacts-spheres data loss
+  // (PT/MCI free_pt + free_mci channels reset before evaluators apply
+  // them; pruneContactsSpheres then truncates the array). Harness
+  // supplies its rules via getRulesBySource directly, so we return a
+  // non-null sentinel here so the guard sees the cache as 'loaded'
+  // and proceeds with the derivation under test.
+  getRulesCache: () => ({ rule_grant: [], rule_nine_again: [], rule_skill_bonus: [], rule_speciality_grant: [], rule_tier_budget: [] }),
   getRulesBySource: (source) => {
     if (source === 'Professional Training') {
       return {

--- a/server/tests/applyDerivedMerits-null-cache-guard.test.js
+++ b/server/tests/applyDerivedMerits-null-cache-guard.test.js
@@ -1,0 +1,165 @@
+/**
+ * Unit tests — null-cache guard in applyDerivedMerits + pruneContactsSpheres
+ * (#249 HOTFIX, 2026-05-09).
+ *
+ * Pre-fix race: when the rules cache was null (preloadRules silent failure
+ * or pre-resolution), applyDerivedMerits cleared `m.free_pt = 0` then ran
+ * the PT evaluator with empty grants, leaving `free_pt` at 0. The
+ * subsequent pruneContactsSpheres call computed
+ * `r = cp + xp + meritFreeSum(m)` without the PT contribution and
+ * physically truncated the spheres array — permanent data loss on save.
+ *
+ * Yusuf's canonical merit shape (per data/dev-fixtures/characters.json):
+ *   - rating 3 = 1 free_mci + 2 free_pt
+ *   - spheres: ['Legal', 'Street', 'Underworld']
+ *
+ * Pre-fix bug fired: `m.spheres` truncated to ['Legal'] (Street + Underworld
+ * physically deleted from the array) when applyDerivedMerits ran with a
+ * null cache. Post-fix: applyDerivedMerits bails out at the top, preserving
+ * spheres.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Browser globals stubbed for the import chain.
+vi.mock('../../public/js/data/api.js', () => ({
+  apiGet:   () => Promise.resolve(null),
+  apiPost:  () => Promise.resolve(null),
+  apiPut:   () => Promise.resolve(null),
+  apiPatch: () => Promise.resolve(null),
+  apiDelete:() => Promise.resolve(null),
+}));
+
+// Control the cache state per test via the rule-engine loader.
+vi.mock('../../public/js/editor/rule_engine/load-rules.js', async () => {
+  const actual = await vi.importActual('../../public/js/editor/rule_engine/load-rules.js');
+  return {
+    ...actual,
+    getRulesCache: () => globalThis.__TEST_RULES_CACHE__,
+    getRulesBySource: () => ({
+      grants: [], nineAgain: [], skillBonus: [], specialityGrants: [], tierBudget: null,
+    }),
+  };
+});
+
+// State module pulls in browser-y dependencies; keep it inert for the test.
+vi.mock('../../public/js/data/state.js', () => ({ default: {} }));
+
+// data/loader.js + cache hooks pulled in by mci.js's MCI-evaluator chain.
+vi.mock('../../public/js/data/loader.js', () => ({
+  getRulesCache: () => null,
+  getRuleByKey: () => null,
+  getRulesByCategory: () => [],
+  getRulesBySource: () => ({ grants: [], nineAgain: [], skillBonus: [] }),
+}));
+
+import { applyDerivedMerits } from '../../public/js/editor/mci.js';
+import { pruneContactsSpheres } from '../../public/js/editor/domain.js';
+
+function yusufLikeChar() {
+  return {
+    name: 'Test Yusuf',
+    merits: [
+      {
+        category: 'influence',
+        name: 'Contacts',
+        rating: 3,
+        spheres: ['Legal', 'Street', 'Underworld'],
+        cp: 0,
+        xp: 0,
+        free_mci: 1,
+        free_pt: 2,
+      },
+    ],
+    skills: {},
+    attributes: {},
+    disciplines: {},
+  };
+}
+
+describe('applyDerivedMerits — null-cache guard (#249)', () => {
+  let warnSpy;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('bails out and preserves Contacts spheres when rules cache is null', () => {
+    globalThis.__TEST_RULES_CACHE__ = null;
+    const c = yusufLikeChar();
+
+    applyDerivedMerits(c);
+
+    const contacts = c.merits.find(m => m.name === 'Contacts');
+    expect(contacts.spheres).toEqual(['Legal', 'Street', 'Underworld']);
+    expect(contacts.spheres.length).toBe(3);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('rules cache not loaded'));
+  });
+
+  it('does not zero free_pt or free_mci when cache is null (rating math preserved)', () => {
+    globalThis.__TEST_RULES_CACHE__ = null;
+    const c = yusufLikeChar();
+
+    applyDerivedMerits(c);
+
+    const contacts = c.merits.find(m => m.name === 'Contacts');
+    expect(contacts.free_pt).toBe(2);
+    expect(contacts.free_mci).toBe(1);
+  });
+
+  it('proceeds with derivation when rules cache is loaded (sentinel object)', () => {
+    globalThis.__TEST_RULES_CACHE__ = { rule_grant: [], rule_nine_again: [] };
+    const c = yusufLikeChar();
+
+    applyDerivedMerits(c);
+
+    // Cache is non-null so the guard doesn't fire; the body runs and
+    // clears free_pt before the PT evaluator (which our mock no-ops),
+    // so free_pt ends at 0. This is the *expected* post-bail behaviour
+    // when the cache exists but the PT evaluator finds no grants —
+    // separate concern from the null-cache hotfix.
+    const contacts = c.merits.find(m => m.name === 'Contacts');
+    expect(contacts.spheres.length).toBeGreaterThan(0);
+  });
+});
+
+describe('pruneContactsSpheres — belt-and-braces null-cache guard (#249)', () => {
+  let warnSpy;
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('does not truncate spheres when called directly with null cache', () => {
+    globalThis.__TEST_RULES_CACHE__ = null;
+    const m = {
+      name: 'Contacts',
+      cp: 0, xp: 0, free_mci: 1, free_pt: 2,
+      spheres: ['Legal', 'Street', 'Underworld'],
+    };
+
+    pruneContactsSpheres(m);
+
+    expect(m.spheres).toEqual(['Legal', 'Street', 'Underworld']);
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('rules cache not loaded'));
+  });
+
+  it('still truncates spheres normally when cache is loaded and rating drops below sphere count', () => {
+    globalThis.__TEST_RULES_CACHE__ = { rule_grant: [] };
+    const m = {
+      name: 'Contacts',
+      cp: 0, xp: 0,
+      // No free_* contributions → effective rating 0, but spheres has 3.
+      spheres: ['Legal', 'Street', 'Underworld'],
+    };
+
+    pruneContactsSpheres(m);
+
+    expect(m.spheres).toEqual([]);
+  });
+
+  it('no-ops when merit is not Contacts', () => {
+    globalThis.__TEST_RULES_CACHE__ = null;
+    const m = { name: 'Allies', spheres: ['Police', 'Media'] };
+    pruneContactsSpheres(m);
+    expect(m.spheres).toEqual(['Police', 'Media']);
+  });
+});

--- a/server/tests/bloodline-parallel-write.test.js
+++ b/server/tests/bloodline-parallel-write.test.js
@@ -35,7 +35,7 @@ vi.mock('../../public/js/data/loader.js', () => ({
 vi.mock('../../public/js/editor/rule_engine/load-rules.js', () => ({
   preloadRules: async () => {},
   invalidateRulesCache: () => {},
-  getRulesCache: () => null,
+  getRulesCache: () => ({ rule_grant: [], rule_nine_again: [], rule_skill_bonus: [], rule_speciality_grant: [], rule_tier_budget: [] }),  // #249 hotfix: non-null sentinel so applyDerivedMerits guard does not bail
   getRulesBySource: () => store,
 }));
 

--- a/server/tests/mci-parallel-write.test.js
+++ b/server/tests/mci-parallel-write.test.js
@@ -37,7 +37,7 @@ vi.mock('../../public/js/data/loader.js', () => ({
 vi.mock('../../public/js/editor/rule_engine/load-rules.js', () => ({
   preloadRules: async () => {},
   invalidateRulesCache: () => {},
-  getRulesCache: () => null,
+  getRulesCache: () => ({ rule_grant: [], rule_nine_again: [], rule_skill_bonus: [], rule_speciality_grant: [], rule_tier_budget: [] }),  // #249 hotfix: non-null sentinel so applyDerivedMerits guard does not bail
   getRulesBySource: () => store,
 }));
 

--- a/server/tests/mdb-parallel-write.test.js
+++ b/server/tests/mdb-parallel-write.test.js
@@ -27,7 +27,7 @@ vi.mock('../../public/js/data/loader.js', () => ({
 vi.mock('../../public/js/editor/rule_engine/load-rules.js', () => ({
   preloadRules: async () => {},
   invalidateRulesCache: () => {},
-  getRulesCache: () => null,
+  getRulesCache: () => ({ rule_grant: [], rule_nine_again: [], rule_skill_bonus: [], rule_speciality_grant: [], rule_tier_budget: [] }),  // #249 hotfix: non-null sentinel so applyDerivedMerits guard does not bail
   getRulesBySource: (source) =>
     storeMap[source] || { grants: [], nineAgain: [], skillBonus: [], specialityGrants: [], tierBudget: null },
 }));

--- a/server/tests/ohm-parallel-write.test.js
+++ b/server/tests/ohm-parallel-write.test.js
@@ -37,7 +37,7 @@ vi.mock('../../public/js/data/loader.js', () => ({
 vi.mock('../../public/js/editor/rule_engine/load-rules.js', () => ({
   preloadRules: async () => {},
   invalidateRulesCache: () => {},
-  getRulesCache: () => null,
+  getRulesCache: () => ({ rule_grant: [], rule_nine_again: [], rule_skill_bonus: [], rule_speciality_grant: [], rule_tier_budget: [] }),  // #249 hotfix: non-null sentinel so applyDerivedMerits guard does not bail
   getRulesBySource: () => store,
 }));
 

--- a/server/tests/ots-parallel-write.test.js
+++ b/server/tests/ots-parallel-write.test.js
@@ -27,7 +27,7 @@ vi.mock('../../public/js/data/loader.js', () => ({
 vi.mock('../../public/js/editor/rule_engine/load-rules.js', () => ({
   preloadRules: async () => {},
   invalidateRulesCache: () => {},
-  getRulesCache: () => null,
+  getRulesCache: () => ({ rule_grant: [], rule_nine_again: [], rule_skill_bonus: [], rule_speciality_grant: [], rule_tier_budget: [] }),  // #249 hotfix: non-null sentinel so applyDerivedMerits guard does not bail
   getRulesBySource: (source) =>
     storeMap[source] || { grants: [], nineAgain: [], skillBonus: [], specialityGrants: [], tierBudget: null },
 }));

--- a/server/tests/pool-parallel-write.test.js
+++ b/server/tests/pool-parallel-write.test.js
@@ -34,7 +34,7 @@ vi.mock('../../public/js/data/loader.js', () => ({
 vi.mock('../../public/js/editor/rule_engine/load-rules.js', () => ({
   preloadRules: async () => {},
   invalidateRulesCache: () => {},
-  getRulesCache: () => null,
+  getRulesCache: () => ({ rule_grant: [], rule_nine_again: [], rule_skill_bonus: [], rule_speciality_grant: [], rule_tier_budget: [] }),  // #249 hotfix: non-null sentinel so applyDerivedMerits guard does not bail
   getRulesBySource: (source) =>
     storeMap[source] || { grants: [], nineAgain: [], skillBonus: [], specialityGrants: [], tierBudget: null },
 }));

--- a/server/tests/pt-parallel-write.test.js
+++ b/server/tests/pt-parallel-write.test.js
@@ -32,7 +32,7 @@ vi.mock('../../public/js/data/loader.js', () => ({
 vi.mock('../../public/js/editor/rule_engine/load-rules.js', () => ({
   preloadRules: async () => {},
   invalidateRulesCache: () => {},
-  getRulesCache: () => null,
+  getRulesCache: () => ({ rule_grant: [], rule_nine_again: [], rule_skill_bonus: [], rule_speciality_grant: [], rule_tier_budget: [] }),  // #249 hotfix: non-null sentinel so applyDerivedMerits guard does not bail
   getRulesBySource: () => store,
 }));
 

--- a/server/tests/rule-engine-integration.test.js
+++ b/server/tests/rule-engine-integration.test.js
@@ -35,7 +35,7 @@ vi.mock('../../public/js/data/loader.js', () => ({
 vi.mock('../../public/js/editor/rule_engine/load-rules.js', () => ({
   preloadRules: async () => {},
   invalidateRulesCache: () => {},
-  getRulesCache: () => null,
+  getRulesCache: () => ({ rule_grant: [], rule_nine_again: [], rule_skill_bonus: [], rule_speciality_grant: [], rule_tier_budget: [] }),  // #249 hotfix: non-null sentinel so applyDerivedMerits guard does not bail
   getRulesBySource: (source) =>
     storeMap[source] || { grants: [], nineAgain: [], skillBonus: [], specialityGrants: [], tierBudget: null },
 }));

--- a/server/tests/safe-word-parallel-write.test.js
+++ b/server/tests/safe-word-parallel-write.test.js
@@ -27,7 +27,7 @@ vi.mock('../../public/js/data/loader.js', () => ({
 vi.mock('../../public/js/editor/rule_engine/load-rules.js', () => ({
   preloadRules: async () => {},
   invalidateRulesCache: () => {},
-  getRulesCache: () => null,
+  getRulesCache: () => ({ rule_grant: [], rule_nine_again: [], rule_skill_bonus: [], rule_speciality_grant: [], rule_tier_budget: [] }),  // #249 hotfix: non-null sentinel so applyDerivedMerits guard does not bail
   getRulesBySource: (source) =>
     storeMap[source] || { grants: [], nineAgain: [], skillBonus: [], specialityGrants: [], tierBudget: null },
 }));

--- a/server/tests/style-retainer-parallel-write.test.js
+++ b/server/tests/style-retainer-parallel-write.test.js
@@ -28,7 +28,7 @@ vi.mock('../../public/js/data/loader.js', () => ({
 vi.mock('../../public/js/editor/rule_engine/load-rules.js', () => ({
   preloadRules: async () => {},
   invalidateRulesCache: () => {},
-  getRulesCache: () => null,
+  getRulesCache: () => ({ rule_grant: [], rule_nine_again: [], rule_skill_bonus: [], rule_speciality_grant: [], rule_tier_budget: [] }),  // #249 hotfix: non-null sentinel so applyDerivedMerits guard does not bail
   getRulesBySource: (source) =>
     storeMap[source] || { grants: [], nineAgain: [], skillBonus: [], specialityGrants: [], tierBudget: null },
 }));

--- a/server/tests/vm-parallel-write.test.js
+++ b/server/tests/vm-parallel-write.test.js
@@ -27,7 +27,7 @@ vi.mock('../../public/js/data/loader.js', () => ({
 vi.mock('../../public/js/editor/rule_engine/load-rules.js', () => ({
   preloadRules: async () => {},
   invalidateRulesCache: () => {},
-  getRulesCache: () => null,
+  getRulesCache: () => ({ rule_grant: [], rule_nine_again: [], rule_skill_bonus: [], rule_speciality_grant: [], rule_tier_budget: [] }),  // #249 hotfix: non-null sentinel so applyDerivedMerits guard does not bail
   getRulesBySource: (source) =>
     storeMap[source] || { grants: [], nineAgain: [], skillBonus: [], specialityGrants: [], tierBudget: null },
 }));


### PR DESCRIPTION
## Summary

**HOTFIX. Cycle-blocker, data-loss class.** Closes #249. Applied Option C hybrid per the issue's recommendation.

## Pre-fix race

When the rules cache is null (preloadRules silent failure or pre-resolution race):

1. `applyDerivedMerits` (`mci.js:42`) clears `m.free_pt = 0` on every merit BEFORE applying PT rules.
2. `applyPTRulesFromDb` no-ops because `getRulesBySource` returns empty arrays for a null cache. `free_pt` stays 0.
3. `pruneContactsSpheres` (`mci.js:102`) computes `r = cp + xp + meritFreeSum(m)` with the PT contribution missing, and physically truncates `m.spheres.length = r`.
4. Next save persists the truncated array → **permanent data loss**.

Yusuf's canonical fixture: rating 3 = 1 free_mci + 2 free_pt with `['Legal', 'Street', 'Underworld']`. Bug fired → spheres collapsed to `['Legal']` (Street + Underworld physically deleted from the array). DT form's contact-action rendering then surfaced only 1 row instead of 3.

Surface has existed since 2026-05-07 (commits `c7d2ea58` + `f77799df`). Race pattern is the intermittency giveaway.

## Fix — Option C hybrid

| # | Change | File |
|---|---|---|
| 1 | **Primary guard at top of `applyDerivedMerits`** — bail out with `console.warn` when `getRulesCache()` is null. The `m.free_pt = 0` clear never executes; existing free_* values stay intact. | `public/js/editor/mci.js` |
| 2 | **Belt-and-braces guard inside `pruneContactsSpheres`** — same null-cache short-circuit. Dead code under normal call patterns; protects any future caller that bypasses `applyDerivedMerits`. | `public/js/editor/domain.js` |
| 3 | **Non-silent error on preloadRules failure** — replaced `await preloadRules().catch(() => {})` with explicit `try`/`catch` that logs to `console.error` + writes to an `app-status-banner` element if present. | `public/js/app.js`, `player.js`, `admin.js` |

## Test-infrastructure update

Discovered during regression: 11 parallel-write test files mock `getRulesCache: () => null` while supplying rules separately via `getRulesBySource`. Pre-fix that worked because nothing checked `getRulesCache` directly; the new guard breaks them.

Updated all 11 mocks (plus the apply-derived-merits-harness suite) to return a non-null sentinel `{ rule_grant: [], … }`. Each updated line has an inline `// #249 hotfix:` comment so future readers see why. The mocks' `getRulesBySource` continues to supply canonical rules; only the cache-presence sentinel changed.

Files updated: `bloodline-`, `mci-`, `mdb-`, `ohm-`, `ots-`, `pool-`, `pt-`, `rule-engine-integration`, `safe-word-`, `style-retainer-`, `vm-` parallel-write tests + the `apply-derived-merits-harness` suite.

## New tests

`server/tests/applyDerivedMerits-null-cache-guard.test.js` — 6 unit tests:

- `applyDerivedMerits` with null cache preserves Yusuf's spheres array (canonical bug repro).
- `free_pt` + `free_mci` preserved when cache is null (rating math stays whole).
- Non-null cache: derivation proceeds normally.
- `pruneContactsSpheres` direct-call with null cache: no truncation.
- `pruneContactsSpheres` direct-call with loaded cache + low rating: still truncates (existing path unchanged for the canonical case).
- Non-Contacts merit: no-op (existing behaviour preserved).

## Verification

- **Server tests**: 742/742 pass (was 736; +6 from this file).
- **Parse-check**: clean across all 5 modified client files.
- **Three `preloadRules` consumers** (app.js, player.js, admin.js) all log explicitly on failure.

## Recovery for affected production data

Out of scope for this PR but flagged in dispatch. Affected characters need manual re-add of any PT/MCI-granted Contacts spheres. Audit query (pseudo): characters where Contacts merit's `spheres.length < (cp + xp + free_mci + free_pt + free_*)`. ST can re-add via the contacts-dot-row sphere selectors at `public/js/editor/sheet.js:833`.

## Test plan (browser smoke deferred to user)

- [ ] Open Yusuf in admin sheet — 3 contact spheres render.
- [ ] Open DT form for Yusuf — 3 contact-action rows surface.
- [ ] Simulate cache fetch failure (block `/api/rules` in DevTools): `console.error` logs; status banner shows if wired in HTML; spheres preserved on save.
- [ ] Cache loads normally: derivation runs, ratings + spheres correct.

## Branch

`dev` per house rule. Per Khepri's process: NOT auto-merging — pinging Khepri after this opens for Ma'at static review routing. User pre-authorised dev → main hotfix promotion path in this dispatch.