### PR TITLE
perf(dt): batch hold-flag lookup into single endpoint (#257)

### DIFF
--- a/public/js/data/dt-hold-flag.js
+++ b/public/js/data/dt-hold-flag.js
@@ -9,11 +9,26 @@
  * session is being held at false until the form clears the minimum bar.
  *
  * Browser-only. The pure rule encoder is in `dt-completeness.js`.
+ *
+ * Issue #257 (perf, 2026-05-11): collapsed the per-character fetch loop
+ * into a single batch endpoint call. Pre-fix this looped over every
+ * character and awaited /api/downtime_submissions?cycle_id=X&character_id=Y
+ * — ~30 sequential MongoDB queries per ST/dev boot, 1–3 for a player.
+ * Post-fix one call to /api/downtime_submissions/hold-flags returns the
+ * full { <character_id>: bool } map.
  */
 
 import { apiGet } from './api.js';
 
-export async function loadDowntimeHoldFlag(chars, { isST = false } = {}) {
+/**
+ * @param {Array} chars - characters to annotate with `_dtHoldFlag`.
+ * @param {object} [opts] - back-compat opts arg. The previous `isST`
+ *   flag is no longer needed (server-side auth scopes the cohort);
+ *   the signature stays the same so existing callers (app.js:543,
+ *   player.js:188) don't have to change. The arg is currently ignored.
+ */
+// eslint-disable-next-line no-unused-vars
+export async function loadDowntimeHoldFlag(chars, opts = {}) {
   if (!Array.isArray(chars) || chars.length === 0) return;
 
   // Default flag to false (not on hold) before any async work, so renderers
@@ -29,27 +44,24 @@ export async function loadDowntimeHoldFlag(chars, { isST = false } = {}) {
   } catch { /* fall through — flag stays false */ }
   if (!activeCycle?._id) return;
 
+  // Single batched fetch — server returns { <character_id>: bool } map.
+  // Auth-scoped server-side: player sees only own; ST sees all.
+  let map = null;
+  try {
+    map = await apiGet(
+      `/api/downtime_submissions/hold-flags?cycle_id=${encodeURIComponent(activeCycle._id)}`
+    );
+  } catch {
+    // Best-effort — if the call fails, leave the prior flag values intact.
+    return;
+  }
+  if (!map || typeof map !== 'object') return;
+
   for (const c of chars) {
-    try {
-      const subs = await apiGet(
-        `/api/downtime_submissions?cycle_id=${encodeURIComponent(activeCycle._id)}&character_id=${encodeURIComponent(c._id)}`
-      );
-      const sub = Array.isArray(subs) ? subs[0] : null;
-      if (!sub) {
-        // No submission yet for this cycle ⇒ definitely below-minimum.
-        c._dtHoldFlag = true;
-        continue;
-      }
-      const r = sub.responses || {};
-      // Trust the persisted derived bool when present; otherwise fall back
-      // to the submission's coarse status (mirrored by the lifecycle hook).
-      if (typeof r._has_minimum === 'boolean') {
-        c._dtHoldFlag = !r._has_minimum;
-      } else {
-        c._dtHoldFlag = sub.status !== 'submitted';
-      }
-    } catch {
-      // Best-effort — if a single fetch fails, leave the prior flag value.
-    }
+    const key = String(c._id);
+    // Server returns entries only for chars with a submission. Anything
+    // absent from the map → no submission for this cycle ⇒ on hold (true).
+    // Matches the pre-fix fallback at the old line 39.
+    c._dtHoldFlag = Object.prototype.hasOwnProperty.call(map, key) ? !!map[key] : true;
   }
 }

--- a/server/routes/downtime.js
+++ b/server/routes/downtime.js
@@ -569,6 +569,72 @@ submissionsRouter.post('/', validate(downtimeSubmissionSchema), async (req, res)
   res.status(201).json(created);
 });
 
+// GET /api/downtime_submissions/hold-flags?cycle_id=<id>
+// Returns { <character_id>: bool } — true == on hold (below-minimum or
+// missing submission). ST sees every character in the cycle; player sees
+// only their own characters' entries.
+//
+// Issue #257 (perf): replaces the prior N-char client loop in
+// `public/js/data/dt-hold-flag.js` (one /api/downtime_submissions GET
+// per character) with a single round-trip + one indexed `find` on the
+// submissions collection. Biggest MongoDB-cost reduction on ST/dev
+// boot (~30 calls → 1).
+//
+// Note: returns entries ONLY for characters that have a submission for
+// the cycle. The client defaults to `true` (on hold) for any character
+// absent from the map — matches the existing fallback semantics at
+// dt-hold-flag.js line 39 ('No submission yet for this cycle ⇒
+// definitely below-minimum.'). Keeping the absence-as-true contract
+// server-side too would require knowing every character ID in scope,
+// which is unnecessary work.
+//
+// Registered BEFORE `GET /` so Express routes `/hold-flags` to this
+// handler rather than treating it as a query of the list endpoint.
+submissionsRouter.get('/hold-flags', async (req, res) => {
+  if (!req.query.cycle_id) {
+    return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'cycle_id required' });
+  }
+  const cycleOid = parseId(req.query.cycle_id);
+  if (!cycleOid) {
+    return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid cycle_id format' });
+  }
+
+  // Accept both ObjectId and legacy string representations of cycle_id
+  // (mirrors `GET /` filter shape below for CSV-imported docs).
+  const filter = { $or: [{ cycle_id: cycleOid }, { cycle_id: req.query.cycle_id }] };
+
+  // Player: restrict to their characters (mirrors `GET /` scoping).
+  if (req.user.role === 'player') {
+    const charIdOids = (req.user.character_ids || []).map(id =>
+      id instanceof ObjectId ? id : new ObjectId(id)
+    );
+    const charIdStrs = charIdOids.map(id => id.toString());
+    filter.character_id = { $in: [...charIdOids, ...charIdStrs] };
+  }
+
+  // Project only fields needed for the flag derivation — keeps the
+  // wire size small even on ST cohorts of 30+ chars.
+  const docs = await submissions()
+    .find(filter, { projection: { character_id: 1, status: 1, 'responses._has_minimum': 1 } })
+    .toArray();
+
+  const map = {};
+  for (const doc of docs) {
+    const key = String(doc.character_id);
+    const hasMin = doc.responses?._has_minimum;
+    // Derivation mirrors the pre-fix client logic at
+    // dt-hold-flag.js:43-50 exactly: trust the persisted derived bool
+    // when present; otherwise fall back to the submission's coarse
+    // status (status !== 'submitted' ⇒ on hold).
+    if (typeof hasMin === 'boolean') {
+      map[key] = !hasMin;
+    } else {
+      map[key] = doc.status !== 'submitted';
+    }
+  }
+  res.json(map);
+});
+
 // GET /api/downtime_submissions — ST gets all, player gets only their own (st_review stripped)
 submissionsRouter.get('/', async (req, res) => {
   const filter = {};

--- a/server/tests/api-downtime-hold-flags.test.js
+++ b/server/tests/api-downtime-hold-flags.test.js
@@ -1,0 +1,170 @@
+/**
+ * API tests — GET /api/downtime_submissions/hold-flags (issue #257 perf batch).
+ *
+ * The endpoint collapses the prior N-character client-side loop into a
+ * single round-trip. Validates auth-scoped cohorts (ST sees all, player
+ * sees own), the two derivation paths (`_has_minimum` boolean vs
+ * `status` fallback), and edge cases (missing submission, invalid cycle).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import request from 'supertest';
+import 'dotenv/config';
+import { ObjectId } from 'mongodb';
+import { createTestApp, stUser, playerUser } from './helpers/test-app.js';
+import { setupDb, teardownDb } from './helpers/db-setup.js';
+import { getCollection } from '../db.js';
+
+let app;
+
+const CHAR_A = new ObjectId().toHexString();
+const CHAR_B = new ObjectId().toHexString();
+const CHAR_C = new ObjectId().toHexString();
+const OTHER_PLAYER_CHAR = new ObjectId().toHexString();
+
+let insertedCycleIds = [];
+let insertedSubmissionIds = [];
+
+beforeAll(async () => {
+  await setupDb();
+  app = createTestApp();
+});
+
+afterEach(async () => {
+  const cycleCol = getCollection('downtime_cycles');
+  const subCol   = getCollection('downtime_submissions');
+  for (const id of insertedCycleIds) await cycleCol.deleteOne({ _id: id });
+  for (const id of insertedSubmissionIds) await subCol.deleteOne({ _id: id });
+  insertedCycleIds = [];
+  insertedSubmissionIds = [];
+});
+
+afterAll(async () => {
+  await teardownDb();
+});
+
+async function insertCycle(overrides = {}) {
+  const col = getCollection('downtime_cycles');
+  const doc = { label: 'Test Cycle', status: 'active', ...overrides };
+  const result = await col.insertOne(doc);
+  insertedCycleIds.push(result.insertedId);
+  return { ...doc, _id: result.insertedId };
+}
+
+async function insertSubmission(cycleId, characterId, overrides = {}) {
+  const col = getCollection('downtime_submissions');
+  const doc = {
+    cycle_id: cycleId,
+    character_id: characterId,
+    status: 'draft',
+    responses: {},
+    ...overrides,
+  };
+  const result = await col.insertOne(doc);
+  insertedSubmissionIds.push(result.insertedId);
+  return { ...doc, _id: result.insertedId };
+}
+
+describe('GET /api/downtime_submissions/hold-flags', () => {
+  it('returns 400 when cycle_id is missing', async () => {
+    const res = await request(app)
+      .get('/api/downtime_submissions/hold-flags')
+      .set('X-Test-User', stUser());
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 when cycle_id is malformed', async () => {
+    const res = await request(app)
+      .get('/api/downtime_submissions/hold-flags?cycle_id=not-an-objectid')
+      .set('X-Test-User', stUser());
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns an empty map when no submissions exist for the cycle', async () => {
+    const cycle = await insertCycle();
+    const res = await request(app)
+      .get(`/api/downtime_submissions/hold-flags?cycle_id=${cycle._id}`)
+      .set('X-Test-User', stUser());
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({});
+  });
+
+  it('ST sees all characters; honours _has_minimum boolean when present', async () => {
+    const cycle = await insertCycle();
+    await insertSubmission(cycle._id, CHAR_A, {
+      responses: { _has_minimum: true },
+      status: 'draft',
+    });
+    await insertSubmission(cycle._id, CHAR_B, {
+      responses: { _has_minimum: false },
+      status: 'draft',
+    });
+    const res = await request(app)
+      .get(`/api/downtime_submissions/hold-flags?cycle_id=${cycle._id}`)
+      .set('X-Test-User', stUser());
+    expect(res.status).toBe(200);
+    expect(res.body[CHAR_A]).toBe(false); // _has_minimum=true → NOT on hold
+    expect(res.body[CHAR_B]).toBe(true);  // _has_minimum=false → on hold
+  });
+
+  it('falls back to status when _has_minimum is absent: submitted → not on hold, draft → on hold', async () => {
+    const cycle = await insertCycle();
+    await insertSubmission(cycle._id, CHAR_A, { responses: {}, status: 'submitted' });
+    await insertSubmission(cycle._id, CHAR_B, { responses: {}, status: 'draft' });
+    const res = await request(app)
+      .get(`/api/downtime_submissions/hold-flags?cycle_id=${cycle._id}`)
+      .set('X-Test-User', stUser());
+    expect(res.status).toBe(200);
+    expect(res.body[CHAR_A]).toBe(false);
+    expect(res.body[CHAR_B]).toBe(true);
+  });
+
+  it('player sees only entries for their own characters', async () => {
+    const cycle = await insertCycle();
+    await insertSubmission(cycle._id, CHAR_A, { responses: { _has_minimum: true } });
+    await insertSubmission(cycle._id, CHAR_B, { responses: { _has_minimum: false } });
+    await insertSubmission(cycle._id, OTHER_PLAYER_CHAR, { responses: { _has_minimum: false } });
+
+    const res = await request(app)
+      .get(`/api/downtime_submissions/hold-flags?cycle_id=${cycle._id}`)
+      .set('X-Test-User', playerUser([CHAR_A, CHAR_B]));
+    expect(res.status).toBe(200);
+    expect(res.body[CHAR_A]).toBe(false);
+    expect(res.body[CHAR_B]).toBe(true);
+    expect(res.body[OTHER_PLAYER_CHAR]).toBeUndefined();
+  });
+
+  it('omits characters that have no submission for the cycle (client defaults absent → true)', async () => {
+    const cycle = await insertCycle();
+    await insertSubmission(cycle._id, CHAR_A, { responses: { _has_minimum: true } });
+    // CHAR_B intentionally has no submission
+
+    const res = await request(app)
+      .get(`/api/downtime_submissions/hold-flags?cycle_id=${cycle._id}`)
+      .set('X-Test-User', playerUser([CHAR_A, CHAR_B]));
+    expect(res.status).toBe(200);
+    expect(res.body[CHAR_A]).toBe(false);
+    expect(CHAR_B in res.body).toBe(false);
+  });
+
+  it('honours legacy string-stored cycle_id (CSV-imported submissions)', async () => {
+    const cycle = await insertCycle();
+    // Submission stored with cycle_id as string (CSV-import shape)
+    await insertSubmission(String(cycle._id), CHAR_A, { responses: { _has_minimum: false } });
+
+    const res = await request(app)
+      .get(`/api/downtime_submissions/hold-flags?cycle_id=${cycle._id}`)
+      .set('X-Test-User', stUser());
+    expect(res.status).toBe(200);
+    expect(res.body[CHAR_A]).toBe(true);
+  });
+
+  it('returns 401 when no auth header is supplied', async () => {
+    const cycle = await insertCycle();
+    const res = await request(app)
+      .get(`/api/downtime_submissions/hold-flags?cycle_id=${cycle._id}`);
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #257 — biggest single MongoDB-cost reduction on ST/dev boot. **N-1 fewer round-trips** per boot (ST/dev: ~30 → 1; player: 1–3 → 1).

> Dispatch-number note: Khepri's dispatch said #255 but content matches #257 (batched hold-flag, biggest win). #255 is the HTTP Cache-Control story. PR targets the content-matched issue. Cross-referencing here so the audit trail stays clean.

## Pre-fix

`public/js/data/dt-hold-flag.js:32-54` looped over every character and awaited a per-character `/api/downtime_submissions?cycle_id=X&character_id=Y` GET. Each call hit MongoDB. ST/dev boot fired ~30 sequential round-trips; players fired 1–3.

## Fix

### Server — new endpoint `GET /api/downtime_submissions/hold-flags`

Returns `{ <character_id>: bool }` map where `true` == on hold (below-minimum or status not `'submitted'`).

- Single MongoDB `find({ cycle_id, character_id: { $in: cohortIds } })` with projection limited to `character_id`, `status`, `responses._has_minimum` — keeps wire size small even on ST cohorts of 30+ chars.
- Auth-scoped: player role auto-restricts to `req.user.character_ids`; ST/dev see every char in scope.
- Derivation mirrors the pre-fix client logic exactly:
  - `responses._has_minimum: boolean` → `!_has_minimum`
  - else → `status !== 'submitted'`
- Returns entries ONLY for characters that have a submission. Client defaults absence → `true` per existing fallback semantics at the old `dt-hold-flag.js:39`. Server stays stateless about cohort membership (no need to know every character ID in scope).
- Accepts both ObjectId and legacy string `cycle_id` (CSV-imported shape) via `$or` filter — mirrors `GET /` at line 579.
- Registered BEFORE `GET /` so Express routes `/hold-flags` to this handler rather than treating it as a query of the list endpoint.

### Client — single batched fetch

- Replaced the for-loop with a single `apiGet('/api/downtime_submissions/hold-flags?cycle_id=…')` call.
- Applies the returned map to `c._dtHoldFlag` for each char; absent keys → `true`.
- `opts.isST` kept in the signature for back-compat (`app.js:543` and `player.js:188` pass it) but ignored — server-side auth scopes the cohort.

## Tests

`server/tests/api-downtime-hold-flags.test.js` — 9 new integration tests covering every AC:

| # | Test |
|---|---|
| 1 | 400 on missing `cycle_id` |
| 2 | 400 on malformed `cycle_id` |
| 3 | Empty map when no submissions exist for the cycle |
| 4 | ST sees all chars; `_has_minimum` boolean honoured both ways |
| 5 | Status-fallback path: `submitted` → not on hold, `draft` → on hold |
| 6 | Player auth-scoping: only own character entries returned |
| 7 | Characters absent from submissions → omitted from map |
| 8 | Legacy string-stored `cycle_id` (CSV-imported shape) honoured |
| 9 | 401 on missing auth header |

## Verification

- **Server tests**: 751/751 pass (was 742; +9 from this file).
- **Parse-check** on client: clean.
- The new endpoint shares the same auth-scoping filter shape as `GET /` — no new auth surface introduced.

## HALT-DAR check

Not triggered. Standard player-vs-ST cohort scoping per dispatch — same shape as the existing list endpoint.

## Test plan (browser smoke deferred to user)

- [ ] ST boot: network panel shows ONE call to `/hold-flags` instead of ~30 to `/downtime_submissions`.
- [ ] Player boot: same single-call shape.
- [ ] Characters with submissions: hold flag matches their submission state (mirrors pre-fix behaviour).
- [ ] Characters without submissions: hold flag defaults to true (mirrors pre-fix line 39 fallback).

## Branch

`dev` per house rule. Per process: NOT auto-merging — pinging Khepri after this opens for Ma'at static review routing.