### PR TITLE
perf: lazy-render inactive tabs in selectCharacter (#258)

### DIFF
--- a/public/js/player.js
+++ b/public/js/player.js
@@ -298,41 +298,83 @@ function showPending() {
   document.getElementById('pending-container').style.display = '';
 }
 
+// Issue #258 (perf, 2026-05-11): per-char lazy-render bookkeeping.
+// `_lazyRenderedTabs` records which char-dependent tabs have already
+// been rendered for the CURRENT character. Reset on every
+// selectCharacter call so a char-switch re-arms every tab.
+// `_lazyRenderers` maps tab name → render fn that closes over the
+// current `activeChar` / `_territories` / `retiredChars` module-level
+// state. Tabs absent from the map (sheet / city / primer / tickets)
+// are not lazy — sheet renders eagerly in selectCharacter; the others
+// are char-independent and rendered once in loadCharacters.
+const _lazyRenderedTabs = new Set();
+
+const _lazyRenderers = {
+  xplog: () => {
+    initOrdeals(activeChar, chars);
+    renderXpLogTab(document.getElementById('tab-xplog'), activeChar);
+  },
+  // Issue #259: selectCharacter just loaded `activeChar` and `_territories`
+  // — pass skipFreshFetch so renderDowntimeTab reuses them instead of
+  // re-fetching. (Same opt-in preserved through the lazy boundary.)
+  downtime: () => renderDowntimeTab(document.getElementById('tab-downtime'), activeChar, _territories, { skipFreshFetch: true }),
+  feeding: () => renderFeedingTab(document.getElementById('feeding-content'), activeChar),
+  story:   () => renderStoryTab(document.getElementById('story-content'), activeChar),
+  status:  () => renderStatusTab(document.getElementById('tab-status'), activeChar, isSTRole()),
+  archive: () => initArchiveTab(document.getElementById('tab-archive'), activeChar, retiredChars),
+  regency: () => renderRegencyTab(document.getElementById('regency-content'), activeChar, _territories),
+  office:  () => renderOfficeTab(document.getElementById('office-content'), activeChar),
+};
+
+/**
+ * Render a lazy tab if not yet rendered for the current character.
+ * Idempotent — re-clicking a tab is a no-op once it's rendered.
+ */
+function _renderTabIfNeeded(tabName) {
+  if (_lazyRenderedTabs.has(tabName)) return;
+  const fn = _lazyRenderers[tabName];
+  if (!fn) return; // sheet / city / primer / tickets — eager / char-independent
+  _lazyRenderedTabs.add(tabName);
+  try {
+    fn();
+  } catch (err) {
+    // Render failure shouldn't poison the lazy state — clear so a
+    // subsequent click retries. Mirrors the catch-and-continue pattern
+    // the eager renderers had pre-fix (per-tab failure didn't kill the
+    // others).
+    _lazyRenderedTabs.delete(tabName);
+    console.error(`[player] tab '${tabName}' render failed:`, err);
+  }
+}
+
 function selectCharacter(activeChars, idx) {
   activeChar = activeChars[idx];
   state.editIdx = chars.indexOf(activeChar);
+
+  // Re-arm lazy state — every tab needs fresh render for the new char.
+  _lazyRenderedTabs.clear();
+
+  // Sheet is the default-active tab on first paint; always render it
+  // eagerly so the user has content immediately.
   renderSheet(activeChar);
-  initOrdeals(activeChar, chars);
-  // Issue #259 (perf): selectCharacter just loaded `activeChar` and
-  // `_territories` 1-2s ago via loadCharacters() — pass skipFreshFetch so
-  // renderDowntimeTab reuses them instead of re-fetching both endpoints.
-  renderDowntimeTab(document.getElementById('tab-downtime'), activeChar, _territories, { skipFreshFetch: true });
-  renderFeedingTab(document.getElementById('feeding-content'), activeChar);
-  renderStoryTab(document.getElementById('story-content'), activeChar);
-  renderXpLogTab(document.getElementById('tab-xplog'), activeChar);
-  renderStatusTab(document.getElementById('tab-status'), activeChar, isSTRole());
-  initArchiveTab(document.getElementById('tab-archive'), activeChar, retiredChars);
 
-  // Derive regent status from territories (single source of truth)
+  // Visibility toggles for conditional tab buttons. The actual tab
+  // CONTENT renders lazily when the user clicks the button. We still
+  // need to set button display here so the sidebar reflects which
+  // tabs exist for this character.
   const regInfo = findRegentTerritory(_territories, activeChar);
-
-  // Regency tab — only visible for regents
   const regBtn = document.getElementById('tab-btn-regency');
-  if (regInfo) {
-    if (regBtn) regBtn.style.display = '';
-    renderRegencyTab(document.getElementById('regency-content'), activeChar, _territories);
-  } else {
-    if (regBtn) regBtn.style.display = 'none';
-  }
+  if (regBtn) regBtn.style.display = regInfo ? '' : 'none';
 
-  // Office tab — only visible for characters with a court office
   const offBtn = document.getElementById('tab-btn-office');
-  if (activeChar.court_category) {
-    if (offBtn) offBtn.style.display = '';
-    renderOfficeTab(document.getElementById('office-content'), activeChar);
-  } else {
-    if (offBtn) offBtn.style.display = 'none';
-  }
+  if (offBtn) offBtn.style.display = activeChar.court_category ? '' : 'none';
+
+  // If the currently-active tab is char-dependent (e.g. user previously
+  // navigated to Downtime, then changed characters), render it now so
+  // they don't see a blank panel.
+  const activeBtn = document.querySelector('.sidebar-btn.on[data-tab]');
+  const activeTab = activeBtn?.dataset.tab;
+  if (activeTab && activeTab !== 'sheet') _renderTabIfNeeded(activeTab);
 }
 
 async function updateCycleIndicators() {
@@ -360,6 +402,11 @@ document.getElementById('sidebar').addEventListener('click', e => {
   btn.classList.add('on');
   const panel = document.getElementById('tab-' + btn.dataset.tab);
   if (panel) panel.classList.add('active');
+
+  // Issue #258 (perf): lazy-render the tab's content if this is its
+  // first activation for the current character. Saves ~15-20 API calls
+  // per char-selection by deferring non-active tab init until needed.
+  _renderTabIfNeeded(btn.dataset.tab);
 });
 
 // ── Sidebar collapse ──


### PR DESCRIPTION
## Summary

Closes #258. Final Tier 1 perf sub-story.

**Eliminates ~15-20 API roundtrips per character selection** by deferring non-active tab renders until the user clicks the tab.

## Pre-fix

`selectCharacter` eagerly rendered every char-dependent tab on first paint:

| Renderer | API calls |
|---|---|
| `renderSheet` | 0 (DOM only) |
| `initOrdeals` | 2-4 |
| `renderDowntimeTab` | 5+ |
| `renderFeedingTab` | 3-5 |
| `renderStoryTab` | 3-5 |
| `renderXpLogTab` | 0-1 |
| `renderStatusTab` | 1-2 |
| `initArchiveTab` | 1-2 |
| `renderRegencyTab` (conditional) | 1-2 |
| `renderOfficeTab` (conditional) | 0 |

All fired before the user clicks anything past the default Sheet tab.

## Fix

**Module-level lazy state**:

- `_lazyRenderedTabs: Set<tabName>` — which char-dependent tabs have already rendered for the current character.
- `_lazyRenderers: Record<tabName, () => void>` — closures over the module's `activeChar` / `_territories` / `retiredChars` that fire the right renderer at click time.

`_renderTabIfNeeded(tabName)` is the single entry point — idempotent (re-clicking is a no-op once rendered), and on render-failure removes the tab from the `rendered` set so a retry on the next click still works.

**`selectCharacter` post-fix**:

1. Set `activeChar` + `editIdx`.
2. Clear `_lazyRenderedTabs` (char-switch re-arms every tab).
3. Render Sheet eagerly (default-active tab).
4. Toggle regency / office button visibility based on this char's state. Button visibility stays in selectCharacter (so the sidebar reflects which tabs exist for this character); content render defers to lazy.
5. If user was on a non-Sheet tab when they switched chars (e.g. viewing Downtime on char A, picks char B from dropdown), the currently-active tab gets a lazy-render fire so they don't see a blank panel.

**Sidebar click handler** now calls `_renderTabIfNeeded(btn.dataset.tab)` after the existing active-class toggle. First click of any char-dependent tab triggers its renderer + API calls on demand.

## Tabs unchanged

- `city` / `primer` / `tickets` — already char-independent, rendered once in `loadCharacters`.
- `sheet` — eager; default-active tab on every char-switch.

## Side-effect audit (HALT-DAR criterion)

Inspected every render-fn signature:

```
editor/sheet.js                  → renderSheet(c, target?)
tabs/ordeals-view.js             → initOrdeals(char, chars, containerEl?)
tabs/downtime-form.js            → renderDowntimeTab(targetEl, char, territories, options?)
tabs/feeding-tab.js              → renderFeedingTab(el, char)
tabs/story-tab.js                → renderStoryTab(el, char)
tabs/xp-log-tab.js               → renderXpLogTab(el, char)
tabs/status-tab.js               → renderStatusTab(el, activeChar, isST?)
tabs/archive-tab.js              → initArchiveTab(el, char, retiredChars)
tabs/regency-tab.js              → renderRegencyTab(container, char, territories)
tabs/office-tab.js               → renderOfficeTab(el, char)
```

All pure renderers — `(el, char, ...) => Promise<void>` or sync. None have exported state-mutation side-effects other modules consume. The render itself is the side effect (DOM mutation + per-tab API fetches the renderer owns). Lazy-firing them at click time is semantically equivalent to firing them eagerly at selectCharacter time, just later.

## Stale-base discipline applied

Stashed during PR #263 conflict-resolution interruption, popped post-#263 merge. Rebased on origin/dev (now includes #253 feeding-tab, #260 batched hold-flag, #261 fresh-fetch skip, #262 aggregated rules + parallelised Phase 1, #263 cache headers + aggregate cache wiring). No conflicts on rebase — player.js diff is localised to `selectCharacter` + the sidebar handler; the morning's merges touched other files.

## Verification

- **Server tests**: 771/771 pass (no server-side change).
- **Parse-check** on player.js: clean.
- Static review of all 10 char-dependent renderers: no side-effect surprises.

## Test plan (browser smoke deferred to user)

- [ ] Player selects a character: network panel shows only the Sheet tab's data fetches (no Downtime / Feeding / Story etc. API calls).
- [ ] Click 'Submit DT': `renderDowntimeTab` fires; API calls appear. Re-click: zero re-renders.
- [ ] Click 'Feeding': `renderFeedingTab` fires; API calls appear. Re-click: zero re-renders.
- [ ] Switch to a different character: Sheet renders eagerly; previously-opened tabs need fresh re-render on click.
- [ ] Regency / Office buttons: visibility correct per char; content renders only when clicked.
- [ ] Primer / Tickets / City unchanged (char-independent).

## Branch

`dev` per house rule. Per process: NOT auto-merging — pinging Khepri after this opens for Ma'at routing (now using worktree-isolated verification per #264). After this lands, full Tier 1 perf march cleared — ready for batched dev → main promote per user's pre-auth.