### PR TITLE
fix(dt-city): add horizontal padding to .spheres-grid (#271)

### DIFF
--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -1011,7 +1011,7 @@ body {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   gap: 8px;
-  padding: 8px 0;
+  padding: 8px 16px;
 }
 .sphere-card {
   background: var(--surf);

--- a/specs/stories/sprint-status.yaml
+++ b/specs/stories/sprint-status.yaml
@@ -754,7 +754,7 @@ development_status:
   # Picked up via tm-gh-issue-pickup skill; story files in specs/stories/issue-*.story.md
 
   issue-12-domain-multi-instance-descriptors: review            # Domain: multi-instance SP/FG, Haven/MG cap system
-  issue-216-alice-regent-territory: review                      # findRegentTerritory canonical-slug guard; PR #223
+  issue-216-alice-regent-territory: done                        # findRegentTerritory canonical-slug guard; PR #223 merged
   issue-224-dt-stale-territory: review                          # renderDowntimeTab territory fresh-fetch + saveTerritory invalidation
   issue-230-dt-form-init-char-mismatch: ready-for-dev           # _buildCharMenu before openChar: sidebar shows wrong char; DT form renders for sheetChar not visual selection
   issue-231-dt-prep-open-override: review                       # DT Prep: manual override flag latches cycle.status to active; deriveCycleStatus + setManualOpen + UI button + banner


### PR DESCRIPTION
## Summary

- Sphere cards in DT City Overview and the standalone Spheres domain view were rendering flush against panel edges — inconsistent with every other content block in City Overview
- Single CSS change: `padding: 8px 0` → `padding: 8px 16px` on `.spheres-grid`; applies equally to both surfaces that share the class, which is appropriate

## Closes

- Closes #271

## Story

_No story referenced_

## Test plan

- [ ] Open DT City → Spheres of Influence → expand section; cards should be inset 16px from both edges
- [ ] Open Spheres domain view; same inset applies
- [ ] Collapse the Spheres section; header appearance unchanged
- [ ] `proc-amb-empty` empty-state padding untouched
- [ ] CI green

## Branch flow

- From: `morningstar-issue-271-spheres-grid-padding`
- Into: `dev`