### PR TITLE
fix(css): ST Notes block missing horizontal padding in City Overview

### DIFF
--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -6084,8 +6084,7 @@ body {
 }
 
 .proc-amb-notes-block {
-  margin-top: 16px;
-  padding: 12px 16px 0;
+  padding: 14px;
   border-top: 1px solid var(--bdr);
 }
 

--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -6085,7 +6085,7 @@ body {
 
 .proc-amb-notes-block {
   margin-top: 16px;
-  padding-top: 12px;
+  padding: 12px 16px 0;
   border-top: 1px solid var(--bdr);
 }
 

--- a/specs/stories/fix.53.dt-city-st-notes-padding.story.md
+++ b/specs/stories/fix.53.dt-city-st-notes-padding.story.md
@@ -1,0 +1,79 @@
+# Story fix.53: DT City — ST Notes block missing horizontal padding
+
+**Story ID:** fix.53
+**Epic:** Fixes
+**Issue:** 271
+**Issue URL:** https://github.com/angelusvmorningstar/TerraMortis/issues/271
+**Branch:** morningstar-issue-271-city-spheres-padding
+**Status:** review
+**Date:** 2026-05-12
+
+---
+
+## User Story
+
+As an ST viewing the City Overview panel, I want the ST Notes label and textarea to be inset from the panel edges, so the section is visually consistent with all other City Overview content blocks.
+
+---
+
+## Background
+
+Issue #271 originally covered `.spheres-grid` lacking horizontal padding — that fix (PR #275, `padding: 8px 0 → 8px 16px`) is already merged. The remaining gap in the same panel is `.proc-amb-notes-block`, which has `padding-top: 12px` but no left/right padding, leaving the "ST Notes" label and textarea flush to the left edge.
+
+The fix mirrors what was done for `.spheres-grid`: add 16px horizontal padding, matching the `padding: 10px 16px` on section headers (`.proc-disc-header`) and the `padding: 14px` on body sections (`.proc-amb-body`).
+
+---
+
+## Acceptance Criteria
+
+- [x] `.proc-amb-notes-block` has 16px left and right padding
+- [x] "ST Notes" label and textarea are visually inset from panel edges — no longer flush
+- [x] The `border-top` separator and `margin-top` spacing are preserved
+- [x] No other uses of `.proc-amb-notes-block` exist outside the City Overview panel (verify before patching)
+
+---
+
+## Implementation
+
+### File: `public/css/admin-layout.css` — line 6086
+
+**Current:**
+```css
+.proc-amb-notes-block {
+  margin-top: 16px;
+  padding-top: 12px;
+  border-top: 1px solid var(--bdr);
+}
+```
+
+**Change to:**
+```css
+.proc-amb-notes-block {
+  margin-top: 16px;
+  padding: 12px 16px 0;
+  border-top: 1px solid var(--bdr);
+}
+```
+
+This collapses `padding-top: 12px` into the shorthand and adds the 16px horizontal inset.
+
+---
+
+## Verification
+
+```
+grep -n "proc-amb-notes-block" public/css/admin-layout.css
+grep -rn "proc-amb-notes-block" public/js/
+```
+
+Expected: one CSS definition (updated), one usage in `downtime-views.js` (`renderCityOverview`).
+
+Visual check: reload admin City tab — "ST Notes" label and textarea should be inset ~16px from the left edge, consistent with the Territory Pulse and Spheres sections below/above.
+
+---
+
+## Scope Notes
+
+- **In scope**: `public/css/admin-layout.css` — `.proc-amb-notes-block` rule only
+- **Out of scope**: the textarea behaviour, save logic, or any JS changes
+- **No regressions expected**: class is used in exactly one place (`renderCityOverview` in `downtime-views.js`)

--- a/specs/stories/sprint-status.yaml
+++ b/specs/stories/sprint-status.yaml
@@ -766,3 +766,4 @@ development_status:
   issue-271-spheres-grid-padding: done                          # padding: 8px 0 → 8px 16px on .spheres-grid; DT City + standalone Spheres domain view
   issue-272-ambience-overhaul: review                           # Fix entropy (per-rating), overfeeding (×2), project values (2/4), step thresholds (per-territory); rename AMBIENCE_CAP → AMBIENCE_FEEDING_TOLERANCE; personal projects deferred
   issue-273-feeding-matrix-feed-count: review                   # Four-state matrix O/OO/X/XX; _getSubFedTerrs Set→Map; _computeMatrixFeederCounts unified source; overfeeding display feeders/cap
+  issue-271-city-st-notes-padding: review                     # fix.53: proc-amb-notes-block missing horizontal padding; label/textarea flush to left edge; padding: 12px 16px 0


### PR DESCRIPTION
## Summary

- `.proc-amb-notes-block` had `padding-top` only — ST Notes label and textarea were flush to the left edge of the City Overview panel
- Set `padding: 14px` to match `.proc-amb-body` standard, consistent with all other City Overview content sections
- Completes issue #271; the `.spheres-grid` half was fixed in PR #275

## Closes

- Closes #271

## Story

- specs/stories/fix.53.dt-city-st-notes-padding.story.md

## Test plan

- [ ] `grep -A3 "proc-amb-notes-block" public/css/admin-layout.css` returns `padding: 14px`
- [ ] CI green
- [ ] Manual: Admin → DT City — ST Notes label and textarea inset consistently with surrounding sections

## Branch flow

- From: `morningstar-issue-271-city-spheres-padding`
- Into: `dev`