### PR TITLE
fix(dt): spec bonus is AoE-only; remove nine-again from predicate

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -744,14 +744,14 @@ function _resolveNineAgainState(rev, poolValidated, char) {
  * @param {object|null} char
  * @returns {string|null}
  */
-function _augmentPoolWithSpecs(poolValidated, activeSpecs, char, nineAgain) {
+function _augmentPoolWithSpecs(poolValidated, activeSpecs, char) {
   if (!poolValidated || !activeSpecs.length) return poolValidated;
   const eqIdx = poolValidated.lastIndexOf('=');
   if (eqIdx === -1) return poolValidated;
   const base     = poolValidated.slice(0, eqIdx).trim();
   const tot      = parseInt(poolValidated.slice(eqIdx + 1).trim()) || 0;
-  const specTotal = activeSpecs.reduce((s, sp) => s + ((nineAgain || (char && hasAoE(char, sp))) ? 2 : 1), 0);
-  const specLabel = activeSpecs.map(sp => `${sp} +${(nineAgain || (char && hasAoE(char, sp))) ? 2 : 1}`).join(', ');
+  const specTotal = activeSpecs.reduce((s, sp) => s + (char && hasAoE(char, sp) ? 2 : 1), 0);
+  const specLabel = activeSpecs.map(sp => `${sp} +${char && hasAoE(char, sp) ? 2 : 1}`).join(', ');
   return `${base} + ${specLabel} = ${tot + specTotal}`;
 }
 
@@ -943,15 +943,13 @@ function buildFeedingPool(char, methodId, ambienceMod, picks = {}) {
     }
   }
 
-  // Spec bonus: +2 if Area-of-Expertise / nine-again, +1 otherwise. Only
-  // counts when the player's picked spec is on the method-derived best
-  // skill (matches feeding-pool.js).
+  // Spec bonus: +2 with Area of Expertise; +1 otherwise.
   let specBonus = 0;
   const playerSpec = picks.spec || '';
   if (playerSpec && bestSkillName) {
     const sk = char.skills?.[bestSkillName];
     if (sk?.specs?.includes(playerSpec)) {
-      specBonus = (sk.nine_again || hasAoE(char, playerSpec)) ? 2 : 1;
+      specBonus = hasAoE(char, playerSpec) ? 2 : 1;
     }
   }
 
@@ -5207,8 +5205,7 @@ function renderProcessingMode(container) {
         ? (characters.find(c => String(c._id) === String(sub.character_id)) || charMap.get((sub.character_name || '').toLowerCase().trim()))
         : null;
       const skillSel = container.querySelector(`.proc-pool-builder[data-proc-key="${key}"] .proc-pool-skill`);
-      const skillNa = char && skillSel ? skNineAgain(char, skillSel.value) : false;
-      const specBonus = activeFeedSpecs.reduce((sum, sp) => sum + ((skillNa || (char && hasAoE(char, sp))) ? 2 : 1), 0);
+      const specBonus = activeFeedSpecs.reduce((sum, sp) => sum + (char && hasAoE(char, sp) ? 2 : 1), 0);
       // pool_mod_spec is applied at roll time only — no re-render needed; checkbox state already reflects the change
       await saveEntryReview(entry, { active_feed_specs: activeFeedSpecs, pool_mod_spec: specBonus });
     });
@@ -7161,7 +7158,7 @@ function _renderProjRightPanel(entry, char, rev) {
   h += `<div class="proc-mod-panel-title">Validation Status</div>`;
   h += _renderValStatusButtons(key, poolStatus, [['pending', 'Pending'], ['committed', 'Committed'], ['rolled', 'Rolled'], ['validated', 'Validated'], ['no_roll', 'No Roll Needed'], ['skipped', 'Skip']]);
   // Committed pool expression with active specs
-  const displayPool = _augmentPoolWithSpecs(poolValidated, rev.active_feed_specs || [], char, nineAgainState);
+  const displayPool = _augmentPoolWithSpecs(poolValidated, rev.active_feed_specs || [], char);
   h += `<div class="proc-feed-committed-pool" data-proc-key="${esc(key)}">${displayPool ? esc(displayPool) : '<span class="dt-dim-italic">Not yet committed</span>'}</div>`;
   // Validation notation: show active flags + validator chip when validated
   if (poolStatus === 'validated') {
@@ -7409,7 +7406,7 @@ function _renderFeedRightPanel(entry, char, rev) {
   h += `<div class="proc-mod-panel-title">Validation Status</div>`;
   h += _renderValStatusButtons(key, poolStatus, [['pending', 'Pending'], ['committed', 'Committed'], ['rolled', 'Rolled'], ['validated', 'Validated'], ['no_feed', 'No Valid Feeding']]);
   // Committed pool expression display — augmented with active spec names if any
-  const displayPool = _augmentPoolWithSpecs(poolValidated, rev.active_feed_specs || [], char, nineAgainStateFeed);
+  const displayPool = _augmentPoolWithSpecs(poolValidated, rev.active_feed_specs || [], char);
   h += `<div class="proc-feed-committed-pool" data-proc-key="${esc(key)}">${displayPool ? esc(displayPool) : '<span class="dt-dim-italic">Not yet committed</span>'}</div>`;
   if (poolValidated) {
     const feedNotes = [];

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -18,7 +18,7 @@ import { actionSpentSummary, formatActionSpentSummary } from '../data/dt-action-
 import { computeBestFeedingPool } from '../data/feeding-pool.js';
 import { ALL_ATTRS, ALL_SKILLS, CLAN_DISCS, BLOODLINE_DISCS, CORE_DISCS, RITUAL_DISCS } from '../data/constants.js';
 import { calcTotalInfluence, domMeritTotal, attacheBonusDots, effectiveInvictusStatus, ssjHerdBonus, flockHerdBonus, meritEffectiveRating, influenceBreakdown } from '../editor/domain.js';
-import { calcVitaeMax, skTotal, skNineAgain, riteCost, skillAcqPoolStr, getAttrEffective, getAttrTotal, discDots } from '../data/accessors.js';
+import { calcVitaeMax, skTotal, riteCost, skillAcqPoolStr, getAttrEffective, getAttrTotal, discDots } from '../data/accessors.js';
 import { xpLeft } from '../editor/xp.js';
 import { meetsPrereq, isMeritExcluded } from '../editor/merits.js';
 import { getRuleByKey, getRulesByCategory } from '../data/loader.js';
@@ -588,9 +588,7 @@ function collectResponses() {
       if (attrName || skillName || discName) {
         const validSpec = !!(specName && skillName
           && (currentChar.skills?.[skillName]?.specs || []).includes(specName));
-        const specBonus = validSpec
-          ? ((skNineAgain(currentChar, skillName) || hasAoE(currentChar, specName)) ? 2 : 1)
-          : 0;
+        const specBonus = validSpec ? (hasAoE(currentChar, specName) ? 2 : 1) : 0;
         let total = 0;
         if (attrName)  total += getAttrEffective(currentChar, attrName);
         if (skillName) total += skTotal(currentChar, skillName);
@@ -3788,8 +3786,7 @@ function renderDicePool(slotNum, poolKey, label, attrs, skills, discs, saved) {
   if (savedSkill) total += skTotal(currentChar, savedSkill);
   if (savedDisc) total += discDots(currentChar, savedDisc);
   if (savedSpec && bestSpecs.includes(savedSpec)) {
-    const na = skNineAgain(currentChar, savedSkill);
-    total += (na || hasAoE(currentChar, savedSpec)) ? 2 : 1;
+    total += hasAoE(currentChar, savedSpec) ? 2 : 1;
   }
 
   let h = '<div class="qf-field">';
@@ -3841,8 +3838,7 @@ function renderDicePool(slotNum, poolKey, label, attrs, skills, discs, saved) {
     h += '<label class="dt-feed-disc-lbl">Specialisation:</label>';
     for (const sp of bestSpecs) {
       const on = savedSpec === sp ? ' dt-feed-spec-on' : '';
-      const na = skNineAgain(currentChar, savedSkill);
-      const bonus = (na || hasAoE(currentChar, sp)) ? 2 : 1;
+      const bonus = hasAoE(currentChar, sp) ? 2 : 1;
       h += `<button type="button" class="dt-feed-spec-chip${on}" data-pool-spec="${esc(prefix)}" data-spec-name="${esc(sp)}">${esc(sp)} <span class="dt-feed-spec-bonus">+${bonus}</span></button>`;
     }
     h += '</div>';
@@ -4846,8 +4842,7 @@ function updatePoolTotal(prefix) {
   if (specEl?.value && skillEl?.value) {
     const specs = currentChar.skills?.[skillEl.value]?.specs || [];
     if (specs.includes(specEl.value)) {
-      const na = skNineAgain(currentChar, skillEl.value);
-      total += (na || hasAoE(currentChar, specEl.value)) ? 2 : 1;
+      total += hasAoE(currentChar, specEl.value) ? 2 : 1;
     }
   }
 

--- a/public/js/tabs/feeding-tab.js
+++ b/public/js/tabs/feeding-tab.js
@@ -11,7 +11,7 @@
 import { apiGet, apiPut } from '../data/api.js';
 import { getGamePhaseCycle } from '../downtime/db.js';
 import { esc, displayName, hasAoE } from '../data/helpers.js';
-import { getAttrEffective as getAttrVal, skDots, skTotal, skSpecStr, skNineAgain, calcVitaeMax } from '../data/accessors.js';
+import { getAttrEffective as getAttrVal, skDots, skTotal, skSpecStr, calcVitaeMax } from '../data/accessors.js';
 import { FEED_METHODS, TERRITORY_DATA } from './downtime-data.js';
 import { SKILLS_MENTAL } from '../data/constants.js';
 import { isSTRole } from '../auth/discord.js';
@@ -427,8 +427,7 @@ function buildPool(method, discName, specName) {
     if (v > bestSV) { bestSV = v; bestS = s; bestSpecs = c.skills?.[s]?.specs || []; }
   }
 
-  const na = bestS ? skNineAgain(c, bestS) : false;
-  const specBonus = specName && bestSpecs.includes(specName) ? ((na || hasAoE(c, specName)) ? 2 : 1) : 0;
+  const specBonus = specName && bestSpecs.includes(specName) ? (hasAoE(c, specName) ? 2 : 1) : 0;
   const discVal = (discName && c.disciplines?.[discName]?.dots) || 0;
   const unskilled = bestSV === 0
     ? (method.skills.some(s => !SKILLS_MENTAL.includes(s)) ? -1 : -3)

--- a/specs/stories/fix.54.dt-spec-bonus-aoe-only.story.md
+++ b/specs/stories/fix.54.dt-spec-bonus-aoe-only.story.md
@@ -1,0 +1,210 @@
+# Story fix.54: DT spec bonus — remove nine-again from predicate; AoE only
+
+**Story ID:** fix.54
+**Epic:** Fixes
+**Issue:** 267
+**Issue URL:** https://github.com/angelusvmorningstar/TerraMortis/issues/267
+**Branch:** morningstar-issue-267-dt-spec-bonus-aoe-only
+**Status:** review
+**Date:** 2026-05-12
+
+---
+
+## User Story
+
+As an ST or player seeing spec bonuses in the DT form or processing panel, I want the displayed die bonus to reflect the actual rules — +1 for any spec, +2 only with Area of Expertise — so that a character with Professional Training's nine-again does not incorrectly show or apply +2.
+
+---
+
+## Background
+
+Nine-again is a reroll-threshold mechanic (re-roll dice that show 9+), not a bonus-die mechanic. It has no effect on the flat +1 die added by a Specialisation. Only Area of Expertise (a Merit, `hasAoE()`) upgrades that to +2.
+
+The predicate `(skNineAgain(c, skill) || hasAoE(c, spec)) ? 2 : 1` appears across eight sites in three files. Each instance must become `hasAoE(c, spec) ? 2 : 1`.
+
+`dice-engine.js:89–94` (`specBonusFor`) is already correct — AoE only. No change needed there.
+
+Supersedes issue #207 (which proposed `skNineAgain || hasAoE` as the canonical predicate — that direction was incorrect).
+
+---
+
+## Acceptance Criteria
+
+- [ ] A character with nine-again on a skill (via PT) and no Area of Expertise sees spec chip `+1` and pool includes `+1 <spec>`
+- [ ] A character with Area of Expertise matching the spec sees `+2` in chip and pool
+- [ ] A character with both nine-again AND Area of Expertise sees `+2` (AoE wins; nine-again does not double-count)
+- [ ] All eight affected sites updated — no remaining `skNineAgain` in spec-bonus expressions
+- [ ] `skNineAgain` removed from imports in `downtime-form.js` and `feeding-tab.js` (no longer used there after fix)
+- [ ] `nineAgain` parameter removed from `_augmentPoolWithSpecs` signature and both callers updated
+- [ ] `dice-engine.js` untouched — already correct
+
+---
+
+## Implementation
+
+### File 1: `public/js/tabs/downtime-form.js`
+
+**Import (line 21) — remove `skNineAgain`:**
+```js
+// CURRENT:
+import { calcVitaeMax, skTotal, skNineAgain, riteCost, skillAcqPoolStr, getAttrEffective, getAttrTotal, discDots } from '../data/accessors.js';
+// CHANGE TO:
+import { calcVitaeMax, skTotal, riteCost, skillAcqPoolStr, getAttrEffective, getAttrTotal, discDots } from '../data/accessors.js';
+```
+
+**Site 1 — line 591-592 (project pool inline):**
+```js
+// CURRENT:
+const specBonus = validSpec
+  ? ((skNineAgain(currentChar, skillName) || hasAoE(currentChar, specName)) ? 2 : 1)
+  : 0;
+// CHANGE TO:
+const specBonus = validSpec ? (hasAoE(currentChar, specName) ? 2 : 1) : 0;
+```
+
+**Site 2 — lines 3791-3792 (saved project pool):**
+```js
+// CURRENT:
+const na = skNineAgain(currentChar, savedSkill);
+total += (na || hasAoE(currentChar, savedSpec)) ? 2 : 1;
+// CHANGE TO:
+total += hasAoE(currentChar, savedSpec) ? 2 : 1;
+```
+(Remove the `const na` line entirely.)
+
+**Site 3 — lines 3844-3845 (spec chip label in project pool):**
+```js
+// CURRENT:
+const na = skNineAgain(currentChar, savedSkill);
+const bonus = (na || hasAoE(currentChar, sp)) ? 2 : 1;
+// CHANGE TO:
+const bonus = hasAoE(currentChar, sp) ? 2 : 1;
+```
+(Remove the `const na` line entirely.)
+
+**Site 4 — lines 4849-4850 (acquisition pool recalc):**
+```js
+// CURRENT:
+const na = skNineAgain(currentChar, skillEl.value);
+total += (na || hasAoE(currentChar, specEl.value)) ? 2 : 1;
+// CHANGE TO:
+total += hasAoE(currentChar, specEl.value) ? 2 : 1;
+```
+(Remove the `const na` line entirely.)
+
+---
+
+### File 2: `public/js/tabs/feeding-tab.js`
+
+**Import (line 14) — remove `skNineAgain`:**
+```js
+// CURRENT:
+import { getAttrEffective as getAttrVal, skDots, skTotal, skSpecStr, skNineAgain, calcVitaeMax } from '../data/accessors.js';
+// CHANGE TO:
+import { getAttrEffective as getAttrVal, skDots, skTotal, skSpecStr, calcVitaeMax } from '../data/accessors.js';
+```
+
+**Site 5 — lines 430-431 (feeding tab pool):**
+```js
+// CURRENT:
+const na = bestS ? skNineAgain(c, bestS) : false;
+const specBonus = specName && bestSpecs.includes(specName) ? ((na || hasAoE(c, specName)) ? 2 : 1) : 0;
+// CHANGE TO:
+const specBonus = specName && bestSpecs.includes(specName) ? (hasAoE(c, specName) ? 2 : 1) : 0;
+```
+(Remove the `const na` line entirely.)
+
+---
+
+### File 3: `public/js/admin/downtime-views.js`
+
+**Site 6 — `_augmentPoolWithSpecs` (lines 747-755):**
+
+Remove the `nineAgain` parameter. It was only used for the spec bonus.
+
+```js
+// CURRENT:
+function _augmentPoolWithSpecs(poolValidated, activeSpecs, char, nineAgain) {
+  if (!poolValidated || !activeSpecs.length) return poolValidated;
+  const eqIdx = poolValidated.lastIndexOf('=');
+  if (eqIdx === -1) return poolValidated;
+  const base     = poolValidated.slice(0, eqIdx).trim();
+  const tot      = parseInt(poolValidated.slice(eqIdx + 1).trim()) || 0;
+  const specTotal = activeSpecs.reduce((s, sp) => s + ((nineAgain || (char && hasAoE(char, sp))) ? 2 : 1), 0);
+  const specLabel = activeSpecs.map(sp => `${sp} +${(nineAgain || (char && hasAoE(char, sp))) ? 2 : 1}`).join(', ');
+  return `${base} + ${specLabel} = ${tot + specTotal}`;
+}
+
+// CHANGE TO:
+function _augmentPoolWithSpecs(poolValidated, activeSpecs, char) {
+  if (!poolValidated || !activeSpecs.length) return poolValidated;
+  const eqIdx = poolValidated.lastIndexOf('=');
+  if (eqIdx === -1) return poolValidated;
+  const base     = poolValidated.slice(0, eqIdx).trim();
+  const tot      = parseInt(poolValidated.slice(eqIdx + 1).trim()) || 0;
+  const specTotal = activeSpecs.reduce((s, sp) => s + (char && hasAoE(char, sp) ? 2 : 1), 0);
+  const specLabel = activeSpecs.map(sp => `${sp} +${char && hasAoE(char, sp) ? 2 : 1}`).join(', ');
+  return `${base} + ${specLabel} = ${tot + specTotal}`;
+}
+```
+
+**Callers of `_augmentPoolWithSpecs` — drop 4th arg (lines 7164 and 7412):**
+```js
+// CURRENT (both lines):
+_augmentPoolWithSpecs(poolValidated, rev.active_feed_specs || [], char, nineAgainState)
+_augmentPoolWithSpecs(poolValidated, rev.active_feed_specs || [], char, nineAgainStateFeed)
+// CHANGE TO (both):
+_augmentPoolWithSpecs(poolValidated, rev.active_feed_specs || [], char)
+```
+
+**Site 7 — line 954 (feeding pool builder):**
+```js
+// CURRENT:
+specBonus = (sk.nine_again || hasAoE(char, playerSpec)) ? 2 : 1;
+// CHANGE TO:
+specBonus = hasAoE(char, playerSpec) ? 2 : 1;
+```
+Also remove the stale comment above it (line 946: "// Spec bonus: +2 if Area-of-Expertise / nine-again") and update to: `// Spec bonus: +2 with Area of Expertise; +1 otherwise`
+
+**Site 8 — lines 5210-5211 (feed spec accumulator):**
+```js
+// CURRENT:
+const skillNa = char && skillSel ? skNineAgain(char, skillSel.value) : false;
+const specBonus = activeFeedSpecs.reduce((sum, sp) => sum + ((skillNa || (char && hasAoE(char, sp))) ? 2 : 1), 0);
+// CHANGE TO:
+const specBonus = activeFeedSpecs.reduce((sum, sp) => sum + (char && hasAoE(char, sp) ? 2 : 1), 0);
+```
+(Remove the `const skillNa` line entirely. `skNineAgain` import in `downtime-views.js` stays — still used at lines 732, 6585, 8284, 10803 for roll nine-again logic.)
+
+---
+
+## Verification
+
+```
+grep -n "skNineAgain" public/js/tabs/downtime-form.js
+grep -n "skNineAgain" public/js/tabs/feeding-tab.js
+```
+Expected: zero matches in both (import removed, no usages remain).
+
+```
+grep -n "nineAgain\|nine_again" public/js/admin/downtime-views.js | grep -i "spec\|bonus"
+```
+Expected: zero matches (no nine-again in spec bonus paths).
+
+```
+grep -n "_augmentPoolWithSpecs" public/js/admin/downtime-views.js
+```
+Expected: definition (3 args) + 2 callers (3 args each).
+
+**Manual smoke test:**
+1. Open a character with PT-granted nine-again, no Area of Expertise — DT form project pool and spec chip shows `+1`
+2. Open a character with Area of Expertise (matching spec) — chip shows `+2`
+3. Admin processing panel spec display matches for both cases
+
+---
+
+## Scope Notes
+
+- **In scope**: Remove `skNineAgain` from spec-bonus predicates at all eight sites; clean up unused `na`/`skillNa` variables and imports
+- **Out of scope**: How nine-again is applied to dice rolls (correct behaviour, untouched); `dice-engine.js` (already correct); any change to `_resolveNineAgain()` logic
+- **Do not touch**: `downtime-views.js` lines 732, 6585, 8284, 10803 — these use `skNineAgain` for roll-modifier logic, not spec bonus

--- a/specs/stories/sprint-status.yaml
+++ b/specs/stories/sprint-status.yaml
@@ -767,3 +767,4 @@ development_status:
   issue-272-ambience-overhaul: review                           # Fix entropy (per-rating), overfeeding (×2), project values (2/4), step thresholds (per-territory); rename AMBIENCE_CAP → AMBIENCE_FEEDING_TOLERANCE; personal projects deferred
   issue-273-feeding-matrix-feed-count: review                   # Four-state matrix O/OO/X/XX; _getSubFedTerrs Set→Map; _computeMatrixFeederCounts unified source; overfeeding display feeders/cap
   issue-271-city-st-notes-padding: review                     # fix.53: proc-amb-notes-block missing horizontal padding; label/textarea flush to left edge; padding: 12px 16px 0
+  issue-267-dt-spec-bonus-aoe-only: review                   # fix.54: remove skNineAgain from spec-bonus predicate at 8 sites (3 files); AoE-only; supersedes #207


### PR DESCRIPTION
## Summary

- Nine-again is a reroll-threshold mechanic, not a die-bonus trigger — a spec always adds +1, +2 only with Area of Expertise
- Removed `skNineAgain` from all 8 spec-bonus sites across `downtime-form.js`, `feeding-tab.js`, and `downtime-views.js`
- Cleaned up now-unused `skNineAgain` imports in `downtime-form.js` and `feeding-tab.js`; dropped the `nineAgain` parameter from `_augmentPoolWithSpecs` and updated both callers
- Supersedes #207 (which proposed the wrong canonical predicate)

## Closes

- Closes #267
- Closes #207

## Story

- specs/stories/fix.54.dt-spec-bonus-aoe-only.story.md

## Test plan

- [ ] `grep -n "skNineAgain" public/js/tabs/downtime-form.js public/js/tabs/feeding-tab.js` → zero matches
- [ ] CI green
- [ ] Manual: character with PT (nine-again, no AoE) → spec chip shows `+1`; character with Area of Expertise → `+2`

## Branch flow

- From: `morningstar-issue-267-dt-spec-bonus-aoe-only`
- Into: `dev`