### PR TITLE
feat(#308): DT processing — replace Committed/Rolled buttons with progress ribbon

### DIFF
--- a/public/css/suite.css
+++ b/public/css/suite.css
@@ -1189,7 +1189,6 @@ body.desktop-mode .sh-powers-grid > .sh-sec{break-inside:avoid;}
 .sheet-picker { padding: 16px; }
 .sheet-picker-grid {
   display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px;
-  max-height: 60vh; overflow-y: auto; overscroll-behavior: contain;
 }
 body.desktop-mode .sheet-picker-grid { grid-template-columns: repeat(6, 1fr); }
 .sheet-char-chip {


### PR DESCRIPTION
## Summary

- Makes `committed` and `rolled` intermediate states read-only: replaces clickable Committed/Rolled buttons with a `Pending → Committed → Rolled` progress ribbon so STs see the state machine without having to click through invisible intermediate steps
- Terminal button clicks now implicitly fire committed side-effects (`pool_committed_by`, `feeding_vitae_tally` snapshot) when the pool hasn't been formally committed yet, preserving data integrity without a separate Committed button click
- Extends Roll button visibility to `pending` state and adds a builder-DOM fallback so a fresh entry can be rolled without a prior Committed step

## Closes

- Closes #308

## Story

- specs/stories/feature.96.dt-status-ribbon.story.md

## Test plan

- [ ] `npx playwright test tests/downtime-processing-feature96.spec.js` — 34 Playwright E2E tests (F96-1 through F96-6), all pass
- [ ] `npx playwright test tests/downtime-processing-dt-fixes.spec.js --grep "DT-Fix-22"` — 4 tests, all pass
- [ ] CI green
- [ ] Manual: open a feeding, project, sorcery, and non-auto merit action in DT processing — verify ribbon renders, Committed/Rolled buttons are absent, Roll is available from pending, clicking a terminal button on a fresh pending entry auto-commits the pool

## Branch flow

- From: `morningstar-issue-308-dt-committed-rolled-ribbon`
- Into: `dev`