### PR TITLE
feat(#310): rename committed → confirmed in DT pool workflow

### DIFF
--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -4719,7 +4719,7 @@ body {
 }
 .proc-row-status.pending     { background: var(--crim-a25); color: var(--result-pend); }
 .proc-row-status.validated   { background: rgba(60,140,60,.25); color: var(--result-succ); }
-.proc-row-status.committed   { background: rgba(180,140,60,0.18); color: var(--gold2); }
+.proc-row-status.confirmed   { background: rgba(180,140,60,0.18); color: var(--gold2); }
 .proc-row-status.rolled      { background: rgba(180,140,60,0.28); color: var(--gold2); }
 .proc-row-status.no_roll     { background: rgba(100,100,100,.25); color: var(--txt2); }
 .proc-row-status.no_feed     { background: var(--crim-a25); color: var(--result-pend); }
@@ -4957,7 +4957,7 @@ body {
 .proc-val-status button.active.resolved    { border-color: var(--result-succ); color: var(--result-succ); background: var(--result-succ-bg); }
 .proc-val-status button.active.no_effect   { border-color: var(--txt2); color: var(--txt2); background: rgba(100,100,100,.15); }
 .proc-val-status button.active.skipped     { border-color: var(--txt2); color: var(--txt2); background: rgba(100,100,100,.15); }
-.proc-val-status button.active.committed   { border-color: var(--gold2); color: var(--gold2); background: rgba(180,140,60,0.15); }
+.proc-val-status button.active.confirmed   { border-color: var(--gold2); color: var(--gold2); background: rgba(180,140,60,0.15); }
 .proc-val-status button.active.rolled      { border-color: var(--gold2); color: var(--gold2); background: rgba(180,140,60,0.2); }
 
 .proc-status-ribbon {
@@ -4972,7 +4972,7 @@ body {
 .proc-ribbon-step.ribbon-past   { color: var(--txt2); border-color: var(--surf3); }
 .proc-ribbon-step.ribbon-active { font-weight: 600; }
 .proc-ribbon-step.ribbon-active.pending   { border-color: var(--result-pend); color: var(--result-pend); }
-.proc-ribbon-step.ribbon-active.committed { border-color: var(--gold2); color: var(--gold2); }
+.proc-ribbon-step.ribbon-active.confirmed { border-color: var(--gold2); color: var(--gold2); }
 .proc-ribbon-step.ribbon-active.rolled    { border-color: var(--gold2); color: var(--gold2); }
 .proc-ribbon-step.ribbon-future { opacity: 0.35; }
 .proc-ribbon-arrow { color: var(--txt3); font-size: 0.7rem; }
@@ -6167,7 +6167,7 @@ body {
 /* Status row badges — dark-mode colours (#ff9090 / #90d090) are unreadable on cream */
 html:not([data-theme="dark"]) .proc-row-status.pending  { background: var(--crim-a15); color: var(--crim); }
 html:not([data-theme="dark"]) .proc-row-status.validated{ background: var(--green-a15); color: var(--green3); }
-html:not([data-theme="dark"]) .proc-row-status.committed { background: rgba(180,140,60,0.12); color: var(--gold2); }
+html:not([data-theme="dark"]) .proc-row-status.confirmed { background: rgba(180,140,60,0.12); color: var(--gold2); }
 html:not([data-theme="dark"]) .proc-row-status.rolled   { background: rgba(180,140,60,0.18); color: var(--gold2); }
 html:not([data-theme="dark"]) .proc-row-status.no_roll  { background: var(--gold-a10); color: var(--txt2); }
 html:not([data-theme="dark"]) .proc-row-status.no_feed  { background: var(--crim-a15); color: var(--crim); }
@@ -6206,11 +6206,11 @@ html:not([data-theme="dark"]) .proc-val-status button.active.resolved     { bord
 html:not([data-theme="dark"]) .proc-val-status button.active.no_effect    { border-color: var(--txt2); color: var(--txt2); background: var(--gold-a10); }
 html:not([data-theme="dark"]) .proc-val-status button.active.skipped      { border-color: var(--txt2); color: var(--txt2); background: var(--gold-a10); }
 html:not([data-theme="dark"]) .proc-val-status button.active.maintenance  { border-color: var(--accent); color: var(--accent); background: var(--accent-a12); }
-html:not([data-theme="dark"]) .proc-val-status button.active.committed    { border-color: var(--story-compl); color: var(--story-compl); background: var(--story-compl-a15); }
+html:not([data-theme="dark"]) .proc-val-status button.active.confirmed    { border-color: var(--story-compl); color: var(--story-compl); background: var(--story-compl-a15); }
 html:not([data-theme="dark"]) .proc-val-status button.active.rolled       { border-color: var(--story-compl); color: var(--story-compl); background: var(--story-compl-a15); }
 html:not([data-theme="dark"]) .proc-val-status button:hover               { border-color: var(--crim-a40); color: var(--txt); }
 html:not([data-theme="dark"]) .proc-ribbon-step.ribbon-active.pending     { border-color: var(--crim); color: var(--crim); }
-html:not([data-theme="dark"]) .proc-ribbon-step.ribbon-active.committed   { border-color: var(--story-compl); color: var(--story-compl); }
+html:not([data-theme="dark"]) .proc-ribbon-step.ribbon-active.confirmed   { border-color: var(--story-compl); color: var(--story-compl); }
 html:not([data-theme="dark"]) .proc-ribbon-step.ribbon-active.rolled      { border-color: var(--story-compl); color: var(--story-compl); }
 html:not([data-theme="dark"]) .proc-row-status.maintenance                { background: var(--accent-a12); color: var(--accent); }
 html:not([data-theme="dark"]) .proc-row-status.resolved                   { background: var(--green-a15); color: var(--green3); }

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -229,7 +229,7 @@ function _computeMeritPoolSize(category, dots) {
 // Human-readable labels for pool_status values across all action types
 const POOL_STATUS_LABELS = {
   pending:     'Pending',
-  committed:   'Committed',
+  confirmed:   'Confirmed',
   rolled:      'Rolled',
   validated:   'Validated',
   no_roll:     'No Roll',
@@ -844,7 +844,7 @@ function renderJointGroup(joint, entries) {
     h += `<span class="proc-row-desc" title="${esc(entry.description || '')}">${esc(shortDesc || '—')}</span>`;
     const _attributedName =
       (status === 'validated' && review?.pool_validated_by) ? review.pool_validated_by :
-      (status === 'committed' && review?.pool_committed_by) ? review.pool_committed_by :
+      (status === 'confirmed' && review?.pool_confirmed_by) ? review.pool_confirmed_by :
       (status === 'resolved'  && review?.pool_resolved_by)  ? review.pool_resolved_by  : '';
     h += `<span class="proc-row-status-cell">`;
     if (_attributedName) h += `<span class="proc-row-validator">${esc(_attributedName)}</span>`;
@@ -4454,7 +4454,7 @@ function renderProcessingMode(container) {
         h += `<span class="proc-row-desc" title="${esc(entry.description)}">${esc(shortDesc || '—')}</span>`;
         const _attributedName =
           (status === 'validated' && review?.pool_validated_by) ? review.pool_validated_by :
-          (status === 'committed' && review?.pool_committed_by) ? review.pool_committed_by :
+          (status === 'confirmed' && review?.pool_confirmed_by) ? review.pool_confirmed_by :
           (status === 'resolved'  && review?.pool_resolved_by)  ? review.pool_resolved_by  : '';
         h += `<span class="proc-row-status-cell">`;
         if (_attributedName) h += `<span class="proc-row-validator">${esc(_attributedName)}</span>`;
@@ -4675,16 +4675,16 @@ function renderProcessingMode(container) {
           }
         }
       }
-      // Implicit committed side-effects when a terminal button is clicked before pool is committed
+      // Implicit confirm side-effects when a terminal button is clicked before pool is confirmed
       const _TERMINAL = new Set(['validated', 'resolved', 'no_roll', 'no_feed', 'no_effect', 'skipped', 'maintenance']);
       if (_TERMINAL.has(status)) {
         const _rev = getEntryReview(entry) || {};
         const _cur = _rev.pool_status || 'pending';
-        if (_cur === 'pending' || _cur === 'committed') {
-          if (!_rev.pool_committed_by) {
+        if (_cur === 'pending' || _cur === 'confirmed') {
+          if (!_rev.pool_confirmed_by) {
             const _u = getUser();
             const _stn = _u?.global_name || _u?.username || 'ST';
-            await saveEntryReview(entry, { pool_committed_by: _stn });
+            await saveEntryReview(entry, { pool_confirmed_by: _stn });
           }
           if (entry.source === 'feeding') {
             const _sub = submissions.find(s => s._id === entry.subId);
@@ -4710,18 +4710,60 @@ function renderProcessingMode(container) {
       }
 
       const statusPatch = { pool_status: status };
-      if (['validated', 'committed', 'resolved'].includes(status)) {
+      if (['validated', 'resolved'].includes(status)) {
         const user = getUser();
         const stName = user?.global_name || user?.username || 'ST';
         if (status === 'validated')  statusPatch.pool_validated_by  = stName;
-        if (status === 'committed')  statusPatch.pool_committed_by  = stName;
         if (status === 'resolved')   statusPatch.pool_resolved_by   = stName;
       }
       await saveEntryReview(entry, statusPatch);
 
-      // When committing a feeding pool, persist the vitae tally so the player
-      // portal can show correct values in the ready state (before they roll).
-      if (status === 'committed' && entry.source === 'feeding') {
+      renderProcessingMode(container);
+    });
+  });
+
+  // Wire clear pool button — clears pool_validated so ST can rebuild from scratch
+  container.querySelectorAll('.proc-pool-clear-btn').forEach(btn => {
+    btn.addEventListener('click', async e => {
+      e.stopPropagation();
+      const key   = btn.dataset.procKey;
+      const entry = _getQueueEntry(key);
+      if (!entry) return;
+      await saveEntryReview(entry, { pool_validated: '', pool_status: 'pending', pool_confirmed_by: '' });
+      renderProcessingMode(container);
+    });
+  });
+
+  // Wire confirm pool button — saves pool expr and advances pool_status to confirmed
+  container.querySelectorAll('.proc-confirm-pool-btn').forEach(btn => {
+    btn.addEventListener('click', async e => {
+      e.stopPropagation();
+      const key   = btn.dataset.procKey;
+      const entry = _getQueueEntry(key);
+      if (!entry) return;
+
+      const user   = getUser();
+      const stName = user?.global_name || user?.username || 'ST';
+      const patch  = { pool_status: 'confirmed', pool_confirmed_by: stName };
+
+      let poolExpr = getEntryReview(entry)?.pool_validated || '';
+      if (!poolExpr) {
+        const builderEl = container.querySelector(`.proc-pool-builder[data-proc-key="${key}"]`);
+        if (builderEl) poolExpr = _readBuilderExpr(builderEl) || '';
+      }
+      if (poolExpr) {
+        const rpanel  = container.querySelector(`.proc-feed-right[data-proc-key="${key}"]`);
+        const _naV    = rpanel?.querySelector('.proc-proj-9a')?.checked  || false;
+        const _8aV    = rpanel?.querySelector('.proc-proj-8a')?.checked  || false;
+        patch.pool_validated = poolExpr;
+        patch.nine_again     = _naV;
+        patch.eight_again    = _8aV;
+        if (entry.source === 'project') {
+          patch.rote = rpanel?.querySelector('.proc-pool-rote')?.checked || false;
+        }
+      }
+
+      if (entry.source === 'feeding') {
         const vitaePanel = container.querySelector(`.proc-feed-vitae-panel[data-proc-key="${key}"]`);
         if (vitaePanel) {
           const vitateTally = {
@@ -4740,18 +4782,7 @@ function renderProcessingMode(container) {
         }
       }
 
-      renderProcessingMode(container);
-    });
-  });
-
-  // Wire clear pool button — clears pool_validated so ST can rebuild from scratch
-  container.querySelectorAll('.proc-pool-clear-btn').forEach(btn => {
-    btn.addEventListener('click', async e => {
-      e.stopPropagation();
-      const key   = btn.dataset.procKey;
-      const entry = _getQueueEntry(key);
-      if (!entry) return;
-      await saveEntryReview(entry, { pool_validated: '' });
+      await saveEntryReview(entry, patch);
       renderProcessingMode(container);
     });
   });
@@ -5163,7 +5194,7 @@ function renderProcessingMode(container) {
             const _8aV = rpanel?.querySelector('.proc-proj-8a')?.checked  || false;
             const _user = getUser();
             const _stName = _user?.global_name || _user?.username || 'ST';
-            await saveEntryReview(entry, { pool_validated: builtExpr, nine_again: _naV, eight_again: _8aV, pool_committed_by: _stName });
+            await saveEntryReview(entry, { pool_validated: builtExpr, nine_again: _naV, eight_again: _8aV, pool_confirmed_by: _stName });
             poolValidated = builtExpr;
           }
         }
@@ -5207,7 +5238,7 @@ function renderProcessingMode(container) {
           await updateSubmission(subId, { feeding_roll: result, feeding_vitae_tally: vitateTally });
           if (sub) { sub.feeding_roll = result; sub.feeding_vitae_tally = vitateTally; }
           const cur = getEntryReview(entry)?.pool_status || 'pending';
-          if (cur === 'pending' || cur === 'committed') {
+          if (cur === 'pending' || cur === 'confirmed') {
             await saveEntryReview(entry, { pool_status: 'rolled' });
           }
           renderProcessingMode(container);
@@ -5269,7 +5300,7 @@ function renderProcessingMode(container) {
             const _8aV   = rpanel?.querySelector('.proc-proj-8a')?.checked    || false;
             const _user = getUser();
             const _stName = _user?.global_name || _user?.username || 'ST';
-            await saveEntryReview(entry, { pool_validated: builtExpr, nine_again: _naV, rote: _roteV, eight_again: _8aV, pool_committed_by: _stName });
+            await saveEntryReview(entry, { pool_validated: builtExpr, nine_again: _naV, rote: _roteV, eight_again: _8aV, pool_confirmed_by: _stName });
             poolValidated = builtExpr;
           }
         }
@@ -5296,7 +5327,7 @@ function renderProcessingMode(container) {
           pool: { expression: poolValidated, total: diceCount },
         });
         const cur = getEntryReview(entry)?.pool_status || 'pending';
-        if (cur === 'pending' || cur === 'committed') {
+        if (cur === 'pending' || cur === 'confirmed') {
           await saveEntryReview(entry, { pool_status: 'rolled' });
         }
         renderProcessingMode(container);
@@ -5325,7 +5356,7 @@ function renderProcessingMode(container) {
           pool: { expression: meritExpr, total: diceCount },
         });
         const cur = getEntryReview(entry)?.pool_status || 'pending';
-        if (cur === 'pending' || cur === 'committed') {
+        if (cur === 'pending' || cur === 'confirmed') {
           await saveEntryReview(entry, { pool_status: 'rolled' });
         }
         renderProcessingMode(container);
@@ -6639,7 +6670,7 @@ function _renderValStatusButtons(key, poolStatus, buttons) {
 }
 
 function _renderStatusRibbon(key, poolStatus) {
-  const steps = [['pending', 'Pending'], ['committed', 'Committed'], ['rolled', 'Rolled']];
+  const steps = [['pending', 'Pending'], ['confirmed', 'Confirmed'], ['rolled', 'Rolled']];
   const activeIdx = steps.findIndex(([val]) => val === poolStatus);
   let h = '<div class="proc-status-ribbon">';
   steps.forEach(([val, label], i) => {
@@ -6898,12 +6929,12 @@ function _renderMeritRightPanel(entry, rev) {
   // ── Status ──
   h += `<div class="proc-feed-right-section proc-feed-right-validation">`;
   h += `<div class="proc-mod-panel-title">Validation Status</div>`;
-  const meritBtns = [['pending', 'Pending'], ['resolved', 'Validated'], ['no_roll', 'No Roll Needed'], ['skipped', 'Skip']];
-  if (!isAuto && ['pending', 'committed', 'rolled'].includes(poolStatus)) h += _renderStatusRibbon(key, poolStatus);
+  const meritBtns = [['resolved', 'Validated'], ['no_roll', 'No Roll Needed'], ['skipped', 'Skip']];
+  if (!isAuto && ['pending', 'confirmed', 'rolled'].includes(poolStatus)) h += _renderStatusRibbon(key, poolStatus);
   h += _renderValStatusButtons(key, poolStatus, meritBtns);
   // Committed pool display
   const poolValidatedMerit = rev.pool_validated || '';
-  h += `<div class="proc-feed-committed-pool" data-proc-key="${esc(key)}">${poolValidatedMerit ? esc(poolValidatedMerit) : '<span class="dt-dim-italic">Not yet committed</span>'}</div>`;
+  h += `<div class="proc-feed-committed-pool" data-proc-key="${esc(key)}">${poolValidatedMerit ? esc(poolValidatedMerit) : '<span class="dt-dim-italic">Not yet confirmed</span>'}</div>`;
   if (poolValidatedMerit) h += `<button class="dt-btn dt-btn-sm proc-pool-clear-btn" data-proc-key="${esc(key)}">Clear Pool</button>`;
   const _isSO_merit = !!rev.second_opinion;
   h += `<button class="proc-second-opinion-btn${_isSO_merit ? ' active' : ''}" data-proc-key="${esc(key)}">${_isSO_merit ? 'Second Opinion' : 'Flag for 2nd opinion'}</button>`;
@@ -6927,14 +6958,14 @@ function _renderSorceryRightPanel(entry, char, sub, rev) {
   const base         = ritInfo ? _computeRitePool(char, ritInfo.attr, ritInfo.skill, ritInfo.disc) : 0;
   const total        = base + 3 + mgDots + eqMod;
 
-  const _sorcCommitted = poolStatus === 'committed';
+  const _sorcCommitted = poolStatus === 'confirmed';
   const _sorcDis = _sorcCommitted ? ' disabled' : '';
 
   let h = `<div class="proc-feed-right" data-proc-key="${esc(key)}">`;
 
   // ── Dice Pool Modifiers ──
   h += `<div class="proc-feed-mod-panel${_sorcCommitted ? ' proc-pool-committed' : ''}" data-proc-key="${esc(key)}">`;
-  h += `<div class="proc-mod-panel-title">Dice Pool Modifiers${_sorcCommitted ? ' <span class="proc-pool-committed-badge">[Committed]</span>' : ''}</div>`;
+  h += `<div class="proc-mod-panel-title">Dice Pool Modifiers${_sorcCommitted ? ' <span class="proc-pool-committed-badge">[Confirmed]</span>' : ''}</div>`;
 
   // +3 Downtime bonus (always on)
   h += `<div class="proc-mod-row"><span class="proc-mod-label">Downtime bonus</span><span class="proc-mod-static">+3</span></div>`;
@@ -6964,8 +6995,8 @@ function _renderSorceryRightPanel(entry, char, sub, rev) {
   // ── Validation Status ──
   h += `<div class="proc-feed-right-section proc-feed-right-validation">`;
   h += `<div class="proc-mod-panel-title">Validation Status</div>`;
-  if (['pending', 'committed', 'rolled'].includes(poolStatus)) h += _renderStatusRibbon(key, poolStatus);
-  h += _renderValStatusButtons(key, poolStatus, [['pending', 'Pending'], ['resolved', 'Resolved'], ['no_effect', 'No Effect'], ['skipped', 'Skip']]);
+  if (['pending', 'confirmed', 'rolled'].includes(poolStatus)) h += _renderStatusRibbon(key, poolStatus);
+  h += _renderValStatusButtons(key, poolStatus, [['resolved', 'Resolved'], ['no_effect', 'No Effect'], ['skipped', 'Skip']]);
   // Committed pool display — shows computed total when rite is selected
   if (canRoll) {
     const poolExprSorc = `${base} + 3${mgDots ? ` + ${mgDots} (Mandragora)` : ''}${eqMod ? ` ${eqMod > 0 ? '+' : ''}${eqMod}` : ''} = ${total} dice`;
@@ -7105,11 +7136,11 @@ function _renderProjRightPanel(entry, char, rev) {
   // ── Validation Status ──
   h += `<div class="proc-feed-right-section proc-feed-right-validation">`;
   h += `<div class="proc-mod-panel-title">Validation Status</div>`;
-  if (['pending', 'committed', 'rolled'].includes(poolStatus)) h += _renderStatusRibbon(key, poolStatus);
-  h += _renderValStatusButtons(key, poolStatus, [['pending', 'Pending'], ['validated', 'Validated'], ['no_roll', 'No Roll Needed'], ['skipped', 'Skip']]);
+  if (['pending', 'confirmed', 'rolled'].includes(poolStatus)) h += _renderStatusRibbon(key, poolStatus);
+  h += _renderValStatusButtons(key, poolStatus, [['validated', 'Validated'], ['no_roll', 'No Roll Needed'], ['skipped', 'Skip']]);
   // Committed pool expression with active specs
   const displayPool = _augmentPoolWithSpecs(poolValidated, rev.active_feed_specs || [], char);
-  h += `<div class="proc-feed-committed-pool" data-proc-key="${esc(key)}">${displayPool ? esc(displayPool) : '<span class="dt-dim-italic">Not yet committed</span>'}</div>`;
+  h += `<div class="proc-feed-committed-pool" data-proc-key="${esc(key)}">${displayPool ? esc(displayPool) : '<span class="dt-dim-italic">Not yet confirmed</span>'}</div>`;
   // Validation notation: show active flags + validator chip when validated
   if (poolStatus === 'validated') {
     const notes = [];
@@ -7130,7 +7161,7 @@ function _renderProjRightPanel(entry, char, rev) {
 
   // ── Roll card ──
   const projRoll    = rev.roll || null;
-  const showRollBtn = poolStatus === 'pending' || poolStatus === 'committed' || poolStatus === 'rolled' || poolStatus === 'validated' || !!projRoll;
+  const showRollBtn = poolStatus === 'pending' || poolStatus === 'confirmed' || poolStatus === 'rolled' || poolStatus === 'validated' || !!projRoll;
   h += _renderRollCard(key, projRoll, null, {
     btnClass:        'proc-proj-roll-btn',
     btnDataAttrs:    ` data-pool-validated="${esc(poolValidated)}"`,
@@ -7138,6 +7169,7 @@ function _renderProjRightPanel(entry, char, rev) {
     noRollMsg:       'Validate pool first',
     successModifier:  succMod,
     contestedRoll:    rev.contested_roll || null,
+    showConfirm:      poolStatus === 'pending',
   });
 
   h += `</div>`; // proc-feed-right
@@ -7354,11 +7386,11 @@ function _renderFeedRightPanel(entry, char, rev) {
   const poolStatus = rev.pool_status || 'pending';
   h += `<div class="proc-feed-right-section proc-feed-right-validation">`;
   h += `<div class="proc-mod-panel-title">Validation Status</div>`;
-  if (['pending', 'committed', 'rolled'].includes(poolStatus)) h += _renderStatusRibbon(key, poolStatus);
-  h += _renderValStatusButtons(key, poolStatus, [['pending', 'Pending'], ['validated', 'Validated'], ['no_feed', 'No Valid Feeding']]);
+  if (['pending', 'confirmed', 'rolled'].includes(poolStatus)) h += _renderStatusRibbon(key, poolStatus);
+  h += _renderValStatusButtons(key, poolStatus, [['validated', 'Validated'], ['no_feed', 'No Valid Feeding']]);
   // Committed pool expression display — augmented with active spec names if any
   const displayPool = _augmentPoolWithSpecs(poolValidated, rev.active_feed_specs || [], char);
-  h += `<div class="proc-feed-committed-pool" data-proc-key="${esc(key)}">${displayPool ? esc(displayPool) : '<span class="dt-dim-italic">Not yet committed</span>'}</div>`;
+  h += `<div class="proc-feed-committed-pool" data-proc-key="${esc(key)}">${displayPool ? esc(displayPool) : '<span class="dt-dim-italic">Not yet confirmed</span>'}</div>`;
   if (poolValidated) {
     const feedNotes = [];
     if (isRote) feedNotes.push('Rote');
@@ -7377,12 +7409,13 @@ function _renderFeedRightPanel(entry, char, rev) {
 
   // ── Roll card ──
   const feedRollObj = feedSub?.feeding_roll || null;
-  const showFeedRollBtn = poolStatus === 'pending' || poolStatus === 'committed' || poolStatus === 'rolled' || poolStatus === 'validated' || !!feedRollObj;
+  const showFeedRollBtn = poolStatus === 'pending' || poolStatus === 'confirmed' || poolStatus === 'rolled' || poolStatus === 'validated' || !!feedRollObj;
   h += _renderRollCard(key, feedRollObj, null, {
-    btnClass:  'proc-feed-roll-btn',
+    btnClass:     'proc-feed-roll-btn',
     btnDataAttrs: ` data-sub-id="${esc(entry.subId)}" data-rote="${isRote}"`,
-    canRoll:   showFeedRollBtn,
-    noRollMsg: 'Commit pool first',
+    canRoll:      showFeedRollBtn,
+    noRollMsg:    'Confirm pool first',
+    showConfirm:  poolStatus === 'pending',
   });
 
   // ── DTFP-5: feed-violence ST override ──
@@ -7439,6 +7472,7 @@ function _renderRollCard(key, roll, poolTotal, opts = {}) {
     targetSuccesses = null,
     successModifier = 0,   // DTR-1: succ_mod_manual from rev
     contestedRoll   = null, // DTR-2: defender roll object
+    showConfirm     = false,
   } = opts;
 
   const poolLabel   = (poolTotal != null && canRoll) ? ` \u2014 ${poolTotal} dice` : '';
@@ -7448,7 +7482,10 @@ function _renderRollCard(key, roll, poolTotal, opts = {}) {
   h += `<div class="proc-mod-panel-title">Roll${poolLabel}${targetLabel}</div>`;
 
   if (canRoll) {
-    const btnLabel = roll ? 'Re-roll' : 'Roll';
+    if (showConfirm) {
+      h += `<button class="dt-btn proc-confirm-pool-btn" data-proc-key="${esc(key)}">Confirm Dice Pool</button>`;
+    }
+    const btnLabel = roll ? 'Re-roll' : 'Roll Dice Pool';
     h += `<button class="dt-btn ${esc(btnClass)}" data-proc-key="${esc(key)}"${btnDataAttrs}>${btnLabel}</button>`;
     if (roll) {
       const dStr   = _formatDiceString(roll.dice_string);
@@ -8200,10 +8237,10 @@ function renderActionPanel(entry, review) {
       const initDiscDots  = (preDisc && preDisc !== 'none') ? (charDiscs.find(d => d.name === preDisc)?.dots || 0) : 0;
       const initTotalStr  = _poolTotalDisplay(preAttr, initAttrDots, preSkill, initSkillDots, preDisc, initDiscDots, initModForDisplay, preSkill);
 
-      const _feedCommitted = poolStatus === 'committed';
+      const _feedCommitted = poolStatus === 'confirmed';
       const _feedDis = _feedCommitted ? ' disabled' : '';
       h += `<div class="proc-pool-builder${_feedCommitted ? ' proc-pool-committed' : ''}" data-proc-key="${esc(entry.key)}">`;
-      h += `<div class="proc-detail-label">ST Pool Builder${!char ? ' <span class="dt-hint">(dot values unavailable \u2014 character not loaded)</span>' : ''}${_feedCommitted ? ' <span class="proc-pool-committed-badge">[Committed]</span>' : ''}</div>`;
+      h += `<div class="proc-detail-label">ST Pool Builder${!char ? ' <span class="dt-hint">(dot values unavailable \u2014 character not loaded)</span>' : ''}${_feedCommitted ? ' <span class="proc-pool-committed-badge">[Confirmed]</span>' : ''}</div>`;
       if (showParseRef) {
         h += `<div class="proc-pool-parse-ref">Could not restore selection \u2014 previous: "${esc(poolValidated)}"</div>`;
       }
@@ -8285,10 +8322,10 @@ function renderActionPanel(entry, review) {
     const _pnA  = char && preSkill ? skNineAgain(char, preSkill) : false;
     const initTotalStr  = _poolTotalDisplay(preAttr, initAttrDots, preSkill, initSkillDots, preDisc, initDiscDots, initModForDisplay, preSkill, _pnA);
 
-    const _projCommitted = poolStatus === 'committed';
+    const _projCommitted = poolStatus === 'confirmed';
     const _projDis = _projCommitted ? ' disabled' : '';
     h += `<div class="proc-pool-builder${_projCommitted ? ' proc-pool-committed' : ''}" data-proc-key="${esc(entry.key)}">`;
-    h += `<div class="proc-detail-label">ST Pool Builder${!char ? ' <span class="dt-hint">(dot values unavailable \u2014 character not loaded)</span>' : ''}${_projCommitted ? ' <span class="proc-pool-committed-badge">[Committed]</span>' : ''}</div>`;
+    h += `<div class="proc-detail-label">ST Pool Builder${!char ? ' <span class="dt-hint">(dot values unavailable \u2014 character not loaded)</span>' : ''}${_projCommitted ? ' <span class="proc-pool-committed-badge">[Confirmed]</span>' : ''}</div>`;
     if (showParseRef) {
       h += `<div class="proc-pool-parse-ref">Could not restore selection \u2014 previous: "${esc(poolValidated)}"</div>`;
     }

--- a/server/scripts/migrate-pool-status-committed-to-confirmed.js
+++ b/server/scripts/migrate-pool-status-committed-to-confirmed.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+
+/**
+ * Rename pool_status 'committed' → 'confirmed' across all downtime submissions.
+ *
+ * feature.310 renamed the intermediate pool state. The value is stored in nested
+ * subdocuments: feeding_review, projects_resolved[n], merit_actions_resolved[n],
+ * sorcery_review[n], st_actions_resolved[n].
+ *
+ * Also renames pool_committed_by → pool_confirmed_by wherever found.
+ *
+ * Idempotent: re-running produces zero updates.
+ *
+ * Usage:
+ *   node server/scripts/migrate-pool-status-committed-to-confirmed.js --dry-run
+ *   node server/scripts/migrate-pool-status-committed-to-confirmed.js --apply
+ */
+
+import 'dotenv/config';
+import { MongoClient } from 'mongodb';
+
+const MONGODB_URI = process.env.MONGODB_URI;
+if (!MONGODB_URI) {
+  console.error('MONGODB_URI not set.');
+  process.exit(1);
+}
+
+const APPLY   = process.argv.includes('--apply');
+const DRY_RUN = !APPLY;
+
+function migrateReview(rev) {
+  if (!rev || typeof rev !== 'object') return { changed: false, obj: rev };
+  let changed = false;
+  const out = { ...rev };
+  if (out.pool_status === 'committed') {
+    out.pool_status = 'confirmed';
+    changed = true;
+  }
+  if ('pool_committed_by' in out) {
+    out.pool_confirmed_by = out.pool_committed_by;
+    delete out.pool_committed_by;
+    changed = true;
+  }
+  return { changed, obj: out };
+}
+
+function migrateArray(arr) {
+  if (!Array.isArray(arr)) return { changed: false, arr };
+  let anyChanged = false;
+  const out = arr.map(item => {
+    const { changed, obj } = migrateReview(item);
+    if (changed) anyChanged = true;
+    return obj;
+  });
+  return { changed: anyChanged, arr: out };
+}
+
+async function main() {
+  console.log(`Mode: ${APPLY ? 'APPLY (will write)' : 'DRY RUN (read only)'}`);
+  const client = new MongoClient(MONGODB_URI, { serverSelectionTimeoutMS: 10000 });
+
+  try {
+    await client.connect();
+    const db   = client.db(process.env.MONGODB_DB || 'tm_suite');
+    const coll = db.collection('downtime_submissions');
+
+    const subs = await coll.find({}).toArray();
+    console.log(`Loaded ${subs.length} downtime submissions\n`);
+
+    let totalUpdated = 0;
+
+    for (const sub of subs) {
+      const update = {};
+      let touched = false;
+
+      const fr = migrateReview(sub.feeding_review);
+      if (fr.changed) { update.feeding_review = fr.obj; touched = true; }
+
+      const pr = migrateArray(sub.projects_resolved);
+      if (pr.changed) { update.projects_resolved = pr.arr; touched = true; }
+
+      const mr = migrateArray(sub.merit_actions_resolved);
+      if (mr.changed) { update.merit_actions_resolved = mr.arr; touched = true; }
+
+      const sar = migrateArray(sub.st_actions_resolved);
+      if (sar.changed) { update.st_actions_resolved = sar.arr; touched = true; }
+
+      if (sub.sorcery_review && typeof sub.sorcery_review === 'object') {
+        const srcOut = {};
+        let srcChanged = false;
+        for (const [k, v] of Object.entries(sub.sorcery_review)) {
+          const { changed, obj } = migrateReview(v);
+          srcOut[k] = obj;
+          if (changed) srcChanged = true;
+        }
+        if (srcChanged) { update.sorcery_review = srcOut; touched = true; }
+      }
+
+      if (touched) {
+        totalUpdated++;
+        const label = sub._id;
+        console.log(`${label}: ${Object.keys(update).join(', ')}`);
+        if (APPLY) {
+          await coll.updateOne({ _id: sub._id }, { $set: update });
+        }
+      }
+    }
+
+    console.log(`\n${DRY_RUN ? '[DRY RUN] Would update' : 'Updated'} ${totalUpdated} submissions.`);
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/specs/stories/feature.310.dt-confirmed-ribbon-redesign.story.md
+++ b/specs/stories/feature.310.dt-confirmed-ribbon-redesign.story.md
@@ -1,0 +1,503 @@
+# Story feature.310: DT Processing — Confirmed Ribbon Redesign
+
+## Status: review
+
+---
+
+## Metadata
+
+```yaml
+issue: 310
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/310
+branch: morningstar-issue-310-dt-confirmed-ribbon-redesign
+```
+
+---
+
+## Story
+
+**As an** ST processing downtimes,
+**I want** the pool progress steps labelled Pending / Confirmed / Rolled with a "Confirm Dice Pool" button and "Roll Dice Pool" button in the Roll card,
+**so that** the workflow is unambiguous and there is a deliberate one-click action to confirm a pool before rolling, while still allowing direct roll from Pending as a shortcut.
+
+---
+
+## Background
+
+Feature.96 (#308) replaced the Committed/Rolled clickable buttons with a read-only ribbon. This left a gap: the ribbon showed "Committed" as a step but there was no way to advance to it. After reviewing the design with the ST team:
+
+- The intermediate step is renamed `committed` → `confirmed` (both the DB value and the label).
+- A "Confirm Dice Pool" button is added inside the Roll card, visible from `pending`.
+- The "Roll" button label becomes "Roll Dice Pool".
+- The "Pending" button is removed from the Validation Status row — Clear Pool is the only reset path.
+- Rolling directly from `pending` remains valid (shortcut that skips Confirm).
+
+**Status flow after this story:**
+
+| `pool_status` | Ribbon active step | Confirm button | Roll Dice Pool button |
+|---|---|---|---|
+| `pending` | **Pending** | Visible | Visible |
+| `confirmed` | **Confirmed** | Hidden | Visible |
+| `rolled` | **Rolled** | Hidden | Visible (re-roll) |
+| terminal | Hidden | Hidden | Hidden |
+
+---
+
+## Acceptance Criteria
+
+1. `'committed'` → `'confirmed'` everywhere as a `pool_status` value in JS code and CSS classes.
+2. Ribbon label shows "Confirmed" (not "Committed") when that step is active.
+3. No "Pending" button in the Validation Status button row for any of the 4 pool-builder action types.
+4. "Confirm Dice Pool" button renders inside the Roll card when `pool_status === 'pending'`; absent when `'confirmed'`, `'rolled'`, or terminal.
+5. Clicking "Confirm Dice Pool" saves the builder expression to `pool_validated`, sets `pool_status: 'confirmed'`, sets `pool_confirmed_by: stName`.
+6. For feeding entries, clicking "Confirm Dice Pool" also snapshots the vitae tally to `feeding_vitae_tally` (mirrors the old Committed button logic).
+7. "Roll Dice Pool" button label (first roll) replaces the plain "Roll" label. Re-roll label stays "Re-roll".
+8. "Roll Dice Pool" button is visible from `pending` AND `confirmed` AND `rolled` (no regression).
+9. "Clear Pool" resets `pool_validated`, `pool_status: 'pending'`, and `pool_confirmed_by: ''` in one save.
+10. Pool roll handlers (`proc-feed-roll-btn`, `proc-proj-roll-btn`) advance `pool_status → 'rolled'` when current status is `pending` OR `confirmed` (previously only checked for `pending`/`committed`).
+11. DB migration script updates any existing `pool_status: 'committed'` records in `entry_reviews` to `'confirmed'`.
+12. All feature.96 E2E tests updated: `'committed'` → `'confirmed'`, "Committed" label checks → "Confirmed", tests for Pending button absence, tests for "Confirm Dice Pool" and "Roll Dice Pool" buttons.
+
+---
+
+## Tasks / Subtasks
+
+### [x] Task 1: Rename `committed` → `confirmed` in `_renderStatusRibbon`
+
+**File:** `public/js/admin/downtime-views.js`, line 6642
+
+```js
+// BEFORE:
+const steps = [['pending', 'Pending'], ['committed', 'Committed'], ['rolled', 'Rolled']];
+
+// AFTER:
+const steps = [['pending', 'Pending'], ['confirmed', 'Confirmed'], ['rolled', 'Rolled']];
+```
+
+### [x] Task 2: Update ribbon guard conditions at the 4 call sites
+
+Each of the 4 call sites has `['pending', 'committed', 'rolled'].includes(poolStatus)`. Change `'committed'` → `'confirmed'` at all four:
+
+- **Merit non-auto** — line 6902: `if (!isAuto && ['pending', 'confirmed', 'rolled'].includes(poolStatus))`
+- **Sorcery** — line 6967: `if (['pending', 'confirmed', 'rolled'].includes(poolStatus))`
+- **Project** — line 7108: `if (['pending', 'confirmed', 'rolled'].includes(poolStatus))`
+- **Feeding** — line 7357: `if (['pending', 'confirmed', 'rolled'].includes(poolStatus))`
+
+### [x] Task 3: Remove "Pending" button from the 4 call sites
+
+Each `_renderValStatusButtons(...)` call currently includes `['pending', 'Pending']`. Remove it from all four.
+
+**Merit non-auto** (line 6901, variable `meritBtns`):
+```js
+// BEFORE:
+const meritBtns = [['pending', 'Pending'], ['resolved', 'Validated'], ['no_roll', 'No Roll Needed'], ['skipped', 'Skip']];
+
+// AFTER:
+const meritBtns = [['resolved', 'Validated'], ['no_roll', 'No Roll Needed'], ['skipped', 'Skip']];
+```
+
+**Sorcery** (line 6968):
+```js
+// BEFORE:
+h += _renderValStatusButtons(key, poolStatus, [['pending', 'Pending'], ['resolved', 'Resolved'], ['no_effect', 'No Effect'], ['skipped', 'Skip']]);
+
+// AFTER:
+h += _renderValStatusButtons(key, poolStatus, [['resolved', 'Resolved'], ['no_effect', 'No Effect'], ['skipped', 'Skip']]);
+```
+
+**Project** (line 7109):
+```js
+// BEFORE:
+h += _renderValStatusButtons(key, poolStatus, [['pending', 'Pending'], ['validated', 'Validated'], ['no_roll', 'No Roll Needed'], ['skipped', 'Skip']]);
+
+// AFTER:
+h += _renderValStatusButtons(key, poolStatus, [['validated', 'Validated'], ['no_roll', 'No Roll Needed'], ['skipped', 'Skip']]);
+```
+
+**Feeding** (line 7358):
+```js
+// BEFORE:
+h += _renderValStatusButtons(key, poolStatus, [['pending', 'Pending'], ['validated', 'Validated'], ['no_feed', 'No Valid Feeding']]);
+
+// AFTER:
+h += _renderValStatusButtons(key, poolStatus, [['validated', 'Validated'], ['no_feed', 'No Valid Feeding']]);
+```
+
+### [x] Task 4: Add "Confirm Dice Pool" button + rename "Roll" in `_renderRollCard`
+
+**File:** `public/js/admin/downtime-views.js`, function `_renderRollCard` at line 7433.
+
+**4a.** Add `showConfirm = false` and `confirmKey = ''` to the opts destructure (line ~7434):
+```js
+const {
+  btnClass        = 'proc-proj-roll-btn',
+  btnDataAttrs    = '',
+  canRoll         = true,
+  noRollMsg       = 'No roll available',
+  targetSuccesses = null,
+  successModifier = 0,
+  contestedRoll   = null,
+  showConfirm     = false,   // NEW: show Confirm Dice Pool button
+} = opts;
+```
+
+**4b.** Inside the `if (canRoll)` block (line ~7450), add the Confirm button BEFORE the Roll button, and rename "Roll" to "Roll Dice Pool":
+```js
+if (canRoll) {
+  if (showConfirm) {
+    h += `<button class="dt-btn proc-confirm-pool-btn" data-proc-key="${esc(key)}">Confirm Dice Pool</button>`;
+  }
+  const btnLabel = roll ? 'Re-roll' : 'Roll Dice Pool';
+  h += `<button class="dt-btn ${esc(btnClass)}" data-proc-key="${esc(key)}"${btnDataAttrs}>${btnLabel}</button>`;
+  // ... rest unchanged
+```
+
+### [x] Task 5: Pass `showConfirm` to the Project and Feeding roll card calls
+
+**Project** — lines 7134–7141. The `poolStatus` variable is in scope at this point:
+```js
+// BEFORE:
+h += _renderRollCard(key, projRoll, null, {
+  btnClass:        'proc-proj-roll-btn',
+  btnDataAttrs:    ` data-pool-validated="${esc(poolValidated)}"`,
+  canRoll:          showRollBtn,
+  noRollMsg:       'Validate pool first',
+  successModifier:  succMod,
+  contestedRoll:    rev.contested_roll || null,
+});
+
+// AFTER:
+h += _renderRollCard(key, projRoll, null, {
+  btnClass:        'proc-proj-roll-btn',
+  btnDataAttrs:    ` data-pool-validated="${esc(poolValidated)}"`,
+  canRoll:          showRollBtn,
+  noRollMsg:       'Validate pool first',
+  successModifier:  succMod,
+  contestedRoll:    rev.contested_roll || null,
+  showConfirm:      poolStatus === 'pending',
+});
+```
+
+**Feeding** — lines 7381–7386. The `poolStatus` variable is in scope (line 7354):
+```js
+// BEFORE:
+h += _renderRollCard(key, feedRollObj, null, {
+  btnClass:  'proc-feed-roll-btn',
+  btnDataAttrs: ` data-sub-id="${esc(entry.subId)}" data-rote="${isRote}"`,
+  canRoll:   showFeedRollBtn,
+  noRollMsg: 'Commit pool first',
+});
+
+// AFTER:
+h += _renderRollCard(key, feedRollObj, null, {
+  btnClass:     'proc-feed-roll-btn',
+  btnDataAttrs: ` data-sub-id="${esc(entry.subId)}" data-rote="${isRote}"`,
+  canRoll:      showFeedRollBtn,
+  noRollMsg:    'Confirm pool first',
+  showConfirm:  poolStatus === 'pending',
+});
+```
+
+Note: also update `noRollMsg` from `'Commit pool first'` to `'Confirm pool first'` on the feeding call.
+
+### [x] Task 6: Wire `.proc-confirm-pool-btn` click handler
+
+Add immediately after the `.proc-pool-clear-btn` handler block (after line 4757):
+
+```js
+// Wire confirm pool button — saves pool expr and advances to confirmed status
+container.querySelectorAll('.proc-confirm-pool-btn').forEach(btn => {
+  btn.addEventListener('click', async e => {
+    e.stopPropagation();
+    const key   = btn.dataset.procKey;
+    const entry = _getQueueEntry(key);
+    if (!entry) return;
+
+    const user   = getUser();
+    const stName = user?.global_name || user?.username || 'ST';
+    const patch  = { pool_status: 'confirmed', pool_confirmed_by: stName };
+
+    // Read builder expression if not already saved
+    let poolExpr = getEntryReview(entry)?.pool_validated || '';
+    if (!poolExpr) {
+      const builderEl = container.querySelector(`.proc-pool-builder[data-proc-key="${key}"]`);
+      if (builderEl) poolExpr = _readBuilderExpr(builderEl) || '';
+    }
+    if (poolExpr) {
+      const rpanel     = container.querySelector(`.proc-feed-right[data-proc-key="${key}"]`);
+      const _naV       = rpanel?.querySelector('.proc-proj-9a')?.checked  || false;
+      const _8aV       = rpanel?.querySelector('.proc-proj-8a')?.checked  || false;
+      patch.pool_validated = poolExpr;
+      patch.nine_again     = _naV;
+      patch.eight_again    = _8aV;
+      if (entry.source === 'project') {
+        patch.rote = rpanel?.querySelector('.proc-pool-rote')?.checked || false;
+      }
+    }
+
+    // For feeding: snapshot vitae tally on confirm
+    if (entry.source === 'feeding') {
+      const vitaePanel = container.querySelector(`.proc-feed-vitae-panel[data-proc-key="${key}"]`);
+      if (vitaePanel) {
+        const vitateTally = {
+          herd:               parseInt(vitaePanel.dataset.herd,       10) || 0,
+          ambience:           parseInt(vitaePanel.dataset.ambience,   10) || 0,
+          ambience_territory: vitaePanel.dataset.terrLabel || '',
+          oath_of_fealty:     parseInt(vitaePanel.dataset.oof,        10) || 0,
+          ghouls:             parseInt(vitaePanel.dataset.ghouls,     10) || 0,
+          rite_cost:          parseInt(vitaePanel.dataset.riteCost,   10) || 0,
+          manual:             parseInt(vitaePanel.dataset.manual,     10) || 0,
+          total_bonus:        parseInt(vitaePanel.dataset.totalBonus, 10) || 0,
+        };
+        await updateSubmission(entry.subId, { feeding_vitae_tally: vitateTally });
+        const sub = submissions.find(s => s._id === entry.subId);
+        if (sub) sub.feeding_vitae_tally = vitateTally;
+      }
+    }
+
+    await saveEntryReview(entry, patch);
+    renderProcessingMode(container);
+  });
+});
+```
+
+### [x] Task 7: Update Clear Pool handler to fully reset state
+
+**File:** `public/js/admin/downtime-views.js`, line 4754.
+
+```js
+// BEFORE:
+await saveEntryReview(entry, { pool_validated: '' });
+
+// AFTER:
+await saveEntryReview(entry, { pool_validated: '', pool_status: 'pending', pool_confirmed_by: '' });
+```
+
+### [x] Task 8: Update Roll handlers for `confirmed` status
+
+**Feed roll handler** (~line 5209–5212):
+```js
+// BEFORE:
+const cur = getEntryReview(entry)?.pool_status || 'pending';
+if (cur === 'pending' || cur === 'committed') {
+  await saveEntryReview(entry, { pool_status: 'rolled' });
+}
+
+// AFTER:
+const cur = getEntryReview(entry)?.pool_status || 'pending';
+if (cur === 'pending' || cur === 'confirmed') {
+  await saveEntryReview(entry, { pool_status: 'rolled' });
+}
+```
+
+**Project roll handler** (~line 5298–5301): same pattern:
+```js
+// BEFORE:
+const cur = getEntryReview(entry)?.pool_status || 'pending';
+if (cur === 'pending' || cur === 'committed') {
+  await saveEntryReview(entry, { pool_status: 'rolled' });
+}
+
+// AFTER:
+const cur = getEntryReview(entry)?.pool_status || 'pending';
+if (cur === 'pending' || cur === 'confirmed') {
+  await saveEntryReview(entry, { pool_status: 'rolled' });
+}
+```
+
+**Feed roll handler builder-fallback save** (line 5166):
+```js
+// BEFORE:
+await saveEntryReview(entry, { pool_validated: builtExpr, nine_again: _naV, eight_again: _8aV, pool_committed_by: _stName });
+
+// AFTER:
+await saveEntryReview(entry, { pool_validated: builtExpr, nine_again: _naV, eight_again: _8aV, pool_confirmed_by: _stName });
+```
+
+**Project roll handler builder-fallback save** (line 5272):
+```js
+// BEFORE:
+await saveEntryReview(entry, { pool_validated: builtExpr, nine_again: _naV, rote: _roteV, eight_again: _8aV, pool_committed_by: _stName });
+
+// AFTER:
+await saveEntryReview(entry, { pool_validated: builtExpr, nine_again: _naV, rote: _roteV, eight_again: _8aV, pool_confirmed_by: _stName });
+```
+
+### [x] Task 9: Clean up dead code in the `proc-val-btn` click handler
+
+**File:** `public/js/admin/downtime-views.js`, lines 4678–4707.
+
+`'committed'` can no longer be clicked via a val button (the Confirm button uses its own class). Remove dead code:
+
+```js
+// BEFORE (lines 4679–4684):
+if (['validated', 'committed', 'resolved'].includes(status)) {
+  const user = getUser();
+  const stName = user?.global_name || user?.username || 'ST';
+  if (status === 'validated')  statusPatch.pool_validated_by  = stName;
+  if (status === 'committed')  statusPatch.pool_committed_by  = stName;
+  if (status === 'resolved')   statusPatch.pool_resolved_by   = stName;
+}
+
+// AFTER:
+if (['validated', 'resolved'].includes(status)) {
+  const user = getUser();
+  const stName = user?.global_name || user?.username || 'ST';
+  if (status === 'validated')  statusPatch.pool_validated_by  = stName;
+  if (status === 'resolved')   statusPatch.pool_resolved_by   = stName;
+}
+```
+
+Also remove the old committed-vitae-snapshot block (~lines 4688–4707) — this logic now lives in the Confirm button handler (Task 6):
+
+```js
+// REMOVE entirely:
+// When committing a feeding pool, persist the vitae tally...
+if (status === 'committed' && entry.source === 'feeding') {
+  ...
+}
+```
+
+### [x] Task 10: Update CSS — rename `committed` class to `confirmed`
+
+**File:** `public/css/admin-layout.css`
+
+Line 4975 (dark theme active state):
+```css
+/* BEFORE: */
+.proc-ribbon-step.ribbon-active.committed { border-color: var(--gold2); color: var(--gold2); }
+
+/* AFTER: */
+.proc-ribbon-step.ribbon-active.confirmed { border-color: var(--gold2); color: var(--gold2); }
+```
+
+Line 6213 (parchment theme override):
+```css
+/* BEFORE: */
+html:not([data-theme="dark"]) .proc-ribbon-step.ribbon-active.committed { border-color: var(--story-compl); color: var(--story-compl); }
+
+/* AFTER: */
+html:not([data-theme="dark"]) .proc-ribbon-step.ribbon-active.confirmed { border-color: var(--story-compl); color: var(--story-compl); }
+```
+
+### [x] Task 11: Write DB migration script
+
+**New file:** `server/scripts/migrate-pool-status-committed-to-confirmed.js`
+
+Pattern follows other scripts in that folder (ES modules, `dotenv/config`, direct MongoDB driver).
+
+```js
+import 'dotenv/config';
+import { MongoClient } from 'mongodb';
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+const db = client.db('tm_suite');
+
+const result = await db.collection('entry_reviews').updateMany(
+  { pool_status: 'committed' },
+  { $set: { pool_status: 'confirmed' }, $rename: { pool_committed_by: 'pool_confirmed_by' } }
+);
+
+console.log(`Updated ${result.modifiedCount} entry_review records.`);
+await client.close();
+```
+
+Note: `$rename` and `$set` can be combined in a single `updateMany` call. Run this AFTER deploying the code changes, not before.
+
+### [x] Task 12: Update E2E tests in `tests/downtime-processing-feature96.spec.js`
+
+All `'committed'` string literals → `'confirmed'`. All `"Committed"` label checks → `"Confirmed"`. Specific changes:
+
+1. **F96-1 ribbon tests**: `.proc-ribbon-step.ribbon-active.committed` → `.proc-ribbon-step.ribbon-active.confirmed`; label assertion `"Committed"` → `"Confirmed"`.
+2. **F96-2 button-absent tests**: The Pending button is now also absent — add assertions that `.proc-val-btn[data-status="pending"]` has count 0 alongside the existing confirmed/rolled absent checks.
+3. **F96-4 Roll from pending tests**: The roll button label is now `"Roll Dice Pool"` — update label assertions if any.
+4. **F96-5 / F96-6**: Update any `pool_committed_by` references to `pool_confirmed_by` in mock response checks.
+5. Add a new test group **F96-7: Confirm button** — verify `.proc-confirm-pool-btn` is visible when poolStatus is `pending`, hidden when `confirmed`, hidden when terminal.
+
+---
+
+## Dev Notes
+
+### Key files
+
+| File | Change |
+|------|--------|
+| `public/js/admin/downtime-views.js` | Tasks 1–9: ribbon rename, no Pending button, Confirm button, Roll rename, Clear Pool reset, roll handler updates, dead code removal |
+| `public/css/admin-layout.css` | Task 10: CSS class rename |
+| `server/scripts/migrate-pool-status-committed-to-confirmed.js` | Task 11: new migration script |
+| `tests/downtime-processing-feature96.spec.js` | Task 12: test updates |
+
+### Where each `'committed'` reference lives
+
+| Line | Context | Change |
+|------|---------|--------|
+| 6642 | `_renderStatusRibbon` step definition | `'committed'` → `'confirmed'` |
+| 6902, 6967, 7108, 7357 | Ribbon guard conditions | `'committed'` → `'confirmed'` |
+| 4679 | `proc-val-btn` click handler includes array | Remove `'committed'` entirely |
+| 4683 | `pool_committed_by` assignment | Remove entirely |
+| 4690 | Committed feeding vitae snapshot | Remove block entirely |
+| 5166 | Feed roll handler builder fallback | `pool_committed_by` → `pool_confirmed_by` |
+| 5210 | Feed roll pool_status advance check | `'committed'` → `'confirmed'` |
+| 5272 | Project roll handler builder fallback | `pool_committed_by` → `pool_confirmed_by` |
+| 5299 | Project roll pool_status advance check | `'committed'` → `'confirmed'` |
+| 7133 | `showRollBtn` | `poolStatus === 'committed'` → `poolStatus === 'confirmed'` |
+| 7380 | `showFeedRollBtn` | `poolStatus === 'committed'` → `poolStatus === 'confirmed'` |
+| CSS 4975 | `.ribbon-active.committed` | → `.ribbon-active.confirmed` |
+| CSS 6213 | parchment `.ribbon-active.committed` | → `.ribbon-active.confirmed` |
+
+### Confirm button wiring location
+
+The `.proc-confirm-pool-btn` handler goes immediately after the `.proc-pool-clear-btn` handler block, which ends at line 4757. Insert after line 4757, before line 4759 (the feeding description card event wires).
+
+### `_renderRollCard` receives `canRoll` from caller — check the feeding `showFeedRollBtn` and project `showRollBtn` conditions
+
+Both currently include `poolStatus === 'committed'`. Update to `poolStatus === 'confirmed'`:
+
+- Line 7133: `poolStatus === 'committed'` → `poolStatus === 'confirmed'`
+- Line 7380: `poolStatus === 'committed'` → `poolStatus === 'confirmed'`
+
+These are NOT covered by the "each `committed` reference" table above — easy to miss. Do not forget them.
+
+### Vitae tally fields passed to `proc-feed-vitae-panel`
+
+The `data-*` attributes read in the Confirm handler are the same as the old committed-click block (lines 4693–4701). They are `data-herd`, `data-ambience`, `data-terr-label`, `data-oof`, `data-ghouls`, `data-rite-cost`, `data-manual`, `data-total-bonus`. These attribute names are set elsewhere in the rendering code; do not change them.
+
+### Sorcery roll card — no Confirm button
+
+The sorcery roll card (line 6957) passes `canRoll = !!ritInfo` — not poolStatus-based. Sorcery pools are auto-computed, not ST-built. Do NOT add `showConfirm` to the sorcery call. Leave it unchanged.
+
+### Merit non-auto — no dedicated roll card in this render path
+
+The merit compact panel (`_renderCompactMeritPanel`) does not call `_renderRollCard`. Merit rolls (if applicable) use `.proc-merit-roll-btn` (line 5307), which is a separate auto-computed pool mechanism. The merit section only needs Tasks 2–3 (ribbon guard + remove Pending button). No Confirm button for merits.
+
+### `pool_confirmed_by` field is new — no migration concern for the field name
+
+Only `pool_status: 'committed'` values need migration. The `pool_committed_by` field in old records can stay as-is (it's a name string, not a status gate). The migration script renames it using `$rename` for completeness, but it is not functionally required.
+
+### Clear Pool must reset `pool_status` explicitly
+
+Currently (line 4754) Clear Pool only clears `pool_validated`. Without an explicit `pool_status: 'pending'` in the patch, a confirmed or rolled entry would clear its pool expression but stay at `confirmed`/`rolled` on the ribbon — wrong. The fix in Task 7 resets all three fields atomically.
+
+---
+
+## Dev Agent Record
+
+### Agent Model Used
+claude-sonnet-4-6
+
+### Completion Notes
+All 12 tasks implemented. Key decisions: (1) "Not yet committed" placeholder text updated to "Not yet confirmed" (missed in task scope but caught during final grep sweep). (2) Internal CSS class names `.proc-feed-committed-pool`, `.proc-pool-committed`, `.proc-pool-committed-badge` intentionally left unchanged — these are visual lock-state selectors, not pool_status data values, and renaming them would require coordinated JS+CSS changes with no functional benefit. (3) Light-theme `.proc-val-status button.active.committed` (line 6209) was missed in the initial sweep but caught during final CSS verification pass. All 39 E2E tests pass (34 original + 5 new F96-7 Confirm Dice Pool tests).
+
+### File List
+- `public/js/admin/downtime-views.js`
+- `public/css/admin-layout.css`
+- `server/scripts/migrate-pool-status-committed-to-confirmed.js`
+- `tests/downtime-processing-feature96.spec.js`
+
+## Change Log
+
+| Date | Version | Description | Author |
+|------|---------|-------------|--------|
+| 2026-05-14 | 1.0 | Created from issue #310 and conversation scope | BMAD SM |
+| 2026-05-14 | 1.1 | All 12 tasks implemented; 39/39 E2E tests passing | claude-sonnet-4-6 |

--- a/tests/downtime-processing-feature96.spec.js
+++ b/tests/downtime-processing-feature96.spec.js
@@ -158,6 +158,21 @@ const SUBMISSION_AUTO_MERIT_PENDING = {
   st_review: { territory_overrides: {} },
 };
 
+// Project in 'rolled' state (for AC 4 / AC 8 tests)
+const SUBMISSION_PROJECT_ROLLED = {
+  _id: 'sub-f310-proj-rolled',
+  cycle_id: 'cycle-001',
+  character_name: 'Charlie Test', character_id: 'char-pt4', player_name: 'Test Player',
+  submitted_at: '2026-05-14T00:00:00Z',
+  _raw: {
+    projects: [{ action_type: 'ambience_increase', desired_outcome: 'Increase ambience', detail: 'Scout the district.', primary_pool: { expression: 'Strength 3 + Weaponry 4 = 7' } }],
+    feeding: null, sphere_actions: [], contact_actions: { requests: [] }, retainer_actions: { actions: [] },
+  },
+  responses: { project_1_action: 'ambience_increase', project_1_outcome: 'Increase ambience', project_1_description: 'Scout the district.', project_1_pool_expr: 'Strength 3 + Weaponry 4 = 7' },
+  projects_resolved: [{ pool_status: 'rolled', pool_validated: 'Strength 3 + Weaponry 4 = 7', pool_confirmed_by: 'Test ST', roll: { dice_string: '[8,7,5]', successes: 2, exceptional: false } }],
+  feeding_review: null, merit_actions_resolved: [], st_review: { territory_overrides: {} },
+};
+
 // ── Setup helpers ──────────────────────────────────────────────────────────────
 
 async function setupDowntimeProcessing(page, submissions, chars = [CHAR_PT4]) {
@@ -602,6 +617,193 @@ test.describe('F96-7: Confirm Dice Pool button visible from pending; absent once
 
     const rollBtn = page.locator('.proc-proj-roll-btn').first();
     await expect(rollBtn).toHaveText('Roll Dice Pool');
+  });
+
+});
+
+// ── F310-1: Pending button absent on all 4 action types ──────────────────────
+
+test.describe('F310-1: Pending button absent from feeding, sorcery, and merit action types', () => {
+
+  test('feeding panel has NO Pending button', async ({ page }) => {
+    await setupDowntimeProcessing(page, [SUBMISSION_FEEDING_PENDING]);
+    await openFirstAction(page, 'Feeding');
+
+    await expect(page.locator('.proc-val-btn[data-status="pending"]')).toHaveCount(0);
+  });
+
+  test('sorcery panel has NO Pending button', async ({ page }) => {
+    await setupDowntimeProcessing(page, [SUBMISSION_SORCERY_PENDING]);
+    await openFirstAction(page, 'Sorcery');
+
+    await expect(page.locator('.proc-val-btn[data-status="pending"]')).toHaveCount(0);
+  });
+
+  test('non-auto merit panel has NO Pending button', async ({ page }) => {
+    await setupDowntimeProcessing(page, [SUBMISSION_MERIT_INVEST_PENDING]);
+    await openFirstAction(page, 'Investigative');
+
+    await expect(page.locator('.proc-val-btn[data-status="pending"]')).toHaveCount(0);
+  });
+
+});
+
+// ── F310-2: Confirm button absent in rolled and terminal states ───────────────
+
+test.describe('F310-2: Confirm Dice Pool button absent when rolled or terminal', () => {
+
+  test('project panel has NO Confirm Dice Pool button when pool_status is rolled', async ({ page }) => {
+    await setupDowntimeProcessing(page, [SUBMISSION_PROJECT_ROLLED]);
+    await openFirstAction(page, 'Ambience');
+
+    await expect(page.locator('.proc-confirm-pool-btn')).toHaveCount(0);
+  });
+
+  test('project panel has NO Confirm Dice Pool button when pool_status is terminal (validated)', async ({ page }) => {
+    await setupDowntimeProcessing(page, [SUBMISSION_PROJECT_VALIDATED]);
+    await openFirstAction(page, 'Ambience');
+
+    await expect(page.locator('.proc-confirm-pool-btn')).toHaveCount(0);
+  });
+
+});
+
+// ── F310-3: Confirm button click triggers API write ───────────────────────────
+
+test.describe('F310-3: Confirm Dice Pool click triggers pool_status save', () => {
+
+  test('clicking Confirm Dice Pool on pending project triggers at least one API write', async ({ page }) => {
+    const writes = [];
+
+    await page.addInitScript(({ user }) => {
+      localStorage.setItem('tm_auth_token', 'local-test-token');
+      localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+      localStorage.setItem('tm_auth_user', JSON.stringify(user));
+    }, { user: ST_USER });
+
+    await page.route('http://localhost:3000/**', route => {
+      const url = route.request().url();
+      const method = route.request().method();
+      const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+
+      if (method === 'PUT' || method === 'PATCH' || method === 'POST') {
+        writes.push({ method, url });
+        return ok({ ok: true });
+      }
+
+      if (url.includes('/api/downtime_submissions'))    return ok([SUBMISSION_PROJECT_PENDING]);
+      if (url.includes('/api/downtime_cycles'))         return ok([TEST_CYCLE]);
+      if (url.includes('/api/characters/names'))        return ok([{ _id: CHAR_PT4._id, name: CHAR_PT4.name, moniker: null, honorific: null }]);
+      if (url.includes('/api/characters'))              return ok([CHAR_PT4]);
+      if (url.includes('/api/territories'))             return ok([]);
+      if (url.includes('/api/game_sessions'))           return ok([]);
+      if (url.includes('/api/session_logs'))            return ok([]);
+      return ok([]);
+    });
+
+    await page.goto('/admin.html');
+    await page.waitForSelector('#admin-app', { state: 'visible', timeout: 10000 });
+    await page.click('[data-domain="downtime"]');
+    await page.waitForTimeout(1000);
+    await openFirstAction(page, 'Ambience');
+
+    writes.length = 0;
+
+    const confirmBtn = page.locator('.proc-confirm-pool-btn').first();
+    await expect(confirmBtn).toBeVisible({ timeout: 5000 });
+    await confirmBtn.click();
+    await page.waitForTimeout(600);
+
+    expect(writes.length).toBeGreaterThanOrEqual(1);
+  });
+
+});
+
+// ── F310-4: Clear Pool click triggers API write ───────────────────────────────
+
+test.describe('F310-4: Clear Pool click triggers API write resetting pool_status', () => {
+
+  test('clicking Clear Pool on confirmed project triggers at least one API write', async ({ page }) => {
+    const writes = [];
+
+    await page.addInitScript(({ user }) => {
+      localStorage.setItem('tm_auth_token', 'local-test-token');
+      localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+      localStorage.setItem('tm_auth_user', JSON.stringify(user));
+    }, { user: ST_USER });
+
+    await page.route('http://localhost:3000/**', route => {
+      const url = route.request().url();
+      const method = route.request().method();
+      const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+
+      if (method === 'PUT' || method === 'PATCH' || method === 'POST') {
+        writes.push({ method, url });
+        return ok({ ok: true });
+      }
+
+      if (url.includes('/api/downtime_submissions'))    return ok([SUBMISSION_PROJECT_CONFIRMED]);
+      if (url.includes('/api/downtime_cycles'))         return ok([TEST_CYCLE]);
+      if (url.includes('/api/characters/names'))        return ok([{ _id: CHAR_PT4._id, name: CHAR_PT4.name, moniker: null, honorific: null }]);
+      if (url.includes('/api/characters'))              return ok([CHAR_PT4]);
+      if (url.includes('/api/territories'))             return ok([]);
+      if (url.includes('/api/game_sessions'))           return ok([]);
+      if (url.includes('/api/session_logs'))            return ok([]);
+      return ok([]);
+    });
+
+    await page.goto('/admin.html');
+    await page.waitForSelector('#admin-app', { state: 'visible', timeout: 10000 });
+    await page.click('[data-domain="downtime"]');
+    await page.waitForTimeout(1000);
+    await openFirstAction(page, 'Ambience');
+
+    writes.length = 0;
+
+    const clearBtn = page.locator('.proc-pool-clear-btn').first();
+    await expect(clearBtn).toBeVisible({ timeout: 5000 });
+    await clearBtn.click();
+    await page.waitForTimeout(600);
+
+    expect(writes.length).toBeGreaterThanOrEqual(1);
+  });
+
+});
+
+// ── F310-5: Additional label and state coverage ───────────────────────────────
+
+test.describe('F310-5: Label text, Re-roll label, and rolled-state roll button', () => {
+
+  test('confirmed ribbon step contains text "Confirmed"', async ({ page }) => {
+    await setupDowntimeProcessing(page, [SUBMISSION_PROJECT_CONFIRMED]);
+    await openFirstAction(page, 'Ambience');
+
+    const activeStep = page.locator('.proc-ribbon-step.ribbon-active.confirmed').first();
+    await expect(activeStep).toContainText('Confirmed');
+  });
+
+  test('feeding Roll Dice Pool button label is correct (first roll, no prior roll)', async ({ page }) => {
+    await setupDowntimeProcessing(page, [SUBMISSION_FEEDING_PENDING]);
+    await openFirstAction(page, 'Feeding');
+
+    const rollBtn = page.locator('.proc-feed-roll-btn').first();
+    await expect(rollBtn).toHaveText('Roll Dice Pool');
+  });
+
+  test('project Roll button label is Re-roll when a prior roll exists', async ({ page }) => {
+    await setupDowntimeProcessing(page, [SUBMISSION_PROJECT_ROLLED]);
+    await openFirstAction(page, 'Ambience');
+
+    const rollBtn = page.locator('.proc-proj-roll-btn').first();
+    await expect(rollBtn).toHaveText('Re-roll');
+  });
+
+  test('project Roll Dice Pool button visible from rolled state', async ({ page }) => {
+    await setupDowntimeProcessing(page, [SUBMISSION_PROJECT_ROLLED]);
+    await openFirstAction(page, 'Ambience');
+
+    const rollBtn = page.locator('.proc-proj-roll-btn').first();
+    await expect(rollBtn).toBeVisible({ timeout: 5000 });
   });
 
 });

--- a/tests/downtime-processing-feature96.spec.js
+++ b/tests/downtime-processing-feature96.spec.js
@@ -1,12 +1,13 @@
 /**
- * Downtime Processing — Feature 96: Committed/Rolled Progress Ribbon
- * Covers changes from 2026-05-14:
- *   F96-1: Progress ribbon renders for intermediate pool states (pending/committed)
- *   F96-2: Committed and Rolled removed as clickable buttons for pool-builder action types
- *   F96-3: Terminal buttons and Pending reset remain clickable
+ * Downtime Processing — Feature 96/310: Confirmed/Rolled Progress Ribbon
+ * Covers changes from 2026-05-14 (f96) and 2026-05-14 (f310):
+ *   F96-1: Progress ribbon renders for intermediate pool states (pending/confirmed)
+ *   F96-2: Committed/Confirmed and Rolled removed as clickable buttons for pool-builder action types
+ *   F96-3: Terminal buttons remain clickable; Pending button absent (removed in f310)
  *   F96-4: Auto-merit action type unaffected (no ribbon, compact panel unchanged)
- *   F96-5: Roll button visible from pending state (no longer requires Committed first)
- *   F96-6: Terminal button click on pending entry triggers implicit commit API write
+ *   F96-5: Roll Dice Pool button visible from pending state
+ *   F96-6: Terminal button click triggers pool_validated save + status save API writes
+ *   F96-7: Confirm Dice Pool button visible from pending; absent once confirmed
  */
 
 const { test, expect } = require('@playwright/test');
@@ -53,9 +54,9 @@ const SUBMISSION_PROJECT_PENDING = {
   feeding_review: null, merit_actions_resolved: [], st_review: { territory_overrides: {} },
 };
 
-// Project in 'committed' state (ribbon should show Committed as active step)
-const SUBMISSION_PROJECT_COMMITTED = {
-  _id: 'sub-f96-proj-committed',
+// Project in 'confirmed' state (ribbon should show Confirmed as active step)
+const SUBMISSION_PROJECT_CONFIRMED = {
+  _id: 'sub-f96-proj-confirmed',
   cycle_id: 'cycle-001',
   character_name: 'Charlie Test', character_id: 'char-pt4', player_name: 'Test Player',
   submitted_at: '2026-05-14T00:00:00Z',
@@ -64,7 +65,7 @@ const SUBMISSION_PROJECT_COMMITTED = {
     feeding: null, sphere_actions: [], contact_actions: { requests: [] }, retainer_actions: { actions: [] },
   },
   responses: { project_1_action: 'ambience_increase', project_1_outcome: 'Increase ambience', project_1_description: 'Scout the district.', project_1_pool_expr: 'Strength 3 + Weaponry 4 = 7' },
-  projects_resolved: [{ pool_status: 'committed', pool_validated: 'Strength 3 + Weaponry 4 = 7', pool_committed_by: 'Test ST' }],
+  projects_resolved: [{ pool_status: 'confirmed', pool_validated: 'Strength 3 + Weaponry 4 = 7', pool_confirmed_by: 'Test ST' }],
   feeding_review: null, merit_actions_resolved: [], st_review: { territory_overrides: {} },
 };
 
@@ -79,7 +80,7 @@ const SUBMISSION_PROJECT_VALIDATED = {
     feeding: null, sphere_actions: [], contact_actions: { requests: [] }, retainer_actions: { actions: [] },
   },
   responses: { project_1_action: 'ambience_increase', project_1_outcome: 'Increase ambience', project_1_description: 'Scout the district.', project_1_pool_expr: 'Strength 3 + Weaponry 4 = 7' },
-  projects_resolved: [{ pool_status: 'validated', pool_validated: 'Strength 3 + Weaponry 4 = 7', pool_committed_by: 'Test ST', pool_validated_by: 'Test ST', roll: { dice_string: '[8,7,5]', successes: 2, exceptional: false } }],
+  projects_resolved: [{ pool_status: 'validated', pool_validated: 'Strength 3 + Weaponry 4 = 7', pool_confirmed_by: 'Test ST', pool_validated_by: 'Test ST', roll: { dice_string: '[8,7,5]', successes: 2, exceptional: false } }],
   feeding_review: null, merit_actions_resolved: [], st_review: { territory_overrides: {} },
 };
 
@@ -220,7 +221,7 @@ test.describe('F96-1: Progress ribbon renders for intermediate pool states', () 
     await expect(page.locator('.proc-ribbon-step.ribbon-active.pending').first()).toBeVisible({ timeout: 5000 });
   });
 
-  test('project ribbon shows Committed and Rolled as future steps when pool_status is pending', async ({ page }) => {
+  test('project ribbon shows Confirmed and Rolled as future steps when pool_status is pending', async ({ page }) => {
     await setupDowntimeProcessing(page, [SUBMISSION_PROJECT_PENDING]);
     await openFirstAction(page, 'Ambience');
 
@@ -228,15 +229,15 @@ test.describe('F96-1: Progress ribbon renders for intermediate pool states', () 
     await expect(future).toHaveCount(2);
   });
 
-  test('project ribbon highlights Committed step as active when pool_status is committed', async ({ page }) => {
-    await setupDowntimeProcessing(page, [SUBMISSION_PROJECT_COMMITTED]);
+  test('project ribbon highlights Confirmed step as active when pool_status is confirmed', async ({ page }) => {
+    await setupDowntimeProcessing(page, [SUBMISSION_PROJECT_CONFIRMED]);
     await openFirstAction(page, 'Ambience');
 
-    await expect(page.locator('.proc-ribbon-step.ribbon-active.committed').first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.proc-ribbon-step.ribbon-active.confirmed').first()).toBeVisible({ timeout: 5000 });
   });
 
-  test('project ribbon shows Pending as past step when pool_status is committed', async ({ page }) => {
-    await setupDowntimeProcessing(page, [SUBMISSION_PROJECT_COMMITTED]);
+  test('project ribbon shows Pending as past step when pool_status is confirmed', async ({ page }) => {
+    await setupDowntimeProcessing(page, [SUBMISSION_PROJECT_CONFIRMED]);
     await openFirstAction(page, 'Ambience');
 
     const past = page.locator('.proc-ribbon-step.ribbon-past');
@@ -367,11 +368,11 @@ test.describe('F96-3: Terminal buttons and Pending reset remain clickable', () =
     await expect(page.locator('.proc-val-btn[data-status="skipped"]').first()).toBeVisible({ timeout: 5000 });
   });
 
-  test('project panel still has Pending reset button', async ({ page }) => {
+  test('project panel has NO Pending reset button (removed in f310 — Clear Pool is the reset path)', async ({ page }) => {
     await setupDowntimeProcessing(page, [SUBMISSION_PROJECT_PENDING]);
     await openFirstAction(page, 'Ambience');
 
-    await expect(page.locator('.proc-val-btn[data-status="pending"]').first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.proc-val-btn[data-status="pending"]')).toHaveCount(0);
   });
 
   test('feeding panel still has Validated button', async ({ page }) => {
@@ -453,8 +454,8 @@ test.describe('F96-5: Roll button visible from pending (no longer requires Commi
     await expect(rollBtn).toBeVisible({ timeout: 5000 });
   });
 
-  test('project Roll button remains visible after pool_status advances to committed (no regression)', async ({ page }) => {
-    await setupDowntimeProcessing(page, [SUBMISSION_PROJECT_COMMITTED]);
+  test('project Roll Dice Pool button remains visible after pool_status advances to confirmed (no regression)', async ({ page }) => {
+    await setupDowntimeProcessing(page, [SUBMISSION_PROJECT_CONFIRMED]);
     await openFirstAction(page, 'Ambience');
 
     const rollBtn = page.locator('.proc-proj-roll-btn').first();
@@ -509,11 +510,11 @@ test.describe('F96-6: Terminal button click triggers implicit commit API write',
     await validatedBtn.click();
     await page.waitForTimeout(600);
 
-    // Implicit commit (pool_committed_by) + normal status save = at least 2 writes
+    // pool_validated save + statusPatch save = at least 2 writes
     expect(writes.length).toBeGreaterThanOrEqual(2);
   });
 
-  test('clicking a terminal button on already-committed entry makes one status save (no duplicate implicit commit)', async ({ page }) => {
+  test('clicking a terminal button on already-confirmed entry makes at least one status save', async ({ page }) => {
     const writes = [];
 
     await page.addInitScript(({ user }) => {
@@ -532,7 +533,7 @@ test.describe('F96-6: Terminal button click triggers implicit commit API write',
         return ok({ ok: true });
       }
 
-      if (url.includes('/api/downtime_submissions'))    return ok([SUBMISSION_PROJECT_COMMITTED]);
+      if (url.includes('/api/downtime_submissions'))    return ok([SUBMISSION_PROJECT_CONFIRMED]);
       if (url.includes('/api/downtime_cycles'))         return ok([TEST_CYCLE]);
       if (url.includes('/api/characters/names'))        return ok([{ _id: CHAR_PT4._id, name: CHAR_PT4.name, moniker: null, honorific: null }]);
       if (url.includes('/api/characters'))              return ok([CHAR_PT4]);
@@ -555,9 +556,52 @@ test.describe('F96-6: Terminal button click triggers implicit commit API write',
     await validatedBtn.click();
     await page.waitForTimeout(600);
 
-    // Already-committed entry (pool_committed_by is set): only the main status save fires
-    // The implicit commit block skips pool_committed_by because it's already set
     expect(writes.length).toBeGreaterThanOrEqual(1);
+  });
+
+});
+
+// ── F96-7: Confirm Dice Pool button (feature.310) ─────────────────────────────
+
+test.describe('F96-7: Confirm Dice Pool button visible from pending; absent once confirmed', () => {
+
+  test('project panel shows Confirm Dice Pool button when pool_status is pending', async ({ page }) => {
+    await setupDowntimeProcessing(page, [SUBMISSION_PROJECT_PENDING]);
+    await openFirstAction(page, 'Ambience');
+
+    const confirmBtn = page.locator('.proc-confirm-pool-btn').first();
+    await expect(confirmBtn).toBeVisible({ timeout: 5000 });
+  });
+
+  test('project Confirm Dice Pool button is labelled correctly', async ({ page }) => {
+    await setupDowntimeProcessing(page, [SUBMISSION_PROJECT_PENDING]);
+    await openFirstAction(page, 'Ambience');
+
+    const confirmBtn = page.locator('.proc-confirm-pool-btn').first();
+    await expect(confirmBtn).toHaveText('Confirm Dice Pool');
+  });
+
+  test('project panel has NO Confirm Dice Pool button when pool_status is confirmed', async ({ page }) => {
+    await setupDowntimeProcessing(page, [SUBMISSION_PROJECT_CONFIRMED]);
+    await openFirstAction(page, 'Ambience');
+
+    await expect(page.locator('.proc-confirm-pool-btn')).toHaveCount(0);
+  });
+
+  test('feeding panel shows Confirm Dice Pool button when pool_status is pending', async ({ page }) => {
+    await setupDowntimeProcessing(page, [SUBMISSION_FEEDING_PENDING]);
+    await openFirstAction(page, 'Feeding');
+
+    const confirmBtn = page.locator('.proc-confirm-pool-btn').first();
+    await expect(confirmBtn).toBeVisible({ timeout: 5000 });
+  });
+
+  test('project Roll Dice Pool button label is correct (first roll, no prior roll)', async ({ page }) => {
+    await setupDowntimeProcessing(page, [SUBMISSION_PROJECT_PENDING]);
+    await openFirstAction(page, 'Ambience');
+
+    const rollBtn = page.locator('.proc-proj-roll-btn').first();
+    await expect(rollBtn).toHaveText('Roll Dice Pool');
   });
 
 });


### PR DESCRIPTION
## Summary

- Renames the intermediate `pool_status` value from `committed` to `confirmed` throughout the DT processing panel — JS, CSS, tests, and a DB migration script — so the label in the UI matches the intended workflow step
- Adds a dedicated "Confirm Dice Pool" button inside the Roll card (visible from `pending`, hidden once confirmed), replacing the removed Committed button from feature.96
- Removes the "Pending" reset button from all four val-status rows; Clear Pool is now the only reset path, which also explicitly zeroes `pool_confirmed_by`
- Renames the first-roll label to "Roll Dice Pool" to distinguish it from Re-roll

## Closes

- Closes #310

## Story

- specs/stories/feature.310.dt-confirmed-ribbon-redesign.story.md

## Test plan

- [ ] `npx playwright test tests/downtime-processing-feature96.spec.js` — 50/50 pass
- [ ] CI green
- [ ] Manual: open DT processing panel on a pending project action, verify Confirm Dice Pool button appears, click it, verify ribbon advances to Confirmed, verify Roll Dice Pool button is visible; also verify Clear Pool resets to Pending
- [ ] Run migration script on dev DB after deploy: `node server/scripts/migrate-pool-status-committed-to-confirmed.js --dry-run` then `--apply`

## Branch flow

- From: `morningstar-issue-310-dt-confirmed-ribbon-redesign`
- Into: `dev`