### PR TITLE
feat(#315): DT Processing — XP Spend card structured breakdown

### DIFF
--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -5781,6 +5781,17 @@ body {
 }
 .proc-proj-field:last-child { margin-bottom: 0; }
 
+/* ── feature.97: XP Spend structured breakdown table ── */
+.proc-xp-breakdown { align-items: flex-start; }
+.proc-xp-table { border-collapse: collapse; margin-top: 4px; font-size: 0.85em; }
+.proc-xp-table td { padding: 2px 8px 2px 0; vertical-align: top; }
+.proc-xp-cat { color: var(--txt3, #999); min-width: 76px; }
+.proc-xp-trait { color: var(--txt2); }
+.proc-xp-cost { text-align: right; padding-left: 12px; color: var(--txt2); }
+.proc-xp-totals { border-top: 1px solid var(--surf3, #333); font-weight: 600; }
+.proc-xp-totals td { padding-top: 4px; }
+.proc-xp-remaining--over { color: var(--crim, #8B0000); }
+
 /* ── feature.68: Merit action validator ── */
 .proc-merit-header {
   display: flex;

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -2977,14 +2977,17 @@ function buildProcessingQueue(subs) {
       // legacy single-row keys.
       const _projInvestigateLead = resp[`project_${slot}_investigate_lead`] || '';
       let _projXpBreakdown = '';
+      let _projXpRows = [];
+      let _projXpBudgetSnapshot = null;
       if (effectiveActionType === 'xp_spend') {
         const _rj = resp[`project_${slot}_xp_rows`] || '';
         if (_rj) {
           try {
-            const _xpRows = JSON.parse(_rj);
-            if (Array.isArray(_xpRows) && _xpRows.length) {
-              _projXpBreakdown = _xpRows
-                .filter(r => r && (r.category || r.item))
+            const _parsed = JSON.parse(_rj);
+            if (Array.isArray(_parsed) && _parsed.length) {
+              _projXpRows = _parsed.filter(r => r && (r.category || r.item));
+              // Legacy flat string kept as fallback for submissions pre-dating feature.97
+              _projXpBreakdown = _projXpRows
                 .map(r => {
                   const _dots = r.dotsBuying ? ` (${r.dotsBuying} dot${r.dotsBuying === 1 ? '' : 's'})` : '';
                   return `${r.category || ''}: ${r.item || ''}${_dots}`;
@@ -3000,6 +3003,9 @@ function buildProcessingQueue(subs) {
           const _item = resp[`project_${slot}_xp_item`]     || '';
           if (_cat && _item) _projXpBreakdown = `${_cat}: ${_item}`;
         }
+        // feature.97: budget snapshot stored at submit time
+        const _snap = resp.xp_budget_snapshot;
+        if (typeof _snap === 'number') _projXpBudgetSnapshot = _snap;
       }
 
       queue.push({
@@ -3024,7 +3030,9 @@ function buildProcessingQueue(subs) {
         projTerritory:   _projTerritory,
         projTarget:      _projTarget,
         projInvestigateLead: _projInvestigateLead,
-        projXpBreakdown: _projXpBreakdown,
+        projXpBreakdown:      _projXpBreakdown,
+        projXpRows:           _projXpRows,
+        projXpBudgetSnapshot: _projXpBudgetSnapshot,
         // JDT-5: joint membership — populated when the slot belongs to a joint.
         joint_id:        _jointInfo?.joint?._id || null,
         joint_role:      _jointInfo?.role || null,
@@ -7410,6 +7418,64 @@ function _renderRollCard(key, roll, poolTotal, opts = {}) {
  * @param {object} rev    - review object for the entry
  * @param {object|null} char - resolved character (used for hide_protect merit list and merit-link)
  */
+// feature.97: structured XP-spend breakdown table for ST processing card.
+// Replaces the flat category:item string when structured row data is available.
+function _renderXpSpendBreakdown(rows, budget) {
+  const CAT_LABELS = {
+    attribute: 'Attribute', skill: 'Skill', discipline: 'Discipline',
+    merit: 'Merit', devotion: 'Devotion', rite: 'Rite',
+  };
+
+  let tbody = '';
+  let totalCost = 0;
+  let hasCosts = false;
+
+  for (const r of rows) {
+    const catLabel  = CAT_LABELS[r.category] || (r.category || '');
+    const rawItem   = r.item || '';
+    const parts     = rawItem.split('|');
+    const traitName = parts[0] || rawItem;
+
+    // Dot transition: merits encode current dots in parts[2]; others show +N dots
+    let transition = '';
+    if (r.dotsBuying) {
+      if (r.category === 'merit' && parts[1] === 'grad' && parts[2] !== undefined) {
+        const cur = parseInt(parts[2], 10) || 0;
+        transition = ` (${cur} → ${cur + r.dotsBuying})`;
+      } else {
+        transition = ` (+${r.dotsBuying} dot${r.dotsBuying === 1 ? '' : 's'})`;
+      }
+    }
+
+    const costCell = (typeof r.xpCost === 'number' && r.xpCost > 0)
+      ? `${r.xpCost} XP`
+      : '';
+    if (typeof r.xpCost === 'number') { totalCost += r.xpCost; hasCosts = true; }
+
+    tbody += `<tr>`;
+    tbody += `<td class="proc-xp-cat">${esc(catLabel)}</td>`;
+    tbody += `<td class="proc-xp-trait">${esc(traitName)}${esc(transition)}</td>`;
+    tbody += `<td class="proc-xp-cost">${esc(costCell)}</td>`;
+    tbody += `</tr>`;
+  }
+
+  let tfoot = '';
+  if (hasCosts && typeof budget === 'number') {
+    const remaining = budget - totalCost;
+    const overClass = remaining < 0 ? ' proc-xp-remaining--over' : '';
+    tfoot  = `<tfoot class="proc-xp-totals">`;
+    tfoot += `<tr><td colspan="2">Total</td><td class="proc-xp-cost">${totalCost} XP</td></tr>`;
+    tfoot += `<tr><td colspan="2">Budget</td><td class="proc-xp-cost">${budget} XP available</td></tr>`;
+    tfoot += `<tr><td colspan="2">Remaining</td><td class="proc-xp-cost${overClass}">${remaining} XP</td></tr>`;
+    tfoot += `</tfoot>`;
+  }
+
+  return `<div class="proc-proj-field proc-xp-breakdown">` +
+    `<span class="proc-feed-lbl">XP Spend</span>` +
+    `<table class="proc-xp-table"><tbody>${tbody}</tbody>${tfoot}</table>` +
+    `</div>`;
+}
+
 function _renderActionTypeRow(entry, rev, char) {
   const key        = entry.key;
   const actionType = entry.actionType;
@@ -7702,7 +7768,12 @@ function renderActionPanel(entry, review) {
       if (descVal)       h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Description</span> ${esc(descVal)}</div>`;
       if (entry.projTarget) h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Target</span> ${esc(entry.projTarget)}</div>`;
       if (entry.projInvestigateLead) h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Lead</span> ${esc(entry.projInvestigateLead)}</div>`;
-      if (entry.projXpBreakdown) h += `<div class="proc-proj-field"><span class="proc-feed-lbl">XP Spend</span> ${esc(entry.projXpBreakdown)}</div>`;
+      // feature.97: structured table when row data available; flat string fallback for legacy submissions
+      if (entry.projXpRows && entry.projXpRows.length) {
+        h += _renderXpSpendBreakdown(entry.projXpRows, entry.projXpBudgetSnapshot);
+      } else if (entry.projXpBreakdown) {
+        h += `<div class="proc-proj-field"><span class="proc-feed-lbl">XP Spend</span> ${esc(entry.projXpBreakdown)}</div>`;
+      }
       if (playerPoolVal) h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Player's Pool</span> ${esc(playerPoolVal)}</div>`;
       if (meritsVal)     h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Merits &amp; Bonuses</span> ${esc(meritsVal)}</div>`;
       if (!titleVal && !outcomeVal && !descVal) h += `<div class="proc-proj-field proc-feed-desc-empty">\u2014 No details recorded</div>`;

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -645,7 +645,7 @@ function collectResponses() {
           const category = catEl ? catEl.value : '';
           const item     = itemEl ? itemEl.value : '';
           const dotsBuying = dotsEl ? (parseInt(dotsEl.value, 10) || 0) : 0;
-          if (category) rows.push({ category, item, dotsBuying });
+          if (category) rows.push({ category, item, dotsBuying, xpCost: getRowCost({ category, item, dotsBuying }) });
         });
         responses[`project_${n}_xp_rows`] = JSON.stringify(rows);
       }
@@ -1028,6 +1028,7 @@ function collectResponses() {
   }
   if (_hasAnyXpRows) {
     responses['xp_spend'] = JSON.stringify(_topLevelMirror);
+    responses['xp_budget_snapshot'] = xpLeft(currentChar);
   }
 
   return responses;

--- a/server/schemas/downtime_submission.schema.js
+++ b/server/schemas/downtime_submission.schema.js
@@ -370,7 +370,8 @@ export const downtimeSubmissionSchema = {
         // XP spend grid: JSON array of { category, item, dotsBuying }
         // category: "attribute" | "skill" | "discipline" | "merit" | "devotion" | "rite"
         // item: attribute/skill/discipline name, or "MeritName|flat|rating|0" / "MeritName|grad|currentDots|maxTarget"
-        xp_spend:      { type: 'string' },
+        xp_spend:           { type: 'string' },
+        xp_budget_snapshot: { type: 'number', nullable: true },
         lore_request:  { type: 'string' },   // Rules/lore questions for STs
         form_rating:   { type: 'string' },   // "1"–"10" (half-star widget)
         form_feedback: { type: 'string' },   // Form UX feedback

--- a/specs/stories/feature.97.dt-xp-spend-card-breakdown.story.md
+++ b/specs/stories/feature.97.dt-xp-spend-card-breakdown.story.md
@@ -1,0 +1,313 @@
+---
+issue: 315
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/315
+branch: morningstar-issue-315-dt-xp-spend-breakdown
+status: review
+---
+
+# Story feature.97: DT Processing — XP Spend card structured breakdown
+
+## Status: review
+
+## Story
+
+**As an** ST processing a player's XP Spend downtime action,
+**I want** the action card to show me each requested purchase with its cost, the player's budget, and what they'd have left,
+**so that** I can review and approve XP spends without navigating away to the player's submitted form.
+
+---
+
+## Background
+
+The DT Processing view in ST Admin renders each action as a card. For XP Spend actions, the card currently shows a flat summary string built by joining raw item identifiers:
+
+```
+XP Spend  merit: Haven|grad|0|3 (1 dot) — discipline: Auspex — skill: Socialise — skill: Investigation
+```
+
+This string is unreadable: raw merit keys (`Haven|grad|0|3`), no XP costs, no dot transitions, no budget context. To understand the actual request the ST must open the player's submission form in a separate tab.
+
+The player's submission form already displays all of this information (see issue #315 screenshots):
+- Category, trait name, current→target transition, per-item XP cost
+- Slot total, cycle budget, XP remaining
+
+This feature brings that same information into the ST-facing processing card as a structured read-only table.
+
+---
+
+## Acceptance Criteria
+
+1. The XP Spend action card in DT Processing displays each spend item as a structured row: **category label**, **trait name** (human-readable, not raw merit key), **current→target transition**, and **XP cost** for that item.
+2. A totals section below the rows shows: **Total XP requested**, **Cycle budget (XP available)**, **XP remaining** (budget − total).
+3. If the spend exceeds the budget (edge case — player-side validation should prevent it, but display it correctly if it occurs), the remaining figure is rendered in a warning colour (red / `--crim`).
+4. Data is sourced from the stored `xp_spend` data in the submission (`project_${n}_xp_rows`) — no re-parsing of the flat summary string, no character data lookups at ST render time.
+5. XP cost per row is read from a `xpCost` field stored on each row at player-submission time. Existing submissions without `xpCost` gracefully fall back to displaying the row without a cost figure (not an error).
+6. Cycle budget is read from a `xp_budget_snapshot` field stored in responses at player-submission time. If absent (legacy submissions), the totals section is omitted rather than showing a wrong number.
+7. Human-readable trait names are derived from the `item` field: merit items strip the `|grad|...|...` suffix and display only the name portion.
+8. ST does not need to navigate away from the processing view to see any of this.
+
+---
+
+## Tasks / Subtasks
+
+### Task 1: [x] Extend `xp_rows` to store `xpCost` per row
+
+**File:** `public/js/tabs/downtime-form.js`
+
+At line ~648 where rows are pushed for `project_${n}_xp_rows`:
+
+```javascript
+// BEFORE
+if (category) rows.push({ category, item, dotsBuying });
+
+// AFTER
+if (category) {
+  const xpCost = getRowCost({ category, item, dotsBuying });
+  rows.push({ category, item, dotsBuying, xpCost });
+}
+```
+
+`getRowCost` is already defined in the same file (line 4216) and already has access to `currentChar` via `isClanDisc` for correct clan vs out-of-clan discipline pricing. No new logic needed.
+
+### Task 2: [x] Store `xp_budget_snapshot` at submission time
+
+**File:** `public/js/tabs/downtime-form.js`
+
+In `collectResponses()` (the function that builds the full responses object before saving/submitting), after the xp_rows loop has run, store the current XP budget:
+
+```javascript
+// After xp_rows are built — store budget snapshot for ST view
+const hasXpSpend = [1, 2, 3, 4].some(n => responses[`project_${n}_action`] === 'xp_spend');
+if (hasXpSpend) {
+  responses.xp_budget_snapshot = xpLeft(currentChar);
+}
+```
+
+`xpLeft(currentChar)` is already called nearby for validation (line 1151). This snapshot captures the player's budget at the moment of submission so the ST view is not dependent on character state at processing time.
+
+### Task 3: [x] Allow new fields through server schema
+
+**File:** `server/schemas/downtime_submission.schema.js`
+
+Add one new top-level field:
+
+```javascript
+xp_budget_snapshot: { type: 'number', optional: true },
+```
+
+The `xpCost` field is embedded inside the JSON string value of `project_${n}_xp_rows` and is schema-transparent (no schema change needed for it).
+
+### Task 4: [x] Pass xp_rows and budget snapshot through the queue entry
+
+**File:** `public/js/admin/downtime-views.js`
+
+In `buildProcessingQueue()`, at the xp_spend block (lines ~2980–3003), parse the xp_rows and attach to the queue entry:
+
+```javascript
+let _xpRows = [];
+let _xpBudgetSnapshot = null;
+
+if (effectiveActionType === 'xp_spend') {
+  const _rj = resp[`project_${slot}_xp_rows`] || '';
+  if (_rj) {
+    try { _xpRows = JSON.parse(_rj).filter(r => r && (r.category || r.item)); } catch { /* fall through */ }
+  }
+  const snap = resp.xp_budget_snapshot;
+  if (typeof snap === 'number') _xpBudgetSnapshot = snap;
+  // Legacy flat string fallback (keep for submissions without xp_rows)
+  if (!_xpRows.length) { /* existing single-row fallback, unchanged */ }
+}
+```
+
+Add to the queue entry object:
+```javascript
+projXpRows:           _xpRows,
+projXpBudgetSnapshot: _xpBudgetSnapshot,
+```
+
+Keep `projXpBreakdown` on the entry as a legacy fallback for submissions pre-dating this feature.
+
+### Task 5: [x] Render structured breakdown in the action card
+
+**File:** `public/js/admin/downtime-views.js`
+
+At line ~7705, replace the flat string line:
+```javascript
+if (entry.projXpBreakdown) h += `<div class="proc-proj-field"><span class="proc-feed-lbl">XP Spend</span> ${esc(entry.projXpBreakdown)}</div>`;
+```
+
+With a conditional that renders a table when structured data is available, or falls back to the flat string:
+
+```javascript
+if (entry.projXpRows && entry.projXpRows.length) {
+  h += _renderXpSpendBreakdown(entry.projXpRows, entry.projXpBudgetSnapshot);
+} else if (entry.projXpBreakdown) {
+  h += `<div class="proc-proj-field"><span class="proc-feed-lbl">XP Spend</span> ${esc(entry.projXpBreakdown)}</div>`;
+}
+```
+
+### Task 6: [x] Implement `_renderXpSpendBreakdown(rows, budget)`
+
+**File:** `public/js/admin/downtime-views.js`
+
+Add a new private helper function. Place it near other `_render*` helpers in the file.
+
+**Row display rules:**
+
+- `category`: use `ACTION_TYPE_LABELS` or a local label map to convert `'discipline'` → `'Discipline'`, `'merit'` → `'Merit'`, etc.
+- `item` (trait name): for merits, strip the pipe-delimited suffix. `'Haven|grad|0|3'` → `'Haven'`. For everything else, use as-is.
+- Transition: for rows with `dotsBuying`, show `(+${dotsBuying} dot${dotsBuying === 1 ? '' : 's'})`. If the item encodes current dots (merit `|grad|currentDots|max`), show `(${currentDots} → ${currentDots + dotsBuying})` instead.
+- Cost: if `row.xpCost` is present and > 0, show `${row.xpCost} XP`. If absent (legacy row), show nothing.
+
+**Totals section:**
+
+```
+Total XP:   <sum of row.xpCost for rows that have it>  XP
+Budget:     <budget> XP available          (omit entire totals block if budget === null)
+Remaining:  <budget - total> XP            (red if negative)
+```
+
+**Markup sketch** (use existing `proc-proj-field`, `proc-feed-lbl` classes; add `proc-xp-table` for the list):
+
+```html
+<div class="proc-proj-field proc-xp-breakdown">
+  <span class="proc-feed-lbl">XP Spend</span>
+  <table class="proc-xp-table">
+    <tbody>
+      <tr><td class="proc-xp-cat">Merit</td><td class="proc-xp-trait">Haven (0 → 1)</td><td class="proc-xp-cost">1 XP</td></tr>
+      <tr><td class="proc-xp-cat">Discipline</td><td class="proc-xp-trait">Auspex (1 → 2)</td><td class="proc-xp-cost">3 XP</td></tr>
+      <tr><td class="proc-xp-cat">Skill</td><td class="proc-xp-trait">Socialise (2 → 3)</td><td class="proc-xp-cost">2 XP</td></tr>
+      <tr><td class="proc-xp-cat">Skill</td><td class="proc-xp-trait">Investigation (3 → 4)</td><td class="proc-xp-cost">2 XP</td></tr>
+    </tbody>
+    <tfoot class="proc-xp-totals">
+      <tr><td colspan="2">Total</td><td>8 XP</td></tr>
+      <tr><td colspan="2">Budget</td><td>13 XP available</td></tr>
+      <tr><td colspan="2">Remaining</td><td>5 XP</td></tr>  <!-- red if negative -->
+    </tfoot>
+  </table>
+</div>
+```
+
+### Task 7: [x] CSS for the breakdown table
+
+**File:** `public/css/admin-dt-processing.css` (or the active DT processing stylesheet — confirm location)
+
+Add minimal styles scoped to `.proc-xp-table`:
+
+```css
+.proc-xp-breakdown { align-items: flex-start; }
+.proc-xp-table { border-collapse: collapse; margin-top: 4px; font-size: 0.85em; }
+.proc-xp-table td { padding: 2px 8px 2px 0; vertical-align: top; }
+.proc-xp-cat { color: var(--muted, #999); text-transform: capitalize; min-width: 80px; }
+.proc-xp-cost { text-align: right; padding-left: 12px; }
+.proc-xp-totals { border-top: 1px solid var(--border, #444); font-weight: 600; }
+.proc-xp-totals .proc-xp-remaining--over { color: var(--crim, #8B0000); }
+```
+
+### Task 8: Manual verification
+
+- [ ] Load DT Processing for Alice Vunder's XP Spend action (or any recent submission with xp_spend)
+- [ ] Verify: structured table appears with category, trait name, transition, cost per row
+- [ ] Verify: totals row shows total XP, budget, remaining
+- [ ] Verify: a submission without `xp_budget_snapshot` (legacy) shows the table rows but omits the budget/remaining totals (no broken display)
+- [ ] Verify: a submission without `xp_rows` at all (very old) falls back to the flat string (no regression)
+- [ ] Submit a new XP Spend draft, save, and verify `xpCost` is present on each row in the saved responses (inspect via browser network tab or MongoDB)
+
+---
+
+## Dev Notes
+
+### Data flow summary
+
+```
+Player form (downtime-form.js)
+  collectResponses()
+    → project_N_xp_rows = JSON.stringify([{ category, item, dotsBuying, xpCost }])   ← NEW: xpCost added
+    → xp_budget_snapshot = xpLeft(currentChar)                                        ← NEW: budget stored
+
+Server (downtime_submission.schema.js)
+    → xp_budget_snapshot: { type: 'number', optional: true }                          ← NEW: schema field
+
+ST Admin (downtime-views.js)
+  buildProcessingQueue()
+    → entry.projXpRows = parsed _xp_rows array
+    → entry.projXpBudgetSnapshot = resp.xp_budget_snapshot
+  _renderProjectDetails()
+    → _renderXpSpendBreakdown(entry.projXpRows, entry.projXpBudgetSnapshot)
+```
+
+### Why store costs at submit time, not recompute at render time
+
+`getXpCost('discipline', item)` calls `isClanDisc(item)` which uses `currentChar.clan` to determine 3 vs 4 XP. On the ST side, the character object would need to be loaded and passed into the rendering function. This is feasible (characters are available in `buildProcessingQueue`) but fragile: if the character's clan changes between submission and processing, the displayed cost would differ from what the player committed to. Storing `xpCost` at submission time preserves what the player understood they were spending.
+
+### Merit item field format
+
+Merit items stored in `xp_rows.item` follow the `MERITS_DB` key format: `name|type|value|max`. Examples:
+- `Haven|grad|0|3` — graduated merit, name is `Haven`
+- `Resources|flat|3|0` — flat merit, name is `Resources`
+
+To extract the display name: `item.split('|')[0]`.
+
+For the dot transition on graduated merits: current dots = `parseInt(item.split('|')[2])`, target = `currentDots + dotsBuying`.
+
+### Existing XP Review Step (lines ~4048–4166)
+
+There is an existing "XP Review Step" section in the downtime-views.js — this is a separate ST workflow step (a checklist-style approval flow), distinct from the per-action card in the processing queue. This story only touches the **action card** in the processing queue, not the XP Review Step. Do not conflate them.
+
+### Legacy fallback required
+
+Submissions from DT2 (before this feature) have `project_N_xp_rows` rows without `xpCost`, and no `xp_budget_snapshot`. The card must degrade gracefully:
+- Rows without `xpCost`: show category + trait + transition, omit cost column value (or show `—`)
+- No `xp_budget_snapshot`: omit the totals footer entirely
+
+---
+
+## Files to Touch
+
+| File | Change |
+|------|--------|
+| `public/js/tabs/downtime-form.js` | Add `xpCost` to each row; store `xp_budget_snapshot` in responses |
+| `server/schemas/downtime_submission.schema.js` | Add `xp_budget_snapshot` field |
+| `public/js/admin/downtime-views.js` | Parse rows + budget into queue entry; replace flat render with `_renderXpSpendBreakdown` |
+| `public/css/admin-dt-processing.css` (or equivalent) | Add `.proc-xp-table` styles |
+
+---
+
+## Dev Agent Record
+
+### Completion Notes
+
+Implemented 2026-05-15. Four files changed, no new dependencies.
+
+- `downtime-form.js:648` — `xpCost: getRowCost(...)` added inline to each row push. `getRowCost` is defined in the same file and uses `currentChar.clan` via `isClanDisc()` for correct clan/outclan discipline pricing.
+- `downtime-form.js:1031` — `xp_budget_snapshot = xpLeft(currentChar)` written into responses inside the `_hasAnyXpRows` guard, so it only appears on submissions that actually have XP spend rows.
+- `downtime_submission.schema.js:373` — `xp_budget_snapshot: { type: 'number', nullable: true }` added after `xp_spend`.
+- `downtime-views.js:2980` — `_projXpRows` and `_projXpBudgetSnapshot` parsed and stored on queue entries alongside existing `_projXpBreakdown` (kept as legacy fallback).
+- `downtime-views.js:7413` — `_renderXpSpendBreakdown(rows, budget)` helper added. Handles: human-readable category labels, merit name extraction (`item.split('|')[0]`), graduated merit dot transitions (`cur → cur + dotsBuying`), missing `xpCost` on legacy rows (cell left blank), missing `budget` (totals footer omitted).
+- `downtime-views.js:7776` — Flat string render replaced with structured call; falls back to flat string for submissions without `projXpRows`.
+- `admin-layout.css:5783` — `.proc-xp-table`, `.proc-xp-cat`, `.proc-xp-trait`, `.proc-xp-cost`, `.proc-xp-totals`, `.proc-xp-remaining--over` styles added.
+
+### File List
+
+- `public/js/tabs/downtime-form.js`
+- `server/schemas/downtime_submission.schema.js`
+- `public/js/admin/downtime-views.js`
+- `public/css/admin-layout.css`
+- `specs/stories/feature.97.dt-xp-spend-card-breakdown.story.md`
+
+### Change Log
+
+- 2026-05-15: Implemented feature.97 — XP Spend card structured breakdown in DT Processing
+
+---
+
+## References
+
+- Issue #315: https://github.com/angelusvmorningstar/TerraMortis/issues/315
+- `public/js/admin/downtime-views.js:2970–3003` — current xp_rows composition
+- `public/js/admin/downtime-views.js:7705` — current flat string render point
+- `public/js/tabs/downtime-form.js:648` — where rows are pushed (add xpCost here)
+- `public/js/tabs/downtime-form.js:4216–4225` — `getRowCost()` function
+- `public/js/tabs/downtime-form.js:1148–1155` — existing budget validation (model for snapshot write)
+- `server/schemas/downtime_submission.schema.js:100–113` — existing xp_rows schema entry
+- `public/js/editor/xp.js` — `xpLeft()`, `xpEarned()`, `xpSpent()` functions

--- a/tests/issue-315-xp-spend-breakdown.spec.js
+++ b/tests/issue-315-xp-spend-breakdown.spec.js
@@ -1,0 +1,299 @@
+/**
+ * issue-315: XP Spend card structured breakdown in DT Processing
+ * feature.97 — replaces flat summary string with per-row table + totals
+ *
+ * Test scenarios:
+ *   1. Structured table renders with costs + totals when xpCost + budget stored
+ *   2. Merit name extracted from raw key (Haven|grad|0|3 → Haven, 0 → 1)
+ *   3. Skill and discipline rows show correct labels and transitions
+ *   4. Legacy rows (no xpCost) show table but no cost values / totals
+ *   5. No xp_budget_snapshot — totals footer omitted
+ *   6. Over-budget remaining gets warning class
+ *   7. Very old submission (no xp_rows) falls back to flat string
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Shared stubs ───────────────────────────────────────────────────────────────
+
+const ST_USER = {
+  id: '315000001', username: 'test_st', global_name: 'Test ST',
+  avatar: null, role: 'st', player_id: 'p-315', character_ids: [], is_dual_role: false,
+};
+
+const CHAR_MEKHET = {
+  _id: 'char-alice-315', name: 'Alice Vunder', moniker: null, honorific: null,
+  clan: 'Mekhet', covenant: 'Ordo Dracul', player: 'Alice Player',
+  blood_potency: 1, humanity: 7, humanity_base: 7, court_title: null,
+  retired: false,
+  status: {
+    city: 0, clan: 0,
+    covenant: { 'Carthian Movement': 0, 'Circle of the Crone': 0, 'Invictus': 0, 'Lancea et Sanctum': 0, 'Ordo Dracul': 0 },
+  },
+  attributes: {
+    Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+    Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+    Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: {
+    Socialise:     { dots: 2, bonus: 0, specs: [], nine_again: false },
+    Investigation: { dots: 3, bonus: 0, specs: [], nine_again: false },
+  },
+  disciplines: { Auspex: { dots: 1 } },
+  merits: [],
+  powers: [], ordeals: [],
+};
+
+// 'active' status is what the smoke test uses; ensures the DT panel renders
+const TEST_CYCLE = {
+  _id: 'cycle-315', cycle_number: 3, status: 'active',
+  confirmed_ambience: {}, narrative_notes: '', phase_signoff: {},
+};
+
+// Rows stored post-feature.97: each row has xpCost
+const XP_ROWS_WITH_COSTS = [
+  { category: 'merit',      item: 'Haven|grad|0|3', dotsBuying: 1, xpCost: 1 },
+  { category: 'discipline', item: 'Auspex',          dotsBuying: 1, xpCost: 3 },
+  { category: 'skill',      item: 'Socialise',       dotsBuying: 1, xpCost: 2 },
+  { category: 'skill',      item: 'Investigation',   dotsBuying: 1, xpCost: 2 },
+];
+
+// Legacy rows: saved before feature.97; no xpCost field
+const XP_ROWS_LEGACY = [
+  { category: 'discipline', item: 'Celerity',  dotsBuying: 1 },
+  { category: 'skill',      item: 'Athletics', dotsBuying: 1 },
+];
+
+function makeXpSub(overrides = {}) {
+  const rows      = overrides.rows      ?? XP_ROWS_WITH_COSTS;
+  const budget    = overrides.budget    ?? 13;
+  const hasBudget = overrides.hasBudget ?? true;
+  const responses = {
+    project_1_action:   'xp_spend',
+    project_1_xp_rows:  JSON.stringify(rows),
+    xp_spend:           JSON.stringify(rows),
+    ...(hasBudget ? { xp_budget_snapshot: budget } : {}),
+  };
+  return {
+    _id: overrides._id ?? 'sub-xp-315',
+    cycle_id: 'cycle-315',
+    character_name: 'Alice Vunder',
+    character_id:   'char-alice-315',
+    player_name:    'Alice Player',
+    submitted_at:   '2026-05-15T00:00:00Z',
+    _raw: {
+      projects: [
+        { action_type: 'xp_spend', desired_outcome: '', detail: '', primary_pool: { expression: '' } },
+      ],
+      feeding: null, sphere_actions: [],
+      contact_actions: { requests: [] }, retainer_actions: { actions: [] },
+    },
+    responses,
+    projects_resolved: [{}],
+    feeding_review: null,
+    merit_actions_resolved: [],
+    st_review: { territory_overrides: {} },
+  };
+}
+
+// Old-format: no xp_rows, only legacy flat keys
+function makeLegacyFlatSub() {
+  return {
+    _id: 'sub-xp-legacy-315',
+    cycle_id: 'cycle-315',
+    character_name: 'Alice Vunder',
+    character_id:   'char-alice-315',
+    player_name:    'Alice Player',
+    submitted_at:   '2026-05-01T00:00:00Z',
+    _raw: {
+      projects: [
+        { action_type: 'xp_spend', desired_outcome: '', detail: '', primary_pool: { expression: '' } },
+      ],
+      feeding: null, sphere_actions: [],
+      contact_actions: { requests: [] }, retainer_actions: { actions: [] },
+    },
+    responses: {
+      project_1_action:      'xp_spend',
+      project_1_xp_category: 'skill',
+      project_1_xp_item:     'Athletics',
+    },
+    projects_resolved: [{}],
+    feeding_review: null,
+    merit_actions_resolved: [],
+    st_review: { territory_overrides: {} },
+  };
+}
+
+// ── Setup helpers ──────────────────────────────────────────────────────────────
+
+async function setup(page, submissions) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'local-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url    = route.request().url();
+    const method = route.request().method();
+    const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+
+    if (method === 'PUT' || method === 'PATCH' || method === 'POST') return ok({ ok: true });
+    if (url.includes('/api/downtime_submissions')) return ok(submissions);
+    if (url.includes('/api/downtime_cycles'))      return ok([TEST_CYCLE]);
+    if (url.includes('/api/characters/names'))     return ok([{ _id: CHAR_MEKHET._id, name: CHAR_MEKHET.name, moniker: null, honorific: null }]);
+    if (url.includes('/api/characters'))           return ok([CHAR_MEKHET]);
+    if (url.includes('/api/territories'))          return ok([]);
+    if (url.includes('/api/game_sessions'))        return ok([]);
+    if (url.includes('/api/session_logs'))         return ok([]);
+    return ok([]);
+  });
+
+  await page.goto('/admin.html');
+  await page.waitForSelector('#admin-app', { state: 'visible', timeout: 10000 });
+  await page.click('[data-domain="downtime"]');
+  // Wait for the phase ribbon before proceeding
+  await page.waitForSelector('#dt-phase-ribbon', { state: 'visible', timeout: 8000 });
+  await page.click('#dt-phase-ribbon .pr-tab[data-phase="projects"]');
+  await page.waitForTimeout(300);
+}
+
+// Expand the 'misc' phase section (where xp_spend actions live) and open the first card.
+async function openXpSpendCard(page) {
+  // Wait for the misc phase header — proves data has loaded and rendered
+  await page.waitForSelector('[data-toggle-phase="misc"]', { state: 'visible', timeout: 10000 });
+  // Expand the misc section with a regular click (no force needed — header is always visible)
+  await page.locator('[data-toggle-phase="misc"]').click();
+  await page.waitForTimeout(200);
+  // Click the first action row to open the card
+  const rows = page.locator('.proc-action-row');
+  await expect(rows.first()).toBeVisible({ timeout: 5000 });
+  await rows.first().click();
+  await page.waitForTimeout(400);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+test.describe('issue-315: XP Spend — structured breakdown (feature.97)', () => {
+
+  test('XP Spend card renders a table (.proc-xp-table) for a modern submission', async ({ page }) => {
+    await setup(page, [makeXpSub()]);
+    await openXpSpendCard(page);
+    await expect(page.locator('.proc-xp-table').first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('table shows all four spend rows from the submission', async ({ page }) => {
+    await setup(page, [makeXpSub()]);
+    await openXpSpendCard(page);
+    await expect(page.locator('.proc-xp-table tbody tr')).toHaveCount(4, { timeout: 5000 });
+  });
+
+  test('merit name extracted from raw key — "Haven|grad|0|3" shows as "Haven"', async ({ page }) => {
+    await setup(page, [makeXpSub()]);
+    await openXpSpendCard(page);
+    const table = page.locator('.proc-xp-table').first();
+    await expect(table).toContainText('Haven', { timeout: 5000 });
+    await expect(table).not.toContainText('|grad|');
+  });
+
+  test('graduated merit shows dot transition (0 → 1)', async ({ page }) => {
+    await setup(page, [makeXpSub()]);
+    await openXpSpendCard(page);
+    await expect(page.locator('.proc-xp-table').first()).toContainText('0 → 1', { timeout: 5000 });
+  });
+
+  test('skill rows show category label and trait name', async ({ page }) => {
+    await setup(page, [makeXpSub()]);
+    await openXpSpendCard(page);
+    const table = page.locator('.proc-xp-table').first();
+    await expect(table).toContainText('Skill', { timeout: 5000 });
+    await expect(table).toContainText('Socialise');
+    await expect(table).toContainText('Investigation');
+  });
+
+  test('discipline row shows category label and trait name', async ({ page }) => {
+    await setup(page, [makeXpSub()]);
+    await openXpSpendCard(page);
+    const table = page.locator('.proc-xp-table').first();
+    await expect(table).toContainText('Discipline', { timeout: 5000 });
+    await expect(table).toContainText('Auspex');
+  });
+
+  test('per-row XP costs are shown (1 XP, 3 XP, 2 XP)', async ({ page }) => {
+    await setup(page, [makeXpSub()]);
+    await openXpSpendCard(page);
+    const table = page.locator('.proc-xp-table').first();
+    await expect(table).toContainText('1 XP', { timeout: 5000 });
+    await expect(table).toContainText('3 XP');
+    await expect(table).toContainText('2 XP');
+  });
+
+  test('totals footer shows Total, Budget, and Remaining', async ({ page }) => {
+    await setup(page, [makeXpSub()]);
+    await openXpSpendCard(page);
+    const tfoot = page.locator('.proc-xp-totals').first();
+    await expect(tfoot).toBeVisible({ timeout: 5000 });
+    await expect(tfoot).toContainText('Total');
+    await expect(tfoot).toContainText('Budget');
+    await expect(tfoot).toContainText('Remaining');
+  });
+
+  test('totals show correct values: 8 XP total, 13 XP budget, 5 XP remaining', async ({ page }) => {
+    await setup(page, [makeXpSub({ budget: 13 })]);
+    await openXpSpendCard(page);
+    const tfoot = page.locator('.proc-xp-totals').first();
+    await expect(tfoot).toContainText('8 XP', { timeout: 5000 });
+    await expect(tfoot).toContainText('13 XP');
+    await expect(tfoot).toContainText('5 XP');
+  });
+
+  test('over-budget remaining gets .proc-xp-remaining--over class and shows negative value', async ({ page }) => {
+    // Total 8 XP, budget 5 → remaining = -3
+    await setup(page, [makeXpSub({ budget: 5 })]);
+    await openXpSpendCard(page);
+    const overEl = page.locator('.proc-xp-remaining--over').first();
+    await expect(overEl).toBeVisible({ timeout: 5000 });
+    await expect(overEl).toContainText('-3 XP');
+  });
+
+  test('within-budget remaining does NOT get .proc-xp-remaining--over', async ({ page }) => {
+    await setup(page, [makeXpSub({ budget: 13 })]);
+    await openXpSpendCard(page);
+    await expect(page.locator('.proc-xp-remaining--over')).toHaveCount(0, { timeout: 5000 });
+  });
+
+  test('totals footer omitted when xp_budget_snapshot is absent', async ({ page }) => {
+    await setup(page, [makeXpSub({ hasBudget: false })]);
+    await openXpSpendCard(page);
+    await expect(page.locator('.proc-xp-table').first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.proc-xp-totals')).toHaveCount(0);
+  });
+
+  test('legacy rows without xpCost show table rows but no XP cost text', async ({ page }) => {
+    await setup(page, [makeXpSub({ rows: XP_ROWS_LEGACY, hasBudget: false })]);
+    await openXpSpendCard(page);
+    await expect(page.locator('.proc-xp-table').first()).toBeVisible({ timeout: 5000 });
+    const costCells = page.locator('.proc-xp-cost');
+    const texts = await costCells.allTextContents();
+    expect(texts.some(t => /\d+ XP/.test(t))).toBe(false);
+  });
+
+  test('very old submission (no xp_rows) does not render .proc-xp-table — no crash', async ({ page }) => {
+    await setup(page, [makeLegacyFlatSub()]);
+    await openXpSpendCard(page);
+    // Structured table should be absent
+    await expect(page.locator('.proc-xp-table')).toHaveCount(0, { timeout: 5000 });
+    // No error banner
+    await expect(page.locator('.dt-error, .error-banner')).toHaveCount(0);
+  });
+
+  test('XP Spend label shown in action queue row before card is opened', async ({ page }) => {
+    await setup(page, [makeXpSub()]);
+    // Wait for misc section header and expand it — don't open the card
+    await page.waitForSelector('[data-toggle-phase="misc"]', { state: 'visible', timeout: 10000 });
+    await page.locator('[data-toggle-phase="misc"]').click();
+    await page.waitForTimeout(200);
+    await expect(page.locator('.proc-action-row').first()).toContainText('XP Spend', { timeout: 5000 });
+  });
+
+});


### PR DESCRIPTION
## Summary

- Replaces the flat unreadable merit-key string in the DT Processing XP Spend card with a per-row table showing category label, human-readable trait name, dot transition, and per-item XP cost — so STs can review requests without navigating to the player's form
- Totals footer (Total / Budget / Remaining) rendered when `xp_budget_snapshot` is present; omitted for legacy submissions without it
- Over-budget remaining rendered in warning colour (`--crim`); graceful fallback for very old submissions with no `xp_rows`
- 15/15 E2E Playwright tests added and passing; one implementation bug caught during QA (totals section was incorrectly shown without a budget)

## Closes

- Closes #315

## Story

- specs/stories/feature.97.dt-xp-spend-card-breakdown.story.md

## Test plan

- [x] 15/15 E2E tests passing: `npx playwright test tests/issue-315-xp-spend-breakdown.spec.js`
- [ ] CI green
- [ ] Manual: load DT Processing for an XP Spend submission — verify structured table appears with category, trait, transition, cost per row; verify totals row shows Total / Budget / Remaining; verify legacy fallback (no budget → totals omitted, no xp_rows → flat string)

## Branch flow

- From: `morningstar-issue-315-dt-xp-spend-breakdown`
- Into: `dev`