### PR TITLE
fix(#335): bonus dot stepper hollow-dot display for influence and domain merits

### DIFF
--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -799,7 +799,7 @@ export function shRenderInfluenceMerits(c, editMode) {
       } else {
         _areaHtml = _inflArea(m, idx, false);
       }
-      h += '<div class="infl-edit-row"><select class="infl-type" onchange="shEditInflMerit(' + idx + ',\'name\',this.value);renderSheet(chars[editIdx])">' + tOpts + '</select>' + _areaHtml + '<span class="infl-dots-derived">' + '\u25CF'.repeat(_iPurch) + '\u25CB'.repeat(Math.max(0, dd - _iPurch)) + '</span><span class="infl-inf">' + (inf ? '<span class="infl-tier-chip">' + inf + ' Inf</span>' : '') + '</span>';
+      h += '<div class="infl-edit-row"><select class="infl-type" onchange="shEditInflMerit(' + idx + ',\'name\',this.value);renderSheet(chars[editIdx])">' + tOpts + '</select>' + _areaHtml + '<span class="infl-dots-derived">' + '\u25CF'.repeat(_iPurch) + '\u25CB'.repeat(Math.max(0, dd + (m.bonus || 0) - _iPurch)) + '</span><span class="infl-inf">' + (inf ? '<span class="infl-tier-chip">' + inf + ' Inf</span>' : '') + '</span>';
       if (m.granted_by) h += '<span class="gen-granted-tag">' + esc(m.granted_by) + '</span>';
       h += '<button class="dev-rm-btn" onclick="shRemoveInflMerit(' + idx + ')" title="Remove">&times;</button></div>';
       const _isAttacheVariant = m.name?.startsWith('Attach\u00e9 (');
@@ -843,7 +843,7 @@ export function shRenderInfluenceMerits(c, editMode) {
       const narrow = m.name === 'Status' && m.narrow && typeof m.narrow === 'string' ? m.narrow.trim() : '';
       const displayArea = narrow ? (area ? area + ' — ' + narrow : narrow) : area;
       const iRIdx = c.merits.indexOf(m);
-      const iPurch = (m.cp || 0) + (m.xp || 0), iBon = meritFreeSum(m) + attacheBonusDots(c, displayArea ? m.name + ' (' + displayArea + ')' : m.name);
+      const iPurch = (m.cp || 0) + (m.xp || 0), iBon = meritFreeSum(m) + attacheBonusDots(c, displayArea ? m.name + ' (' + displayArea + ')' : m.name) + (m.bonus || 0);
       h += shRenderMeritRow((displayArea ? m.name + ' (' + displayArea + gt + ')' : m.name + gt) + gb, 'infl', idx, shDotsMixed(iPurch, iBon));
     });
     const ce = inflM.filter(m => m.name === 'Contacts');
@@ -934,7 +934,7 @@ export function shRenderDomainMerits(c, editMode) {
             ? shDotsMixed(Math.min(_capSharedEff, _dPurch), Math.max(0, _capSharedEff - Math.min(_capSharedEff, _dPurch)))
             : shDotsMixed(Math.min(_capEff, _dPurch), Math.max(0, (_capStored || 0) - Math.min(_capEff, _dPurch))))
         : _totalDots;
-      h += '<div class="dom-edit-block"><div class="infl-edit-row"><select class="infl-type" onchange="shEditDomMerit(' + di + ',\'name\',this.value)">' + tOpts + '</select><span class="dom-contrib-lbl">My dots: ' + '\u25CF'.repeat(_dPurch) + '\u25CB'.repeat(Math.max(0, dd - _dPurch)) + '</span><span class="dom-total-lbl" title="Total across all contributors (\u25CF own, \u25CB partners)">Total: ' + (_isCapped ? _capTotalDots : _totalDots) + '</span><button class="dev-rm-btn" onclick="shRemoveDomMerit(' + di + ')" title="Remove">&times;</button></div>';
+      h += '<div class="dom-edit-block"><div class="infl-edit-row"><select class="infl-type" onchange="shEditDomMerit(' + di + ',\'name\',this.value)">' + tOpts + '</select><span class="dom-contrib-lbl">My dots: ' + '\u25CF'.repeat(_dPurch) + '\u25CB'.repeat(Math.max(0, dd + (m.bonus || 0) - _dPurch)) + '</span><span class="dom-total-lbl" title="Total across all contributors (\u25CF own, \u25CB partners)">Total: ' + (_isCapped ? _capTotalDots : _totalDots) + '</span><button class="dev-rm-btn" onclick="shRemoveDomMerit(' + di + ')" title="Remove">&times;</button></div>';
       // Qualifier input for Safe Place / Feeding Grounds
       if (['Safe Place', 'Feeding Grounds'].includes(m.name)) {
         const _qErr = c._domQualError && !m.qualifier ? '<span class="dom-qual-error">' + esc(c._domQualError) + '</span>' : (c._domQualError && m.qualifier ? '<span class="dom-qual-error">' + esc(c._domQualError) + '</span>' : '');
@@ -978,15 +978,16 @@ export function shRenderDomainMerits(c, editMode) {
       const dp = m.shared_with && m.shared_with.length ? m.shared_with : null;
       // de: per-instance effective rating (handles cap for Haven/MG, multi-instance for SP/FG)
       const de = meritEffectiveRating(c, m);
-      const _dRaw = (m.cp || 0) + (m.free_bloodline || 0) + (m.free_pet || 0) + (m.free_mci || 0) + (m.free_vm || 0) + (m.free_lk || 0) + (m.free_inv || 0) + attacheBonusDots(c, m.area ? m.name + ' (' + m.area + ')' : m.name) + (m.xp || 0), ssjB = !dp && m.name === 'Herd' ? ssjHerdBonus(c) : 0, flockB = !dp && m.name === 'Herd' ? flockHerdBonus(c) : 0, fwbB = !dp ? (m.free_fwb || 0) : 0, attB = !dp ? (m.free_attache || 0) : 0;
-      const _viewStored = (m.cp || 0) + (m.xp || 0) + meritFreeSum(m);
+      const mBon = m.bonus || 0;
+      const _dRaw = (m.cp || 0) + (m.free_bloodline || 0) + (m.free_pet || 0) + (m.free_mci || 0) + (m.free_vm || 0) + (m.free_lk || 0) + (m.free_inv || 0) + attacheBonusDots(c, m.area ? m.name + ' (' + m.area + ')' : m.name) + (m.xp || 0) + mBon, ssjB = !dp && m.name === 'Herd' ? ssjHerdBonus(c) : 0, flockB = !dp && m.name === 'Herd' ? flockHerdBonus(c) : 0, fwbB = !dp ? (m.free_fwb || 0) : 0, attB = !dp ? (m.free_attache || 0) : 0;
+      const _viewStored = (m.cp || 0) + (m.xp || 0) + meritFreeSum(m) + mBon;
       const _isCappedView = ['Haven', 'Mandragora Garden'].includes(m.name);
       // Dot display: for capped merits show solid up to eff, hollow for over-cap stored dots
       let dotHtml;
       if (_isCappedView) {
         const _cPurch = Math.min(de, (m.cp || 0) + (m.xp || 0));
         dotHtml = shDotsMixed(_cPurch, Math.max(0, _viewStored - _cPurch));
-      } else if (ssjB > 0 || flockB > 0 || fwbB > 0 || attB > 0) {
+      } else if (ssjB > 0 || flockB > 0 || fwbB > 0 || attB > 0 || mBon > 0) {
         const dPurch = _dRaw;
         dotHtml = shDotsMixed(dPurch, Math.max(0, de - dPurch));
       } else {

--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -979,7 +979,7 @@ export function shRenderDomainMerits(c, editMode) {
       // de: per-instance effective rating (handles cap for Haven/MG, multi-instance for SP/FG)
       const de = meritEffectiveRating(c, m);
       const mBon = m.bonus || 0;
-      const _dRaw = (m.cp || 0) + (m.free_bloodline || 0) + (m.free_pet || 0) + (m.free_mci || 0) + (m.free_vm || 0) + (m.free_lk || 0) + (m.free_inv || 0) + attacheBonusDots(c, m.area ? m.name + ' (' + m.area + ')' : m.name) + (m.xp || 0) + mBon, ssjB = !dp && m.name === 'Herd' ? ssjHerdBonus(c) : 0, flockB = !dp && m.name === 'Herd' ? flockHerdBonus(c) : 0, fwbB = !dp ? (m.free_fwb || 0) : 0, attB = !dp ? (m.free_attache || 0) : 0;
+      const _dRaw = (m.cp || 0) + (m.free_bloodline || 0) + (m.free_pet || 0) + (m.free_mci || 0) + (m.free_vm || 0) + (m.free_lk || 0) + (m.free_inv || 0) + attacheBonusDots(c, m.area ? m.name + ' (' + m.area + ')' : m.name) + (m.xp || 0), ssjB = !dp && m.name === 'Herd' ? ssjHerdBonus(c) : 0, flockB = !dp && m.name === 'Herd' ? flockHerdBonus(c) : 0, fwbB = !dp ? (m.free_fwb || 0) : 0, attB = !dp ? (m.free_attache || 0) : 0;
       const _viewStored = (m.cp || 0) + (m.xp || 0) + meritFreeSum(m) + mBon;
       const _isCappedView = ['Haven', 'Mandragora Garden'].includes(m.name);
       // Dot display: for capped merits show solid up to eff, hollow for over-cap stored dots
@@ -989,7 +989,7 @@ export function shRenderDomainMerits(c, editMode) {
         dotHtml = shDotsMixed(_cPurch, Math.max(0, _viewStored - _cPurch));
       } else if (ssjB > 0 || flockB > 0 || fwbB > 0 || attB > 0 || mBon > 0) {
         const dPurch = _dRaw;
-        dotHtml = shDotsMixed(dPurch, Math.max(0, de - dPurch));
+        dotHtml = shDotsMixed(dPurch, Math.max(0, de - dPurch) + mBon);
       } else {
         dotHtml = '<span class="trait-dots">' + shDots(de) + '</span>';
       }

--- a/specs/stories/feature.335.influence-domain-merit-bonus-stepper.story.md
+++ b/specs/stories/feature.335.influence-domain-merit-bonus-stepper.story.md
@@ -213,6 +213,10 @@ Contacts has its own separate render block (not in `nonContacts.forEach`). Its d
 
 All 4 tasks implemented and verified. E2E test file written covering AC1 (influence edit hollow dot increment), AC1b (two up, one down), AC3 (domain edit hollow dot increment), AC5 (influence total unchanged), AC6 (PUT payload includes bonus).
 
+### QA Findings (addressed)
+
+**Bug found during QA (AC4 failure):** Task 4b incorrectly added `mBon` to `_dRaw`, which is used as the filled-dot count in `shDotsMixed`. This caused `de - dPurch` to go negative (clamped to 0), so no hollow dots appeared in view mode for plain domain merits. Fixed by removing `mBon` from `_dRaw` and instead adding it to the hollow side: `shDotsMixed(dPurch, Math.max(0, de - dPurch) + mBon)`. `_viewStored` retains `mBon` as capped merits (Haven/MG) use a different formula. Added AC2 and AC4 view-mode tests which caught this regression.
+
 ## File List
 
 - `public/js/editor/sheet.js` (Tasks 1–4)
@@ -222,3 +226,5 @@ All 4 tasks implemented and verified. E2E test file written covering AC1 (influe
 
 - fix(#335): include m.bonus in influence and domain merit dot display (2026-05-17)
 - test(#335): E2E Playwright tests for influence/domain merit bonus dot display (2026-05-17)
+- fix(#335): correct domain view-mode hollow-dot formula; mBon on hollow side not filled side (2026-05-17)
+- test(#335): add AC2/AC4 view-mode tests that caught the formula regression (2026-05-17)

--- a/specs/stories/feature.335.influence-domain-merit-bonus-stepper.story.md
+++ b/specs/stories/feature.335.influence-domain-merit-bonus-stepper.story.md
@@ -1,0 +1,224 @@
+# Story Feature.335: Bonus Dot Stepper — Influence and Domain Merits
+
+## Status: review
+
+## Metadata
+- issue: 335
+- issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/335
+- branch: ms/issue-335-bonus-stepper-influence-domain
+
+---
+
+## Story
+
+**As an** ST editing a character's influence or domain merits,
+**I want** the Bonus ▼/▲ stepper to visually update the hollow-dot display on those merit rows,
+**so that** bonus dots granted via the stepper are reflected on the sheet in the same way they are for general merits.
+
+---
+
+## Background
+
+### What #333 delivered
+
+Issue #333 added the manual bonus dot stepper across the sheet editor:
+
+1. **`meritBdRow` (xp.js)** — the Bonus ▼/▲ row was added **unconditionally** to the shared breakdown row function. Because `meritBdRow` is called inside `editMode` for ALL merit categories (general, influence, domain, standing), the stepper buttons themselves appear on every merit category after merging #333.
+2. **`shAdjMeritBonus` (edit.js)** — handler that writes `m.bonus`, clamps to ≥ 0, calls `_markDirty` + `_renderSheet`. Wired to `window` in both `admin.js` and `app.js`.
+3. **`merit.bonus` schema whitelist (character.schema.js)** — added to `additionalProperties` so PUT saves don't fail validation.
+4. **General merit dot display (sheet.js `shRenderGeneralMerits`)** — the dot formula in both edit mode and view mode was updated to include `m.bonus` in the hollow-dot count.
+
+### What #333 did NOT do
+
+The dot display formulas in `shRenderInfluenceMerits` and `shRenderDomainMerits` were **not** updated to include `m.bonus`. Clicking the stepper on an influence or domain merit saves the value to the character object and re-renders, but the rendering formula doesn't read `m.bonus`, so the hollow-dot count in the name row never changes.
+
+The result: the Bonus ▼/▲ row correctly shows "+1 / +2 / etc." in the breakdown panel, but the ●●○ dot string in the merit's header row does not update.
+
+### Key functions NOT to touch
+
+- `meritFreeSum(m)` — sums all `free_*` channels; does not and should not include `m.bonus` (bonus is a display override, not an earned-dot channel)
+- `syncMeritRating(m)` — writes `m.rating = cp + xp + meritFreeSum(m)`; must not include `m.bonus`
+- `meritEffectiveRating(c, m)` — used for pool calculations and prerequisite checks; must not include `m.bonus`
+- `shAdjMeritBonus` — already correct; no changes needed
+- `meritBdRow` — already correct; no changes needed
+- `admin.js` / `app.js` wiring — already correct; no changes needed
+
+---
+
+## Branch Sync (Do First)
+
+Before making any code changes, merge dev into the working branch. Our branch was cut from `Morningstar` which is behind origin/dev by the full #333 implementation:
+
+```sh
+git fetch origin
+git merge origin/dev
+```
+
+Resolve any conflicts (unlikely — no overlapping edits). After the merge, `meritBdRow` in `xp.js` will include the Bonus row and `shAdjMeritBonus` will be live. The remaining work is the dot display fix only.
+
+---
+
+## Acceptance Criteria
+
+- [x] Influence merit rows: clicking Bonus ▲ in the breakdown panel increases the hollow-dot count in the merit name row immediately (no save/reload required).
+- [x] Influence merit rows: view mode (non-edit) also shows bonus dots as hollow circles after the filled inherent dots.
+- [x] Domain merit rows: same as above — edit mode dot count updates immediately, view mode renders hollow bonus dots.
+- [x] Bonus dots are additive with existing `free_*` derived hollow dots — no regression on rule-granted hollows.
+- [x] XP totals are unchanged (verify xpSpent on the XP tab after setting a bonus).
+- [x] Pool calculations and influence totals are unchanged.
+- [x] Bonus persists across save and reload.
+
+---
+
+## Tasks
+
+All changes are in **`public/js/editor/sheet.js`** only.
+
+---
+
+### Task 1 — Influence merits: edit-mode dot display
+
+**Function:** `shRenderInfluenceMerits`, inside the `if (editMode)` block, inside `nonContacts.forEach`.
+
+**Locate this line** (the long `const` that defines `dd` for non-Contacts influence merits):
+```js
+const idx = inflM.indexOf(m), inf = calcMeritInfluence(...), tOpts = buildSubCategoryMeritOptions(...), rIdx = c.merits.indexOf(m), dd = (m.cp || 0) + (m.xp || 0) + meritFreeSum(m) + attacheBonusDots(c, m.area ? m.name + ' (' + m.area + ')' : m.name);
+const _iPurch = (m.cp || 0) + (m.xp || 0);
+```
+
+**Locate the dot display span** immediately downstream (inside the `infl-edit-row` div):
+```js
+'<span class="infl-dots-derived">' + '●'.repeat(_iPurch) + '○'.repeat(Math.max(0, dd - _iPurch)) + '</span>'
+```
+
+**Change** the hollow-dot count to include `m.bonus`:
+```js
+'<span class="infl-dots-derived">' + '●'.repeat(_iPurch) + '○'.repeat(Math.max(0, dd + (m.bonus || 0) - _iPurch)) + '</span>'
+```
+
+---
+
+### Task 2 — Influence merits: view-mode dot display
+
+**Function:** `shRenderInfluenceMerits`, inside the `else` block (non-edit view).
+
+**Locate this line** inside the `.forEach` for non-Contacts merits:
+```js
+const iPurch = (m.cp || 0) + (m.xp || 0), iBon = meritFreeSum(m) + attacheBonusDots(c, displayArea ? m.name + ' (' + displayArea + ')' : m.name);
+```
+
+**Change** `iBon` to include `m.bonus`:
+```js
+const iPurch = (m.cp || 0) + (m.xp || 0), iBon = meritFreeSum(m) + attacheBonusDots(c, displayArea ? m.name + ' (' + displayArea + ')' : m.name) + (m.bonus || 0);
+```
+
+---
+
+### Task 3 — Domain merits: edit-mode dot display
+
+**Function:** `shRenderDomainMerits`, inside the `if (editMode)` block, inside `domM.forEach`.
+
+**Locate this line** (the long `const` that defines `dd`):
+```js
+const rIdx = c.merits.indexOf(m), dd = (m.cp || 0) + (m.xp || 0) + meritFreeSum(m) + attacheBonusDots(c, m.area ? m.name + ' (' + m.area + ')' : m.name), parts = ...
+```
+
+**Locate the "My dots" dot display** in the `infl-edit-row` div:
+```js
+'<span class="dom-contrib-lbl">My dots: ' + '●'.repeat(_dPurch) + '○'.repeat(Math.max(0, dd - _dPurch)) + '</span>'
+```
+
+**Change** the hollow-dot count to include `m.bonus`:
+```js
+'<span class="dom-contrib-lbl">My dots: ' + '●'.repeat(_dPurch) + '○'.repeat(Math.max(0, dd + (m.bonus || 0) - _dPurch)) + '</span>'
+```
+
+---
+
+### Task 4 — Domain merits: view-mode dot display
+
+**Function:** `shRenderDomainMerits`, inside the `else` block (non-edit view), inside `domM.forEach`.
+
+The view-mode path has three display branches — capped merits (Haven/MG), merits with existing bonuses (SSJ/Flock/FWB/Attaché), and plain merits. Update all three to include `m.bonus`.
+
+**Step 4a** — Declare `mBon` at the top of the `domM.forEach` callback (before `_dRaw` and `_viewStored`):
+```js
+const mBon = m.bonus || 0;
+```
+
+**Step 4b** — Update `_dRaw` to include `mBon`:
+```js
+const _dRaw = (m.cp || 0) + ... + (m.xp || 0) + mBon;
+```
+(Add `+ mBon` at the end of the existing `_dRaw` declaration.)
+
+**Step 4c** — Update `_viewStored` to include `mBon`:
+```js
+const _viewStored = (m.cp || 0) + (m.xp || 0) + meritFreeSum(m) + mBon;
+```
+
+**Step 4d** — Add `mBon > 0` to the condition guarding `shDotsMixed`:
+```js
+} else if (ssjB > 0 || flockB > 0 || fwbB > 0 || attB > 0 || mBon > 0) {
+```
+
+This ensures that a plain domain merit with only a manual bonus (no SSJ/Flock/etc.) still renders the mixed dot display rather than falling through to the all-solid `shDots(de)` path. Because `_dRaw` now includes `mBon`, the formula `shDotsMixed(dPurch, Math.max(0, de - dPurch))` where `dPurch = _dRaw` naturally shows `mBon` as hollow dots (since `de = meritEffectiveRating` does not include `mBon`, the difference produces the right count).
+
+---
+
+## Dev Notes
+
+### Why only `sheet.js`
+
+The Bonus ▼/▲ stepper (in `meritBdRow`), the save handler (`shAdjMeritBonus`), the window wiring (`admin.js`, `app.js`), and the schema whitelist (`character.schema.js`) were all completed in #333. The only gap is that `shRenderInfluenceMerits` and `shRenderDomainMerits` don't read `m.bonus` when building their dot strings.
+
+### Why `m.bonus` must NOT go into the helpers
+
+`meritFreeSum`, `syncMeritRating`, and `meritEffectiveRating` are used by XP calculations, influence totals, pool formulas, and prereq checks. The manual bonus is a display-only ST override. Adding it to any of those helpers would silently inflate XP spent, influence totals, and pool sizes. Do not touch those functions.
+
+### "My dots" vs "Total" in domain edit mode
+
+Domain merits have two dot displays in edit mode: "My dots" (own contribution: `dd - _dPurch` hollow) and "Total" (`_totalDots` = solid own + hollow partners). Only "My dots" needs to include `m.bonus` — the "Total" display reflects the shared pool and should not double-count a per-character display override.
+
+### Contacts merit (influence)
+
+Contacts has its own separate render block (not in `nonContacts.forEach`). Its dot display shows `baseDots` filled + granted hollow. Check whether Contacts has its own dot-string line that also needs `m.bonus`. If it does, apply the same pattern: `Math.max(0, rating + (m.bonus || 0) - baseDots)`. If the existing code already uses a formula that would include it, leave it.
+
+### Testing checklist (manual)
+
+1. Open sheet editor for a character with at least one Influence merit (e.g., Allies) and one Domain merit (e.g., Safe Place).
+2. Click Bonus ▲ on the Allies merit → breakdown panel shows "+1", dot row shows one extra ○ immediately.
+3. Click ▲ again → "+2", two extra ○.
+4. Click ▼ → back to "+1", one extra ○.
+5. Save and reload: bonus persists.
+6. Switch to view mode: Allies row shows filled ●● (purchased) + hollow ○ (bonus) side by side.
+7. Repeat for a Domain merit (Safe Place, Herd, etc.).
+8. Open the XP tab: `xpSpent` total is unchanged.
+9. Check influence total in the Influence header: unchanged from before the bonus.
+10. Open DT form: pool calculations unaffected.
+
+---
+
+## Dev Agent Record
+
+### Implementation Notes
+
+- Branch synced with `origin/dev` before any edits — `meritBdRow` (xp.js) and `shAdjMeritBonus` (edit.js) were already live from #333; no changes needed to those files.
+- All 4 edits made exclusively in `public/js/editor/sheet.js`; parse check passed (`node --check`).
+- Contacts merit (influence): reviewed separately per dev note. Contacts uses `baseDots` + granted hollow via `attacheBonusDots`; the stepper appears in the breakdown panel but no dot-string change was made to the Contacts header block — adding hollow dots without sphere pickers would misrepresent the rating. Left unchanged.
+- Domain view mode: three branches updated. `mBon` declared at top of `domM.forEach`, added to both `_dRaw` and `_viewStored`, and `|| mBon > 0` guard added to the `shDotsMixed` condition so plain domain merits with only a manual bonus render hollow dots instead of all-solid.
+- `meritFreeSum`, `syncMeritRating`, `meritEffectiveRating` — not touched. `m.bonus` remains display-only per story constraints.
+
+### Completion Notes
+
+All 4 tasks implemented and verified. E2E test file written covering AC1 (influence edit hollow dot increment), AC1b (two up, one down), AC3 (domain edit hollow dot increment), AC5 (influence total unchanged), AC6 (PUT payload includes bonus).
+
+## File List
+
+- `public/js/editor/sheet.js` (Tasks 1–4)
+- `tests/issue-335-influence-domain-merit-bonus-display.spec.js` (new — E2E tests for AC1/AC1b/AC3/AC5/AC6)
+
+## Change Log
+
+- fix(#335): include m.bonus in influence and domain merit dot display (2026-05-17)
+- test(#335): E2E Playwright tests for influence/domain merit bonus dot display (2026-05-17)

--- a/tests/issue-335-influence-domain-merit-bonus-display.spec.js
+++ b/tests/issue-335-influence-domain-merit-bonus-display.spec.js
@@ -1,0 +1,209 @@
+/**
+ * Issue #335 — Influence and Domain Merit Bonus Dot Display
+ *
+ * After merging #333, meritBdRow shows a Bonus ▼/▲ stepper for ALL merit
+ * categories. This issue fixes the dot display in shRenderInfluenceMerits
+ * and shRenderDomainMerits so that clicking the stepper visually updates the
+ * hollow-dot count in the merit's header row — matching the existing behaviour
+ * for general merits.
+ *
+ * AC1 — Influence merit edit mode: clicking Bonus ▲ increases hollow-dot count
+ *        in the infl-dots-derived span immediately.
+ * AC2 — Influence merit view mode: hollow dots appear in the merit row when
+ *        bonus > 0 (shDotsMixed path via iBon).
+ * AC3 — Domain merit edit mode: clicking Bonus ▲ increases hollow-dot count
+ *        in the dom-contrib-lbl span immediately.
+ * AC4 — Domain merit view mode: hollow dots appear when bonus > 0.
+ * AC5 — XP totals and influence totals are unchanged by bonus increments.
+ * AC6 — Bonus persists in PUT payload.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const ST_USER = {
+  id: '335000001', username: 'test_st_335', global_name: 'Test ST 335',
+  avatar: null, role: 'st', player_id: 'p-335', character_ids: [], is_dual_role: false,
+};
+
+const TEST_CHAR = {
+  _id: 'char-335-001',
+  name: 'Display Tester',
+  moniker: null, honorific: null,
+  clan: 'Daeva', covenant: 'Invictus',
+  player: 'Test Player',
+  blood_potency: 2,
+  humanity: 7, humanity_base: 7,
+  court_title: null, retired: false,
+  status: {
+    city: 1, clan: 0,
+    covenant: { 'Carthian Movement': 0, 'Circle of the Crone': 0, 'Invictus': 1, 'Lancea et Sanctum': 0, 'Ordo Dracul': 0 },
+  },
+  attributes: {
+    Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+    Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+    Presence: { dots: 3, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: {
+    Academics: { dots: 1, bonus: 0, specs: [], nine_again: false },
+  },
+  disciplines: {},
+  merits: [
+    // Influence merit — 2 cp dots (2 filled, 0 hollow initially)
+    { name: 'Allies', category: 'influence', cp: 2, xp: 0, bonus: 0, area: 'Academic' },
+    // Domain merit — 2 cp dots
+    { name: 'Safe Place', category: 'domain', cp: 2, xp: 0, bonus: 0, qualifier: 'Penthouse' },
+  ],
+  powers: [], ordeals: [],
+};
+
+// ── Setup helpers ─────────────────────────────────────────────────────────────
+
+let lastPutBody = null;
+
+async function setup(page) {
+  lastPutBody = null;
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'local-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url    = route.request().url();
+    const method = route.request().method();
+    const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+
+    if (method === 'PUT') {
+      lastPutBody = route.request().postDataJSON();
+      return ok({ ok: true });
+    }
+    if (method === 'PATCH' || method === 'POST') return ok({ ok: true });
+    if (url.match(/\/api\/characters\/char-335-001$/))   return ok(TEST_CHAR);
+    if (url.includes('/api/characters/names'))            return ok([{ _id: TEST_CHAR._id, name: TEST_CHAR.name, moniker: null, honorific: null }]);
+    if (url.includes('/api/characters'))                  return ok([TEST_CHAR]);
+    if (url.includes('/api/territories'))                 return ok([]);
+    if (url.includes('/api/game_sessions'))               return ok([]);
+    if (url.includes('/api/session_logs'))                return ok([]);
+    if (url.includes('/api/downtime_cycles'))             return ok([]);
+    if (url.includes('/api/downtime_submissions'))        return ok([]);
+    if (url.includes('/api/players'))                     return ok([]);
+    return ok([]);
+  });
+}
+
+async function openEditor(page) {
+  await page.goto('http://localhost:8080/admin.html');
+  await page.waitForSelector('.char-card', { timeout: 10000 });
+  await page.locator('.char-card').first().click();
+  await page.waitForSelector('.sh-sec-title', { timeout: 8000 });
+  // Enter edit mode
+  const editBtn = page.locator('button', { hasText: /edit/i }).first();
+  if (await editBtn.isVisible()) await editBtn.click();
+  await page.waitForSelector('.merit-bd-row', { timeout: 8000 });
+}
+
+// ── Helper: count hollow dots (○) in an element's text content ───────────────
+async function hollowDotCount(locator) {
+  const text = await locator.textContent();
+  return (text.match(/○/g) || []).length;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('Issue #335 — Influence and Domain merit bonus dot display', () => {
+
+  test.beforeEach(async ({ page }) => {
+    await setup(page);
+    await openEditor(page);
+  });
+
+  // ── AC1: Influence merit edit mode ─────────────────────────────────────────
+  test('AC1 — Influence merit edit mode: Bonus ▲ adds hollow dot to infl-dots-derived span', async ({ page }) => {
+    // Locate the Allies merit row and its breakdown panel
+    const alliesSection = page.locator('.sh-sec').filter({ hasText: 'Influence Merits' });
+    const editRow = alliesSection.locator('.infl-edit-row').first();
+    const dotSpan = editRow.locator('.infl-dots-derived');
+
+    const initialHollow = await hollowDotCount(dotSpan);
+
+    // Locate the Bonus ▲ button inside the merit-bd-row that follows this merit's edit row
+    const bdRow = alliesSection.locator('.attr-derived-row').filter({ hasText: 'Bonus' }).first();
+    const upBtn = bdRow.locator('button').last();
+
+    await upBtn.click();
+    const afterHollow = await hollowDotCount(dotSpan);
+    expect(afterHollow).toBe(initialHollow + 1);
+  });
+
+  test('AC1b — Influence merit edit mode: Bonus ▲▲ adds two hollow dots; ▼ removes one', async ({ page }) => {
+    const alliesSection = page.locator('.sh-sec').filter({ hasText: 'Influence Merits' });
+    const editRow = alliesSection.locator('.infl-edit-row').first();
+    const dotSpan = editRow.locator('.infl-dots-derived');
+    const bdRow = alliesSection.locator('.attr-derived-row').filter({ hasText: 'Bonus' }).first();
+    const upBtn = bdRow.locator('button').last();
+    const downBtn = bdRow.locator('button').first();
+
+    const initial = await hollowDotCount(dotSpan);
+
+    await upBtn.click();
+    await upBtn.click();
+    const afterTwo = await hollowDotCount(dotSpan);
+    expect(afterTwo).toBe(initial + 2);
+
+    await downBtn.click();
+    const afterOne = await hollowDotCount(dotSpan);
+    expect(afterOne).toBe(initial + 1);
+  });
+
+  // ── AC3: Domain merit edit mode ────────────────────────────────────────────
+  test('AC3 — Domain merit edit mode: Bonus ▲ adds hollow dot to dom-contrib-lbl span', async ({ page }) => {
+    const domSection = page.locator('.sh-sec').filter({ hasText: 'Domain Merits' });
+    const editBlock = domSection.locator('.dom-edit-block').first();
+    const contribSpan = editBlock.locator('.dom-contrib-lbl');
+
+    const initialHollow = await hollowDotCount(contribSpan);
+
+    const bdRow = editBlock.locator('.attr-derived-row').filter({ hasText: 'Bonus' }).first();
+    const upBtn = bdRow.locator('button').last();
+
+    await upBtn.click();
+    const afterHollow = await hollowDotCount(contribSpan);
+    expect(afterHollow).toBe(initialHollow + 1);
+  });
+
+  // ── AC5: XP and influence totals unchanged ─────────────────────────────────
+  test('AC5 — Influence total unchanged after setting Bonus on Allies', async ({ page }) => {
+    const alliesSection = page.locator('.sh-sec').filter({ hasText: 'Influence Merits' });
+    const inflTotal = alliesSection.locator('.infl-total .inf-n');
+    const totalBefore = await inflTotal.textContent();
+
+    const bdRow = alliesSection.locator('.attr-derived-row').filter({ hasText: 'Bonus' }).first();
+    await bdRow.locator('button').last().click();
+
+    const totalAfter = await inflTotal.textContent();
+    expect(totalAfter).toBe(totalBefore);
+  });
+
+  // ── AC6: PUT payload includes updated bonus ────────────────────────────────
+  test('AC6 — Save PUT payload includes merit bonus for Allies', async ({ page }) => {
+    const alliesSection = page.locator('.sh-sec').filter({ hasText: 'Influence Merits' });
+    const bdRow = alliesSection.locator('.attr-derived-row').filter({ hasText: 'Bonus' }).first();
+    await bdRow.locator('button').last().click();
+
+    // Trigger save
+    const saveBtn = page.locator('button', { hasText: /save/i }).first();
+    if (await saveBtn.isVisible()) {
+      await saveBtn.click();
+      await page.waitForTimeout(500);
+    }
+
+    if (lastPutBody && lastPutBody.merits) {
+      const allies = lastPutBody.merits.find(m => m.name === 'Allies' && m.category === 'influence');
+      expect(allies).toBeTruthy();
+      expect(allies.bonus).toBe(1);
+    }
+  });
+
+});

--- a/tests/issue-335-influence-domain-merit-bonus-display.spec.js
+++ b/tests/issue-335-influence-domain-merit-bonus-display.spec.js
@@ -58,6 +58,15 @@ const TEST_CHAR = {
   powers: [], ordeals: [],
 };
 
+// Character variant with bonus pre-set to 1 on both merits (for view-mode tests)
+const TEST_CHAR_BON = {
+  ...TEST_CHAR,
+  merits: [
+    { name: 'Allies', category: 'influence', cp: 2, xp: 0, bonus: 1, area: 'Academic' },
+    { name: 'Safe Place', category: 'domain', cp: 2, xp: 0, bonus: 1, qualifier: 'Penthouse' },
+  ],
+};
+
 // ── Setup helpers ─────────────────────────────────────────────────────────────
 
 let lastPutBody = null;
@@ -91,6 +100,41 @@ async function setup(page) {
     if (url.includes('/api/players'))                     return ok([]);
     return ok([]);
   });
+}
+
+async function setupWithBonus(page) {
+  lastPutBody = null;
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'local-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url    = route.request().url();
+    const method = route.request().method();
+    const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+
+    if (method === 'PUT') { lastPutBody = route.request().postDataJSON(); return ok({ ok: true }); }
+    if (method === 'PATCH' || method === 'POST') return ok({ ok: true });
+    if (url.match(/\/api\/characters\/char-335-001$/))   return ok(TEST_CHAR_BON);
+    if (url.includes('/api/characters/names'))            return ok([{ _id: TEST_CHAR_BON._id, name: TEST_CHAR_BON.name, moniker: null, honorific: null }]);
+    if (url.includes('/api/characters'))                  return ok([TEST_CHAR_BON]);
+    if (url.includes('/api/territories'))                 return ok([]);
+    if (url.includes('/api/game_sessions'))               return ok([]);
+    if (url.includes('/api/session_logs'))                return ok([]);
+    if (url.includes('/api/downtime_cycles'))             return ok([]);
+    if (url.includes('/api/downtime_submissions'))        return ok([]);
+    if (url.includes('/api/players'))                     return ok([]);
+    return ok([]);
+  });
+}
+
+async function openSheet(page) {
+  await page.goto('http://localhost:8080/admin.html');
+  await page.waitForSelector('.char-card', { timeout: 10000 });
+  await page.locator('.char-card').first().click();
+  await page.waitForSelector('.sh-sec-title', { timeout: 8000 });
 }
 
 async function openEditor(page) {
@@ -204,6 +248,33 @@ test.describe('Issue #335 — Influence and Domain merit bonus dot display', () 
       expect(allies).toBeTruthy();
       expect(allies.bonus).toBe(1);
     }
+  });
+
+});
+
+// ── View-mode tests ───────────────────────────────────────────────────────────
+
+test.describe('Issue #335 — View-mode hollow dot display (bonus pre-set)', () => {
+
+  test.beforeEach(async ({ page }) => {
+    await setupWithBonus(page);
+    await openSheet(page);
+  });
+
+  // ── AC2: Influence merit view mode ─────────────────────────────────────────
+  test('AC2 — Influence merit view mode: hollow dot visible when bonus = 1', async ({ page }) => {
+    const inflSection = page.locator('.sh-sec').filter({ hasText: 'Influence Merits' });
+    await inflSection.waitFor({ timeout: 5000 });
+    const sectionText = await inflSection.textContent();
+    expect((sectionText.match(/○/g) || []).length).toBeGreaterThan(0);
+  });
+
+  // ── AC4: Domain merit view mode ────────────────────────────────────────────
+  test('AC4 — Domain merit view mode: hollow dot visible when bonus = 1', async ({ page }) => {
+    const domSection = page.locator('.sh-sec').filter({ hasText: 'Domain Merits' });
+    await domSection.waitFor({ timeout: 5000 });
+    const sectionText = await domSection.textContent();
+    expect((sectionText.match(/○/g) || []).length).toBeGreaterThan(0);
   });
 
 });


### PR DESCRIPTION
## Summary

- `shRenderInfluenceMerits` and `shRenderDomainMerits` now include `m.bonus` when building the hollow-dot string (●/○), matching the behaviour already present in `shRenderGeneralMerits` after #333
- All changes in `public/js/editor/sheet.js` only — stepper wiring, save handler, and schema whitelist were already complete from #333
- QA caught a formula bug in domain view mode (Task 4b): `mBon` was incorrectly added to `_dRaw` (the filled count), making `de - dPurch` go negative and clamping hollow dots to 0. Fixed by removing `mBon` from `_dRaw` and placing it on the hollow side of `shDotsMixed` instead

## Changes

- **Task 1** — Influence edit mode: `○`.repeat now uses `dd + (m.bonus || 0) - _iPurch`
- **Task 2** — Influence view mode: `iBon` now includes `+ (m.bonus || 0)`
- **Task 3** — Domain edit mode: `○`.repeat now uses `dd + (m.bonus || 0) - _dPurch`
- **Task 4** — Domain view mode: `mBon` declared; added to hollow side of `shDotsMixed` and `_viewStored`; `|| mBon > 0` guard added to the `shDotsMixed` branch condition

## Test plan

- [x] AC1 — Influence edit mode: Bonus ▲ adds hollow dot to `infl-dots-derived` span
- [x] AC1b — Bonus ▲▲ adds two hollow dots; ▼ removes one
- [x] AC2 — Influence view mode: hollow dot visible when bonus = 1
- [x] AC3 — Domain edit mode: Bonus ▲ adds hollow dot to `dom-contrib-lbl` span
- [x] AC4 — Domain view mode: hollow dot visible when bonus = 1
- [x] AC5 — Influence total unchanged after Bonus increment
- [x] AC6 — PUT payload includes `bonus: 1` for Allies
- All 7 Playwright tests pass (`tests/issue-335-influence-domain-merit-bonus-display.spec.js`)

Closes #335

🤖 Generated with [Claude Code](https://claude.com/claude-code)