### PR TITLE
fix(#352): DT Story prompt assembly — player vignette missing, wrong prev-cycle content

### DIFF
--- a/public/js/admin/downtime-story.js
+++ b/public/js/admin/downtime-story.js
@@ -1503,6 +1503,17 @@ function buildTouchstoneContext(char, sub, opts = {}) {
   const touchstones = char?.touchstones || [];
   const playerAspirations = sub.responses?.aspirations || null;
 
+  // Same field priority chain as buildLetterContext — personal_story_text is canonical
+  // post-dt-form.18 (issue #208); legacy keys remain for pre-redesign submissions.
+  const playerVignette =
+    sub.responses?.personal_story_text ||
+    sub.responses?.correspondence ||
+    sub.responses?.letter_to_home ||
+    sub.responses?.letter ||
+    sub.responses?.narrative_letter ||
+    sub.responses?.personal_message ||
+    null;
+
   const lines = ['Draft a Touchstone Vignette for:', '', _compactCharHeader(char)];
   const identLine = _charIdentLine(char);
   if (identLine) lines.push(identLine);
@@ -1518,6 +1529,10 @@ function buildTouchstoneContext(char, sub, opts = {}) {
 
   lines.push('');
   lines.push(`Aspirations: ${playerAspirations ? playerAspirations.trim() : '[No aspirations recorded]'}`);
+
+  lines.push('');
+  lines.push('Player\'s vignette:');
+  lines.push(playerVignette ? playerVignette.trim() : '[No player vignette submitted]');
 
   if (prevVignette) {
     lines.push('');
@@ -3487,16 +3502,17 @@ async function handleCopyStoryMomentContext(btn) {
   }
 
   // ── Format-gated previous content ────────────────────────────────────────
-  // story_moment.format is 'letter' or 'vignette'. Legacy fields are
-  // unambiguous by name (letter_from_home / touchstone).
-  // If story_moment exists but has no format field (old data), neither
-  // gated path fires — legacy fallbacks cover that case.
-  const prevLetterText = (prevStoryMoment?.format === 'letter' && prevStoryMoment.response)
-    ? prevStoryMoment.response
+  // If prevStoryMoment exists it is authoritative — use format-gated value,
+  // null if the wrong format. Legacy fallbacks only activate when prevStoryMoment
+  // is entirely absent (pre-consolidation DT1 data where story_moment was never
+  // written). Without this gate, a DT2 letter's format mismatch fell through to
+  // st_narrative.touchstone.response, causing letter content in the vignette slot.
+  const prevLetterText = prevStoryMoment
+    ? (prevStoryMoment.format === 'letter' && prevStoryMoment.response ? prevStoryMoment.response : null)
     : prevLegacyLetter;
 
-  const prevVignetteText = (prevStoryMoment?.format === 'vignette' && prevStoryMoment.response)
-    ? prevStoryMoment.response
+  const prevVignetteText = prevStoryMoment
+    ? (prevStoryMoment.format === 'vignette' && prevStoryMoment.response ? prevStoryMoment.response : null)
     : prevLegacyVignette;
 
   const targetName = storyMomentTarget?.name || null;

--- a/specs/stories/fix.50.dt-story-prompt-assembly.story.md
+++ b/specs/stories/fix.50.dt-story-prompt-assembly.story.md
@@ -1,0 +1,211 @@
+# Story fix.50: DT Story — prompt assembly missing player submission + wrong previous-cycle content
+
+**Story ID:** fix.50
+**Issue:** #352
+**Issue URL:** https://github.com/angelusvmorningstar/TerraMortis/issues/352
+**Branch:** ms/issue-352-downtime-prompt-dt3-submissions
+**Epic:** Fixes
+**Status:** review
+**Date:** 2026-05-18
+
+---
+
+## User Story
+
+As an ST generating a Copy Context prompt for a player's Letter from Home or Touchstone Vignette, I want the prompt to include the player's current-cycle submission text and the correct previous-cycle output, so that I can draft the narrative with accurate material and not accidentally produce output based on wrong or missing data.
+
+---
+
+## Background
+
+Two bugs in `public/js/admin/downtime-story.js` corrupt the Copy Context prompt for the Story Moment section. Both are in the prompt-assembly and previous-cycle-fetch logic triggered by clicking "Copy Context" on the Story Moment card. Both must be fixed in this story.
+
+### Bug 1 — `buildTouchstoneContext` never includes the player's DT submission text
+
+`buildLetterContext` (line ~1426) correctly reads the player's submission:
+```js
+const playerLetter =
+  sub.responses?.personal_story_text ||
+  sub.responses?.correspondence ||
+  sub.responses?.letter_to_home ||
+  ...
+  null;
+```
+It then writes `Player-submitted letter: [text or sentinel]` into the prompt.
+
+`buildTouchstoneContext` (line ~1500) has **no equivalent**. It reads only `aspirations` from `sub.responses`. The player's DT vignette scene — stored in `personal_story_text` — is silently dropped from the generated prompt.
+
+**Confirmed instance:** Reed Justice DT3 — player submitted a vignette scene (scale-model phone call with mother). The Copy Context prompt contained only DT2 previous-vignette material; no DT3 player content appeared. ST drafted from DT2 by mistake.
+
+**Why it matters:** An empty player-submission field is indistinguishable from "player submitted nothing." When the ST sees no content they may assume the player didn't submit and invent material or carry over the prior cycle. Both outcomes silently ignore player-authored content.
+
+### Bug 2 — Wrong previous-cycle content type in vignette slot
+
+In `handleCopyStoryMomentContext` (line ~3432), previous-cycle content is derived at lines ~3494-3500:
+
+```js
+const prevLetterText = (prevStoryMoment?.format === 'letter' && prevStoryMoment.response)
+  ? prevStoryMoment.response
+  : prevLegacyLetter;
+
+const prevVignetteText = (prevStoryMoment?.format === 'vignette' && prevStoryMoment.response)
+  ? prevStoryMoment.response
+  : prevLegacyVignette;   // ← the bug is here
+```
+
+The fallback `prevLegacyVignette = prevSub.st_narrative?.touchstone?.response`.
+
+If the previous cycle's `story_moment` exists (modern submission — DT2 onwards) **but was a letter** (`format === 'letter'`), the vignette check fails and falls through to `prevLegacyVignette`. If `st_narrative.touchstone.response` was ever populated — by older processing code or as a legacy field — it serves that content as the "previous vignette" even though it contains letter text.
+
+**Confirmed instances:** Julia Dolancia, Ludica Lachramore, Macheath — "previous vignette (DT2)" field contained their DT2 letter text, signed "Yours, Ian" / "Falcone" / "P". The actual DT2 vignette was not loaded.
+
+**Root cause:** When `prevStoryMoment` is present, it should be the authoritative source. If `prevStoryMoment.format === 'letter'`, the character did a letter in the previous cycle — there is no previous vignette to pull. The fallback to legacy fields should only activate when `prevStoryMoment` is entirely absent (pre-consolidation DT1 data).
+
+---
+
+## Files
+
+**Single file, two focused changes:**
+
+- `public/js/admin/downtime-story.js`
+
+No schema, no API, no CSS.
+
+---
+
+## Acceptance Criteria
+
+- [ ] `buildTouchstoneContext` includes the player's DT submission text under a "Player's vignette:" label. When `personal_story_text` (and all fallbacks) are null, it prints `[No player vignette submitted]` — never an empty field.
+- [ ] `buildLetterContext` already prints `[No player letter submitted]` when the player has not submitted — verify this is intact and not regressed.
+- [ ] The previous-cycle vignette field in the Touchstone Vignette prompt is never populated with letter-format content.
+- [ ] When the previous cycle has `story_moment.format === 'letter'`, the vignette prompt omits the "previous vignette" section entirely (no fallback to `st_narrative.touchstone.response`).
+- [ ] When the previous cycle has `story_moment.format === 'vignette'`, the vignette prompt includes the correct `story_moment.response` as the previous vignette.
+- [ ] When the previous cycle has no `story_moment` (legacy DT1 data), existing fallback behaviour is preserved: `prevLegacyLetter` → letter slot, `prevLegacyVignette` → vignette slot.
+- [ ] `_storyMomentNameCheck` validation is unchanged — name-matching still wraps both paths.
+- [ ] The Copy Context button for a letter-format story moment is unaffected (no regression).
+- [ ] The Copy Context buttons for all other sections (projects, territories, patrol, etc.) are unaffected.
+
+---
+
+## Implementation
+
+### Change 1 — `buildTouchstoneContext`: add player submission section
+
+**Location:** `buildTouchstoneContext` function, starting at line ~1500.
+
+Add player vignette extraction using the **same field priority chain** as `buildLetterContext`. Both use `personal_story_text` as the primary key (comment at line ~1573 explains why: dt-form.18 collapsed the personal-story narrative to this field):
+
+```js
+const playerVignette =
+  sub.responses?.personal_story_text ||
+  sub.responses?.correspondence ||
+  sub.responses?.letter_to_home ||
+  sub.responses?.letter ||
+  sub.responses?.narrative_letter ||
+  sub.responses?.personal_message ||
+  null;
+```
+
+Then, after the Aspirations line and before the `prevVignette` block:
+
+```js
+lines.push('');
+lines.push('Player\'s vignette:');
+lines.push(playerVignette ? playerVignette.trim() : '[No player vignette submitted]');
+```
+
+Place it in the same position as "Player-submitted letter" in `buildLetterContext` (after aspirations, before previous-cycle content).
+
+### Change 2 — `handleCopyStoryMomentContext`: authoritative previous-cycle source gate
+
+**Location:** Lines ~3494-3500 in `handleCopyStoryMomentContext`.
+
+Replace the current fallback logic:
+
+```js
+// BEFORE (buggy):
+const prevLetterText = (prevStoryMoment?.format === 'letter' && prevStoryMoment.response)
+  ? prevStoryMoment.response
+  : prevLegacyLetter;
+
+const prevVignetteText = (prevStoryMoment?.format === 'vignette' && prevStoryMoment.response)
+  ? prevStoryMoment.response
+  : prevLegacyVignette;
+```
+
+```js
+// AFTER (fixed):
+// If prevStoryMoment exists, it is authoritative. Use format-gated value; null if wrong format.
+// Only fall back to legacy fields when prevStoryMoment is entirely absent (pre-DT2 data).
+const prevLetterText = prevStoryMoment
+  ? (prevStoryMoment.format === 'letter' && prevStoryMoment.response ? prevStoryMoment.response : null)
+  : prevLegacyLetter;
+
+const prevVignetteText = prevStoryMoment
+  ? (prevStoryMoment.format === 'vignette' && prevStoryMoment.response ? prevStoryMoment.response : null)
+  : prevLegacyVignette;
+```
+
+The `_storyMomentNameCheck` calls on lines ~3503-3504 and the downstream branching are unchanged.
+
+---
+
+## Dev Notes
+
+### Field naming context
+
+`personal_story_text` is the canonical player narrative field post-dt-form.18 (issue #208). The legacy chain (`correspondence`, `letter_to_home`, etc.) exists for pre-redesign submissions that predate the field rename. Use the full chain in both builders; do not shorten it.
+
+### Why the legacy fallback must be gated by `prevStoryMoment === null`
+
+DT2 submissions used the new `story_moment` field. Some characters also have residual content in `st_narrative.touchstone.response` from DT1 or from the old code path that predates the format consolidation. If a DT2 submission is a letter (`story_moment.format = 'letter'`), `st_narrative.touchstone.response` should be ignored entirely for the previous-cycle vignette slot — the character had no vignette that cycle. The old code's fallthrough caused that legacy residual to appear as "previous vignette".
+
+### `renderStoryMoment` already shows the player submission correctly in the UI
+
+The context block at line ~1634-1641 reads `playerLetter` from `personal_story_text` and renders it under "Player's letter:". The bug is exclusively in the **Copy Context prompt** (`buildTouchstoneContext`), not in the rendered panel. The UI display is correct; only the clipboard text is broken.
+
+### Issue #341 is a related but separate bug
+
+Issue #341 (`story_moment_format` radio ignoring `personal_story_kind`) means the radio may default to 'letter' even when the player submitted a vignette. That story is tracked separately. This story (fix.50) fixes the prompt content bugs regardless of which radio the ST has selected.
+
+### Operational note (not code)
+
+Any DT3 prompts already generated and copied this cycle that were affected by these bugs will need to be re-copied after the fix is deployed. The ST should check:
+- Any character whose DT3 Copy Context was used but whose player submitted a vignette scene.
+- Any character whose "previous vignette" field looked like a signed letter.
+
+These are manual re-copy actions. No code change is required for this.
+
+---
+
+## Testing
+
+Manual test cases (no automated test framework):
+
+1. **Bug 1 — player vignette present:**
+   - Open a DT3 submission where the player submitted a vignette scene (`personal_story_text` is non-empty, `personal_story_kind = 'touchstone'`).
+   - Select the "Touchstone Vignette" radio on the Story Moment card.
+   - Click "Copy Context" and paste into a text editor.
+   - Verify "Player's vignette:" section appears with the player's text verbatim.
+
+2. **Bug 1 — no player vignette:**
+   - Find or create a submission where `personal_story_text` is null.
+   - Same steps. Verify "Player's vignette: [No player vignette submitted]" appears.
+
+3. **Bug 1 — letter path not regressed:**
+   - Select "Letter from Home" radio on a submission with player text.
+   - Copy Context. Verify "Player-submitted letter:" still appears correctly.
+
+4. **Bug 2 — previous cycle was letter, vignette field now empty:**
+   - Open a DT3 character whose DT2 story moment was a letter.
+   - Select "Touchstone Vignette" radio. Copy Context.
+   - Verify "Previous vignette with this touchstone (Downtime 2):" does **not** appear (or the vignette section is absent entirely).
+   - Verify no signed-off letter content appears in the prompt.
+
+5. **Bug 2 — previous cycle was vignette, loads correctly:**
+   - Open a DT3 character whose DT2 story moment was a vignette.
+   - Copy Context (vignette mode). Verify "Previous vignette with this touchstone (Downtime 2):" appears with the correct vignette text.
+
+6. **Regression — Copy Context for project/territory/feeding sections:**
+   - Spot-check Copy Context on a project action and a territory section.
+   - Verify content is unaffected.

--- a/specs/stories/sprint-status.yaml
+++ b/specs/stories/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-15
-# last_updated: 2026-05-14 (issue-297 + issue-300 marked done; Barrens slug fix committed to dev; issue-302 + issue-303 done)
+# last_updated: 2026-05-18 (issue-352 fix.50 story created: dt-story prompt assembly — missing player vignette + wrong prev-cycle content; issue-297 + issue-300 marked done; Barrens slug fix committed to dev; issue-302 + issue-303 done)
 # project: TM Suite
 # project_key: NOKEY
 # tracking_system: file-system
@@ -790,3 +790,4 @@ development_status:
   issue-330-ambience-underfeeding-bonus: done                # overfeedVal only calculates penalty; add feeders < cap ? (cap-feeders) : 0 branch; update display in _buildAmbienceHtml line 10357
   issue-331-disc-profile-oid-key: done                      # recomputeDisciplineProfile writes slug-keyed profile; renderer expects OID-keyed (ADR-002); fix: ensureTerritories + slugToOid map in writer
   issue-332-territory-pulse-influence-exceptional: done      # _buildTerritoryPulsePromptText gains influence contributors (pos/neg) and exceptional ambience project sections; clan+covenant included for vibe
+  issue-352-dt-story-prompt-assembly: review                 # fix.50: buildTouchstoneContext missing player vignette text (personal_story_text never read); prevVignetteText falls through to legacy when prevStoryMoment exists as letter-format — causes letter content in vignette slot

--- a/tests/issue-352-dt-story-prompt-assembly.spec.js
+++ b/tests/issue-352-dt-story-prompt-assembly.spec.js
@@ -1,0 +1,283 @@
+/**
+ * issue-352: DT Story prompt assembly — missing player vignette + wrong previous-cycle content.
+ *
+ * Validates both bugs fixed in fix.50:
+ *
+ *   Bug 1 — buildTouchstoneContext never read personal_story_text. The player's
+ *   DT vignette scene was silently absent from the generated Copy Context prompt.
+ *
+ *   Bug 2 — prevVignetteText fell back to st_narrative.touchstone.response even
+ *   when prevStoryMoment existed as a letter (format='letter'). Legacy letter
+ *   content ended up in the "previous vignette" slot.
+ *
+ * Test scenarios:
+ *   1. Bug 1 — vignette Copy Context includes player's submission text verbatim.
+ *   2. Bug 1 — vignette Copy Context shows sentinel when player has not submitted.
+ *   3. Bug 1 — letter Copy Context is not regressed (player text still present).
+ *   4. Bug 2 — prev cycle was letter → "Previous vignette" section absent from vignette prompt.
+ *   5. Bug 2 — prev cycle was vignette → "Previous vignette" section present with correct text.
+ *   6. Bug 2 — prev cycle letter → letter Copy Context still shows prev letter correctly.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Shared stubs ───────────────────────────────────────────────────────────────
+
+const ST_USER = {
+  id: '352000001', username: 'test_st', global_name: 'Test ST',
+  avatar: null, role: 'st', player_id: 'p-352', character_ids: [], is_dual_role: false,
+};
+
+const CHAR_REED = {
+  _id: 'char-reed-352', name: 'Reed Justice', moniker: null, honorific: null,
+  clan: 'Mekhet', covenant: 'Carthian Movement', player: 'Reed Player',
+  blood_potency: 2, humanity: 7, humanity_base: 7, court_title: null, retired: false,
+  mask: 'Bon Vivant', dirge: 'Idealist',
+  status: {
+    city: 1, clan: 0,
+    covenant: { 'Carthian Movement': 1, 'Circle of the Crone': 0, 'Invictus': 0, 'Lancea et Sanctum': 0, 'Ordo Dracul': 0 },
+  },
+  attributes: {
+    Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+    Intelligence: { dots: 3, bonus: 0 }, Wits: { dots: 3, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+    Presence: { dots: 3, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: {}, disciplines: {}, merits: [], powers: [], ordeals: [],
+  touchstones: [{ name: 'His Mother', humanity: 7, desc: 'Retired schoolteacher' }],
+};
+
+// DT2 and DT3 cycles. game_number is used by handleCopyStoryMomentContext to find
+// "the cycle with game_number one less than the current one".
+const DT2_CYCLE = {
+  _id: 'cycle-352-dt2', game_number: 2, status: 'closed',
+  cycle_number: 2, submission_count: 1, phase_signoff: {},
+  confirmed_ambience: {}, narrative_notes: '', label: 'Downtime 2',
+};
+
+const DT3_CYCLE = {
+  _id: 'cycle-352-dt3', game_number: 3, status: 'active',
+  cycle_number: 3, submission_count: 1, phase_signoff: {},
+  confirmed_ambience: {}, narrative_notes: '', label: 'Downtime 3',
+};
+
+// ── Submission builders ────────────────────────────────────────────────────────
+
+/** DT3 submission. personal_story_text drives the player-submission section. */
+function makeDt3Sub({ personalStoryText = null } = {}) {
+  return {
+    _id: 'sub-352-dt3-reed',
+    cycle_id: DT3_CYCLE._id,
+    character_name: 'Reed Justice',
+    character_id: CHAR_REED._id,
+    player_name: 'Reed Player',
+    submitted_at: '2026-05-17T00:00:00Z',
+    _raw: { projects: [], feeding: null, sphere_actions: [], contact_actions: { requests: [] }, retainer_actions: { actions: [] } },
+    responses: {
+      ...(personalStoryText ? { personal_story_text: personalStoryText } : {}),
+    },
+    projects_resolved: [],
+    feeding_review: null,
+    merit_actions_resolved: [],
+    st_review: { territory_overrides: {} },
+    st_narrative: {},
+  };
+}
+
+/**
+ * DT2 submission. stNarrative shapes the previous-cycle content.
+ *
+ * Bug 2 trigger: both story_moment (format='letter') AND touchstone.response set.
+ * The bug caused touchstone.response to bleed into the vignette slot for DT3.
+ */
+function makeDt2Sub(stNarrative = {}) {
+  return {
+    _id: 'sub-352-dt2-reed',
+    cycle_id: DT2_CYCLE._id,
+    character_name: 'Reed Justice',
+    character_id: CHAR_REED._id,
+    player_name: 'Reed Player',
+    submitted_at: '2026-05-10T00:00:00Z',
+    _raw: { projects: [], feeding: null, sphere_actions: [], contact_actions: { requests: [] }, retainer_actions: { actions: [] } },
+    responses: {},
+    projects_resolved: [],
+    feeding_review: null,
+    merit_actions_resolved: [],
+    st_review: { territory_overrides: {} },
+    st_narrative: stNarrative,
+  };
+}
+
+// ── Page setup helpers ─────────────────────────────────────────────────────────
+
+/** Stub clipboard so tests can read what was written without permissions. */
+function addClipboardStub(page) {
+  return page.addInitScript(() => {
+    window.__lastClipboardText = null;
+    const stub = {
+      writeText(text) {
+        window.__lastClipboardText = text;
+        return Promise.resolve();
+      },
+      readText() {
+        return Promise.resolve(window.__lastClipboardText || '');
+      },
+    };
+    try {
+      Object.defineProperty(navigator, 'clipboard', { get: () => stub, configurable: true });
+    } catch {
+      navigator.clipboard = stub;
+    }
+  });
+}
+
+async function setupPage(page, { dt3Sub, dt2Sub = null } = {}) {
+  await addClipboardStub(page);
+
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'local-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url = route.request().url();
+    const method = route.request().method();
+    const ok = body => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+
+    if (method === 'PUT' || method === 'PATCH' || method === 'POST') return ok({ ok: true });
+
+    if (url.includes('/api/downtime_submissions')) {
+      const m = url.match(/[?&]cycle_id=([^&]+)/);
+      if (m) {
+        const cid = decodeURIComponent(m[1]);
+        if (cid === DT3_CYCLE._id) return ok([dt3Sub]);
+        if (cid === DT2_CYCLE._id) return ok(dt2Sub ? [dt2Sub] : []);
+      }
+      return ok([dt3Sub]);
+    }
+    if (url.includes('/api/downtime_cycles')) return ok([DT3_CYCLE, DT2_CYCLE]);
+    if (url.includes('/api/characters/names')) return ok([
+      { _id: CHAR_REED._id, name: CHAR_REED.name, moniker: null, honorific: null },
+    ]);
+    if (url.includes('/api/characters'))  return ok([CHAR_REED]);
+    if (url.includes('/api/territories')) return ok([]);
+    if (url.includes('/api/game_sessions')) return ok([]);
+    if (url.includes('/api/session_logs')) return ok([]);
+    if (url.includes('/api/relationships')) return ok(null);
+    if (url.includes('/api/npcs')) return ok([]);
+    return ok([]);
+  });
+
+  await page.goto('/admin.html');
+  await page.waitForSelector('#admin-app', { state: 'visible', timeout: 10000 });
+  await page.click('[data-domain="downtime"]');
+  await page.waitForSelector('#dt-phase-ribbon', { state: 'visible', timeout: 8000 });
+
+  // Open DT Story tab.
+  await page.click('#dt-phase-ribbon .pr-tab[data-phase="story"]');
+  await page.waitForSelector('#dt-story-panel', { state: 'visible', timeout: 5000 });
+
+  // Wait for nav rail to populate.
+  await page.waitForFunction(() => {
+    const rail = document.getElementById('dt-story-nav-rail');
+    return rail && rail.querySelector('.dt-story-pill') !== null;
+  }, { timeout: 5000 });
+
+  // Select Reed's pill to load the character view.
+  await page.locator('.dt-story-pill[data-char-id="char-reed-352"]').click();
+  await page.waitForSelector('.dt-story-char-content', { state: 'visible', timeout: 5000 });
+}
+
+/** Read the clipboard stub value after a Copy Context click. */
+async function captureCtxClick(page, format) {
+  // Select the radio for this format.
+  await page.locator(`input[name="story-moment-format"][value="${format}"]`).check();
+
+  const copyBtn = page.locator('.dt-story-section[data-section="story_moment"] .dt-story-copy-ctx-btn');
+  await copyBtn.click();
+
+  // Wait for the success feedback — clipboard write is async.
+  await expect(copyBtn).toHaveText('Copied!', { timeout: 5000 });
+
+  return page.evaluate(() => window.__lastClipboardText);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+test.describe('issue-352: DT Story prompt assembly', () => {
+
+  test('Bug 1 — vignette Copy Context includes player submission text verbatim', async ({ page }) => {
+    const dt3Sub = makeDt3Sub({ personalStoryText: 'The call connects on the second ring. You hear her voice, thin and bright.' });
+    await setupPage(page, { dt3Sub });
+
+    const text = await captureCtxClick(page, 'vignette');
+
+    expect(text).toContain("Player's vignette:");
+    expect(text).toContain('The call connects on the second ring. You hear her voice, thin and bright.');
+    expect(text).not.toContain('[No player vignette submitted]');
+  });
+
+  test('Bug 1 — vignette Copy Context shows sentinel when player has not submitted', async ({ page }) => {
+    const dt3Sub = makeDt3Sub({ personalStoryText: null });
+    await setupPage(page, { dt3Sub });
+
+    const text = await captureCtxClick(page, 'vignette');
+
+    expect(text).toContain("Player's vignette:");
+    expect(text).toContain('[No player vignette submitted]');
+  });
+
+  test('Bug 1 — letter Copy Context still shows player letter (regression check)', async ({ page }) => {
+    const dt3Sub = makeDt3Sub({ personalStoryText: 'Dear Mother,\n\nI am well.\n\nYours, Reed' });
+    await setupPage(page, { dt3Sub });
+
+    const text = await captureCtxClick(page, 'letter');
+
+    expect(text).toContain('Player-submitted letter:');
+    expect(text).toContain('Dear Mother,');
+    expect(text).not.toContain('[No player letter submitted]');
+  });
+
+  test('Bug 2 — prev cycle was letter: "Previous vignette" section absent from vignette prompt', async ({ page }) => {
+    // DT2 was a letter. Legacy touchstone.response also set — this was the bug trigger.
+    const dt2Sub = makeDt2Sub({
+      story_moment: { format: 'letter', response: 'Dear Marcus,\n\nYours, Reed.', status: 'complete' },
+      touchstone:   { response: 'Dear Marcus,\n\nYours, Reed (legacy copy).' },
+    });
+    const dt3Sub = makeDt3Sub({ personalStoryText: 'You watch the warehouse from across the street.' });
+    await setupPage(page, { dt3Sub, dt2Sub });
+
+    const text = await captureCtxClick(page, 'vignette');
+
+    expect(text).not.toContain('Previous vignette with this touchstone');
+    // Specifically verify the letter content did not bleed through.
+    expect(text).not.toContain('Yours, Reed');
+  });
+
+  test('Bug 2 — prev cycle was vignette: "Previous vignette" section present with correct text', async ({ page }) => {
+    const dt2Sub = makeDt2Sub({
+      story_moment: { format: 'vignette', response: 'You stand at the chain-link fence, watching the lights go out one by one.', status: 'complete' },
+    });
+    const dt3Sub = makeDt3Sub({ personalStoryText: 'You watch the warehouse from across the street.' });
+    await setupPage(page, { dt3Sub, dt2Sub });
+
+    const text = await captureCtxClick(page, 'vignette');
+
+    expect(text).toContain('Previous vignette with this touchstone (Downtime 2):');
+    expect(text).toContain('You stand at the chain-link fence, watching the lights go out one by one.');
+  });
+
+  test('Bug 2 — prev cycle was letter: letter Copy Context still shows prev letter (regression)', async ({ page }) => {
+    const dt2Sub = makeDt2Sub({
+      story_moment: { format: 'letter', response: 'Dear Reed,\n\nYours, Marcus.', status: 'complete' },
+    });
+    const dt3Sub = makeDt3Sub({ personalStoryText: 'Dear Marcus,\n\nI have been thinking.' });
+    await setupPage(page, { dt3Sub, dt2Sub });
+
+    const text = await captureCtxClick(page, 'letter');
+
+    expect(text).toContain('Previous letter from this correspondent (Downtime 2):');
+    expect(text).toContain('Yours, Marcus.');
+  });
+
+});


### PR DESCRIPTION
## Summary

- `buildTouchstoneContext` never read `personal_story_text`, so the player's DT vignette scene was silently absent from every Copy Context prompt — ST had no way to distinguish "player didn't submit" from "submission failed to load"
- Previous-cycle vignette slot fell through to `st_narrative.touchstone.response` when `prevStoryMoment` existed as a letter, causing signed letter text (Yours, Ian / Falcone / P) to appear as "previous vignette"
- Fix: gate both prev-cycle slots on `prevStoryMoment` presence — if the field exists, it is authoritative; null out the wrong-format slot rather than falling back to legacy fields

## Closes

- Closes #352

## Story

- specs/stories/fix.50.dt-story-prompt-assembly.story.md

## ADR / Design

_None_

## Test plan

- [ ] `npx playwright test tests/issue-352-dt-story-prompt-assembly.spec.js` — 6 tests, all green
- [ ] CI green
- [ ] Manual: open a DT3 character whose DT2 story_moment was a letter → select Touchstone Vignette radio → Copy Context → confirm no letter content in "previous vignette" slot; confirm "Player's vignette:" section appears with submission text

## Branch flow

- From: `ms/issue-352-downtime-prompt-dt3-submissions`
- Into: `dev`