### PR TITLE
feat(#358): STM-1 backend st_mods + st_mod_audit CRUD + audit log

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -32,6 +32,7 @@ import {
 } from './routes/rules-engine.js';
 import adminMigrationsRouter from './routes/admin-migrations.js';
 import contestedRollsRouter from './routes/contested-rolls.js';
+import stModsRouter, { auditRouter as stModAuditRouter } from './routes/st_mods.js';
 import { attachWS } from './ws.js';
 // NOTE: The old /api/pdf route was removed. Character sheet PDFs are now
 // rendered client-side via public/js/print/. See
@@ -152,6 +153,11 @@ app.use('/api/npcs', requireAuth, noCache(), npcsRouter);
 app.use('/api/relationships', requireAuth, noCache(), relationshipsRouter);
 app.use('/api/npc-flags', requireAuth, noCache(), npcFlagsRouter);
 app.use('/api/admin', requireAuth, requireRole('st'), noCache(), adminMigrationsRouter);
+// Epic STM (issue #358): ST mod overlay foundation. ST-auth gated at the
+// router level (requireRole('st')); requireAuth must run first to populate
+// req.user. no-cache since mods mutate frequently from the admin panel.
+app.use('/api/st_mods', requireAuth, noCache(), stModsRouter);
+app.use('/api/st_mod_audit', requireAuth, noCache(), stModAuditRouter);
 
 // Start server first, then attempt DB connection
 // Server must be reachable even if MongoDB is unavailable

--- a/server/routes/st_mods.js
+++ b/server/routes/st_mods.js
@@ -1,0 +1,172 @@
+import { Router } from 'express';
+import { ObjectId } from 'mongodb';
+import { getCollection } from '../db.js';
+import { requireRole } from '../middleware/auth.js';
+
+const router = Router();
+const mods = () => getCollection('st_mods');
+const audit = () => getCollection('st_mod_audit');
+
+// Canonical attribute/skill lists — mirror public/js/data/constants.js
+// (Capitalised — that's how they're keyed on the character document; the
+// lowercase examples in ADR-004 §D3 were illustrative, not normative.)
+const ATTRS = [
+  'Intelligence', 'Wits', 'Resolve',
+  'Strength', 'Dexterity', 'Stamina',
+  'Presence', 'Manipulation', 'Composure',
+];
+const SKILLS = [
+  'Academics', 'Computer', 'Crafts', 'Investigation', 'Medicine', 'Occult', 'Politics', 'Science',
+  'Athletics', 'Brawl', 'Drive', 'Firearms', 'Larceny', 'Stealth', 'Survival', 'Weaponry',
+  'Animal Ken', 'Empathy', 'Expression', 'Intimidation', 'Persuasion', 'Socialise', 'Streetwise', 'Subterfuge',
+];
+
+// Static stat_path whitelist. Sourced from ADR-004 §D3, with field-name
+// corrections per the §Concerns Item 4 hand-off:
+//   - PRD example `current.damage / current.willpower / current.vitae` does NOT
+//     resolve on the character document — those values live in the separate
+//     `tracker_state` collection, not on the character. The overlay is a
+//     character-render feature (ADR-004 §D1), so the whitelist surfaces only
+//     character-document fields. Current state slots that exist on the char doc:
+//     `blood_potency` and `humanity` (both top-level).
+//   - Damage/wp-current/vitae-current can be re-added later if a future story
+//     extends the overlay into the tracker render path.
+const STATIC_WHITELIST = new Set([
+  ...ATTRS.flatMap(a => [`attributes.${a}.dots`, `attributes.${a}.bonus`]),
+  ...SKILLS.flatMap(s => [`skills.${s}.dots`, `skills.${s}.bonus`]),
+  'blood_potency',
+  'humanity',
+  'derived.defence',
+  'derived.health_max',
+  'derived.willpower_max',
+  'derived.size',
+  'derived.speed',
+  'derived.initiative',
+]);
+
+const DYNAMIC_PATH_RE = /^(merits|disciplines)\.[0-9]+\.dots$/;
+
+function isValidStatPath(p) {
+  return typeof p === 'string' && (STATIC_WHITELIST.has(p) || DYNAMIC_PATH_RE.test(p));
+}
+
+function parseId(id) {
+  try { return new ObjectId(id); } catch { return null; }
+}
+
+function nowIso() { return new Date().toISOString(); }
+
+function creatorFromUser(user) {
+  return {
+    discord_id: String(user?.id || ''),
+    discord_name: user?.global_name || user?.username || '',
+  };
+}
+
+// ─── POST /api/st_mods ───────────────────────────────────────────────
+// Creates an st_mod and a paired st_mod_audit row in the same handler.
+// Sequential write with best-effort rollback on audit failure (no Mongo
+// transaction — v1 acceptable per story §Tasks Task 3).
+router.post('/', requireRole('st'), async (req, res) => {
+  const { character_id, stat_path, delta, reason, show_reason_to_player } = req.body || {};
+
+  if (!character_id || typeof character_id !== 'string') {
+    return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'character_id is required' });
+  }
+  if (!Number.isInteger(delta)) {
+    return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'delta must be integer' });
+  }
+  const trimmedReason = typeof reason === 'string' ? reason.trim() : '';
+  if (!trimmedReason) {
+    return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'reason is required' });
+  }
+  if (!isValidStatPath(stat_path)) {
+    return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'invalid stat_path', stat_path });
+  }
+
+  const createdBy = creatorFromUser(req.user);
+  const createdAt = nowIso();
+
+  const modDoc = {
+    character_id: String(character_id),
+    stat_path,
+    delta,
+    reason: trimmedReason,
+    show_reason_to_player: !!show_reason_to_player,
+    created_by: createdBy,
+    created_at: createdAt,
+  };
+
+  const modResult = await mods().insertOne(modDoc);
+  const modId = modResult.insertedId;
+
+  // Audit row mirrors the mod (minus show_reason_to_player, per AC#2) and
+  // references the mod by st_mod_id so revoke-time matching is trivial.
+  const auditDoc = {
+    st_mod_id: modId,
+    character_id: String(character_id),
+    stat_path,
+    delta,
+    reason: trimmedReason,
+    created_by: createdBy,
+    created_at: createdAt,
+  };
+
+  try {
+    await audit().insertOne(auditDoc);
+  } catch (err) {
+    // Best-effort rollback: drop the mod so we don't leave an unrecoverable
+    // mod with no audit trail. Audit-survives-revoke is the load-bearing
+    // contract; audit-survives-failed-insert isn't.
+    try { await mods().deleteOne({ _id: modId }); } catch { /* best-effort */ }
+    console.error('[st_mods] audit insert failed, rolled back mod:', err);
+    return res.status(500).json({ error: 'INTERNAL_ERROR', message: 'Failed to write audit row' });
+  }
+
+  const created = await mods().findOne({ _id: modId });
+  res.status(201).json(created);
+});
+
+// ─── GET /api/st_mods?character_id=:id ───────────────────────────────
+// Active mods for a character, oldest first (creation order — multi-mod
+// stack downstream renders top-to-bottom in this order).
+router.get('/', requireRole('st'), async (req, res) => {
+  const { character_id } = req.query;
+  if (!character_id || typeof character_id !== 'string') {
+    return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'character_id is required' });
+  }
+  const docs = await mods()
+    .find({ character_id: String(character_id) })
+    .sort({ created_at: 1 })
+    .toArray();
+  res.json(docs);
+});
+
+// ─── DELETE /api/st_mods/:id ─────────────────────────────────────────
+// Hard-delete the mod. Audit row is intentionally LEFT IN PLACE.
+router.delete('/:id', requireRole('st'), async (req, res) => {
+  const oid = parseId(req.params.id);
+  if (!oid) return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid ID' });
+  const result = await mods().deleteOne({ _id: oid });
+  if (!result.deletedCount) return res.status(404).json({ error: 'NOT_FOUND' });
+  res.json({ deleted: true });
+});
+
+export default router;
+
+// ─── GET /api/st_mod_audit?character_id=:id ──────────────────────────
+// Mounted as its own router by server/index.js so the path namespace
+// stays clean (POST/GET/DELETE /api/st_mods + GET /api/st_mod_audit).
+export const auditRouter = Router();
+
+auditRouter.get('/', requireRole('st'), async (req, res) => {
+  const { character_id } = req.query;
+  if (!character_id || typeof character_id !== 'string') {
+    return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'character_id is required' });
+  }
+  const docs = await audit()
+    .find({ character_id: String(character_id) })
+    .sort({ created_at: 1 })
+    .toArray();
+  res.json(docs);
+});

--- a/server/tests/api-st-mods.test.js
+++ b/server/tests/api-st-mods.test.js
@@ -1,0 +1,291 @@
+/**
+ * API tests — /api/st_mods + /api/st_mod_audit (Epic STM, issue #358)
+ *
+ * Covers AC#1..#8 from specs/stories/issue-358-stm-1-backend-st-mods.story.md.
+ * In place of the literal curl smoke (AC#8): the create → list → revoke →
+ * audit-survives sequence runs as the first test in this file, top to bottom,
+ * so its output is the smoke artefact.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { ObjectId } from 'mongodb';
+import { createTestApp, stUser, playerUser } from './helpers/test-app.js';
+import { setupDb, teardownDb } from './helpers/db-setup.js';
+import { getCollection } from '../db.js';
+
+let app;
+const CHAR_ID = new ObjectId().toHexString();
+const CREATED_MOD_IDS = [];
+const CREATED_AUDIT_IDS = [];
+
+beforeAll(async () => {
+  await setupDb();
+  app = createTestApp();
+  // Clean any prior test residue for this character (idempotent across runs).
+  await getCollection('st_mods').deleteMany({ character_id: CHAR_ID });
+  await getCollection('st_mod_audit').deleteMany({ character_id: CHAR_ID });
+});
+
+afterAll(async () => {
+  if (CREATED_MOD_IDS.length) {
+    await getCollection('st_mods').deleteMany({
+      _id: { $in: CREATED_MOD_IDS.map(id => new ObjectId(id)) },
+    });
+  }
+  if (CREATED_AUDIT_IDS.length) {
+    await getCollection('st_mod_audit').deleteMany({
+      _id: { $in: CREATED_AUDIT_IDS.map(id => new ObjectId(id)) },
+    });
+  }
+  // Also clear any audit rows tied to the test character — these survive
+  // mod deletion by design (AC#5) so the _id-based cleanup above misses them
+  // when the test under "audit survives revoke" already deleted the mod.
+  await getCollection('st_mod_audit').deleteMany({ character_id: CHAR_ID });
+  await teardownDb();
+});
+
+// ── End-to-end smoke (AC#8) ──────────────────────────────────────────
+
+describe('AC#8 — end-to-end smoke (create → list → revoke → audit survives)', () => {
+  it('walks the full lifecycle', async () => {
+    // 1. CREATE
+    const createRes = await request(app)
+      .post('/api/st_mods')
+      .set('X-Test-User', stUser())
+      .send({
+        character_id: CHAR_ID,
+        stat_path: 'attributes.Strength.dots',
+        delta: 1,
+        reason: 'Smoke-test grant',
+        show_reason_to_player: true,
+      });
+    expect(createRes.status).toBe(201);
+    expect(createRes.body._id).toBeTruthy();
+    expect(createRes.body.delta).toBe(1);
+    expect(createRes.body.stat_path).toBe('attributes.Strength.dots');
+    expect(createRes.body.show_reason_to_player).toBe(true);
+    expect(createRes.body.created_by).toMatchObject({ discord_id: 'test-st-001' });
+    const modId = createRes.body._id;
+    CREATED_MOD_IDS.push(modId);
+
+    // 2. LIST (active mods for the character)
+    const listRes = await request(app)
+      .get(`/api/st_mods?character_id=${CHAR_ID}`)
+      .set('X-Test-User', stUser());
+    expect(listRes.status).toBe(200);
+    expect(Array.isArray(listRes.body)).toBe(true);
+    expect(listRes.body.find(m => String(m._id) === String(modId))).toBeTruthy();
+
+    // 3. REVOKE (hard-delete)
+    const delRes = await request(app)
+      .delete(`/api/st_mods/${modId}`)
+      .set('X-Test-User', stUser());
+    expect(delRes.status).toBe(200);
+    expect(delRes.body).toEqual({ deleted: true });
+
+    // 4. CONFIRM gone from st_mods
+    const listAfter = await request(app)
+      .get(`/api/st_mods?character_id=${CHAR_ID}`)
+      .set('X-Test-User', stUser());
+    expect(listAfter.status).toBe(200);
+    expect(listAfter.body.find(m => String(m._id) === String(modId))).toBeUndefined();
+
+    // 5. AUDIT SURVIVES (AC#5, AC#6)
+    const auditRes = await request(app)
+      .get(`/api/st_mod_audit?character_id=${CHAR_ID}`)
+      .set('X-Test-User', stUser());
+    expect(auditRes.status).toBe(200);
+    const auditRow = auditRes.body.find(a => String(a.st_mod_id) === String(modId));
+    expect(auditRow).toBeTruthy();
+    expect(auditRow.stat_path).toBe('attributes.Strength.dots');
+    expect(auditRow.delta).toBe(1);
+    expect(auditRow.reason).toBe('Smoke-test grant');
+    // AC#2: audit row shape = mod minus show_reason_to_player
+    expect(auditRow.show_reason_to_player).toBeUndefined();
+    CREATED_AUDIT_IDS.push(auditRow._id);
+  });
+});
+
+// ── Auth (AC#7) ──────────────────────────────────────────────────────
+
+describe('AC#7 — authentication', () => {
+  it('401 on GET /api/st_mods without auth', async () => {
+    const res = await request(app).get(`/api/st_mods?character_id=${CHAR_ID}`);
+    expect(res.status).toBe(401);
+  });
+  it('401 on POST /api/st_mods without auth', async () => {
+    const res = await request(app).post('/api/st_mods').send({});
+    expect(res.status).toBe(401);
+  });
+  it('401 on DELETE /api/st_mods/:id without auth', async () => {
+    const res = await request(app).delete(`/api/st_mods/${new ObjectId().toHexString()}`);
+    expect(res.status).toBe(401);
+  });
+  it('401 on GET /api/st_mod_audit without auth', async () => {
+    const res = await request(app).get(`/api/st_mod_audit?character_id=${CHAR_ID}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('403 to non-ST callers (player) on POST', async () => {
+    const res = await request(app)
+      .post('/api/st_mods')
+      .set('X-Test-User', playerUser([CHAR_ID]))
+      .send({ character_id: CHAR_ID, stat_path: 'attributes.Wits.dots', delta: 1, reason: 'x' });
+    expect(res.status).toBe(403);
+  });
+  it('403 to non-ST callers (player) on GET', async () => {
+    const res = await request(app)
+      .get(`/api/st_mods?character_id=${CHAR_ID}`)
+      .set('X-Test-User', playerUser([CHAR_ID]));
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── Validation (AC#3) ────────────────────────────────────────────────
+
+describe('AC#3 — input validation', () => {
+  it('400 when delta is non-integer (float)', async () => {
+    const res = await request(app).post('/api/st_mods').set('X-Test-User', stUser()).send({
+      character_id: CHAR_ID, stat_path: 'attributes.Wits.dots', delta: 1.5, reason: 'x',
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/delta must be integer/);
+  });
+  it('400 when delta is string', async () => {
+    const res = await request(app).post('/api/st_mods').set('X-Test-User', stUser()).send({
+      character_id: CHAR_ID, stat_path: 'attributes.Wits.dots', delta: '1', reason: 'x',
+    });
+    expect(res.status).toBe(400);
+  });
+  it('400 when delta is null', async () => {
+    const res = await request(app).post('/api/st_mods').set('X-Test-User', stUser()).send({
+      character_id: CHAR_ID, stat_path: 'attributes.Wits.dots', delta: null, reason: 'x',
+    });
+    expect(res.status).toBe(400);
+  });
+  it('400 when reason is empty', async () => {
+    const res = await request(app).post('/api/st_mods').set('X-Test-User', stUser()).send({
+      character_id: CHAR_ID, stat_path: 'attributes.Wits.dots', delta: 1, reason: '',
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/reason is required/);
+  });
+  it('400 when reason is whitespace only', async () => {
+    const res = await request(app).post('/api/st_mods').set('X-Test-User', stUser()).send({
+      character_id: CHAR_ID, stat_path: 'attributes.Wits.dots', delta: 1, reason: '   ',
+    });
+    expect(res.status).toBe(400);
+  });
+  it('400 when stat_path is off-whitelist', async () => {
+    const res = await request(app).post('/api/st_mods').set('X-Test-User', stUser()).send({
+      character_id: CHAR_ID, stat_path: 'bogus.field.path', delta: 1, reason: 'x',
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/invalid stat_path/);
+  });
+  it('accepts merits[N].dots regex path', async () => {
+    const res = await request(app).post('/api/st_mods').set('X-Test-User', stUser()).send({
+      character_id: CHAR_ID, stat_path: 'merits.3.dots', delta: 1, reason: 'merit dot grant',
+    });
+    expect(res.status).toBe(201);
+    CREATED_MOD_IDS.push(res.body._id);
+  });
+  it('accepts disciplines[N].dots regex path', async () => {
+    const res = await request(app).post('/api/st_mods').set('X-Test-User', stUser()).send({
+      character_id: CHAR_ID, stat_path: 'disciplines.0.dots', delta: 1, reason: 'discipline dot',
+    });
+    expect(res.status).toBe(201);
+    CREATED_MOD_IDS.push(res.body._id);
+  });
+  it('rejects merits.X.dots where X is not numeric', async () => {
+    const res = await request(app).post('/api/st_mods').set('X-Test-User', stUser()).send({
+      character_id: CHAR_ID, stat_path: 'merits.foo.dots', delta: 1, reason: 'x',
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── Ordering (AC#4) ──────────────────────────────────────────────────
+
+describe('AC#4 — GET returns mods ordered by created_at ascending', () => {
+  it('returns mods in creation order', async () => {
+    const orderChar = new ObjectId().toHexString();
+    const a = await request(app).post('/api/st_mods').set('X-Test-User', stUser()).send({
+      character_id: orderChar, stat_path: 'derived.defence', delta: 1, reason: 'first',
+    });
+    // Force a measurable created_at gap — the route stamps ISO strings with
+    // millisecond precision; same-tick inserts can tie.
+    await new Promise(r => setTimeout(r, 5));
+    const b = await request(app).post('/api/st_mods').set('X-Test-User', stUser()).send({
+      character_id: orderChar, stat_path: 'derived.defence', delta: -1, reason: 'second',
+    });
+    CREATED_MOD_IDS.push(a.body._id, b.body._id);
+
+    const list = await request(app)
+      .get(`/api/st_mods?character_id=${orderChar}`)
+      .set('X-Test-User', stUser());
+    expect(list.status).toBe(200);
+    expect(list.body).toHaveLength(2);
+    expect(list.body[0].reason).toBe('first');
+    expect(list.body[1].reason).toBe('second');
+
+    // Cleanup
+    await getCollection('st_mods').deleteMany({ character_id: orderChar });
+    await getCollection('st_mod_audit').deleteMany({ character_id: orderChar });
+  });
+});
+
+// ── Persistence shape (AC#1, AC#2) ───────────────────────────────────
+
+describe('AC#1, AC#2 — collection shapes', () => {
+  it('persists the documented mod shape', async () => {
+    const res = await request(app).post('/api/st_mods').set('X-Test-User', stUser()).send({
+      character_id: CHAR_ID,
+      stat_path: 'skills.Animal Ken.dots',
+      delta: 2,
+      reason: 'Shape check',
+      show_reason_to_player: false,
+    });
+    expect(res.status).toBe(201);
+    CREATED_MOD_IDS.push(res.body._id);
+
+    const stored = await getCollection('st_mods').findOne({ _id: new ObjectId(res.body._id) });
+    expect(stored).toMatchObject({
+      character_id: CHAR_ID,
+      stat_path: 'skills.Animal Ken.dots',
+      delta: 2,
+      reason: 'Shape check',
+      show_reason_to_player: false,
+      created_by: { discord_id: 'test-st-001' },
+    });
+    expect(typeof stored.created_at).toBe('string');
+
+    // Audit row written in the same request (AC#2)
+    const auditRow = await getCollection('st_mod_audit').findOne({
+      st_mod_id: stored._id,
+    });
+    expect(auditRow).toBeTruthy();
+    expect(auditRow.show_reason_to_player).toBeUndefined();
+    expect(auditRow.reason).toBe('Shape check');
+    expect(auditRow.character_id).toBe(CHAR_ID);
+    CREATED_AUDIT_IDS.push(auditRow._id);
+  });
+});
+
+// ── DELETE 404 (defensive) ───────────────────────────────────────────
+
+describe('DELETE /:id edge cases', () => {
+  it('404 on unknown id', async () => {
+    const res = await request(app)
+      .delete(`/api/st_mods/${new ObjectId().toHexString()}`)
+      .set('X-Test-User', stUser());
+    expect(res.status).toBe(404);
+  });
+  it('400 on invalid id format', async () => {
+    const res = await request(app)
+      .delete('/api/st_mods/not-an-objectid')
+      .set('X-Test-User', stUser());
+    expect(res.status).toBe(400);
+  });
+});

--- a/server/tests/helpers/test-app.js
+++ b/server/tests/helpers/test-app.js
@@ -24,6 +24,7 @@ import {
 import relationshipsRouter from '../../routes/relationships.js';
 import npcFlagsRouter from '../../routes/npc-flags.js';
 import npcsRouter from '../../routes/npcs.js';
+import stModsRouter, { auditRouter as stModAuditRouter } from '../../routes/st_mods.js';
 
 /**
  * Create a test app with a mock user injected via header.
@@ -87,6 +88,9 @@ export function createTestApp() {
   app.use('/api/relationships', mockAuth, noCache(), relationshipsRouter);
   app.use('/api/npcs', mockAuth, noCache(), npcsRouter);
   app.use('/api/npc-flags', mockAuth, noCache(), npcFlagsRouter);
+  // Epic STM (issue #358): ST mod overlay foundation
+  app.use('/api/st_mods', mockAuth, noCache(), stModsRouter);
+  app.use('/api/st_mod_audit', mockAuth, noCache(), stModAuditRouter);
 
   return app;
 }

--- a/specs/stories/issue-358-stm-1-backend-st-mods.story.md
+++ b/specs/stories/issue-358-stm-1-backend-st-mods.story.md
@@ -1,0 +1,118 @@
+# Issue #358: STM-1 — Backend st_mods + st_mod_audit collections, CRUD API, audit log
+
+Status: Ready for Review
+
+issue: 358
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/358
+branch: piatra/issue-358-stm-1-backend-st-mods
+epic: STM (specs/epic-stm-st-mods.md)
+adr: ADR-004 (specs/architecture/adr-004-st-mods-overlay.md)
+dispatch: PROCEED-WITH-NOTICE — pure new backend; no ADR-D touchpoints
+
+## Story
+
+As a Storyteller,
+I want a backend store and CRUD API for ST mods plus an immutable audit log,
+so that downstream stories (STM-2 overlay, STM-4 sheet UX, STM-5 admin panel) have a stable foundation, and every mod creation event is recoverable even after the mod itself is revoked.
+
+## Acceptance Criteria
+
+1. New collection `tm_suite.st_mods` accepts inserts via `POST /api/st_mods` with the documented shape (character_id, stat_path, delta, reason, show_reason_to_player, created_by, created_at).
+2. New collection `tm_suite.st_mod_audit` accepts inserts via the same handler and is written **inside the same request** as the `st_mods` insert. Audit row is the same shape minus `show_reason_to_player`.
+3. `POST /api/st_mods` validates inputs and returns `400` when: `delta` is not an integer, `reason` is empty/whitespace, or `stat_path` is not on the whitelist (static set from ADR-004 §D3 plus regex `^(merits|disciplines)\.[0-9]+\.dots$`).
+4. `GET /api/st_mods?character_id=:id` returns active mods for a character (ordered by `created_at` ascending so multi-mod stacks render in creation order downstream).
+5. `DELETE /api/st_mods/:id` hard-deletes the document from `st_mods` and **leaves the `st_mod_audit` row intact**.
+6. `GET /api/st_mod_audit?character_id=:id` returns audit history for a character, including audit rows whose `st_mods` document has since been deleted.
+7. All four routes return `401` to unauthenticated callers (use existing Discord OAuth ST-auth middleware).
+8. Manual smoke (curl or Postman) sequence passes end-to-end: create → list → revoke → confirm audit row survives.
+
+## Tasks / Subtasks
+
+- [x] Task 1 — Create new route file `server/routes/st_mods.js` mounting the four endpoints (AC: 1, 4, 5, 6, 7)
+  - [x] Import the existing ST-auth middleware (match the pattern used in `server/routes/characters.js` or whichever route file is the cleanest current ST-auth gate)
+  - [x] Wire `GET /api/st_mods`, `POST /api/st_mods`, `DELETE /api/st_mods/:id`, `GET /api/st_mod_audit` — all behind the ST-auth middleware
+  - [x] Mount the router in the app's main route table (likely `server/index.js` or `server/app.js` — confirm against current convention)
+- [x] Task 2 — Implement `stat_path` validation whitelist (AC: 3)
+  - [x] Define the static whitelist inline in the route file. Source: ADR-004 §D3 — `Attributes` (9 attrs × {dots, bonus}), `Skills` (24 skills × {dots, bonus}), `Current State` (damage / willpower / vitae / blood_potency — verify exact field names against `public/js/data/accessors.js` before pinning), `Derived` (defence, health_max, willpower_max, size, speed, initiative).
+  - [x] Combined predicate: `path ∈ STATIC_WHITELIST || /^(merits|disciplines)\.[0-9]+\.dots$/.test(path)`
+  - [x] Reject with `400 { error: 'invalid stat_path', stat_path }` when neither matches
+  - [x] Reject with `400 { error: 'delta must be integer' }` when delta is non-integer (including float, string, null)
+  - [x] Reject with `400 { error: 'reason is required' }` when reason is missing or trims to empty
+- [x] Task 3 — Implement audit-row coupling in `POST /api/st_mods` (AC: 2)
+  - [x] Insert into `st_mods` first; on success, insert into `st_mod_audit` with the same payload (minus `show_reason_to_player`) and the `st_mods` `_id` reused as the audit row's `_id` (so revoke-time matching is trivial) OR a separate ObjectId — Ptah's call, document in PR
+  - [x] If the audit insert fails after the `st_mods` insert succeeds, **roll back** the `st_mods` insert (best-effort sequential rollback acceptable; full transaction not required for v1). Document the choice in the PR description.
+- [x] Task 4 — Manual smoke verification (AC: 8)
+  - [x] Pick a known character ObjectId from `tm_suite.characters`
+  - [x] curl sequence: POST (valid mod) → GET (verify present) → DELETE → GET (verify gone from st_mods) → GET /api/st_mod_audit (verify audit row survived)
+  - [x] Capture the curl session output in the PR description's test plan
+
+## Dev Notes
+
+### Files to create
+
+**`server/routes/st_mods.js`** (new) — single route file mounting the four endpoints.
+
+### Files to modify
+
+**`server/index.js`** or whichever file currently mounts the API route table — add the `st_mods` router. Match the existing import + `app.use('/api/...', router)` pattern verbatim; one line of change is the target.
+
+### What NOT to change
+
+- `server/routes/characters.js` — not in STM-1's scope; STM-3 will add the `st_mods_suppressed` PATCH endpoint there
+- The `characters` collection schema — STM-1 does not touch it
+- `public/` — no client work in this story; STM-2+ own the render integration
+- `CLAUDE.md` — the "Derived stats are never stored" amendment lands in STM-2, NOT here
+- `specs/architecture/adr-004-st-mods-overlay.md` — ADR is frozen; don't edit
+
+### Reference materials
+
+- **ADR-004** at `specs/architecture/adr-004-st-mods-overlay.md`:
+  - §D3 — the static whitelist composition (Attributes/Skills/Current State/Derived)
+  - §"Concerns" item 2 — explicit rationale for whitelist-at-write-time
+- **PRD** at `specs/epic-stm-st-mods.md`:
+  - §"Design Decisions / Audit log is append-only" — confirms audit-survives-revoke contract
+  - STM-1 story block at the bottom of the file
+- **`server/db.js`** — `getCollection(name)` pattern for new collection access. No schema migration; Mongo creates the collection on first insert.
+
+### Pre-commit hygiene checklist (per saved feedback)
+
+- [ ] `git status | head -1` immediately after branch creation — confirm on `piatra/issue-358-stm-1-backend-st-mods`
+- [ ] `git status | head -1` before staging — confirm no stray files from a parallel session
+- [ ] `git status | head -1` before commit — same check, last line of defence
+
+### Branch hygiene
+
+Branch from current `dev` (which is up to date as of 2026-05-18). Do **not** merge `dev` into the branch mid-implementation unless `dev` lands a conflicting commit — there are no in-flight PRs touching `server/routes/` or `server/index.js`, so this should not happen.
+
+### Coverage that is explicitly NOT required
+
+- No frontend changes — defer to STM-2..STM-6
+- No CLAUDE.md amendment — defer to STM-2
+- No `app_settings` collection — defer to STM-3
+- No `st_mods_suppressed` PATCH — defer to STM-3
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-7 (Ptah / DEV)
+
+### Completion Notes List
+
+- **AC#8 substitution.** Per agreement with the user, the literal-curl smoke (no local Mongo available in this dev env) was substituted with a vitest integration test that walks the identical create → list → revoke → audit-survives sequence end-to-end via supertest. Test name: `AC#8 — end-to-end smoke (create → list → revoke → audit survives) > walks the full lifecycle`. Same assertions a curl run would make, but it lives in CI so it cannot rot.
+- **Audit row _id strategy.** Separate ObjectId per audit row, linked to the mod via `st_mod_id` field. Rationale: gives the audit table its own identity (forward-compat for future audit events on the same mod, e.g. revocation rows), and the lookup-by-st_mod_id is just as cheap as lookup-by-_id with a single index later.
+- **Audit-rollback-on-failure.** Sequential write with best-effort rollback. If `st_mods` insert succeeds but `st_mod_audit` insert throws, we attempt to delete the freshly-inserted mod and return 500. No Mongo transaction in v1 — full transaction would require a replica-set test environment we don't currently configure. The audit-survives contract (AC#5) is about the *revoke* path, not the *creation-failed* path, so this is the correct trade-off.
+- **stat_path whitelist field-name divergence from ADR-004 §D3.** ADR's `current.damage / current.willpower / current.vitae` paths do not resolve on the character document — those values live in the separate `tracker_state` collection (see `public/js/game/tracker.js`). The overlay is a character-render feature (ADR §D1), so the whitelist surfaces only character-document fields. Substituted with the real top-level `blood_potency` and `humanity` fields that *do* live on the character. STM-2/STM-5 can extend later if the overlay grows into the tracker render path. This matches the ADR §Concerns Item 4 hand-off ("if the actual fields are at the top level ... the static map needs to match"). Documented inline in `server/routes/st_mods.js`.
+- **Attribute/skill case.** Capitalised (`attributes.Strength.dots`, not `attributes.strength.dots`) — the ADR examples used lowercase, but the actual character documents key on Capitalised names (`public/js/data/constants.js`). Treated the ADR examples as illustrative, not normative.
+- **Branch hygiene.** Three `git status | head -1` checkpoints honoured (post-branch-create, pre-stage, pre-commit). Branched from current `dev` tip (13622427) which was up to date as of dispatch.
+
+### File List
+
+- `server/routes/st_mods.js` (new) — four endpoints (POST/GET/DELETE /api/st_mods, GET /api/st_mod_audit), whitelist, audit coupling
+- `server/index.js` (modified) — mount `stModsRouter` and `stModAuditRouter` under requireAuth + noCache
+- `server/tests/helpers/test-app.js` (modified) — register the new routers in the test app
+- `server/tests/api-st-mods.test.js` (new) — 20-test integration suite covering AC#1..#8
+
+### Change Log
+
+- 2026-05-18 (Ptah): STM-1 initial implementation


### PR DESCRIPTION
## Summary

- Adds backend foundation for Epic STM (ST mod overlay): two new MongoDB collections (`st_mods`, `st_mod_audit`) and four ST-auth-gated routes under `/api/st_mods` and `/api/st_mod_audit`
- `stat_path` whitelist enforced at write time (per ADR-004 §D3 + §Concerns Item 2)
- Audit row written inside the same handler as the mod insert; survives mod revoke (AC#5)

Closes #358 (manual close on dev-merge per `feedback_github_autoclose_dev_gap`)

## Design decisions documented for review

1. **Audit row `_id` strategy → separate ObjectId, linked via `st_mod_id`.** Reuse-the-mod-`_id` would have been simpler today but blocks future audit-event extensibility (e.g. revoke rows on the same mod). Lookup cost is identical with the right index.

2. **Audit-rollback on failure → sequential write + best-effort rollback.** If `st_mod_audit` insert throws after the `st_mods` insert succeeded, we attempt `deleteOne` on the freshly-inserted mod and return 500. No Mongo transaction (would require replica-set test env we don't currently configure). The audit-survives contract (AC#5) is about the *revoke* path, not the *creation-failed* path, so this trade-off is correct for v1.

3. **`stat_path` whitelist field-name divergence from ADR-004 §D3.** ADR's PRD-derived `current.damage / current.willpower / current.vitae` paths do not resolve on the character document — those values live in the separate `tracker_state` collection (`public/js/game/tracker.js`). The overlay is a character-render feature (ADR §D1), so the whitelist surfaces only character-document fields. Substituted with the real top-level `blood_potency` and `humanity` fields. This is exactly the hand-off ADR-004 §Concerns Item 4 anticipated: *\"if the actual fields are at the top level ... the static map needs to match\"*. Documented inline in `server/routes/st_mods.js`.

4. **Attribute/skill case.** Capitalised (`attributes.Strength.dots`), matching the actual character documents (`public/js/data/constants.js`). The ADR's lowercase examples were illustrative.

## Acceptance criteria coverage

| AC | Where | Status |
|----|-------|--------|
| 1 — `POST /api/st_mods` accepts documented shape | `routes/st_mods.js` POST handler | ✅ AC#1, AC#2 test |
| 2 — audit row written in same request | same handler, sequential insert | ✅ AC#1, AC#2 test |
| 3 — 400 on invalid delta / empty reason / off-whitelist stat_path | validation block | ✅ AC#3 — 9 tests |
| 4 — GET ordered by `created_at` asc | `.sort({ created_at: 1 })` | ✅ AC#4 test |
| 5 — DELETE hard-deletes mod, audit survives | `deleteOne` on mods only | ✅ AC#8 smoke test |
| 6 — audit GET returns history incl. revoked-mod rows | `auditRouter` | ✅ AC#8 smoke test |
| 7 — 401 on unauthenticated | `requireAuth` at mount + `requireRole('st')` at router | ✅ AC#7 — 7 tests |
| 8 — manual smoke end-to-end | substituted with integration test (see below) | ✅ AC#8 smoke test |

## AC#8 — substitution from curl to vitest integration

Local Mongo + ST token weren't available in this dev environment, so per agreement with the user the literal-curl smoke was substituted with a vitest integration test that walks the **identical** sequence end-to-end via supertest. Captured in `server/tests/api-st-mods.test.js`:

```
✓ AC#8 — end-to-end smoke (create → list → revoke → audit survives) > walks the full lifecycle (229ms)
```

Same assertions a curl run would make:
1. `POST /api/st_mods` → 201, returns shape
2. `GET /api/st_mods?character_id=…` → mod present
3. `DELETE /api/st_mods/:id` → 200 `{ deleted: true }`
4. `GET /api/st_mods?character_id=…` → mod gone
5. `GET /api/st_mod_audit?character_id=…` → audit row survives, `show_reason_to_player` field absent

Stronger than a one-off curl — runs in CI on every PR.

## Test plan

- [x] Parse-check `server/routes/st_mods.js` and `server/index.js` (`node --check`)
- [x] New integration suite: **20/20 passing**
- [x] Full server test suite: **820/820 passing** (66 files, 76s)
- [x] No client / frontend changes (deferred to STM-2..STM-6 per dispatch)

## Files

- `server/routes/st_mods.js` (new)
- `server/index.js` (+5 lines — router mount)
- `server/tests/helpers/test-app.js` (+3 lines — register routers in test app)
- `server/tests/api-st-mods.test.js` (new)
- `specs/stories/issue-358-stm-1-backend-st-mods.story.md` (Dev Agent Record filled, status flipped)

## What's explicitly NOT in this PR

- Frontend (STM-2..STM-6)
- CLAUDE.md amendment (STM-2)
- characters schema changes (STM-3 will add `st_mods_suppressed`)
- `app_settings` collection (STM-3)