### PR TITLE
chore(stm-1): flip story status to Done

### DIFF
--- a/specs/stories/issue-358-stm-1-backend-st-mods.story.md
+++ b/specs/stories/issue-358-stm-1-backend-st-mods.story.md
@@ -1,6 +1,6 @@
 # Issue #358: STM-1 — Backend st_mods + st_mod_audit collections, CRUD API, audit log
 
-Status: Ready for Review
+Status: Done
 
 issue: 358
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/358


### PR DESCRIPTION
Tiny bookkeeping flip after PR #359 (STM-1 backend) merged as b950867f.

Story file status was at "Ready for Review" because that was the pre-merge state when Ptah opened #359. Now flipped to "Done" per `feedback_bookkeeping_default`.

No code change, no test impact.