### PR TITLE
DT Story copy-context pipeline: 5 bug fixes + 4 prompt quality features (#363-#371)

### DIFF
--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -9145,3 +9145,47 @@ html:not([data-theme="dark"]) .rules-tbl tbody tr:hover            { background:
 .hd-btn-delete:not(:disabled):hover { background: #a00; }
 .cd-hard-delete-btn { border-color: var(--crim, #8B0000) !important; color: var(--err, #c0392b) !important; }
 .cd-hard-delete-btn:hover { background: rgba(139,0,0,.15) !important; }
+
+/* === DT STORY: Calibration panel === */
+.dt-story-calibration-panel {
+  margin-bottom: 1rem;
+  border: 1px solid var(--surf3);
+  border-radius: 4px;
+}
+.dt-story-calibration-header {
+  padding: 0.4rem 0.75rem;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  background: var(--surf2);
+}
+.dt-story-calibration-hint {
+  font-size: 0.75rem;
+  color: var(--txt3);
+}
+.dt-story-calibration-body {
+  padding: 0.5rem 0.75rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.dt-story-calibration-body.hidden { display: none; }
+.dt-story-calibration-ta {
+  width: 100%;
+  box-sizing: border-box;
+  resize: vertical;
+  min-height: 4rem;
+  background: var(--surf1);
+  color: var(--txt);
+  border: 1px solid var(--surf3);
+  border-radius: 3px;
+  padding: 0.4rem;
+  font-family: inherit;
+  font-size: 0.85rem;
+}
+.dt-story-calibration-save-btn { align-self: flex-start; }
+.dt-story-calibration-status {
+  font-size: 0.8rem;
+  color: var(--gold2);
+}

--- a/public/js/admin/downtime-story.js
+++ b/public/js/admin/downtime-story.js
@@ -470,7 +470,7 @@ function formatPool(pool) {
 
 /** "Lord Marcus — Ventrue / Invictus — The Politician" */
 function _compactCharHeader(char) {
-  const name  = [char?.honorific, char ? displayName(char) : 'Unknown'].filter(Boolean).join(' ');
+  const name  = char ? displayName(char) : 'Unknown';  // displayName already includes honorific
   const ident = [char?.clan, char?.covenant].filter(Boolean).join(' / ');
   return [name, ident, char?.concept || null].filter(Boolean).join(' \u2014 ');
 }
@@ -494,12 +494,18 @@ function buildProjectContext(char, sub, idx, cycleData, territories) {
   const title       = sub.responses?.[`project_${slot}_title`]       || '';
   const outcome     = sub.responses?.[`project_${slot}_outcome`]     || '';
   const description = sub.responses?.[`project_${slot}_description`] || '';
-  const terrRaw     = sub.responses?.[`project_${slot}_territory`]   || '';
   const castRaw     = sub.responses?.[`project_${slot}_cast`]        || '';
   const meritsRaw   = sub.responses?.[`project_${slot}_merits`]      || '';
 
   const rev        = sub.projects_resolved?.[idx] || {};
   const actionType = rev.action_type_override || rev.action_type || sub.responses?.[`project_${slot}_action`] || '';
+
+  // Ambience actions use a dedicated territory field; patrol uses another.
+  // Read the action-type-appropriate field so territory is never 'Unknown'.
+  const isAmbience = actionType === 'ambience_increase' || actionType === 'ambience_decrease';
+  const terrRaw    = isAmbience
+    ? (sub.responses?.[`project_${slot}_ambience_target`] || sub.responses?.[`project_${slot}_territory`] || '')
+    : (sub.responses?.[`project_${slot}_territory`] || '');
   const pool       = formatPool(rev.pool_validated) || formatPool(rev.pool_player) || '';
   const roll       = rev.roll || null;
   const notes      = Array.isArray(rev.notes_thread) ? rev.notes_thread : [];
@@ -569,7 +575,14 @@ function buildProjectContext(char, sub, idx, cycleData, territories) {
       (s.projects_resolved || []).forEach((r, i) => {
         if (!r || r.pool_status === 'skipped') return;
         const sl = i + 1;
-        if (resolveTerrId(s.responses?.[`project_${sl}_territory`] || '') !== terrId) return;
+        const otherType = r.action_type_override || r.action_type || '';
+        const otherIsAmb = otherType === 'ambience_increase' || otherType === 'ambience_decrease';
+        const otherTerrRaw = otherIsAmb
+          ? (s.responses?.[`project_${sl}_ambience_target`] || s.responses?.[`project_${sl}_territory`] || '')
+          : otherType === 'patrol_scout'
+            ? (s.responses?.[`project_${sl}_target_terr`] || s.responses?.[`project_${sl}_territory`] || '')
+            : (s.responses?.[`project_${sl}_territory`] || '');
+        if (resolveTerrId(otherTerrRaw) !== terrId) return;
         const aType = ACTION_TYPE_LABELS[r.action_type] || r.action_type || 'Action';
         otherActions.push(`${s.character_name || 'Unknown'} (${aType})`);
       });
@@ -682,7 +695,8 @@ function buildPatrolContext(char, sub, idx, cycleData, territories) {
   const title       = sub.responses?.[`project_${slot}_title`]       || '';
   const outcome     = sub.responses?.[`project_${slot}_outcome`]     || '';
   const description = sub.responses?.[`project_${slot}_description`] || '';
-  const terrRaw     = sub.responses?.[`project_${slot}_territory`]   || '';
+  // Patrol uses _target_terr (modern DT form); fall back to _territory for legacy submissions.
+  const terrRaw     = sub.responses?.[`project_${slot}_target_terr`] || sub.responses?.[`project_${slot}_territory`] || '';
   const meritsRaw   = sub.responses?.[`project_${slot}_merits`]      || '';
 
   const rev        = sub.projects_resolved?.[idx] || {};
@@ -757,11 +771,18 @@ function buildPatrolContext(char, sub, idx, cycleData, territories) {
     (s.projects_resolved || []).forEach((r, i) => {
       if (!r || r.pool_status === 'skipped') return;
       const sl = i + 1;
-      if (resolveTerrId(s.responses?.[`project_${sl}_territory`] || '') !== terrId) return;
       const aType = r.action_type_override || r.action_type || '';
+      const otherIsAmb = aType === 'ambience_increase' || aType === 'ambience_decrease';
+      const otherIsPatrol = aType === 'patrol_scout' || aType === 'support';
+      const otherTerrRaw = otherIsAmb
+        ? (s.responses?.[`project_${sl}_ambience_target`] || s.responses?.[`project_${sl}_territory`] || '')
+        : otherIsPatrol
+          ? (s.responses?.[`project_${sl}_target_terr`] || s.responses?.[`project_${sl}_territory`] || '')
+          : (s.responses?.[`project_${sl}_territory`] || '');
+      if (resolveTerrId(otherTerrRaw) !== terrId) return;
       const cName = s.character_name || 'Unknown';
-      if (aType === 'ambience_increase' || aType === 'ambience_decrease') ambienceChars.push(cName);
-      else if (aType === 'patrol_scout' || aType === 'support') patrolChars.push(cName);
+      if (otherIsAmb) ambienceChars.push(cName);
+      else if (otherIsPatrol) patrolChars.push(cName);
       else if (aType === 'investigate') investigateChars.push(cName);
       else miscChars.push(cName);
     });
@@ -1494,6 +1515,16 @@ function buildTouchstoneContext(char, sub) {
   const touchstones = char?.touchstones || [];
   const playerAspirations = sub.responses?.aspirations || null;
 
+  // Player's submitted narrative — same priority chain as buildLetterContext
+  const playerLetter =
+    sub.responses?.personal_story_text ||
+    sub.responses?.correspondence ||
+    sub.responses?.letter_to_home ||
+    sub.responses?.letter ||
+    sub.responses?.narrative_letter ||
+    sub.responses?.personal_message ||
+    null;
+
   const lines = ['Draft a Touchstone Vignette for:', '', _compactCharHeader(char)];
   const identLine = _charIdentLine(char);
   if (identLine) lines.push(identLine);
@@ -1509,6 +1540,10 @@ function buildTouchstoneContext(char, sub) {
 
   lines.push('');
   lines.push(`Aspirations: ${playerAspirations ? playerAspirations.trim() : '[No aspirations recorded]'}`);
+
+  lines.push('');
+  lines.push('Player-submitted narrative:');
+  lines.push(playerLetter ? playerLetter.trim() : '[No player narrative submitted this cycle]');
 
   lines.push('');
   lines.push('Apply TOUCHSTONE_CALIBRATION. 100-300 words. Use house style.');
@@ -3412,22 +3447,22 @@ async function handleSignOff(btn) {
 
 async function handleCopyStoryMomentContext(btn) {
   if (!_currentSub) return;
-  const char = getCharForSub(_currentSub);
+  const sub  = _currentSub;                              // snapshot — prevents stale read if ST switches characters during fetch
+  const char = getCharForSub(sub);
 
   const card   = btn.closest('.dt-story-section[data-section="story_moment"]');
   const format = card?.querySelector('input[name="story-moment-format"]:checked')?.value || 'letter';
 
   if (format === 'vignette') {
-    copyToClipboard(buildTouchstoneContext(char, _currentSub), btn);
+    copyToClipboard(buildTouchstoneContext(char, sub), btn);
     return;
   }
 
-  // Letter format: assemble previous-cycle correspondence + story-moment target,
-  // same as the pre-DTSR-2 handleCopyLetterContext logic.
+  // Letter format: assemble previous-cycle correspondence + story-moment target.
   let prevCorrespondence = null;
   let prevCycleNumber    = null;
   try {
-    const cycleId   = _currentSub.cycle_id;
+    const cycleId   = sub.cycle_id;
     const allCycles = await apiGet('/api/downtime_cycles').catch(() => []);
     const cycles    = Array.isArray(allCycles) ? allCycles : [];
     const currentCycle   = cycles.find(c => String(c._id) === String(cycleId));
@@ -3438,22 +3473,26 @@ async function handleCopyStoryMomentContext(btn) {
       if (prevCycle) {
         const prevSubs = await apiGet(`/api/downtime_submissions?cycle_id=${prevCycle._id}`).catch(() => []);
         const prevSub  = (Array.isArray(prevSubs) ? prevSubs : [])
-          .find(s => String(s.character_id) === String(_currentSub.character_id));
-        prevCorrespondence = prevSub?.st_narrative?.story_moment?.response
-          || prevSub?.st_narrative?.letter_from_home?.response
-          || null;
-        prevCycleNumber = prevCycle.game_number;
+          .find(s => String(s.character_id) === String(sub.character_id));
+        if (prevSub) {
+          prevCorrespondence =
+            prevSub.st_narrative?.story_moment?.response
+            || prevSub.st_narrative?.letter_from_home?.response
+            || prevSub.st_narrative?.touchstone?.response   // legacy vignette field
+            || null;
+          prevCycleNumber = prevCycle.game_number;
+        }
       }
     }
   } catch { /* leave nulls */ }
 
-  const stVoiceNote = _currentSub.st_narrative?.story_moment?.voice_note
-    || _currentSub.st_narrative?.letter_from_home?.voice_note
+  const stVoiceNote = sub.st_narrative?.story_moment?.voice_note
+    || sub.st_narrative?.letter_from_home?.voice_note
     || null;
 
   // NPCR.12: resolve story-moment relationship target name for the prompt.
   let storyMomentTarget = null;
-  const relId = _currentSub.responses?.story_moment_relationship_id;
+  const relId = sub.responses?.story_moment_relationship_id;
   if (relId) {
     try {
       const edge = await apiGet(`/api/relationships/${encodeURIComponent(relId)}`);
@@ -3463,7 +3502,7 @@ async function handleCopyStoryMomentContext(btn) {
           custom_label: edge.custom_label || null,
           name: null,
         };
-        const charId = String(_currentSub.character_id);
+        const charId = String(sub.character_id);
         const other  = String(edge.a?.id) === charId ? edge.b : edge.a;
         if (other?.type === 'npc' && other.id) {
           const npcs = await apiGet('/api/npcs').catch(() => []);
@@ -3477,7 +3516,7 @@ async function handleCopyStoryMomentContext(btn) {
     } catch { /* leave null */ }
   }
 
-  const text = buildLetterContext(char, _currentSub, {
+  const text = buildLetterContext(char, sub, {
     prevCorrespondence, prevCycleNumber, stVoiceNote, storyMomentTarget,
   });
   copyToClipboard(text, btn);
@@ -3552,19 +3591,20 @@ function _refreshProgressTracker() {
 
 async function handleCopyProjectContext(btn) {
   if (!_currentSub) return;
+  const sub  = _currentSub;                              // snapshot — prevents stale read if ST switches characters during fetch
   const card = btn.closest('.dt-story-proj-card');
   if (!card) return;
   const idx  = parseInt(card.dataset.projIdx, 10);
-  const char = getCharForSub(_currentSub);
+  const char = getCharForSub(sub);
 
-  const rev        = _currentSub.projects_resolved?.[idx] || {};
+  const rev        = sub.projects_resolved?.[idx] || {};
   const slot       = idx + 1;
   const actionType = rev.action_type_override || rev.action_type
-    || _currentSub.responses?.[`project_${slot}_action`] || '';
+    || sub.responses?.[`project_${slot}_action`] || '';
 
   let cycleData = null, territories = [];
   try {
-    const cycleId = _currentSub.cycle_id;
+    const cycleId = sub.cycle_id;
     const [allCycles, terrs] = await Promise.all([
       apiGet('/api/downtime_cycles').catch(() => []),
       apiGet('/api/territories').catch(() => []),
@@ -3575,10 +3615,10 @@ async function handleCopyProjectContext(btn) {
 
   const isMainten = actionType === 'maintenance' || rev.pool_status === 'maintenance';
   const text = actionType === 'patrol_scout'
-    ? buildPatrolContext(char, _currentSub, idx, cycleData, territories)
+    ? buildPatrolContext(char, sub, idx, cycleData, territories)
     : isMainten
-      ? buildMaintenanceContext(char, _currentSub, idx)
-      : buildProjectContext(char, _currentSub, idx, cycleData, territories);
+      ? buildMaintenanceContext(char, sub, idx)
+      : buildProjectContext(char, sub, idx, cycleData, territories);
   copyToClipboard(text, btn);
 }
 
@@ -3660,22 +3700,23 @@ async function handleProjectSave(btn, status) {
 
 async function handleCopyTerritoryContext(btn) {
   if (!_currentSub) return;
-  const char   = getCharForSub(_currentSub);
+  const sub    = _currentSub;                            // snapshot — prevents stale read if ST switches characters during fetch
+  const char   = getCharForSub(sub);
   const terrId = btn.dataset.terrId;
   if (!terrId) return;
 
   let cycleData = null, territories = [];
   try {
-    const cycleId = _currentSub.cycle_id;
+    const cycleId = sub.cycle_id;
     const [allCycles, terrs] = await Promise.all([
       apiGet('/api/downtime_cycles').catch(() => []),
       apiGet('/api/territories').catch(() => []),
     ]);
-    cycleData  = (Array.isArray(allCycles) ? allCycles : []).find(c => String(c._id) === String(cycleId)) || null;
+    cycleData   = (Array.isArray(allCycles) ? allCycles : []).find(c => String(c._id) === String(cycleId)) || null;
     territories = Array.isArray(terrs) ? terrs : [];
   } catch { /* use nulls */ }
 
-  const text = buildTerritoryContext(char, _currentSub, terrId, _allSubmissions, _allCharacters, cycleData, territories);
+  const text = buildTerritoryContext(char, sub, terrId, _allSubmissions, _allCharacters, cycleData, territories);
   copyToClipboard(text, btn);
 }
 

--- a/public/js/admin/downtime-story.js
+++ b/public/js/admin/downtime-story.js
@@ -260,6 +260,14 @@ export async function initDtStory(cycleId) {
     const toggleLink = e.target.closest('.dt-story-context-toggle');
     if (toggleLink) { handleContextToggle(toggleLink); return; }
 
+    // Calibration panel toggle
+    const calHeader = e.target.closest('.dt-story-calibration-header[data-toggle="calibration"]');
+    if (calHeader) { handleCalibrationToggle(calHeader); return; }
+
+    // Calibration save
+    const calSaveBtn = e.target.closest('.dt-story-calibration-save-btn');
+    if (calSaveBtn && !calSaveBtn.disabled) { handleCalibrationSave(calSaveBtn); return; }
+
     // Determine which section the clicked element belongs to
     const sectionKey = e.target.closest('.dt-story-section')?.dataset.section;
 
@@ -475,6 +483,13 @@ function _compactCharHeader(char) {
   return [name, ident, char?.concept || null].filter(Boolean).join(' \u2014 ');
 }
 
+/** Returns lines to inject per-character calibration notes into a context prompt. */
+function _calibrationBlock(char) {
+  const cal = char?.dt_story_calibration?.trim();
+  if (!cal) return [];
+  return ['', 'Voice calibration (apply throughout):', cal];
+}
+
 /** "Mask: Bon Vivant | Dirge: Martyr | Humanity: 6" */
 function _charIdentLine(char) {
   const parts = [];
@@ -521,6 +536,28 @@ function buildProjectContext(char, sub, idx, cycleData, territories) {
   const lines = ['Draft a project response for:', '', _compactCharHeader(char)];
   const identLine = _charIdentLine(char);
   if (identLine) lines.push(identLine);
+  lines.push(..._calibrationBlock(char));
+
+  // XP spend this cycle (player-written justification, if any)
+  const xpRows = sub.responses?.xp_rows;
+  const xpItem = sub.responses?.xp_item;
+  const xpNote = sub.responses?.xp_spend_note || sub.responses?.xp_note || '';
+  let xpSummary = '';
+  if (xpRows) {
+    try {
+      const rows = typeof xpRows === 'string' ? JSON.parse(xpRows) : xpRows;
+      if (Array.isArray(rows) && rows.length) {
+        xpSummary = rows.map(r => `${r.item || r.name || '?'} (${r.cost ?? r.xp ?? '?'} XP)`).join(', ');
+      }
+    } catch { /* skip */ }
+  } else if (xpItem) {
+    xpSummary = xpItem;
+  }
+  if (xpSummary) {
+    lines.push('');
+    lines.push(`XP spend this cycle: ${xpSummary}`);
+    if (xpNote) lines.push(`Player note: ${xpNote}`);
+  }
 
   lines.push('');
   lines.push(`Action: ${actionLabel}`);
@@ -529,6 +566,11 @@ function buildProjectContext(char, sub, idx, cycleData, territories) {
   if (description) lines.push(`Description: ${description}`);
   if (merits)  lines.push(`Merits & Bonuses: ${merits}`);
   if (cast)    lines.push(`Connected Characters: ${cast}`);
+
+  if (isAmbience) {
+    lines.push('');
+    lines.push('Framing: An ambience action represents covenant investment in or destabilisation of a feeding ground. Ground the narrative in the territorial politics of the city \u2014 acknowledge the covenant pressure being applied or resisted where the fiction allows it.');
+  }
 
   if (poolStatus === 'no_roll' || poolStatus === 'maintenance') {
     lines.push('No roll required');
@@ -539,6 +581,10 @@ function buildProjectContext(char, sub, idx, cycleData, territories) {
       const successes = roll.successes ?? 0;
       const exc       = roll.exceptional ? ', Exceptional' : '';
       lines.push(`Roll Result: ${successes} success${successes !== 1 ? 'es' : ''}${exc}${diceStr ? ' \u2014 Dice: ' + diceStr : ''}`);
+    }
+    if (isInvestigation && pool) {
+      const foundDisc = _PATROL_DISCS.find(d => pool.includes(d));
+      if (foundDisc) lines.push(`Discipline: ${foundDisc}`);
     }
   }
 
@@ -606,7 +652,14 @@ function buildProjectContext(char, sub, idx, cycleData, territories) {
     lines.push(`Player-facing note: ${rev.player_facing_note}`);
   }
 
-  // ST directives
+  // Existing draft
+  if (existingDraft) {
+    lines.push('');
+    lines.push('Existing draft (revise unless told to rewrite):');
+    lines.push(existingDraft);
+  }
+
+  // ST directives — placed immediately before the rubric so the AI weights them highest
   const hasDirectives = rev.st_note || notes.length;
   if (hasDirectives) {
     lines.push('');
@@ -615,20 +668,13 @@ function buildProjectContext(char, sub, idx, cycleData, territories) {
     for (const n of notes) lines.push(`- [${n.author_name || 'ST'}] ${n.text || ''}`);
   }
 
-  // Existing draft
-  if (existingDraft) {
-    lines.push('');
-    lines.push('Existing draft (revise unless told to rewrite):');
-    lines.push(existingDraft);
-  }
-
   lines.push('');
   const isInvestigation = actionType === 'investigate';
   const isFeed = actionType === 'feed';
   const rubric = [
     isInvestigation ? 'Apply INVESTIGATION_THRESHOLDS.' : null,
     isFeed ? 'Apply FEEDING_CONSTRAINTS.' : null,
-    'One paragraph, 80-120 words. Use house style.',
+    'No more than 120 words; shorter is better. Do not open with atmosphere or mood-setting — begin on action or consequence. Use house style.',
   ].filter(Boolean).join(' ');
   lines.push(rubric);
 
@@ -661,6 +707,7 @@ function buildMaintenanceContext(char, sub, idx) {
 
   const lines = ['Draft a maintenance response for:', '', _compactCharHeader(char)];
   if (char?.humanity != null) lines.push(`Humanity: ${char.humanity}`);
+  lines.push(..._calibrationBlock(char));
 
   lines.push('');
   if (meritType) lines.push(`Merit maintained: ${meritName} (${meritType})`);
@@ -674,7 +721,7 @@ function buildMaintenanceContext(char, sub, idx) {
   }
 
   lines.push('');
-  lines.push('No roll required. 50-80 words. Use house style.');
+  lines.push('No roll required. No more than 80 words; shorter is better. No scene-setting opener. Use house style.');
 
   return lines.join('\n');
 }
@@ -709,6 +756,28 @@ function buildPatrolContext(char, sub, idx, cycleData, territories) {
   const lines = ['Draft a Patrol response for:', '', _compactCharHeader(char)];
   const identLine = _charIdentLine(char);
   if (identLine) lines.push(identLine);
+  lines.push(..._calibrationBlock(char));
+
+  // XP spend this cycle (player-written justification, if any)
+  const xpRowsP = sub.responses?.xp_rows;
+  const xpItemP = sub.responses?.xp_item;
+  const xpNoteP = sub.responses?.xp_spend_note || sub.responses?.xp_note || '';
+  let xpSummaryP = '';
+  if (xpRowsP) {
+    try {
+      const rows = typeof xpRowsP === 'string' ? JSON.parse(xpRowsP) : xpRowsP;
+      if (Array.isArray(rows) && rows.length) {
+        xpSummaryP = rows.map(r => `${r.item || r.name || '?'} (${r.cost ?? r.xp ?? '?'} XP)`).join(', ');
+      }
+    } catch { /* skip */ }
+  } else if (xpItemP) {
+    xpSummaryP = xpItemP;
+  }
+  if (xpSummaryP) {
+    lines.push('');
+    lines.push(`XP spend this cycle: ${xpSummaryP}`);
+    if (xpNoteP) lines.push(`Player note: ${xpNoteP}`);
+  }
 
   lines.push('');
   lines.push('Action: Patrol / Scout');
@@ -804,7 +873,16 @@ function buildPatrolContext(char, sub, idx, cycleData, territories) {
     const netStr = netChange != null ? `, net ${netChange > 0 ? '+' : ''}${netChange}` : '';
     lines.push(`Ambience: ${ambLine}${wasStr}${netStr}`);
   }
-  lines.push(`Residents: ${residentCount} | Poachers: ${poacherCount}`);
+  // Patrolling character's own feed status in this territory
+  let selfFeedStatus = 'Not feeding here';
+  if (terrSlug) {
+    let selfTerrs = {};
+    try { selfTerrs = JSON.parse(sub.responses?.feeding_territories || '{}'); } catch { /* ok */ }
+    const selfVal = selfTerrs[terrSlug];
+    if (selfVal === 'resident') selfFeedStatus = 'Resident';
+    else if (selfVal && selfVal !== 'none') selfFeedStatus = 'Poacher';
+  }
+  lines.push(`Residents: ${residentCount} | Poachers: ${poacherCount} | Self: ${selfFeedStatus}`);
 
   if (feeders.length) {
     lines.push('');
@@ -828,7 +906,13 @@ function buildPatrolContext(char, sub, idx, cycleData, territories) {
     lines.push(`Player-facing note: ${rev.player_facing_note}`);
   }
 
-  // ST directives
+  if (existingDraft) {
+    lines.push('');
+    lines.push('Existing draft (revise unless told to rewrite):');
+    lines.push(existingDraft);
+  }
+
+  // ST directives — placed immediately before the rubric so the AI weights them highest
   if (rev.st_note || notes.length) {
     lines.push('');
     lines.push('ST directives (must reflect):');
@@ -836,14 +920,8 @@ function buildPatrolContext(char, sub, idx, cycleData, territories) {
     for (const n of notes) lines.push(`- [${n.author_name || 'ST'}] ${n.text || ''}`);
   }
 
-  if (existingDraft) {
-    lines.push('');
-    lines.push('Existing draft (revise unless told to rewrite):');
-    lines.push(existingDraft);
-  }
-
   lines.push('');
-  lines.push('Apply PATROL_SCALE. One paragraph, 80-120 words. Use house style.');
+  lines.push('Apply PATROL_SCALE. No more than 120 words; shorter is better. Do not open with atmosphere or mood-setting — begin on action or consequence. Use house style.');
 
   return lines.join('\n');
 }
@@ -1141,6 +1219,22 @@ function renderCharacterView(char, sub) {
   h += `</div>`;
 
   h += renderProgressTracker(char, sub);
+
+  // Voice calibration panel — per-character ST notes injected into all prompts
+  const calText = char?.dt_story_calibration || '';
+  h += `<div class="dt-story-calibration-panel">`;
+  h += `<div class="dt-story-calibration-header" data-toggle="calibration" role="button">`;
+  h += `<span class="dt-story-section-label">Voice calibration</span>`;
+  h += `<span class="dt-story-calibration-hint">${calText ? '(saved)' : '(none — prompts use defaults)'}</span>`;
+  h += `</div>`;
+  h += `<div class="dt-story-calibration-body${calText ? '' : ' hidden'}" data-char-id="${charId}">`;
+  h += `<textarea class="dt-story-calibration-ta" rows="3" placeholder="Voice, tone, recurring motifs for this character — injected into every prompt…">${esc(calText)}</textarea>`;
+  h += `<div class="dt-story-card-actions">`;
+  h += `<button class="dt-story-calibration-save-btn" data-char-id="${charId}">Save Calibration</button>`;
+  h += `<span class="dt-story-calibration-status"></span>`;
+  h += `</div>`;
+  h += `</div>`;
+  h += `</div>`;
 
   for (const section of sections) {
     h += renderSection(section, char, sub, stNarrative);
@@ -1462,6 +1556,15 @@ function buildLetterContext(char, sub, opts = {}) {
   const lines = ['Draft a Letter from Home for:', '', _compactCharHeader(char)];
   const identLine = _charIdentLine(char);
   if (identLine) lines.push(identLine);
+  lines.push(..._calibrationBlock(char));
+
+  // NPCR.12: correspondent near the top so the AI's persona is set before reading the player letter
+  if (storyMomentTarget?.name) {
+    const kindLabel = storyMomentTarget.custom_label || storyMomentTarget.kind || '';
+    lines.push('');
+    lines.push(`Correspondent: ${storyMomentTarget.name}${kindLabel ? ` (${kindLabel})` : ''}`);
+    lines.push('Write in this correspondent\'s voice.');
+  }
 
   if (touchstones.length) {
     lines.push('');
@@ -1474,14 +1577,6 @@ function buildLetterContext(char, sub, opts = {}) {
 
   lines.push('');
   lines.push(`Aspirations: ${playerAspirations ? playerAspirations.trim() : '[No aspirations recorded]'}`);
-
-  // NPCR.12: player's chosen story-moment target (if any). Surfaces name +
-  // kind as prompt context so the letter can acknowledge that focus.
-  if (storyMomentTarget?.name) {
-    const kindLabel = storyMomentTarget.custom_label || storyMomentTarget.kind || '';
-    lines.push('');
-    lines.push(`Story-moment target: ${storyMomentTarget.name} (${kindLabel})`);
-  }
 
   lines.push('');
   lines.push('Player-submitted letter:');
@@ -1499,7 +1594,7 @@ function buildLetterContext(char, sub, opts = {}) {
   }
 
   lines.push('');
-  lines.push('Apply LETTER_CORRESPONDENT_RULES. 100-300 words. Use house style.');
+  lines.push('Apply LETTER_CORRESPONDENT_RULES. No more than 300 words. Do not open with pleasantries or greetings — begin with the letter\'s substance. Use house style.');
 
   return lines.join('\n');
 }
@@ -1528,6 +1623,7 @@ function buildTouchstoneContext(char, sub) {
   const lines = ['Draft a Touchstone Vignette for:', '', _compactCharHeader(char)];
   const identLine = _charIdentLine(char);
   if (identLine) lines.push(identLine);
+  lines.push(..._calibrationBlock(char));
 
   if (touchstones.length) {
     lines.push('');
@@ -1541,12 +1637,22 @@ function buildTouchstoneContext(char, sub) {
   lines.push('');
   lines.push(`Aspirations: ${playerAspirations ? playerAspirations.trim() : '[No aspirations recorded]'}`);
 
+  // Attendance gate — determines whether in-person scenes are valid in the vignette
+  const attendedGame = sub.responses?.attended_game;
+  const wasPresent   = attendedGame === 'yes' || attendedGame === true;
+  lines.push('');
+  if (wasPresent) {
+    lines.push('Attendance: Character was present at game this cycle.');
+  } else {
+    lines.push('Attendance: Character was not physically present at game this cycle. Vignette must not depict in-person encounters — use remote contact, memory, or received information only.');
+  }
+
   lines.push('');
   lines.push('Player-submitted narrative:');
   lines.push(playerLetter ? playerLetter.trim() : '[No player narrative submitted this cycle]');
 
   lines.push('');
-  lines.push('Apply TOUCHSTONE_CALIBRATION. 100-300 words. Use house style.');
+  lines.push('Apply TOUCHSTONE_CALIBRATION. No more than 200 words; shorter is better. Begin in scene — no mood-setting preamble. Use house style.');
 
   return lines.join('\n');
 }
@@ -2997,6 +3103,8 @@ function buildCacophonySavvyContext(char, noisyAction, slotIdx, csDots) {
   lines.push('');
   lines.push(`Character: ${char ? displayName(char) : 'Unknown'}`);
   lines.push(`Cacophony Savvy: ${csDots} dots (slot ${slotIdx + 1} of ${csDots})`);
+  lines.push(`Covenant filter: ${char?.covenant || 'Unaligned'} — calibrate the rumour channel and language to this covenant's social register.`);
+  lines.push(..._calibrationBlock(char));
   lines.push('');
   lines.push('This slot covers a noisy event that filtered through the Cacophony this cycle:');
   lines.push('');
@@ -3005,7 +3113,7 @@ function buildCacophonySavvyContext(char, noisyAction, slotIdx, csDots) {
   if (noisyAction.territory) lines.push(`Territory: ${noisyAction.territory}`);
   if (noisyAction.outcome)   lines.push(`Declared intent: ${noisyAction.outcome}`);
   lines.push('');
-  lines.push(`Write a short vignette (~75 words) of what ${char ? displayName(char) : 'the character'} heard via the Cacophony about this event.`);
+  lines.push(`Write a vignette of no more than 80 words of what ${char ? displayName(char) : 'the character'} heard via the Cacophony about this event. Begin with the rumour itself, not with the character receiving it.`);
   lines.push('');
   lines.push('Style rules:');
   lines.push('- Third person \u2014 the character hears about someone else, not about themselves');
@@ -3627,6 +3735,37 @@ function handleContextToggle(toggleEl) {
   if (!block) return;
   const collapsed = block.classList.toggle('collapsed');
   toggleEl.textContent = collapsed ? 'Show context' : 'Hide context';
+}
+
+function handleCalibrationToggle(headerEl) {
+  const body = headerEl.closest('.dt-story-calibration-panel')?.querySelector('.dt-story-calibration-body');
+  if (!body) return;
+  body.classList.toggle('hidden');
+}
+
+async function handleCalibrationSave(btn) {
+  const charId = btn.dataset.charId;
+  if (!charId) return;
+  const panel  = btn.closest('.dt-story-calibration-body');
+  const ta     = panel?.querySelector('.dt-story-calibration-ta');
+  const text   = ta?.value || '';
+  const status = panel?.querySelector('.dt-story-calibration-status');
+
+  btn.disabled = true;
+  if (status) status.textContent = 'Saving…';
+  try {
+    await apiPatch(`/api/characters/${charId}`, { dt_story_calibration: text });
+    // Update in-memory record so subsequent Copy Context picks up the new value immediately
+    const c = _allCharacters.find(c => String(c._id) === charId);
+    if (c) c.dt_story_calibration = text;
+    if (status) status.textContent = 'Saved';
+    btn.disabled = false;
+    setTimeout(() => { if (status) status.textContent = ''; }, 2000);
+  } catch (err) {
+    if (status) status.textContent = 'Error';
+    btn.disabled = false;
+    console.error('Calibration save failed:', err);
+  }
 }
 
 async function handleProjectSave(btn, status) {

--- a/server/schemas/character.schema.js
+++ b/server/schemas/character.schema.js
@@ -76,6 +76,7 @@ export const characterSchema = {
     court_title:    { type: ['string', 'null'] },
     court_category: { type: ['string', 'null'], enum: ['Head of State', 'Primogen', 'Administrator', 'Socialite', 'Enforcer', '', null] },
     home_territory: { type: ['string', 'null'] },
+    dt_story_calibration: { type: ['string', 'null'] },
 
     // NPC stub register — placeholder until full NPC Register epic
     npcs: {


### PR DESCRIPTION
## Summary

**9 issues in one pass** — two commits, both targeting the DT Story tab's copy-context prompt pipeline.

### Commit 1: Bug fixes (#363–#367)

- **#363** `handleCopyProjectContext` async race — snapshot `_currentSub` before first `await`; stale module-level read was injecting a prior character's existing draft
- **#364** `handleCopyStoryMomentContext` / `handleCopyTerritoryContext` async races — same snapshot fix; also extended prev-cycle chain to cover legacy `touchstone.response` path for DT2 characters
- **#365** `buildTouchstoneContext` omitted player-submitted narrative — added same priority chain as `buildLetterContext` (`personal_story_text` → `correspondence` → `letter_to_home` → …)
- **#366** Territory shown as "Unknown" in patrol/ambience — DT3 form writes `project_N_target_terr` (patrol) and `project_N_ambience_target` (ambience); builders were reading only `project_N_territory`
- **#367** Double honorific in prompt header — `_compactCharHeader` was prepending `char.honorific` manually; `displayName()` already includes it

### Commit 2: Prompt quality features (#368–#371)

- **#368** Rubric strings tightened across all 6 builders — word ceilings replace word floors, anti-periphrasis instruction added; ST directives block moved immediately before rubric in `buildProjectContext` and `buildPatrolContext`
- **#369** Category framing rules — attendance gate in `buildTouchstoneContext`; ambience territorial framing in `buildProjectContext`; covenant filter in `buildCacophonySavvyContext`
- **#370** Missing context fields — correspondent moved before touchstones in `buildLetterContext`; discipline extraction for investigation actions; self feed status in patrol territory block; XP spend block in project and patrol builders
- **#371** Per-character voice calibration — `dt_story_calibration` field on character doc; collapsible panel in `renderCharacterView` with PATCH save; `_calibrationBlock()` helper injected into all 6 context builders

## Files changed

- `public/js/admin/downtime-story.js` — all logic changes
- `public/css/admin-layout.css` — calibration panel styles
- `server/schemas/character.schema.js` — `dt_story_calibration` field

## Test plan

- [ ] Open DT Story tab, switch between characters — confirm no double honorific in prompt headers
- [ ] Copy Project Context on a patrol action — confirm territory resolves (not "Unknown")
- [ ] Copy Project Context on an ambience action — confirm ambience territory resolves
- [ ] Copy Story Moment context — confirm player narrative appears in touchstone prompt
- [ ] Switch characters quickly and copy context — confirm draft is from correct character (async race fix)
- [ ] Confirm rubric strings in copied prompts reflect new wording (word ceiling, no floor)
- [ ] Voice calibration panel: enter text, Save — confirm "Saved" flash; re-copy context — confirm calibration block appears
- [ ] Character with no calibration saved — confirm calibration block absent from copied prompts

Closes #363, #364, #365, #366, #367, #368, #369, #370, #371

🤖 Generated with [Claude Code](https://claude.com/claude-code)