### PR TITLE
chore(stm-2): flip story status to Done

### DIFF
--- a/specs/stories/issue-372-stm-2-overlay-composition.story.md
+++ b/specs/stories/issue-372-stm-2-overlay-composition.story.md
@@ -1,6 +1,6 @@
 # Issue #372: STM-2 — Client-side overlay composition + tracker_state splice
 
-Status: Ready for Review
+Status: Done
 
 issue: 372
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/372


### PR DESCRIPTION
Tiny bookkeeping flip after PR #375 (STM-2 overlay) merged as 4e87e03d.

Story file status was at "Ready for Review" because that was the pre-merge state. Now flipped to "Done" per `feedback_bookkeeping_default`.

No code change, no test impact.