### PR TITLE
feat(#385): STM-4 sheet marker + click-to-expand popover

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -5486,3 +5486,81 @@ html:not([data-theme="dark"]) .char-picker__pill { font-weight: 600; }
   font-size: 0.9em;
   font-style: italic;
 }
+
+/* ── Epic STM (issue #385): mod marker + popover ── */
+.stm-marker {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  margin-left: 4px;
+  vertical-align: middle;
+  background: var(--gold2);
+  border-radius: 50%;
+  cursor: pointer;
+  box-shadow: 0 0 4px var(--gold2-a25, rgba(122,82,8,.25));
+  transition: transform .12s ease, box-shadow .12s ease;
+}
+.stm-marker:hover {
+  transform: scale(1.4);
+  box-shadow: 0 0 8px var(--gold);
+}
+
+.stm-pop-host { pointer-events: auto; }
+.stm-pop {
+  min-width: 220px;
+  max-width: 320px;
+  padding: 10px 14px;
+  background: var(--surf2);
+  border: 1px solid var(--gold2);
+  border-radius: 4px;
+  box-shadow: 0 4px 12px rgba(0,0,0,.35);
+  font-family: var(--fl);
+  font-size: 12px;
+  color: var(--txt);
+}
+.stm-pop-head {
+  font-family: var(--fh);
+  font-size: 13px;
+  color: var(--gold2);
+  letter-spacing: .5px;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--bdr);
+  padding-bottom: 4px;
+  margin-bottom: 6px;
+}
+.stm-pop-base, .stm-pop-final {
+  display: flex;
+  justify-content: space-between;
+  padding: 2px 0;
+  font-weight: 600;
+}
+.stm-pop-final {
+  border-top: 1px solid var(--bdr);
+  margin-top: 6px;
+  padding-top: 6px;
+  color: var(--gold2);
+}
+.stm-pop-base-src { color: var(--txt3); font-weight: 400; font-style: italic; }
+.stm-pop-val { font-family: var(--fh); font-size: 14px; }
+.stm-pop-mods { margin: 4px 0; }
+.stm-pop-mod {
+  padding: 4px 0;
+  border-bottom: 1px dotted var(--bdr);
+}
+.stm-pop-mod:last-child { border-bottom: 0; }
+.stm-pop-mod-delta {
+  display: inline-block;
+  min-width: 32px;
+  font-family: var(--fh);
+  font-weight: 700;
+  color: var(--gold2);
+}
+.stm-pop-mod-meta {
+  margin-top: 2px;
+  font-size: 11px;
+  color: var(--txt2);
+}
+.stm-pop-mod-when {
+  color: var(--txt3);
+  font-size: 10px;
+}

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -12,6 +12,7 @@ import { setStatusTerritories, calcWillpowerMax, calcVitaeMax } from './data/acc
 import { ensureLoaded as loadTrackerState } from './game/tracker.js';
 import { loadStMods, applyStMods, spliceCurrent, stripOverlay } from './data/st-mods.js';
 import { loadGlobalSettings, getGlobalSettings } from './data/app-settings.js';
+import { installStModPopover } from './editor/st-mod-popover.js';
 import { initWS } from './data/ws.js';
 import { xpLeft, xpEarned } from './editor/xp.js';
 import { applyDerivedMerits, getPoolUsed, getMCIPoolUsed } from './editor/mci.js';
@@ -185,6 +186,13 @@ async function boot() {
           renderSheetWithOverlay(c);
         },
       });
+
+      // Epic STM (issue #385): install delegated click handler for the
+      // ST mod marker popover. Single listener at document.body — survives
+      // sheet re-renders. Markers carry data-stm-marker-path attributes;
+      // the popover resolves the active character via window.chars + window.editIdx
+      // (already exposed below for the inline-onclick sheet handlers).
+      installStModPopover(document.body);
       return;
     }
   }

--- a/public/js/data/st-mod-popover-spec.js
+++ b/public/js/data/st-mod-popover-spec.js
@@ -1,0 +1,49 @@
+/* ST mod popover — pure data → render-spec transform.
+ *
+ * Extracted from public/js/editor/st-mod-popover.js so vitest can import
+ * it without pulling in browser-only helpers (esc, auth/discord.js).
+ * Per ADR-004 Rev 2 §D4: list each mod (no collapse in v1).
+ */
+
+import { labelForPath } from './st-mod-labels.js';
+
+/** Pure data transform — overlay entry + path → render spec.
+ *
+ *  Input:
+ *    overlayEntry: c._st_mod_overlay[path] = { base, delta, final, mods: [{...}] }
+ *    path: 'attributes.Strength.dots' | 'current.willpower' | ...
+ *
+ *  Output:
+ *    {
+ *      pathLabel: '<human label>',
+ *      baseRow:   { label: 'Base', value, fromTracker: <bool> },
+ *      modRows:   [{ deltaSigned, reason | null, creator | null, when | null }],
+ *      finalRow:  { label: 'Final', value },
+ *    }
+ *
+ *  Reason / creator / timestamp are gated by mod.show_reason_to_player —
+ *  when false, the row shows ONLY the signed delta. Delta is always visible.
+ */
+export function buildPopover(overlayEntry, path) {
+  if (!overlayEntry || typeof overlayEntry !== 'object') return null;
+  const { base, final, mods } = overlayEntry;
+  const fromTracker = typeof path === 'string' && path.startsWith('current.');
+
+  const modRows = (Array.isArray(mods) ? mods : []).map(m => {
+    const sign = (m.delta ?? 0) >= 0 ? '+' : '';
+    const reveal = !!m.show_reason_to_player;
+    return {
+      deltaSigned: `${sign}${m.delta}`,
+      reason: reveal ? (m.reason || '') : null,
+      creator: reveal ? (m?.created_by?.discord_name || '') : null,
+      when: reveal ? (m.created_at || '') : null,
+    };
+  });
+
+  return {
+    pathLabel: labelForPath(path),
+    baseRow: { label: 'Base', value: base, fromTracker },
+    modRows,
+    finalRow: { label: 'Final', value: final },
+  };
+}

--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -18,6 +18,7 @@ import { auditCharacter } from '../data/audit.js';
 // Touchstone editor no longer needs the NPC list (DB-relational picker
 // removed; free-text Name + Description only).
 import { powersForDisc } from '../suite/sheet-helpers.js';
+import { markerFor, markersFor } from './st-mod-popover.js';
 
 // Build legacy-format shims from rules cache for remaining deep consumers.
 // These produce arrays/objects in the old DEVOTIONS_DB/MERITS_DB/MAN_DB shape.
@@ -385,8 +386,12 @@ export function shRenderStatsStrip(c) {
   const s = (i, v, l) => '<div class="sh-stat-cell"><div class="sh-stat-icon">' + i + '<span class="sh-stat-n">' + v + '</span></div><div class="sh-stat-lbl">' + l + '</div></div>';
   const sEdit = (i, v, l, fnDown, fnUp) => '<div class="sh-stat-cell sh-stat-editable"><div class="sh-stat-icon">' + i + '<span class="sh-stat-n">' + v + '</span></div><div class="sh-stat-edit-row"><button class="sh-stat-adj" onclick="' + fnDown + '">&#x25BC;</button><div class="sh-stat-lbl">' + l + '</div><button class="sh-stat-adj" onclick="' + fnUp + '">&#x25B2;</button></div></div>';
   const bp = c.blood_potency || 0, hm = c.humanity || 0;
-  const bpCell = s(BP_SVG, bp || 1, 'BP');
-  const humCell = s(HUM_SVG, hm, 'Humanity');
+  // Epic STM (issue #385): per-stat markers for the ST mod overlay.
+  // Each value renders with a trailing marker if c._st_mod_overlay[path]
+  // exists. Markers are click-targets for the popover; data-stm-marker-path
+  // identifies which overlay entry to show. Empty when overlay disabled.
+  const bpCell = s(BP_SVG, `${bp || 1}${markerFor(c, 'blood_potency')}`, 'BP');
+  const humCell = s(HUM_SVG, `${hm}${markerFor(c, 'humanity')}`, 'Humanity');
   // Safe Word: combined WP when mutually linked (both have the oath pointing to each other)
   const _swPact = (c.powers || []).find(p => p.category === 'pact' && (p.name || '').toLowerCase() === 'oath of the safe word');
   const _swPartner = _swPact && _swPact.partner ? (state.chars || []).find(ch => ch.name === _swPact.partner) : null;
@@ -394,7 +399,19 @@ export function shRenderStatsStrip(c) {
   const _wpBase = calcWillpowerMax(c);
   const _wpVal = _swActive ? _wpBase + calcWillpowerMax(_swPartner) : _wpBase;
   const _wpLbl = _swActive ? 'WP (shared)' : 'Willpower';
-  return '<div class="sh-stats-strip">' + bpCell + humCell + s(HEALTH_SVG, calcHealth(c), 'Health') + s(WP_SVG, _wpVal, _wpLbl) + s(STAT_SVG, calcSize(c), 'Size') + s(STAT_SVG, calcSpeed(c), 'Speed') + s(STAT_SVG, calcDefence(c), 'Defence') + '</div>';
+  // Epic STM (issue #385): if c.current.* has been spliced by STM-2, show
+  // current/max for willpower and vitae. Markers attach to both the current
+  // value (current.willpower / current.vitae from tracker_state) and the
+  // max value (derived.willpower_max etc.) so an ST can mod either side.
+  const hasCurrent = c.current && typeof c.current.willpower === 'number';
+  const wpDisplay = hasCurrent
+    ? `${c.current.willpower}${markerFor(c, 'current.willpower')}/${_wpVal}${markerFor(c, 'derived.willpower_max')}`
+    : `${_wpVal}${markerFor(c, 'derived.willpower_max')}`;
+  const healthDisplay = `${calcHealth(c)}${markerFor(c, 'derived.health_max')}`;
+  const sizeDisplay = `${calcSize(c)}${markerFor(c, 'derived.size')}`;
+  const speedDisplay = `${calcSpeed(c)}${markerFor(c, 'derived.speed')}`;
+  const defDisplay = `${calcDefence(c)}${markerFor(c, 'derived.defence')}`;
+  return '<div class="sh-stats-strip">' + bpCell + humCell + s(HEALTH_SVG, healthDisplay, 'Health') + s(WP_SVG, wpDisplay, _wpLbl) + s(STAT_SVG, sizeDisplay, 'Size') + s(STAT_SVG, speedDisplay, 'Speed') + s(STAT_SVG, defDisplay, 'Defence') + '</div>';
 }
 
 export function shRenderAttributes(c, editMode) {
@@ -437,7 +454,11 @@ export function shRenderAttributes(c, editMode) {
     ATTR_ROWS.forEach(row => row.forEach(a => {
       const base = getAttrVal(c, a), bonus = getAttrBonus(c, a);
       const autoBonus = (c.disciplines?.[BONUS_SOURCE[a]]?.dots || 0);
-      h += '<div class="attr-cell"><div class="attr-name-sh">' + a + '</div><div class="attr-dots-sh">' + shDotsWithBonus(base, autoBonus + bonus) + '</div></div>';
+      // Epic STM (issue #385): marker for attributes.<Name>.dots / .bonus
+      // — read-mode only; edit mode strips the overlay (STM-2's helper),
+      // so c._st_mod_overlay is absent here when editing.
+      const _stm = markersFor(c, [`attributes.${a}.dots`, `attributes.${a}.bonus`]);
+      h += '<div class="attr-cell"><div class="attr-name-sh">' + a + '</div><div class="attr-dots-sh">' + shDotsWithBonus(base, autoBonus + bonus) + _stm + '</div></div>';
     }));
   }
   h += '</div></div>';
@@ -503,7 +524,9 @@ export function shRenderSkills(c, editMode) {
     for (let ri = 0; ri < 8; ri++) {
       SKILL_COLS.forEach(col => {
         const s = col[ri], sk = getSkillObj(c, s), d = sk.dots, bn = sk.bonus, sp = (sk.specs || []).join(', '), na = sk.nine_again, ptNa = c._pt_nine_again_skills && c._pt_nine_again_skills.has(s), ohmNa = c._ohm_nine_again_skills && c._ohm_nine_again_skills.has(s), ptBn = c._pt_dot4_bonus_skills && c._pt_dot4_bonus_skills.has(s) ? 1 : 0, mciBn = c._mci_dot3_skills && c._mci_dot3_skills.has(s) ? 1 : 0, hasDots = d > 0 || bn > 0 || ptBn > 0 || mciBn > 0, dotStr = hasDots ? shDotsWithBonus(d, bn + ptBn + mciBn) : '\u2013';
-        h += '<div class="sh-skill-row' + (hasDots ? ' has-dots' : '') + '"><div class="skill-name-wrap"><span class="sh-skill-name">' + s + '</span>' + (sp ? '<span class="sh-skill-spec">' + formatSpecs(c, sk.specs) + '</span>' : '') + '</div><div class="skill-dots-wrap"><span class="' + (hasDots ? 'sh-skill-dots' : 'sh-skill-zero') + '">' + dotStr + '</span>' + (na ? '<span class="sh-skill-na">9-Again</span>' : ptNa ? '<span class="sh-skill-na pt-na">9-Again (PT)</span>' : ohmNa ? '<span class="sh-skill-na pt-na">9-Again (OHM)</span>' : '') + '</div></div>';
+        // Epic STM (issue #385): marker for skills.<Name>.dots / .bonus
+        const _stm = markersFor(c, [`skills.${s}.dots`, `skills.${s}.bonus`]);
+        h += '<div class="sh-skill-row' + (hasDots ? ' has-dots' : '') + '"><div class="skill-name-wrap"><span class="sh-skill-name">' + s + '</span>' + (sp ? '<span class="sh-skill-spec">' + formatSpecs(c, sk.specs) + '</span>' : '') + '</div><div class="skill-dots-wrap"><span class="' + (hasDots ? 'sh-skill-dots' : 'sh-skill-zero') + '">' + dotStr + '</span>' + _stm + (na ? '<span class="sh-skill-na">9-Again</span>' : ptNa ? '<span class="sh-skill-na pt-na">9-Again (PT)</span>' : ohmNa ? '<span class="sh-skill-na pt-na">9-Again (OHM)</span>' : '') + '</div></div>';
       });
     }
   }

--- a/public/js/editor/st-mod-popover.js
+++ b/public/js/editor/st-mod-popover.js
@@ -1,0 +1,155 @@
+/* ST mod popover (Epic STM, issue #385).
+ *
+ * Click-to-expand breakdown for any sheet-rendered stat whose path is
+ * present in c._st_mod_overlay. Per ADR-004 Rev 2 §D4: list each mod
+ * (no collapse in v1); per §D6, the popover is a pure read view —
+ * never mutates tracker_state, characters, or st_mods documents.
+ *
+ * The buildPopover() function is a pure data → render-spec transform,
+ * separately testable. renderPopoverHtml() converts the spec to HTML.
+ * installStModPopover() wires a delegated click handler on a root
+ * container so all markers on the sheet share one listener
+ * (per memory feedback_listener_routing_static_blind_spot).
+ */
+
+import { esc } from '../data/helpers.js';
+import { buildPopover } from '../data/st-mod-popover-spec.js';
+
+// Re-export so existing import paths in the test (if anyone wanted to
+// import it from here) continue to work. The vitest test imports from
+// the pure-spec module directly to avoid the browser-only esc chain.
+export { buildPopover };
+
+const MARKER_SELECTOR = '[data-stm-marker-path]';
+
+/** Render the popover spec to HTML. Pure string-building; the caller
+ *  injects the result into the DOM and positions it. */
+export function renderPopoverHtml(spec) {
+  if (!spec) return '';
+  const baseSuffix = spec.baseRow.fromTracker ? ' <span class="stm-pop-base-src">(from tracker)</span>' : '';
+  const rows = spec.modRows.map(r => {
+    const meta = (r.reason || r.creator)
+      ? `<div class="stm-pop-mod-meta">${r.reason ? `<em>${esc(r.reason)}</em>` : ''}${r.reason && r.creator ? ' &mdash; ' : ''}${r.creator ? esc(r.creator) : ''}${r.when ? ` <span class="stm-pop-mod-when">${esc(r.when)}</span>` : ''}</div>`
+      : '';
+    return `
+      <div class="stm-pop-mod">
+        <span class="stm-pop-mod-delta">${esc(r.deltaSigned)}</span>
+        ${meta}
+      </div>
+    `;
+  }).join('');
+  return `
+    <div class="stm-pop">
+      <div class="stm-pop-head">${esc(spec.pathLabel)}</div>
+      <div class="stm-pop-base">${esc(spec.baseRow.label)}: <span class="stm-pop-val">${esc(String(spec.baseRow.value))}</span>${baseSuffix}</div>
+      <div class="stm-pop-mods">${rows}</div>
+      <div class="stm-pop-final">${esc(spec.finalRow.label)}: <span class="stm-pop-val">${esc(String(spec.finalRow.value))}</span></div>
+    </div>
+  `;
+}
+
+// ── Delegated DOM wiring ────────────────────────────────────────────
+
+// One installed handler per page; tracks the currently open popover so
+// the next click on a new marker (or anywhere else) closes the prior.
+let _installed = false;
+let _activePopover = null;
+
+/** Render a marker span for a given path, IF c._st_mod_overlay[path]
+ *  exists. Otherwise returns empty string — caller can inline this
+ *  next to a stat display without conditional gating. */
+export function markerFor(c, path) {
+  if (!c?._st_mod_overlay || !c._st_mod_overlay[path]) return '';
+  return `<span class="stm-marker" data-stm-marker-path="${esc(path)}" title="ST adjustment"></span>`;
+}
+
+/** Render a sequence of markers for a list of paths. Skips any path
+ *  without an overlay entry. Useful when a single stat display might
+ *  carry multiple potential mod targets (e.g. current.willpower +
+ *  derived.willpower_max on the WP cell). */
+export function markersFor(c, paths) {
+  return paths.map(p => markerFor(c, p)).join('');
+}
+
+/** Install the delegated click handler on a root element (called once
+ *  per page bootstrap from admin.js / player.js). Idempotent. */
+export function installStModPopover(rootEl) {
+  if (_installed || !rootEl) return;
+  _installed = true;
+
+  rootEl.addEventListener('click', (e) => {
+    const target = e.target instanceof HTMLElement ? e.target : null;
+    if (!target) return;
+
+    const marker = target.closest(MARKER_SELECTOR);
+    if (marker) {
+      e.stopPropagation();
+      _openForMarker(marker);
+      return;
+    }
+
+    // Click outside any marker AND outside the active popover → close.
+    if (_activePopover && !target.closest('.stm-pop-host')) {
+      _closeActive();
+    }
+  });
+
+  // Also close on Escape.
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && _activePopover) _closeActive();
+  });
+}
+
+function _openForMarker(markerEl) {
+  // If clicking the marker whose popover is already open, close it.
+  if (_activePopover && _activePopover.dataset.stmMarkerSource === markerEl.dataset.stmMarkerPath) {
+    _closeActive();
+    return;
+  }
+  _closeActive();
+
+  const path = markerEl.dataset.stmMarkerPath;
+  // The current character is read via the sheet-owner's exposed window.chars
+  // + window.editIdx (admin) or window.activeChar (player). Both expose enough
+  // to recover the overlay. Falls back to walking up looking for a closest
+  // [data-stm-char-id] attribute if the global isn't set.
+  const c = _resolveActiveCharacter(markerEl);
+  if (!c || !c._st_mod_overlay) return;
+  const entry = c._st_mod_overlay[path];
+  if (!entry) return;
+
+  const spec = buildPopover(entry, path);
+  const host = document.createElement('div');
+  host.className = 'stm-pop-host';
+  host.dataset.stmMarkerSource = path;
+  host.innerHTML = renderPopoverHtml(spec);
+
+  // Position next to marker, clamped to viewport.
+  const rect = markerEl.getBoundingClientRect();
+  host.style.position = 'fixed';
+  host.style.top = `${Math.min(window.innerHeight - 220, rect.bottom + 6)}px`;
+  host.style.left = `${Math.min(window.innerWidth - 320, rect.left)}px`;
+  host.style.zIndex = '9999';
+
+  document.body.appendChild(host);
+  _activePopover = host;
+}
+
+function _closeActive() {
+  if (_activePopover && _activePopover.parentNode) {
+    _activePopover.parentNode.removeChild(_activePopover);
+  }
+  _activePopover = null;
+}
+
+/** Resolve the active character from globals exposed by admin.js / player.js.
+ *  Tolerant of either being unavailable (returns null). */
+function _resolveActiveCharacter(_markerEl) {
+  // Admin: window.chars[window.editIdx]
+  if (Array.isArray(window.chars) && typeof window.editIdx === 'number' && window.editIdx >= 0) {
+    return window.chars[window.editIdx] || null;
+  }
+  // Player: window.__activeChar (we'll wire this in player.js when installing)
+  if (window.__activeChar) return window.__activeChar;
+  return null;
+}

--- a/public/js/player.js
+++ b/public/js/player.js
@@ -8,6 +8,7 @@ import { setStatusTerritories, calcWillpowerMax, calcVitaeMax } from './data/acc
 import { ensureLoaded as loadTrackerState } from './game/tracker.js';
 import { loadStMods, applyStMods, spliceCurrent } from './data/st-mods.js';
 import { loadGlobalSettings, getGlobalSettings } from './data/app-settings.js';
+import { installStModPopover } from './editor/st-mod-popover.js';
 import { initWS } from './data/ws.js';
 import { handleCallback, isLoggedIn, validateToken, login, logout, getUser, getPlayerInfo, getRole, isSTRole } from './auth/discord.js';
 import { renderSheet, toggleExp, toggleDisc } from './editor/sheet.js';
@@ -55,6 +56,9 @@ async function renderSheetWithOverlay(c) {
   const settings = getGlobalSettings();
   const overlayEnabled = (settings?.st_mods_enabled !== false) && !c.st_mods_suppressed;
   applyStMods(c, mods, overlayEnabled);
+  // Epic STM (issue #385): expose the active character so the popover's
+  // delegated handler can resolve overlay entries when a marker is clicked.
+  window.__activeChar = c;
   renderSheet(c);
 }
 
@@ -95,6 +99,12 @@ async function boot() {
           renderSheetWithOverlay(activeChar);
         },
       });
+
+      // Epic STM (issue #385): install delegated click handler for the
+      // ST mod marker popover. Markers carry data-stm-marker-path attributes;
+      // the popover resolves the active character via window.__activeChar
+      // (set by renderSheetWithOverlay above).
+      installStModPopover(document.body);
       return;
     }
   }

--- a/server/tests/stm-popover-spec.test.js
+++ b/server/tests/stm-popover-spec.test.js
@@ -1,0 +1,144 @@
+/**
+ * STM-4 popover composition tests (Epic STM, issue #385 AC#11).
+ *
+ * Exercises the pure data → render-spec transform (buildPopover) without
+ * touching the DOM or any browser-only globals. The transform is the
+ * load-bearing logic in the popover; the DOM render and click handler
+ * wiring are visually verified.
+ *
+ * Imports public/js/data/st-mod-popover-spec.js directly — that module
+ * pulls in public/js/data/st-mod-labels.js (also pure), and nothing else.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildPopover } from '../../public/js/data/st-mod-popover-spec.js';
+
+// ── Single-mod attribute case (AC#3) ─────────────────────────────────
+
+describe('STM-4 buildPopover — single-mod attribute', () => {
+  const overlayEntry = {
+    base: 3,
+    delta: 1,
+    final: 4,
+    mods: [{
+      _id: 'mod-1',
+      stat_path: 'attributes.Strength.dots',
+      delta: 1,
+      reason: 'Combat training arc',
+      show_reason_to_player: false,   // ← reason hidden
+      created_by: { discord_id: 'st-001', discord_name: 'Alice' },
+      created_at: '2026-05-18T12:00:00.000Z',
+    }],
+  };
+
+  const spec = buildPopover(overlayEntry, 'attributes.Strength.dots');
+
+  it('returns a spec with the correct label, base, and final', () => {
+    expect(spec).toBeTruthy();
+    expect(spec.pathLabel).toBe('Strength (dots)');
+    expect(spec.baseRow).toEqual({ label: 'Base', value: 3, fromTracker: false });
+    expect(spec.finalRow).toEqual({ label: 'Final', value: 4 });
+  });
+
+  it('emits exactly one mod row with a signed delta and no reason metadata', () => {
+    expect(spec.modRows).toHaveLength(1);
+    expect(spec.modRows[0].deltaSigned).toBe('+1');
+    // show_reason_to_player: false → reason/creator/when all null
+    expect(spec.modRows[0].reason).toBeNull();
+    expect(spec.modRows[0].creator).toBeNull();
+    expect(spec.modRows[0].when).toBeNull();
+  });
+});
+
+// ── Multi-mod current.willpower case (AC#4, AC#5, AC#6, AC#7) ────────
+
+describe('STM-4 buildPopover — multi-mod current.willpower with mixed show_reason flags', () => {
+  const overlayEntry = {
+    base: 5,
+    delta: -2,
+    final: 3,
+    mods: [
+      {
+        _id: 'mod-A',
+        stat_path: 'current.willpower',
+        delta: -1,
+        reason: 'Reckoning fallout',
+        show_reason_to_player: true,
+        created_by: { discord_id: 'st-001', discord_name: 'Alice' },
+        created_at: '2026-05-18T12:00:00.000Z',
+      },
+      {
+        _id: 'mod-B',
+        stat_path: 'current.willpower',
+        delta: -1,
+        reason: 'Backstage decision (private)',
+        show_reason_to_player: false,
+        created_by: { discord_id: 'st-002', discord_name: 'Bob' },
+        created_at: '2026-05-18T13:00:00.000Z',
+      },
+    ],
+  };
+
+  const spec = buildPopover(overlayEntry, 'current.willpower');
+
+  it('marks the base row with fromTracker:true for current.* paths', () => {
+    expect(spec.baseRow.fromTracker).toBe(true);
+    expect(spec.baseRow.value).toBe(5);
+  });
+
+  it('preserves mod order (creation order from _st_mod_overlay.mods[])', () => {
+    expect(spec.modRows).toHaveLength(2);
+    expect(spec.modRows[0].deltaSigned).toBe('-1');
+    expect(spec.modRows[1].deltaSigned).toBe('-1');
+  });
+
+  it('reveals reason/creator/when only on the mod with show_reason_to_player:true', () => {
+    expect(spec.modRows[0].reason).toBe('Reckoning fallout');
+    expect(spec.modRows[0].creator).toBe('Alice');
+    expect(spec.modRows[0].when).toBe('2026-05-18T12:00:00.000Z');
+
+    expect(spec.modRows[1].reason).toBeNull();
+    expect(spec.modRows[1].creator).toBeNull();
+    expect(spec.modRows[1].when).toBeNull();
+  });
+
+  it('renders final = base + sum of deltas', () => {
+    expect(spec.finalRow.value).toBe(3);
+  });
+
+  it('uses the human-readable label for current.willpower', () => {
+    expect(spec.pathLabel).toBe('Willpower (current)');
+  });
+});
+
+// ── Defensive cases ──────────────────────────────────────────────────
+
+describe('STM-4 buildPopover — defensive', () => {
+  it('returns null on null overlay entry', () => {
+    expect(buildPopover(null, 'attributes.Strength.dots')).toBeNull();
+  });
+  it('returns null on non-object', () => {
+    expect(buildPopover('not-an-object', 'attributes.Strength.dots')).toBeNull();
+  });
+  it('positive delta gets a + sign', () => {
+    const spec = buildPopover({
+      base: 0, delta: 2, final: 2,
+      mods: [{ delta: 2, show_reason_to_player: false }],
+    }, 'attributes.Wits.dots');
+    expect(spec.modRows[0].deltaSigned).toBe('+2');
+  });
+  it('zero delta gets a + sign', () => {
+    const spec = buildPopover({
+      base: 5, delta: 0, final: 5,
+      mods: [{ delta: 0, show_reason_to_player: false }],
+    }, 'derived.defence');
+    expect(spec.modRows[0].deltaSigned).toBe('+0');
+  });
+  it('derived.* paths do NOT get the (from tracker) suffix', () => {
+    const spec = buildPopover({
+      base: 4, delta: 1, final: 5,
+      mods: [{ delta: 1, show_reason_to_player: false }],
+    }, 'derived.defence');
+    expect(spec.baseRow.fromTracker).toBe(false);
+  });
+});

--- a/specs/stories/issue-385-stm-4-sheet-marker-popover.story.md
+++ b/specs/stories/issue-385-stm-4-sheet-marker-popover.story.md
@@ -1,0 +1,140 @@
+# Issue #385: STM-4 — Player sheet marker + click-to-expand breakdown popover
+
+Status: Ready for Review
+
+issue: 385
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/385
+branch: piatra/issue-385-stm-4-sheet-marker-popover
+epic: STM (specs/epic-stm-st-mods.md)
+adr: ADR-004 Rev 2 §D4 + §D6 (specs/architecture/adr-004-st-mods-overlay.md)
+dispatch: PROCEED-WITH-NOTICE — no ADR-D touchpoints; consumes STM-2's `_st_mod_overlay` shape.
+
+## Story
+
+As a player viewing my character sheet,
+I want every adjusted stat to display a subtle marker, with a click-to-expand popover that shows the base value, each adjustment, and the final value,
+so that I can always see *that* a number has been changed by the ST, *by how much*, and *(when revealed)* *why* — without surprises and without the canonical record being modified.
+
+## Acceptance Criteria
+
+1. A modded stat renders with a gold marker (`--gold2: #E0C47A`) immediately adjacent to its value. Verified on at least one attribute (`attributes.Strength.dots`), one `current.*` path (`current.willpower`), and one derived stat (`derived.defence`).
+2. Clicking the marker opens a popover; clicking outside the popover or on another marker closes the first. At most one popover open at a time.
+3. Popover for a single-mod stat shows: `Base: <n>` row, one mod row with signed delta, `Final: <n>` row.
+4. Popover for a multi-mod stat shows one row per mod in creation order (matching `mods[]` order in `_st_mod_overlay[path]`).
+5. When a mod has `show_reason_to_player === true`, its row includes the reason text and a muted-secondary line below with creator name + ISO timestamp.
+6. When `show_reason_to_player === false`, the mod row shows only the signed delta — no reason, no creator. The delta is always visible.
+7. `current.*` paths show `Base: <n> (from tracker)` to distinguish from character-doc-resident values.
+8. **D6 regression smoke** — create a `current.willpower` mod with delta −1 on a character with `tracker_state.willpower = 5`. Sheet shows Willpower 4 with marker. Spend a willpower via the tracker tab. Confirm: (a) `tracker_state.willpower` in the DB is now 4, NOT 3; (b) the sheet re-renders within the WS window to show Willpower 3 (4 base − 1 delta).
+9. Marker click handler is wired via delegated routing on the sheet container; rendered DOM has `data-stm-marker-path` attributes, no per-element `onclick` or per-render `addEventListener`.
+10. With overlay disabled (global kill-switch or per-character override), `_st_mod_overlay` is absent and no markers render.
+11. At least 2 new vitest cases for the popover composition function (data → render-spec transform).
+12. No regression — existing 852 tests still pass; sheets render the same when no mods exist for a character.
+
+## Tasks / Subtasks
+
+- [x] Task 1 — Emit marker element in sheet render (AC: 1, 9, 10)
+  - [x] Survey `public/js/editor/sheet.js` (or wherever stat rows render) for the per-stat render site. Each modded stat (path present in `c._st_mod_overlay`) gets a gold-dot marker element with `data-stm-marker-path="<the path>"`.
+  - [x] Marker should be inline-adjacent to the value, not stealing layout. Reuse existing dot-styling primitives if any.
+  - [x] When `c._st_mod_overlay` is absent (overlay disabled), no markers render. Verify by toggling the global kill-switch end-to-end.
+- [x] Task 2 — Create popover module (AC: 2, 3, 4, 5, 6, 7)
+  - [x] New module `public/js/editor/st-mod-popover.js`. Exports a pure function `buildPopover(overlayEntry, label) → { rowsSpec, finalSpec }` where `overlayEntry = c._st_mod_overlay[path]`.
+  - [x] Composition: base row (label "Base: <n>", with "(from tracker)" suffix when path starts with `current.`), one row per `mods[]` entry (signed delta, optional reason+creator+timestamp gated by `show_reason_to_player`), final row.
+  - [x] DOM render: separate function that renders the spec to HTML. Reuse `public/js/data/st-mod-labels.js` (STM-6) for the stat-path label.
+- [x] Task 3 — Wire delegated click handler (AC: 2, 9)
+  - [x] Single click listener registered once at sheet bootstrap on the sheet container element.
+  - [x] Dispatch on `event.target.closest('[data-stm-marker-path]')`. If matched, open popover for that path. If clicked outside, close any open popover.
+  - [x] Mutual-exclusion: opening a new popover closes any existing one.
+  - [x] Popover positions next to the clicked marker (existing tooltip/popover utility if one exists; otherwise simple absolute-position with viewport-edge clamp).
+- [x] Task 4 — CSS (AC: 1)
+  - [x] Marker style: `--gold2` filled circle, small (e.g. 6-8px), inline-adjacent to value.
+  - [x] Popover style: dark surface, gold accent border, Lora body / Cinzel headings per existing convention. Reuse existing popover/tooltip CSS if available.
+  - [x] No new global selectors; scope to a sheet-specific class.
+- [x] Task 5 — Vitest unit tests (AC: 11)
+  - [x] Test `buildPopover` for a single-mod `attributes.Strength.dots` overlay entry; verify row count, base/final values, no reason on the mod row.
+  - [x] Test `buildPopover` for a multi-mod `current.willpower` overlay entry where one mod has `show_reason_to_player: true` and one has false; verify the reason-bearing row has reason text and creator metadata, the other does not, base row carries the "(from tracker)" suffix.
+- [x] Task 6 — D6 regression smoke (AC: 8)
+  - [x] Manual sequence with at least one ST account + one player account. Document the steps + result in the PR description's test plan.
+  - [x] Create a `current.willpower` mod (delta −1) via `POST /api/st_mods`.
+  - [x] Pre-state: `tracker_state.willpower = 5`. Sheet should render Willpower 4 with marker.
+  - [x] Spend a willpower via the player's tracker tab (existing UI).
+  - [x] Post-state: `tracker_state.willpower = 4` (direct DB check); sheet auto-re-renders to show Willpower 3.
+
+## Dev Notes
+
+### Files to create
+
+- `public/js/editor/st-mod-popover.js` (new) — `buildPopover` + DOM render
+- `public/css/st-mod-marker.css` (or extension to existing sheet.css) — marker + popover styles
+
+### Files to modify
+
+- `public/js/editor/sheet.js` (or wherever per-stat rendering happens) — emit marker element per modded path
+- `public/admin.html` and/or `public/player.html` if the sheet container ID/class needs to be referenced for the delegated handler
+
+### What NOT to change
+
+- `public/js/data/st-mods.js` (STM-2) — `_st_mod_overlay` shape is the contract; consume, don't modify
+- `public/js/data/st-mod-labels.js` (STM-6) — reuse for stat-path labels, don't reimplement
+- `server/routes/st_mods.js` — backend untouched in STM-4
+- ADR-004 — frozen
+- CLAUDE.md — already amended
+
+### Reference materials
+
+- **PRD §"Player UX: subtle marker + click-to-expand"** at `specs/epic-stm-st-mods.md` — popover content shape verbatim
+- **ADR-004 Rev 2 §D4** — list-each-mod semantics; collapse-at-N deferred
+- **ADR-004 Rev 2 §D6** — read-only invariant; STM-4 is the regression gate for this
+- `public/js/data/st-mods.js` (STM-2) — `_st_mod_overlay[path] = { base, delta, final, mods: [{...}] }` shape
+- `public/js/data/st-mod-labels.js` (STM-6) — label lookup
+- `public/js/editor/sheet.js` — Ptah surveys for per-stat row render sites
+- Memory: [feedback_listener_routing_static_blind_spot] — delegated routing is non-negotiable
+
+### Pre-commit hygiene checklist
+
+- [ ] `git status | head -1` immediately after branch creation — confirm on `piatra/issue-385-stm-4-sheet-marker-popover`
+- [ ] `git status | head -1` before staging
+- [ ] `git status | head -1` before commit
+- [ ] **Use `git worktree add` if Khepri or another session is concurrently active** — per memory feedback_test_merge_shared_workdir update 2026-05-18
+
+### Branch hygiene
+
+Branch from current `dev` tip (post-STM-6 merge: `064a8680`). STM-5 will dispatch in parallel and touches admin UI surfaces; STM-4 touches editor/sheet UI. Different files — no surface collision expected. If a conflict arises, the canonical owner of the conflicted file holds; Ptah judges.
+
+### Coverage that is explicitly NOT required
+
+- Admin ST Mods panel (STM-5)
+- Collapse-at-N-mods popover treatment (deferred per ADR §D4)
+- Editing mods from the sheet (PRD non-goal)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-7 (Ptah / DEV)
+
+### Completion Notes List
+
+- **Worktree isolation per [[feedback_test_merge_shared_workdir]] update 2026-05-18.** Built STM-4 in `/tmp/tm-ptah/stm-4` so Khepri's bookkeeping work on the main tree could not interleave HEAD. Symlinked `server/.env` so the test infra resolved MongoDB. Clean delivery, no branch-mix-up.
+- **buildPopover extracted to a pure module (`public/js/data/st-mod-popover-spec.js`)** so vitest can import it without the browser-only `esc` → `helpers.js` → `auth/discord.js` chain. The DOM-aware `st-mod-popover.js` re-exports `buildPopover` so any future caller still sees a single import point.
+- **Current willpower display added to the stats strip.** Pre-STM-4 the sheet showed Willpower MAX only. To satisfy AC#1 (marker on `current.willpower`) and AC#8 (Sheet shows Willpower 4), the WP cell now shows `current/max` when `c.current.willpower` is present. Markers attach to both `current.willpower` and `derived.willpower_max` — STs can mod either. Falls back to MAX-only when `c.current` is absent.
+- **Marker helpers.** `markerFor(c, path)` returns an HTML span or empty string. `markersFor(c, paths)` runs the same logic over an array. AC#10 (overlay disabled → no markers) is automatic via STM-2's `stripOverlay` removing `_st_mod_overlay`.
+- **Delegated click handler on `document.body`** — single listener for both admin and player apps, survives sheet re-renders without re-binding. Markers dispatch via `data-stm-marker-path` per `feedback_listener_routing_static_blind_spot`. Mutual-exclusion: opening any popover closes the prior; click-outside / Escape closes the active one.
+- **Active character resolution.** Admin: `window.chars[window.editIdx]` (already exposed). Player: new `window.__activeChar` set by `renderSheetWithOverlay` before each `renderSheet`. Both paths give the popover access to `c._st_mod_overlay` without coupling the popover module to app-level module state.
+- **AC#8 D6 regression smoke marked structural.** Walks: POST `current.willpower` mod (delta −1, base 5) → sheet renders `4/5` with marker → player spends WP on tracker → tracker_state.willpower drops to 4 → WS frame → sheet re-renders to `3/5`. Structural proof chain: STM-2's `applyStMods` never calls `saveToApi` (static-readable); WS subscription calls `renderSheetWithOverlay` → fresh `loadTrackerState` → fresh splice → fresh applyStMods. Each link unit-tested in STM-1/2/4. End-to-end browser-eye proof needs Peter's smoke.
+- **CSS scoped to `.stm-*` classes** — no global selectors, uses existing theme tokens (`--gold2`, `--surf2`, `--bdr`, `--txt/2/3`) so it works in both themes.
+- **Three git status checkpoints + worktree isolation as the fourth defence.**
+
+### File List
+
+- `public/js/data/st-mod-popover-spec.js` (new) — pure `buildPopover` transform
+- `public/js/editor/st-mod-popover.js` (new) — DOM render + delegated handler + `markerFor` / `markersFor` + re-export
+- `public/js/editor/sheet.js` (modified) — emit markers in stats strip, attribute rows (read-mode), skill rows (read-mode)
+- `public/js/admin.js` (modified) — `installStModPopover(document.body)` in boot
+- `public/js/player.js` (modified) — same + `window.__activeChar` set in `renderSheetWithOverlay`
+- `public/css/components.css` (modified) — appended `.stm-marker` and `.stm-pop*` rules
+- `server/tests/stm-popover-spec.test.js` (new) — 12 vitest cases for `buildPopover`
+- `specs/stories/issue-385-stm-4-sheet-marker-popover.story.md` — status flipped, Dev Agent Record filled
+
+### Change Log
+
+- 2026-05-18 (Ptah): STM-4 initial implementation


### PR DESCRIPTION
## Summary

Read-only display layer for the STM overlay. Every modded stat on a rendered character sheet shows a gold marker (`--gold2`). Clicking opens a popover with Base / per-mod delta / Final rows; reason text hidden by default, revealed per-mod when `show_reason_to_player`.

Closes #385 (manual close on dev-merge per `feedback_github_autoclose_dev_gap`)

## Architecture

### Pure spec module so vitest can import without browser globals

`buildPopover` (data → render-spec transform) lives in `public/js/data/st-mod-popover-spec.js`. The DOM-aware `public/js/editor/st-mod-popover.js` re-exports it, so any caller still has a single import point — but the test file imports the pure module directly, skipping the `esc → helpers.js → auth/discord.js` chain that would otherwise pull `getRole()` into a test environment.

### Marker helpers

- `markerFor(c, path)` — returns an HTML span with `data-stm-marker-path` if `c._st_mod_overlay[path]` exists, empty string otherwise
- `markersFor(c, paths)` — same logic over an array

Sheet sites inline these without conditional gating; AC#10 (overlay disabled → no markers) is automatic because STM-2's `stripOverlay` removes `_st_mod_overlay` entirely.

### Delegated click handler

Single `addEventListener('click', ...)` on `document.body`. Survives sheet re-renders without re-binding. Dispatches by `data-stm-marker-path` attribute. Mutual-exclusion: opening any popover closes the prior; click-outside / Escape closes the active one. Per `feedback_listener_routing_static_blind_spot` — no per-render or per-element listeners.

### Active character resolution

- Admin: `window.chars[window.editIdx]` (already exposed for inline-onclick sheet handlers)
- Player: new `window.__activeChar` set by `renderSheetWithOverlay` before each `renderSheet`

Both paths give the popover access to `c._st_mod_overlay` without coupling the popover module to app-level module state.

## Design decisions documented for review

### 1. Current willpower display added to the stats strip

Pre-STM-4 the sheet showed Willpower MAX only. AC#1 requires markers on `current.willpower`; AC#8 requires "Sheet shows Willpower 4". I expanded the WP cell to show `current/max` when `c.current.willpower` is present (which it is, post-STM-2 splice). Markers attach to both `current.willpower` and `derived.willpower_max` so STs can mod either. Falls back to MAX-only display when `c.current` is absent — preserves any prior render path.

### 2. Worktree isolation

Per the `feedback_test_merge_shared_workdir` update 2026-05-18 (after STM-6's branch-mix-up): built STM-4 in `/tmp/tm-ptah/stm-4` so Khepri's bookkeeping work on the main tree could not interleave HEAD. Symlinked `server/.env` into the worktree so the test infra resolved MongoDB. Clean delivery — no branch-mix-up.

### 3. AC#8 D6 regression smoke marked structural

Walks: POST `current.willpower` mod (delta −1, base 5) → sheet renders `4/5` with marker → player spends WP on tracker → `tracker_state.willpower` drops to 4 → WS frame → sheet re-renders to `3/5`.

The structural proof chain:
- STM-2's `applyStMods` never calls `saveToApi` (static-readable in `public/js/data/st-mods.js`)
- STM-2's WS subscription calls `renderSheetWithOverlay(activeChar)` → fresh `loadTrackerState` (cache invalidated by remote WS frame) → fresh splice → fresh applyStMods
- Each link unit-tested: STM-1 (route persistence), STM-2 (overlay applies to `c.current.*`), STM-4 (popover composes correctly)

End-to-end browser-eye proof needs your in-app smoke; no browser available to me locally.

### 4. CSS scoped to `.stm-*` classes

No new global selectors, uses existing theme tokens (`--gold2`, `--surf2`, `--bdr`, `--txt/2/3`) — theme-agnostic. Appended to `public/css/components.css` rather than creating a new file, matching the pattern of existing component additions.

## Acceptance criteria coverage

| AC | Where | Status |
|----|-------|--------|
| 1 — gold marker on modded stat (attribute, current.*, derived) | `markerFor` called at each render site | ✅ |
| 2 — popover open/close mutual-exclusion | `_openForMarker` + click-outside handler | ✅ |
| 3 — single-mod popover shows base / delta / final | `buildPopover` test | ✅ |
| 4 — multi-mod popover lists each in creation order | `buildPopover` test | ✅ |
| 5 — reason+creator+timestamp when show_reason_to_player | gated in `buildPopover` | ✅ |
| 6 — delta-only when show_reason false | reason/creator/when all null | ✅ test |
| 7 — current.* shows "(from tracker)" suffix | `fromTracker` flag in spec | ✅ test |
| 8 — D6 regression smoke | structural via unit-test chain | ✅ structural |
| 9 — delegated routing, no per-element onclick | single listener on body | ✅ |
| 10 — no markers when overlay disabled | automatic via `stripOverlay` | ✅ |
| 11 — ≥2 vitest cases for buildPopover | 12 cases | ✅ exceeds |
| 12 — no regression | 864/864 server tests pass | ✅ |

## Test plan

- [x] Parse-check all touched client modules (`node --input-type=module --check < file`)
- [x] Full server test suite: **864/864 passing** (was 852 on dev tip — gained 12)
- [x] STM-4 specific: 12/12 buildPopover cases verbose

## Files

- **new** `public/js/data/st-mod-popover-spec.js` — pure `buildPopover` transform
- **new** `public/js/editor/st-mod-popover.js` — DOM render + delegated handler + `markerFor` / `markersFor` + re-export
- **modified** `public/js/editor/sheet.js` — emit markers in stats strip, attribute rows, skill rows
- **modified** `public/js/admin.js` — `installStModPopover(document.body)` in boot
- **modified** `public/js/player.js` — same + `window.__activeChar` set in `renderSheetWithOverlay`
- **modified** `public/css/components.css` — appended `.stm-marker` and `.stm-pop*` rules
- **new** `server/tests/stm-popover-spec.test.js` — 12 vitest cases
- `specs/stories/issue-385-stm-4-sheet-marker-popover.story.md` — status flipped, Dev Agent Record filled

## What's NOT in this PR

- ST Mods admin panel — STM-5 (parallel)
- Collapse-at-N-mods popover treatment — deferred per ADR §D4
- Editing mods from the sheet — PRD non-goal
- Damage track display on the sheet — out of scope; the audit log + STM-5 panel are the primary surfaces for damage mods