### PR TITLE
fix(#398): revision note label and prompt injection for DT Story context builders

### DIFF
--- a/public/js/admin/downtime-story.js
+++ b/public/js/admin/downtime-story.js
@@ -279,6 +279,8 @@ export async function initDtStory(cycleId) {
       if (sectionKey === 'project_responses')   { handleCopyProjectContext(copyBtn);     return; }
       if (sectionKey === 'story_moment')        { handleCopyStoryMomentContext(copyBtn); return; }
       if (sectionKey === 'cacophony_savvy')     { handleCopyCacophonyContext(copyBtn);   return; }
+      if (sectionKey === 'home_report')         { handleCopyHomeReportContext(copyBtn);  return; }
+      if (sectionKey === 'feeding_validation')  { handleCopyFeedingContext(copyBtn);     return; }
       if (MERIT_SECTIONS.has(sectionKey))       { handleCopyActionContext(copyBtn);      return; }
       return;
     }
@@ -781,6 +783,12 @@ function buildProjectContext(char, sub, idx, cycleData, territories) {
     lines.push('');
     lines.push('Existing draft (revise unless told to rewrite):');
     lines.push(existingDraft);
+  }
+
+  const revisionNote = sub.st_narrative?.project_responses?.[idx]?.revision_note || '';
+  if (revisionNote) {
+    lines.push('');
+    lines.push(`Revision note: ${revisionNote}`);
   }
 
   // ST directives — placed immediately before the rubric so the AI weights them highest
@@ -1497,7 +1505,7 @@ function renderFeedingValidation(char, sub, stNarrative) {
   const fnIsRev    = fnStatus === 'needs_revision';
 
   h += `<div class="dt-feed-val-narrative-block">`;
-  h += `<div class="dt-story-section-subhead">Storyteller narrative</div>`;
+  h += `<div class="dt-story-section-subhead">Storyteller narrative <button class="dt-story-copy-ctx-btn">Copy Context</button></div>`;
   h += `<div class="dt-story-section-prompt">What happened during the feeding that mattered — what did others see, what did the player do, what consequences carry forward?</div>`;
   h += `<textarea class="dt-story-response-ta dt-feed-narrative-ta" placeholder="Write the feeding narrative…">${esc(fnText)}</textarea><span class="dt-story-autosave-status"></span>`;
   h += `<div class="dt-story-card-actions">`;
@@ -1508,7 +1516,7 @@ function renderFeedingValidation(char, sub, stNarrative) {
   h += `</button>`;
   h += `</div>`;
   h += `<div class="dt-story-revision-area${fnIsRev || fnRevNote ? '' : ' hidden'}">`;
-  h += `<textarea class="dt-story-revision-ta" rows="2" placeholder="Revision note…">${esc(fnRevNote)}</textarea><span class="dt-story-autosave-status"></span>`;
+  h += `<textarea class="dt-story-revision-ta" rows="2" placeholder="Revision note for Story…">${esc(fnRevNote)}</textarea><span class="dt-story-autosave-status"></span>`;
   h += `<div class="dt-story-card-actions">`;
   h += `<button class="dt-story-revision-save-btn">Save Revision Note</button>`;
   h += `</div></div>`;
@@ -1638,7 +1646,7 @@ function renderProjectCard(char, sub, idx) {
   h += `</button>`;
   h += `</div>`;
   h += `<div class="dt-story-revision-area${isRevision || revNote ? '' : ' hidden'}">`;
-  h += `<textarea class="dt-story-revision-ta" data-proj-idx="${idx}" rows="2" placeholder="Revision note for player\u2026">${revNote}</textarea><span class="dt-story-autosave-status"></span>`;
+  h += `<textarea class="dt-story-revision-ta" data-proj-idx="${idx}" rows="2" placeholder="Revision note for Story\u2026">${revNote}</textarea><span class="dt-story-autosave-status"></span>`;
   h += `<div class="dt-story-card-actions">`;
   h += `<button class="dt-story-revision-save-btn" data-proj-idx="${idx}">Save Revision</button>`;
   h += `</div>`;
@@ -1718,6 +1726,12 @@ function buildLetterContext(char, sub, opts = {}) {
     lines.push(`Correspondent voice note: ${stVoiceNote.trim()}`);
   }
 
+  const revisionNote = sub?.st_narrative?.story_moment?.revision_note || '';
+  if (revisionNote) {
+    lines.push('');
+    lines.push(`Revision note: ${revisionNote}`);
+  }
+
   lines.push('');
   lines.push('Apply LETTER_CORRESPONDENT_RULES. No more than 300 words. Do not open with pleasantries or greetings — begin with the letter\'s substance. Use house style.');
 
@@ -1782,6 +1796,12 @@ function buildTouchstoneContext(char, sub, opts = {}) {
     lines.push('');
     lines.push(`Previous vignette with this touchstone (Downtime ${prevCycleNumber ?? '?'}):`);
     lines.push(prevVignette.trim());
+  }
+
+  const revisionNote = sub?.st_narrative?.story_moment?.revision_note || '';
+  if (revisionNote) {
+    lines.push('');
+    lines.push(`Revision note: ${revisionNote}`);
   }
 
   lines.push('');
@@ -1928,7 +1948,7 @@ function renderStoryMoment(char, sub, stNarrative) {
   h += `</button>`;
   h += `</div>`;
   h += `<div class="dt-story-revision-area${isRevision || initialRevNote ? '' : ' hidden'}">`;
-  h += `<textarea class="dt-story-revision-ta" rows="2" placeholder="Revision note for player…">${initialRevNote}</textarea><span class="dt-story-autosave-status"></span>`;
+  h += `<textarea class="dt-story-revision-ta" rows="2" placeholder="Revision note for Story…">${initialRevNote}</textarea><span class="dt-story-autosave-status"></span>`;
   h += `<div class="dt-story-card-actions">`;
   h += `<button class="dt-story-revision-save-btn">Save Revision</button>`;
   h += `</div>`;
@@ -2521,6 +2541,12 @@ function buildActionContext(char, sub, idx) {
     lines.push(`Player-facing note: ${rev.player_facing_note}`);
   }
 
+  const revisionNote = sub.st_narrative?.action_responses?.[idx]?.revision_note || '';
+  if (revisionNote) {
+    lines.push('');
+    lines.push(`Revision note: ${revisionNote}`);
+  }
+
   lines.push('');
   lines.push('Apply FEEDING_CONSTRAINTS for merit-source rules. 50-80 words. Intermediary voice businesslike, not dramatic. Use house style.');
 
@@ -2634,7 +2660,7 @@ function renderActionCard(char, sub, idx) {
   h += `</button>`;
   h += `</div>`;
   h += `<div class="dt-story-revision-area${isRevision || revNote ? '' : ' hidden'}">`;
-  h += `<textarea class="dt-story-revision-ta" data-action-idx="${idx}" rows="2" placeholder="Revision note for player\u2026">${revNote}</textarea><span class="dt-story-autosave-status"></span>`;
+  h += `<textarea class="dt-story-revision-ta" data-action-idx="${idx}" rows="2" placeholder="Revision note for Story\u2026">${revNote}</textarea><span class="dt-story-autosave-status"></span>`;
   h += `<div class="dt-story-card-actions">`;
   h += `<button class="dt-story-revision-save-btn" data-action-idx="${idx}">Save Revision</button>`;
   h += `</div>`;
@@ -2907,6 +2933,14 @@ function buildTerritoryContext(char, sub, terrId, allSubmissions, allChars, cycl
     lines.push(`ST notes: ${cycleData.ambience_notes}`);
   }
 
+  const terrReports  = sub.st_narrative?.territory_reports || [];
+  const terrReport   = terrReports.find(r => r?.territory_id === terrId) || {};
+  const revisionNote = terrReport.revision_note || '';
+  if (revisionNote) {
+    lines.push('');
+    lines.push(`Revision note: ${revisionNote}`);
+  }
+
   lines.push('');
   lines.push('Apply AMBIENCE_SIGNATURE and DISCIPLINE_TRACE. One paragraph, 80-120 words. Use house style.');
 
@@ -3015,6 +3049,9 @@ export function buildHomeReportContext(char, sub, allSubmissions) {
     ctx += `No notable activity recorded in ${territory} this cycle. This may be a quiet month.\n\n`;
   }
 
+  const revisionNote = sub.st_narrative?.home_report?.revision_note || '';
+  if (revisionNote) ctx += `\nRevision note: ${revisionNote}\n`;
+
   ctx += `Style: Second person, present tense. No mechanical terms. British English. No em-dashes. ~50–100 words.`;
   return ctx;
 }
@@ -3065,7 +3102,7 @@ function renderHomeReport(char, sub, stNarrative, allSubmissions) {
   h += `</button></div>`;
 
   h += `<div class="dt-story-revision-area${isRevision || revNote ? '' : ' hidden'}">`;
-  h += `<textarea class="dt-story-revision-ta" rows="2" placeholder="Revision note\u2026">${revNote}</textarea><span class="dt-story-autosave-status"></span>`;
+  h += `<textarea class="dt-story-revision-ta" rows="2" placeholder="Revision note for Story\u2026">${revNote}</textarea><span class="dt-story-autosave-status"></span>`;
   h += `<div class="dt-story-card-actions">`;
   h += `<button class="dt-story-revision-save-btn">Save Revision Note</button>`;
   h += `</div></div>`;
@@ -3200,7 +3237,7 @@ function renderTerritoryReports(char, sub, stNarrative, allSubmissions, allChars
     h += `</button>`;
     h += `</div>`;
     h += `<div class="dt-story-revision-area${isRevision || revNote ? '' : ' hidden'}">`;
-    h += `<textarea class="dt-story-revision-ta" data-terr-idx="${idx}" data-terr-id="${terrId}" rows="2" placeholder="Revision note for player\u2026">${revNote}</textarea><span class="dt-story-autosave-status"></span>`;
+    h += `<textarea class="dt-story-revision-ta" data-terr-idx="${idx}" data-terr-id="${terrId}" rows="2" placeholder="Revision note for Story\u2026">${revNote}</textarea><span class="dt-story-autosave-status"></span>`;
     h += `<div class="dt-story-card-actions">`;
     h += `<button class="dt-story-revision-save-btn" data-terr-idx="${idx}" data-terr-id="${terrId}">Save Revision</button>`;
     h += `</div>`;
@@ -3251,7 +3288,7 @@ function scanNoisyActions(allSubmissions, currentCharId, csDots) {
   return candidates.slice(0, csDots);
 }
 
-function buildCacophonySavvyContext(char, noisyAction, slotIdx, csDots) {
+function buildCacophonySavvyContext(char, noisyAction, slotIdx, csDots, sub) {
   const lines = [];
   lines.push('You are helping a Storyteller write a Cacophony Savvy intelligence vignette for a Vampire: The Requiem 2nd Edition LARP character.');
   lines.push('');
@@ -3278,6 +3315,13 @@ function buildCacophonySavvyContext(char, noisyAction, slotIdx, csDots) {
   lines.push('- Do not state what actually happened precisely; write what filtered through the rumour network');
   lines.push('- Do not editorialise about significance');
   lines.push('- No sentence fragments \u2014 every sentence must be grammatically complete');
+
+  const revisionNote = sub?.st_narrative?.cacophony_savvy?.[slotIdx]?.revision_note || '';
+  if (revisionNote) {
+    lines.push('');
+    lines.push(`Revision note: ${revisionNote}`);
+  }
+
   return lines.join('\n');
 }
 
@@ -3355,7 +3399,7 @@ function renderCacophonySavvy(char, sub, stNarrative, allSubmissions) {
       h += `</button>`;
       h += `</div>`;
       h += `<div class="dt-story-revision-area${isRevision || revNote ? '' : ' hidden'}">`;
-      h += `<textarea class="dt-story-revision-ta" data-slot-idx="${slotIdx}" rows="2" placeholder="Revision note for player\u2026">${revNote}</textarea><span class="dt-story-autosave-status"></span>`;
+      h += `<textarea class="dt-story-revision-ta" data-slot-idx="${slotIdx}" rows="2" placeholder="Revision note for Story\u2026">${revNote}</textarea><span class="dt-story-autosave-status"></span>`;
       h += `<div class="dt-story-card-actions">`;
       h += `<button class="dt-story-revision-save-btn" data-slot-idx="${slotIdx}">Save Revision</button>`;
       h += `</div>`;
@@ -4206,7 +4250,7 @@ function handleCopyCacophonyContext(btn) {
   const noisy    = scanNoisyActions(_allSubmissions, _currentSub.character_id, csDots);
   const action   = noisy[slotIdx];
   if (!action) return;
-  copyToClipboard(buildCacophonySavvyContext(char, action, slotIdx, csDots), btn);
+  copyToClipboard(buildCacophonySavvyContext(char, action, slotIdx, csDots, _currentSub), btn);
 }
 
 async function handleCacophonySave(btn, status) {
@@ -4280,6 +4324,64 @@ async function handleCacophonySave(btn, status) {
     btn.innerHTML = originalHTML;
     console.error('Cacophony save failed:', err);
   }
+}
+
+function handleCopyHomeReportContext(btn) {
+  if (!_currentSub) return;
+  const sub  = _currentSub;
+  const char = getCharForSub(sub);
+  const text = buildHomeReportContext(char, sub, _allSubmissions);
+  copyToClipboard(text, btn);
+}
+
+function handleCopyFeedingContext(btn) {
+  if (!_currentSub) return;
+  const sub  = _currentSub;
+  const char = getCharForSub(sub);
+  const fr   = sub.feeding_review || {};
+  const roll = sub.feeding_roll   || null;
+
+  const lines = [`Write a feeding narrative for:`, '', _compactCharHeader(char)];
+  const identLine = _charIdentLine(char);
+  if (identLine) lines.push(identLine);
+  lines.push(..._calibrationBlock(char));
+
+  const poolStr = fr.pool_validated || fr.pool_player || '';
+  if (poolStr) {
+    lines.push('');
+    lines.push(`Feed pool: ${poolStr}`);
+  }
+  if (roll) {
+    const vitae = roll.successes * 2;
+    lines.push(`Result: ${roll.successes} success${roll.successes === 1 ? '' : 'es'}${roll.exceptional ? ' (exceptional)' : ''} — ${vitae} Vitae`);
+  }
+
+  const fv = effectiveFeedViolence(sub);
+  if (fv === 'kiss')    lines.push('Feeding method: The Kiss (subtle, prey unaware)');
+  if (fv === 'violent') lines.push('Feeding method: Violent');
+
+  const constraint = fr.story_context || '';
+  if (constraint) {
+    lines.push('');
+    lines.push(`Narrative constraint (do not contradict): ${constraint}`);
+  }
+
+  const existingDraft = sub.st_narrative?.feeding_narrative?.response || '';
+  if (existingDraft) {
+    lines.push('');
+    lines.push('Existing draft (revise unless told to rewrite):');
+    lines.push(existingDraft);
+  }
+
+  const revisionNote = sub.st_narrative?.feeding_narrative?.revision_note || '';
+  if (revisionNote) {
+    lines.push('');
+    lines.push(`Revision note: ${revisionNote}`);
+  }
+
+  lines.push('');
+  lines.push('Apply AMBIENCE_SIGNATURE. 2–3 sentences. What did others notice? What did the prey experience? British English. No em-dashes. No mechanical terms.');
+  copyToClipboard(lines.join('\n'), btn);
 }
 
 // Populate after all handlers are defined

--- a/server/tests/fix.398.revision-note-prompt-injection.test.js
+++ b/server/tests/fix.398.revision-note-prompt-injection.test.js
@@ -1,0 +1,212 @@
+/**
+ * fix.398 — Revision note label fix and prompt generator injection.
+ *
+ * Verifies:
+ *   AC1 — No 'Revision note for player' placeholder exists in downtime-story.js.
+ *          All 7 revision textareas read 'Revision note for Story'.
+ *   AC2 — Each builder reads the revision_note from the correct st_narrative path.
+ *          Mirrors the field-access pattern for: project, action, territory,
+ *          home report, cacophony savvy, story moment (letter + touchstone),
+ *          feeding narrative.
+ *   AC3 — Injection is conditional: empty / falsy revision note produces no output line.
+ *   AC4 — revision_note is absent from player-facing story-tab.js.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const root       = resolve(import.meta.dirname, '../..');
+const storyJs    = readFileSync(resolve(root, 'public/js/admin/downtime-story.js'), 'utf8');
+const storyTabJs = readFileSync(resolve(root, 'public/js/tabs/story-tab.js'),       'utf8');
+
+// ── AC1: Placeholder text ──────────────────────────────────────────────────────
+
+describe('AC1 — placeholder text', () => {
+  it('no instance of "Revision note for player" remains', () => {
+    expect(storyJs).not.toContain('Revision note for player');
+  });
+
+  it('exactly 7 occurrences of "Revision note for Story" placeholder text', () => {
+    // Count textarea placeholder attributes only (not other uses like heading text)
+    const matches = storyJs.match(/placeholder="Revision note for Story[^"]*"/g) || [];
+    expect(matches.length).toBe(7);
+  });
+
+  it('sections covered: feeding, projects, story-moment, merits, home-report, territories, cacophony-savvy', () => {
+    // Verify each section's revision textarea placeholder by its data attribute or class context.
+    // The feeding revision textarea sits inside dt-feed-val-narrative-block.
+    expect(storyJs).toContain('dt-feed-val-narrative-block');
+    expect(storyJs).toContain('dt-feed-narrative-ta');
+    // Projects: placeholder adjacent to data-proj-idx on the same textarea
+    expect(storyJs).toMatch(/data-proj-idx[^"]*"[^>]*placeholder="Revision note for Story/);
+    // Merits: placeholder adjacent to data-action-idx on the same textarea
+    expect(storyJs).toMatch(/data-action-idx[^"]*"[^>]*placeholder="Revision note for Story/);
+    // Territories: placeholder adjacent to data-terr-idx on the same textarea
+    expect(storyJs).toMatch(/data-terr-idx[^"]*"[^>]*placeholder="Revision note for Story/);
+    // Cacophony Savvy: placeholder adjacent to data-slot-idx on the same textarea
+    expect(storyJs).toMatch(/data-slot-idx[^"]*"[^>]*placeholder="Revision note for Story/);
+  });
+});
+
+// ── AC2: Field path correctness (mirror the access expressions) ───────────────
+
+// Helper: simulate the injection logic for lines-array builders.
+function injectRevisionNote(lines, revisionNote) {
+  if (revisionNote) {
+    lines.push('');
+    lines.push(`Revision note: ${revisionNote}`);
+  }
+}
+
+// Helper: simulate the injection logic for home-report string builder.
+function injectRevisionNoteStr(ctx, revisionNote) {
+  if (revisionNote) ctx += `\nRevision note: ${revisionNote}\n`;
+  return ctx;
+}
+
+describe('AC2 — field path correctness per builder', () => {
+  it('buildProjectContext reads project_responses[idx].revision_note', () => {
+    const sub = { st_narrative: { project_responses: [{}, { revision_note: 'Needs more detail on the contact' }] } };
+    const idx = 1;
+    const revisionNote = sub.st_narrative?.project_responses?.[idx]?.revision_note || '';
+    expect(revisionNote).toBe('Needs more detail on the contact');
+  });
+
+  it('buildProjectContext returns empty string when idx has no revision_note', () => {
+    const sub = { st_narrative: { project_responses: [{ revision_note: '' }] } };
+    const revisionNote = sub.st_narrative?.project_responses?.[0]?.revision_note || '';
+    expect(revisionNote).toBe('');
+  });
+
+  it('buildActionContext reads action_responses[idx].revision_note', () => {
+    const sub = { st_narrative: { action_responses: [{ revision_note: 'Rewrite — too passive' }] } };
+    const revisionNote = sub.st_narrative?.action_responses?.[0]?.revision_note || '';
+    expect(revisionNote).toBe('Rewrite — too passive');
+  });
+
+  it('buildTerritoryContext finds report by territory_id (not by index)', () => {
+    const sub = {
+      st_narrative: {
+        territory_reports: [
+          { territory_id: 'harbour',   revision_note: 'Wrong tone' },
+          { territory_id: 'dockyards', revision_note: 'Check the ambience level' },
+        ],
+      },
+    };
+    const terrId = 'dockyards';
+    const terrReports  = sub.st_narrative?.territory_reports || [];
+    const terrReport   = terrReports.find(r => r?.territory_id === terrId) || {};
+    const revisionNote = terrReport.revision_note || '';
+    expect(revisionNote).toBe('Check the ambience level');
+  });
+
+  it('buildTerritoryContext returns empty string when no matching territory_id', () => {
+    const sub = { st_narrative: { territory_reports: [{ territory_id: 'harbour', revision_note: 'OK' }] } };
+    const terrReport   = (sub.st_narrative?.territory_reports || []).find(r => r?.territory_id === 'academy') || {};
+    const revisionNote = terrReport.revision_note || '';
+    expect(revisionNote).toBe('');
+  });
+
+  it('buildHomeReportContext reads home_report.revision_note', () => {
+    const sub = { st_narrative: { home_report: { revision_note: 'Too long — cut to 60 words' } } };
+    const revisionNote = sub.st_narrative?.home_report?.revision_note || '';
+    expect(revisionNote).toBe('Too long — cut to 60 words');
+  });
+
+  it('buildCacophonySavvyContext reads cacophony_savvy[slotIdx].revision_note', () => {
+    const sub = { st_narrative: { cacophony_savvy: [null, { revision_note: 'Wrong district mentioned' }] } };
+    const slotIdx = 1;
+    const revisionNote = sub?.st_narrative?.cacophony_savvy?.[slotIdx]?.revision_note || '';
+    expect(revisionNote).toBe('Wrong district mentioned');
+  });
+
+  it('buildLetterContext reads story_moment.revision_note', () => {
+    const sub = { st_narrative: { story_moment: { revision_note: 'Touchstone name spelled wrong' } } };
+    const revisionNote = sub?.st_narrative?.story_moment?.revision_note || '';
+    expect(revisionNote).toBe('Touchstone name spelled wrong');
+  });
+
+  it('buildTouchstoneContext reads the same story_moment.revision_note path', () => {
+    const sub = { st_narrative: { story_moment: { revision_note: 'Vignette is too long' } } };
+    const revisionNote = sub?.st_narrative?.story_moment?.revision_note || '';
+    expect(revisionNote).toBe('Vignette is too long');
+  });
+
+  it('handleCopyFeedingContext reads feeding_narrative.revision_note', () => {
+    const sub = { st_narrative: { feeding_narrative: { revision_note: 'Remove the mechanical reference to successes' } } };
+    const revisionNote = sub.st_narrative?.feeding_narrative?.revision_note || '';
+    expect(revisionNote).toBe('Remove the mechanical reference to successes');
+  });
+
+  it('all builders are safe against missing st_narrative (no throw)', () => {
+    const sub = {};
+    expect(() => (sub.st_narrative?.project_responses?.[0]?.revision_note   || '')).not.toThrow();
+    expect(() => (sub.st_narrative?.action_responses?.[0]?.revision_note    || '')).not.toThrow();
+    expect(() => (sub.st_narrative?.territory_reports || []).find(() => false)).not.toThrow();
+    expect(() => (sub.st_narrative?.home_report?.revision_note              || '')).not.toThrow();
+    expect(() => (sub?.st_narrative?.cacophony_savvy?.[0]?.revision_note    || '')).not.toThrow();
+    expect(() => (sub?.st_narrative?.story_moment?.revision_note            || '')).not.toThrow();
+    expect(() => (sub.st_narrative?.feeding_narrative?.revision_note        || '')).not.toThrow();
+  });
+});
+
+// ── AC3: Conditional injection — no empty line emitted ────────────────────────
+
+describe('AC3 — conditional injection (empty revision note produces no line)', () => {
+  it('lines-array builder: non-empty revision note appends two lines', () => {
+    const lines = ['Existing content'];
+    injectRevisionNote(lines, 'Needs rework');
+    expect(lines).toHaveLength(3);
+    expect(lines[1]).toBe('');
+    expect(lines[2]).toBe('Revision note: Needs rework');
+  });
+
+  it('lines-array builder: empty string produces no extra lines', () => {
+    const lines = ['Existing content'];
+    injectRevisionNote(lines, '');
+    expect(lines).toHaveLength(1);
+  });
+
+  it('lines-array builder: null produces no extra lines', () => {
+    const lines = ['Existing content'];
+    injectRevisionNote(lines, null);
+    expect(lines).toHaveLength(1);
+  });
+
+  it('lines-array builder: undefined produces no extra lines', () => {
+    const lines = ['Existing content'];
+    injectRevisionNote(lines, undefined);
+    expect(lines).toHaveLength(1);
+  });
+
+  it('string-concat builder (home report): non-empty note appends correctly', () => {
+    const result = injectRevisionNoteStr('Style: second person.', 'Keep it shorter');
+    expect(result).toContain('\nRevision note: Keep it shorter\n');
+  });
+
+  it('string-concat builder (home report): empty string appends nothing', () => {
+    const original = 'Style: second person.';
+    const result   = injectRevisionNoteStr(original, '');
+    expect(result).toBe(original);
+  });
+
+  it('injected line text exactly matches expected format', () => {
+    const lines = [];
+    injectRevisionNote(lines, 'Rewrite from scratch — tone is wrong');
+    expect(lines[1]).toBe('Revision note: Rewrite from scratch — tone is wrong');
+    expect(lines[1]).not.toMatch(/^Revision note:\s*$/); // no empty-value line
+  });
+});
+
+// ── AC4: Player-facing path clean ─────────────────────────────────────────────
+
+describe('AC4 — revision_note absent from player-facing story-tab.js', () => {
+  it('story-tab.js does not reference revision_note', () => {
+    expect(storyTabJs).not.toContain('revision_note');
+  });
+
+  it('story-tab.js does not import buildHomeReportContext', () => {
+    expect(storyTabJs).not.toContain('buildHomeReportContext');
+  });
+});

--- a/specs/stories/fix.398.revision-note-label-and-prompt-injection.story.md
+++ b/specs/stories/fix.398.revision-note-label-and-prompt-injection.story.md
@@ -1,0 +1,238 @@
+# Story fix.398: Revision note label fix and prompt generator injection
+
+**Story ID:** fix.398
+**Epic:** DT Story tab fixes
+**Status:** review
+**Date:** 2026-05-19
+**Issue:** [#398](https://github.com/angelusvmorningstar/TerraMortis/issues/398)
+**Branch:** ms/issue-398-dt-story-revision-note-label-prompt
+
+---
+
+## User Story
+
+As an ST using the DT Story tab, I want revision note textareas to be clearly labelled as Story-side notes (not player-facing), and I want the prompt generator to include the revision note when one is present — so the AI understands what changed and what to improve.
+
+---
+
+## Background
+
+### Two issues in one story
+
+**Issue 1 — Misleading placeholder text**
+
+Several revision textareas have placeholder `"Revision note for player…"`. The `revision_note` field is stored in `st_narrative` (admin-only) and is confirmed absent from all player-facing JS (`story-tab.js`, no player routes expose it). The "for player" wording implies delivery to the player, which is incorrect and not intended.
+
+Feeding Narrative and Home Report already use `"Revision note…"` (correct). Projects, Merits, Territories, and Cacophony Savvy use the incorrect `"Revision note for player…"`.
+
+**Issue 2 — Prompt generators ignore the revision note**
+
+When an ST marks a section `needs_revision`, they write a revision note explaining what needs to change. When they then click the prompt generator (Copy Context) to regenerate the narrative, the revision note is not included in the prompt. The AI has no knowledge that this is a revision, what was wrong with the prior draft, or what the ST wants changed.
+
+### How context builders are called
+
+Each section's "Copy Context" button calls a context builder function and copies the result to clipboard:
+
+| Section | Builder | Revision note source |
+|---|---|---|
+| Projects | `buildProjectContext(char, sub, idx, ...)` | `sub.st_narrative.project_responses[idx].revision_note` |
+| Merits/Actions | `buildActionContext(char, sub, idx)` | `sub.st_narrative.action_responses[idx].revision_note` |
+| Territories | `buildTerritoryContext(char, sub, terrId, ...)` | `sub.st_narrative.territory_reports[idx].revision_note` |
+| Home Report | `buildHomeReportContext(char, sub, ...)` | `sub.st_narrative.home_report.revision_note` |
+| Cacophony Savvy | `buildCacophonySavvyContext(char, action, slotIdx, csDots)` | `sub.st_narrative.cacophony_savvy[slotIdx].revision_note` |
+| Story Moment | `buildLetterContext` / `buildTouchstoneContext` | `sub.st_narrative.story_moment.revision_note` |
+| Feeding | feeding narrative context (inline in render function) | `sub.st_narrative.feeding_narrative.revision_note` |
+
+The builders already read `sub` or `sub.st_narrative` for other fields. The revision note just needs to be read and injected before the rubric line.
+
+### Pattern from `buildProjectContext`
+
+`buildProjectContext` (line 640) already reads an `existingDraft`:
+
+```js
+const existingDraft = sub.st_narrative?.project_responses?.[idx]?.response || '';
+```
+
+And injects it before the ST directives:
+
+```js
+if (existingDraft) {
+  lines.push('');
+  lines.push('Existing draft (revise unless told to rewrite):');
+  lines.push(existingDraft);
+}
+```
+
+The revision note should follow a similar pattern — injected right after the existing draft block (if any), before the rubric.
+
+### Where the context builder is called from (for prompt generator)
+
+- Projects: line ~1587 (also ~3908 for maintenance/patrol variants)
+- Territories: line ~4037
+- Merits/Actions: line ~2401 (called from render handlers)
+- Home Report: line ~2997 (exported; called from story-tab.js)
+- Cacophony Savvy: line ~4209
+- Story Moment / Letter: lines ~1658, 1733
+
+---
+
+## Acceptance Criteria
+
+- [x] All revision textarea placeholders in Projects, Merits, Territories, Cacophony Savvy, Story Moment, Feeding Narrative, and Home Report read `"Revision note for Story"`. No instance of `"for player"` anywhere.
+- [x] When a project card has a non-empty `revision_note` and the ST clicks Copy Context, the generated prompt includes a `"Revision note: …"` line.
+- [x] Same for: territory cards, merit/action cards, home report, cacophony savvy slots, story moment, feeding narrative.
+- [x] Sections with no revision note produce identical prompt output to today (no empty `"Revision note: "` line emitted).
+- [x] `revision_note` is confirmed not present in any player-facing delivery path — no regression.
+
+---
+
+## Implementation
+
+### File: `public/js/admin/downtime-story.js`
+
+#### Part 1 — Placeholder text (7 instances)
+
+Replace every `"Revision note for player…"` / `"Revision note for player…"` with `"Revision note for Story…"`. Also standardise the two existing `"Revision note…"` instances to `"Revision note for Story…"` for consistency.
+
+Lines to update (approximate — verify by search):
+
+| Line | Section | Current | New |
+|---|---|---|---|
+| ~1511 | Feeding narrative | `Revision note…` | `Revision note for Story…` |
+| ~1641 | Projects | `Revision note for player…` | `Revision note for Story…` |
+| ~1931 | Story Moment | `Revision note for player…` | `Revision note for Story…` |
+| ~2637 | Merits | `Revision note for player…` | `Revision note for Story…` |
+| ~3068 | Home Report | `Revision note…` | `Revision note for Story…` |
+| ~3203 | Territories | `Revision note for player…` | `Revision note for Story…` |
+| ~3358 | Cacophony Savvy | `Revision note for player…` | `Revision note for Story…` |
+
+Use `replace_all: true` on the Edit tool — all instances should become `"Revision note for Story…"`.
+
+#### Part 2 — Prompt injection
+
+Inject the revision note into each context builder. The injection pattern is:
+
+```js
+if (revisionNote) {
+  lines.push('');
+  lines.push(`Revision note: ${revisionNote}`);
+}
+```
+
+Place this **after** the existing draft block (if the builder has one) and **before** the final rubric/style line.
+
+**`buildProjectContext`** (line ~780, after the `existingDraft` block):
+
+```js
+// After existingDraft block:
+const revisionNote = sub.st_narrative?.project_responses?.[idx]?.revision_note || '';
+if (revisionNote) {
+  lines.push('');
+  lines.push(`Revision note: ${revisionNote}`);
+}
+```
+
+**`buildActionContext`** (line ~2513, before the final rubric line):
+
+```js
+const revisionNote = sub.st_narrative?.action_responses?.[idx]?.revision_note || '';
+if (revisionNote) {
+  lines.push('');
+  lines.push(`Revision note: ${revisionNote}`);
+}
+```
+
+**`buildTerritoryContext`** (line ~2910, before `Apply AMBIENCE_SIGNATURE` rubric):
+
+```js
+// Need idx passed in OR looked up from st_narrative.territory_reports array.
+// buildTerritoryContext currently receives terrId, not idx. The territory_reports
+// array is keyed positionally; find by territory_id field:
+const terrReports = sub.st_narrative?.territory_reports || [];
+const terrReport  = terrReports.find(r => r?.territory_id === terrId) || {};
+const revisionNote = terrReport.revision_note || '';
+if (revisionNote) {
+  lines.push('');
+  lines.push(`Revision note: ${revisionNote}`);
+}
+```
+
+**`buildHomeReportContext`** (line ~3018, before style line):
+
+```js
+const revisionNote = sub.st_narrative?.home_report?.revision_note || '';
+if (revisionNote) {
+  ctx += `\nRevision note: ${revisionNote}\n`;
+}
+```
+
+Note: `buildHomeReportContext` builds `ctx` as a string (not `lines` array). Append before the `Style:` line.
+
+**`buildCacophonySavvyContext`** (line ~3281, before `return lines.join('\n')`):
+
+```js
+// slotIdx is already a parameter — use it to read the revision note from sub.
+// Note: sub is not currently a parameter of buildCacophonySavvyContext.
+// The caller (line ~4209) has access to sub. Pass it in as a new optional parameter.
+```
+
+`buildCacophonySavvyContext` currently has signature `(char, noisyAction, slotIdx, csDots)`. Add `sub` as a 5th optional parameter:
+
+```js
+function buildCacophonySavvyContext(char, noisyAction, slotIdx, csDots, sub) {
+  // ... existing code ...
+  const revisionNote = sub?.st_narrative?.cacophony_savvy?.[slotIdx]?.revision_note || '';
+  if (revisionNote) {
+    lines.push('');
+    lines.push(`Revision note: ${revisionNote}`);
+  }
+  return lines.join('\n');
+}
+```
+
+Update the call site at line ~4209 to pass `sub`:
+
+```js
+// Before:
+copyToClipboard(buildCacophonySavvyContext(char, action, slotIdx, csDots), btn);
+// After:
+copyToClipboard(buildCacophonySavvyContext(char, action, slotIdx, csDots, _currentSub), btn);
+```
+
+**Story Moment** — `buildLetterContext` and `buildTouchstoneContext` (lines ~1658, ~1733):
+
+Both builders use `opts` for context. Read the revision note from `sub.st_narrative.story_moment.revision_note` (passed via `sub` which is available in the render scope):
+
+```js
+// In buildLetterContext and buildTouchstoneContext, before the final rubric line:
+const revisionNote = sub?.st_narrative?.story_moment?.revision_note || '';
+if (revisionNote) {
+  lines.push('');
+  lines.push(`Revision note: ${revisionNote}`);
+}
+```
+
+Both functions already receive `sub` as a parameter. Check the signatures at lines 1658 and 1733 to confirm.
+
+**Feeding narrative** — the feeding context is built inline (not a named builder function). Find where the feeding prompt is assembled and inject before the rubric.
+
+---
+
+## Files to Change
+
+| File | Change |
+|---|---|
+| `public/js/admin/downtime-story.js` | 7 placeholder text updates; revision note injection in 7 context builders; `buildCacophonySavvyContext` signature + call site update. |
+
+No schema changes. No API changes. No CSS changes.
+
+---
+
+## Dev Notes
+
+- `replace_all: true` on the placeholder edit is safe — all occurrences of `"Revision note for player…"` should become `"Revision note for Story…"`. Do a final grep after to confirm no stragglers.
+- The injection must be conditional on `revisionNote` being truthy. Never emit an empty `"Revision note: "` line — that would pollute prompts for sections that have never been marked for revision.
+- `buildTerritoryContext` does not currently receive an index — find the territory report by `territory_id` field in the array, not by position. Verify the shape of `territory_reports` entries: `{ territory_id, response, author, status, revision_note }` (set at line ~4062).
+- `buildHomeReportContext` uses string concatenation (`ctx +=`) rather than a `lines` array. Match that pattern for the injection.
+- `buildCacophonySavvyContext` is a pure function with no access to `sub`. Adding `sub` as a 5th optional parameter is the cleanest path; the caller at line ~4209 holds `_currentSub`.
+- Verify no player-facing file reads `revision_note` after this change — it's ST-only data and must stay that way.


### PR DESCRIPTION
## Summary

- Replaces all 7 "Revision note for player…" textarea placeholders with "Revision note for Story…" — the field is ST-only and the old wording falsely implied player delivery
- Injects `revision_note` into every DT Story context builder (project, action, territory, home report, cacophony savvy, letter, touchstone, feeding narrative) so the AI prompt receives revision guidance when an ST marks a section needs-revision
- Wires up the previously-dead Home Report Copy Context button in event delegation; adds a Copy Context button and inline context builder to the Feeding Narrative block
- Extends `buildCacophonySavvyContext` with a 5th `sub` parameter to carry the revision note from caller to builder

## Closes

- Closes #398

## Story

- specs/stories/fix.398.revision-note-label-and-prompt-injection.story.md

## Test plan

- [x] 23 Vitest tests passing (AC1 placeholder text, AC2 field paths per builder, AC3 conditional guard, AC4 player-path clean)
- [ ] CI green
- [ ] Manual: open DT Story tab, mark a project section needs-revision, write a revision note, click Copy Context — confirm "Revision note: …" line appears in clipboard prompt
- [ ] Manual: confirm all revision note textareas read "Revision note for Story…" (not "for player")
- [ ] Manual: click Copy Context on Home Report and Feeding Narrative sections — confirm both now respond

## Branch flow

- From: `ms/issue-398-dt-story-revision-note-label-prompt`
- Into: `dev`