### PR TITLE
fix(#408): STM UX polish — dot-class markers + tooltip + popover hierarchy + toggle copy

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -5487,7 +5487,38 @@ html:not([data-theme="dark"]) .char-picker__pill { font-weight: 600; }
   font-style: italic;
 }
 
-/* ── Epic STM (issue #385): mod marker + popover ── */
+/* ── Epic STM mod marker + popover (issue #385, polished by #408) ── */
+
+/* Modded-dot class: applied directly to individual <span class="pointed"> /
+   "pointed hollow" dots when they fall within an STM-modded sub-range
+   (issue #408 Finding 2). Replaces the standalone .stm-marker pip that
+   visually collided with the dot run. Static gold tint + 1px gold ring;
+   no motion per Peter's choice. The dots inherit "pointed" / "pointed hollow"
+   shapes so the differentiation is colour + ring, not shape. */
+.pointed.stm-modded-dot,
+.pointed.hollow.stm-modded-dot {
+  cursor: pointer;
+  background-color: var(--gold2);
+  outline: 1px solid var(--gold2);
+  outline-offset: 1px;
+  /* Slight glow so hover/discoverability still reads. No keyframes. */
+  box-shadow: 0 0 2px var(--gold2-a25, rgba(122,82,8,.25));
+}
+.pointed.hollow.stm-modded-dot {
+  /* Hollow modded dots: ring without solid fill so they still read as
+     "bonus" but with the gold tint. */
+  background-color: transparent;
+  border-color: var(--gold2);
+}
+.pointed.stm-modded-dot:hover,
+.pointed.hollow.stm-modded-dot:hover {
+  outline-color: var(--gold);
+  box-shadow: 0 0 6px var(--gold);
+}
+
+/* Standalone marker (still used by the stats strip for non-dot displays:
+   blood_potency, humanity, current.*, derived.*). Dot-run paths (attributes /
+   skills) use .stm-modded-dot above. */
 .stm-marker {
   display: inline-block;
   width: 8px;
@@ -5507,9 +5538,9 @@ html:not([data-theme="dark"]) .char-picker__pill { font-weight: 600; }
 
 .stm-pop-host { pointer-events: auto; }
 .stm-pop {
-  min-width: 220px;
-  max-width: 320px;
-  padding: 10px 14px;
+  min-width: 240px;
+  max-width: 340px;
+  padding: 12px 16px;
   background: var(--surf2);
   border: 1px solid var(--gold2);
   border-radius: 4px;
@@ -5524,30 +5555,47 @@ html:not([data-theme="dark"]) .char-picker__pill { font-weight: 600; }
   color: var(--gold2);
   letter-spacing: .5px;
   text-transform: uppercase;
-  border-bottom: 1px solid var(--bdr);
-  padding-bottom: 4px;
-  margin-bottom: 6px;
+  border-bottom: 1px solid var(--bdr2);
+  padding-bottom: 6px;
+  margin-bottom: 8px;
 }
+/* Base / Final rows: label-left, value-right, single line. Issue #408
+   Finding 4 — explicit span pair so flex always keeps them on one line. */
 .stm-pop-base, .stm-pop-final {
   display: flex;
   justify-content: space-between;
-  padding: 2px 0;
+  align-items: baseline;
+  padding: 4px 0;
   font-weight: 600;
 }
+.stm-pop-row-lbl { color: var(--txt2); font-weight: 600; }
+.stm-pop-base { border-bottom: 1px solid var(--bdr); }
 .stm-pop-final {
-  border-top: 1px solid var(--bdr);
-  margin-top: 6px;
-  padding-top: 6px;
+  border-top: 1px solid var(--gold2);
+  margin-top: 4px;
+  padding-top: 8px;
   color: var(--gold2);
+  font-size: 13px;
 }
-.stm-pop-base-src { color: var(--txt3); font-weight: 400; font-style: italic; }
+.stm-pop-base-src { color: var(--txt3); font-weight: 400; font-style: italic; font-size: 11px; }
 .stm-pop-val { font-family: var(--fh); font-size: 14px; }
-.stm-pop-mods { margin: 4px 0; }
+
+/* Adjustments section: small sub-header + indented mod rows so the
+   start → adjust → result hierarchy is visible at a glance. */
+.stm-pop-mods { margin: 0 0 4px 0; padding: 4px 0 0 14px; border-left: 2px solid var(--gold2-a25, rgba(122,82,8,.25)); margin-left: 4px; }
+.stm-pop-mods-hdr {
+  font-family: var(--fh);
+  font-size: 10px;
+  color: var(--txt3);
+  letter-spacing: .8px;
+  text-transform: uppercase;
+  margin: 0 0 4px 0;
+}
 .stm-pop-mod {
   padding: 4px 0;
   border-bottom: 1px dotted var(--bdr);
 }
-.stm-pop-mod:last-child { border-bottom: 0; }
+.stm-pop-mod:last-child { border-bottom: 0; padding-bottom: 0; }
 .stm-pop-mod-delta {
   display: inline-block;
   min-width: 32px;

--- a/public/js/admin/st-mods-panel.js
+++ b/public/js/admin/st-mods-panel.js
@@ -97,13 +97,13 @@ function _renderScaffold() {
       <section class="stm-panel-toggles">
         <label class="stm-toggle">
           <input type="checkbox" data-stm-toggle="global" ${globalEnabled ? 'checked' : ''}>
-          Global overlay <strong>${globalEnabled ? 'ON' : 'OFF'}</strong>
-          <span class="stm-toggle-hint">Affects all characters site-wide.</span>
+          Show ST Mods on sheets <strong>${globalEnabled ? 'ON' : 'OFF'}</strong>
+          <span class="stm-toggle-hint">Master switch. When off, no character sheet shows ST mods anywhere on the site (mods stay in the DB; nothing is deleted). Off acts as an emergency hide-all kill-switch.</span>
         </label>
         <label class="stm-toggle">
           <input type="checkbox" data-stm-toggle="suppress" ${charSuppressed ? 'checked' : ''}>
-          Suppress overlay for this character
-          <span class="stm-toggle-hint">When on, this character's modded values render as base.</span>
+          Hide ST Mods for this character only
+          <span class="stm-toggle-hint">When on, just this character's modded values render as base. Other characters unaffected. Use for a quick &ldquo;reset to canonical&rdquo; on one sheet without touching the master switch.</span>
         </label>
       </section>
 

--- a/public/js/data/helpers.js
+++ b/public/js/data/helpers.js
@@ -99,9 +99,53 @@ export function shDots(n) {
   return '<span class="pointed"></span>'.repeat(Math.max(0, n || 0));
 }
 
-export function shDotsWithBonus(base, bonus) {
-  if (!bonus) return shDots(base);
-  return '<span class="pointed"></span>'.repeat(Math.max(0, base || 0)) + '<span class="pointed hollow"></span>'.repeat(Math.max(0, bonus || 0));
+/** Render `base` filled dots followed by `bonus` hollow dots.
+ *
+ *  Issue #408 (Epic STM UX polish): optional `opts` lets callers tag
+ *  a sub-range of dots as "ST-modded" — those dots receive the
+ *  `stm-modded-dot` class + `data-stm-marker-path` attribute + a
+ *  `title` tooltip. The delegated click handler at document.body
+ *  (`installStModPopover`) dispatches on `data-stm-marker-path`, so
+ *  clicking a modded dot opens the popover. This replaces the
+ *  pre-#408 standalone `.stm-marker` pip that visually collided
+ *  with the dot run.
+ *
+ *  opts = {
+ *    filledMod: { from, to, path, title } | undefined,
+ *    hollowMod: { from, to, path, title } | undefined,
+ *  }
+ *  Indices are zero-based into the respective stream
+ *  (filled = positions [0..base-1]; hollow = positions [0..bonus-1]).
+ *  `to` is exclusive. Callers compute hollow-stream indices including
+ *  any auto-bonus offset (attributes: autoBonus dots come first in
+ *  the hollow stream; modded manual bonus starts at autoBonus + ovBonus.base).
+ *
+ *  No-opts path is byte-identical to the pre-#408 implementation. */
+export function shDotsWithBonus(base, bonus, opts) {
+  if (!opts || (!opts.filledMod && !opts.hollowMod)) {
+    if (!bonus) return shDots(base);
+    return '<span class="pointed"></span>'.repeat(Math.max(0, base || 0)) + '<span class="pointed hollow"></span>'.repeat(Math.max(0, bonus || 0));
+  }
+  const fm = opts.filledMod;
+  const hm = opts.hollowMod;
+  let out = '';
+  const baseN = Math.max(0, base || 0);
+  for (let i = 0; i < baseN; i++) {
+    if (fm && i >= fm.from && i < fm.to) {
+      out += `<span class="pointed stm-modded-dot" data-stm-marker-path="${esc(fm.path || '')}" title="${esc(fm.title || '')}"></span>`;
+    } else {
+      out += '<span class="pointed"></span>';
+    }
+  }
+  const bonusN = Math.max(0, bonus || 0);
+  for (let i = 0; i < bonusN; i++) {
+    if (hm && i >= hm.from && i < hm.to) {
+      out += `<span class="pointed hollow stm-modded-dot" data-stm-marker-path="${esc(hm.path || '')}" title="${esc(hm.title || '')}"></span>`;
+    } else {
+      out += '<span class="pointed hollow"></span>';
+    }
+  }
+  return out;
 }
 
 /** Card name: moniker || name, no honorific. Redacted in dev mode.

--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -18,7 +18,7 @@ import { auditCharacter } from '../data/audit.js';
 // Touchstone editor no longer needs the NPC list (DB-relational picker
 // removed; free-text Name + Description only).
 import { powersForDisc } from '../suite/sheet-helpers.js';
-import { markerFor, markersFor } from './st-mod-popover.js';
+import { markerFor } from './st-mod-popover.js';
 
 // Build legacy-format shims from rules cache for remaining deep consumers.
 // These produce arrays/objects in the old DEVOTIONS_DB/MERITS_DB/MAN_DB shape.
@@ -454,11 +454,32 @@ export function shRenderAttributes(c, editMode) {
     ATTR_ROWS.forEach(row => row.forEach(a => {
       const base = getAttrVal(c, a), bonus = getAttrBonus(c, a);
       const autoBonus = (c.disciplines?.[BONUS_SOURCE[a]]?.dots || 0);
-      // Epic STM (issue #385): marker for attributes.<Name>.dots / .bonus
-      // — read-mode only; edit mode strips the overlay (STM-2's helper),
-      // so c._st_mod_overlay is absent here when editing.
-      const _stm = markersFor(c, [`attributes.${a}.dots`, `attributes.${a}.bonus`]);
-      h += '<div class="attr-cell"><div class="attr-name-sh">' + a + '</div><div class="attr-dots-sh">' + shDotsWithBonus(base, autoBonus + bonus) + _stm + '</div></div>';
+      // Epic STM #408: modded sub-ranges tagged on the dots themselves via
+      // shDotsWithBonus opts (replaces the standalone .stm-marker pip that
+      // visually collided with the dot run). Hollow-stream layout convention:
+      // autoBonus first, then manual bonus — so the modded bonus sub-range
+      // is offset by autoBonus. Edit mode strips _st_mod_overlay (STM-2
+      // stripOverlay) so opts is empty there → backwards-compatible.
+      const ovDots = c._st_mod_overlay?.[`attributes.${a}.dots`];
+      const ovBonus = c._st_mod_overlay?.[`attributes.${a}.bonus`];
+      const opts = {};
+      if (ovDots) {
+        const sign = ovDots.delta >= 0 ? '+' : '';
+        opts.filledMod = {
+          from: ovDots.base, to: ovDots.final,
+          path: `attributes.${a}.dots`,
+          title: `ST adjustment: ${a} (dots) ${sign}${ovDots.delta}. Click for details.`,
+        };
+      }
+      if (ovBonus) {
+        const sign = ovBonus.delta >= 0 ? '+' : '';
+        opts.hollowMod = {
+          from: autoBonus + ovBonus.base, to: autoBonus + ovBonus.final,
+          path: `attributes.${a}.bonus`,
+          title: `ST adjustment: ${a} (bonus) ${sign}${ovBonus.delta}. Click for details.`,
+        };
+      }
+      h += '<div class="attr-cell"><div class="attr-name-sh">' + a + '</div><div class="attr-dots-sh">' + shDotsWithBonus(base, autoBonus + bonus, opts) + '</div></div>';
     }));
   }
   h += '</div></div>';
@@ -523,10 +544,32 @@ export function shRenderSkills(c, editMode) {
   } else {
     for (let ri = 0; ri < 8; ri++) {
       SKILL_COLS.forEach(col => {
-        const s = col[ri], sk = getSkillObj(c, s), d = sk.dots, bn = sk.bonus, sp = (sk.specs || []).join(', '), na = sk.nine_again, ptNa = c._pt_nine_again_skills && c._pt_nine_again_skills.has(s), ohmNa = c._ohm_nine_again_skills && c._ohm_nine_again_skills.has(s), ptBn = c._pt_dot4_bonus_skills && c._pt_dot4_bonus_skills.has(s) ? 1 : 0, mciBn = c._mci_dot3_skills && c._mci_dot3_skills.has(s) ? 1 : 0, hasDots = d > 0 || bn > 0 || ptBn > 0 || mciBn > 0, dotStr = hasDots ? shDotsWithBonus(d, bn + ptBn + mciBn) : '\u2013';
-        // Epic STM (issue #385): marker for skills.<Name>.dots / .bonus
-        const _stm = markersFor(c, [`skills.${s}.dots`, `skills.${s}.bonus`]);
-        h += '<div class="sh-skill-row' + (hasDots ? ' has-dots' : '') + '"><div class="skill-name-wrap"><span class="sh-skill-name">' + s + '</span>' + (sp ? '<span class="sh-skill-spec">' + formatSpecs(c, sk.specs) + '</span>' : '') + '</div><div class="skill-dots-wrap"><span class="' + (hasDots ? 'sh-skill-dots' : 'sh-skill-zero') + '">' + dotStr + '</span>' + _stm + (na ? '<span class="sh-skill-na">9-Again</span>' : ptNa ? '<span class="sh-skill-na pt-na">9-Again (PT)</span>' : ohmNa ? '<span class="sh-skill-na pt-na">9-Again (OHM)</span>' : '') + '</div></div>';
+        const s = col[ri], sk = getSkillObj(c, s), d = sk.dots, bn = sk.bonus, sp = (sk.specs || []).join(', '), na = sk.nine_again, ptNa = c._pt_nine_again_skills && c._pt_nine_again_skills.has(s), ohmNa = c._ohm_nine_again_skills && c._ohm_nine_again_skills.has(s), ptBn = c._pt_dot4_bonus_skills && c._pt_dot4_bonus_skills.has(s) ? 1 : 0, mciBn = c._mci_dot3_skills && c._mci_dot3_skills.has(s) ? 1 : 0, hasDots = d > 0 || bn > 0 || ptBn > 0 || mciBn > 0;
+        // Epic STM #408: modded sub-ranges tagged on the dots themselves.
+        // Skill hollow-stream layout: bn first, then ptBn / mciBn \u2014 so modded
+        // skills.X.bonus sub-range starts at hollow position ovBonus.base
+        // (no offset; bn is at the head of the hollow stream).
+        const ovDots = c._st_mod_overlay?.[`skills.${s}.dots`];
+        const ovBonus = c._st_mod_overlay?.[`skills.${s}.bonus`];
+        const opts = {};
+        if (ovDots) {
+          const sign = ovDots.delta >= 0 ? '+' : '';
+          opts.filledMod = {
+            from: ovDots.base, to: ovDots.final,
+            path: `skills.${s}.dots`,
+            title: `ST adjustment: ${s} (dots) ${sign}${ovDots.delta}. Click for details.`,
+          };
+        }
+        if (ovBonus) {
+          const sign = ovBonus.delta >= 0 ? '+' : '';
+          opts.hollowMod = {
+            from: ovBonus.base, to: ovBonus.final,
+            path: `skills.${s}.bonus`,
+            title: `ST adjustment: ${s} (bonus) ${sign}${ovBonus.delta}. Click for details.`,
+          };
+        }
+        const dotStr = hasDots ? shDotsWithBonus(d, bn + ptBn + mciBn, opts) : '\u2013';
+        h += '<div class="sh-skill-row' + (hasDots ? ' has-dots' : '') + '"><div class="skill-name-wrap"><span class="sh-skill-name">' + s + '</span>' + (sp ? '<span class="sh-skill-spec">' + formatSpecs(c, sk.specs) + '</span>' : '') + '</div><div class="skill-dots-wrap"><span class="' + (hasDots ? 'sh-skill-dots' : 'sh-skill-zero') + '">' + dotStr + '</span>' + (na ? '<span class="sh-skill-na">9-Again</span>' : ptNa ? '<span class="sh-skill-na pt-na">9-Again (PT)</span>' : ohmNa ? '<span class="sh-skill-na pt-na">9-Again (OHM)</span>' : '') + '</div></div>';
       });
     }
   }

--- a/public/js/editor/st-mod-popover.js
+++ b/public/js/editor/st-mod-popover.js
@@ -13,6 +13,7 @@
  */
 
 import { esc } from '../data/helpers.js';
+import { labelForPath } from '../data/st-mod-labels.js';
 import { buildPopover } from '../data/st-mod-popover-spec.js';
 
 // Re-export so existing import paths in the test (if anyone wanted to
@@ -23,7 +24,14 @@ export { buildPopover };
 const MARKER_SELECTOR = '[data-stm-marker-path]';
 
 /** Render the popover spec to HTML. Pure string-building; the caller
- *  injects the result into the DOM and positions it. */
+ *  injects the result into the DOM and positions it.
+ *
+ *  Issue #408 (Epic STM UX polish — Finding 4): clearer visual hierarchy.
+ *  Three logical sections (Base / Adjustments / Final) are emitted as
+ *  distinct rows with explicit label+value span pairs so flex layout
+ *  keeps them on a single line, plus a small "Adjustments" sub-header
+ *  before the mod rows so the popover reads as start → adjust → result
+ *  at a glance. CSS owns the separator borders + indentation. */
 export function renderPopoverHtml(spec) {
   if (!spec) return '';
   const baseSuffix = spec.baseRow.fromTracker ? ' <span class="stm-pop-base-src">(from tracker)</span>' : '';
@@ -31,19 +39,23 @@ export function renderPopoverHtml(spec) {
     const meta = (r.reason || r.creator)
       ? `<div class="stm-pop-mod-meta">${r.reason ? `<em>${esc(r.reason)}</em>` : ''}${r.reason && r.creator ? ' &mdash; ' : ''}${r.creator ? esc(r.creator) : ''}${r.when ? ` <span class="stm-pop-mod-when">${esc(r.when)}</span>` : ''}</div>`
       : '';
-    return `
-      <div class="stm-pop-mod">
-        <span class="stm-pop-mod-delta">${esc(r.deltaSigned)}</span>
-        ${meta}
-      </div>
-    `;
+    return `<div class="stm-pop-mod"><span class="stm-pop-mod-delta">${esc(r.deltaSigned)}</span>${meta}</div>`;
   }).join('');
   return `
     <div class="stm-pop">
       <div class="stm-pop-head">${esc(spec.pathLabel)}</div>
-      <div class="stm-pop-base">${esc(spec.baseRow.label)}: <span class="stm-pop-val">${esc(String(spec.baseRow.value))}</span>${baseSuffix}</div>
-      <div class="stm-pop-mods">${rows}</div>
-      <div class="stm-pop-final">${esc(spec.finalRow.label)}: <span class="stm-pop-val">${esc(String(spec.finalRow.value))}</span></div>
+      <div class="stm-pop-base">
+        <span class="stm-pop-row-lbl">${esc(spec.baseRow.label)}</span>
+        <span class="stm-pop-val">${esc(String(spec.baseRow.value))}${baseSuffix}</span>
+      </div>
+      <div class="stm-pop-mods">
+        <div class="stm-pop-mods-hdr">Adjustments</div>
+        ${rows}
+      </div>
+      <div class="stm-pop-final">
+        <span class="stm-pop-row-lbl">${esc(spec.finalRow.label)}</span>
+        <span class="stm-pop-val">${esc(String(spec.finalRow.value))}</span>
+      </div>
     </div>
   `;
 }
@@ -57,10 +69,21 @@ let _activePopover = null;
 
 /** Render a marker span for a given path, IF c._st_mod_overlay[path]
  *  exists. Otherwise returns empty string — caller can inline this
- *  next to a stat display without conditional gating. */
+ *  next to a stat display without conditional gating.
+ *
+ *  Issue #408 (Epic STM UX polish): for stat displays that are NOT
+ *  dot-runs (current.* / derived.* / blood_potency / humanity in the
+ *  stats strip), the standalone marker still applies. The title is
+ *  now enriched with the stat label + signed delta so a hover
+ *  immediately conveys what changed and by how much without the
+ *  player having to click. Dot-run paths (attributes / skills) are
+ *  marked via the dot class in shDotsWithBonus, not via this helper. */
 export function markerFor(c, path) {
-  if (!c?._st_mod_overlay || !c._st_mod_overlay[path]) return '';
-  return `<span class="stm-marker" data-stm-marker-path="${esc(path)}" title="ST adjustment"></span>`;
+  const overlay = c?._st_mod_overlay?.[path];
+  if (!overlay) return '';
+  const sign = overlay.delta >= 0 ? '+' : '';
+  const title = `ST adjustment: ${labelForPath(path)} ${sign}${overlay.delta}. Click for details.`;
+  return `<span class="stm-marker" data-stm-marker-path="${esc(path)}" title="${esc(title)}"></span>`;
 }
 
 /** Render a sequence of markers for a list of paths. Skips any path

--- a/server/tests/stm-polish-408-dots.test.js
+++ b/server/tests/stm-polish-408-dots.test.js
@@ -1,0 +1,216 @@
+/**
+ * STM polish #408 — shDotsWithBonus opts param.
+ *
+ * Verifies the dot helper marks the right sub-range of dots with the
+ * stm-modded-dot class + data-stm-marker-path attribute + title. This
+ * is the contract that lets clicking a modded dot open the popover
+ * (via the delegated handler on document.body) instead of clicking a
+ * standalone marker pip that visually collided with the dot run.
+ *
+ * Imports from public/js/data/helpers.js. helpers.js imports
+ * auth/discord.js (browser-only) at module load through the redact
+ * chain, so this test inlines shDotsWithBonus + esc to stay in pure
+ * Node — matches the path-resolve sanity / popover-spec test pattern.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// ── Inline mirror of public/js/data/helpers.js#shDotsWithBonus + esc ────
+
+function esc(s) {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+function shDots(n) {
+  return '<span class="pointed"></span>'.repeat(Math.max(0, n || 0));
+}
+function shDotsWithBonus(base, bonus, opts) {
+  if (!opts || (!opts.filledMod && !opts.hollowMod)) {
+    if (!bonus) return shDots(base);
+    return '<span class="pointed"></span>'.repeat(Math.max(0, base || 0)) + '<span class="pointed hollow"></span>'.repeat(Math.max(0, bonus || 0));
+  }
+  const fm = opts.filledMod;
+  const hm = opts.hollowMod;
+  let out = '';
+  const baseN = Math.max(0, base || 0);
+  for (let i = 0; i < baseN; i++) {
+    if (fm && i >= fm.from && i < fm.to) {
+      out += `<span class="pointed stm-modded-dot" data-stm-marker-path="${esc(fm.path || '')}" title="${esc(fm.title || '')}"></span>`;
+    } else {
+      out += '<span class="pointed"></span>';
+    }
+  }
+  const bonusN = Math.max(0, bonus || 0);
+  for (let i = 0; i < bonusN; i++) {
+    if (hm && i >= hm.from && i < hm.to) {
+      out += `<span class="pointed hollow stm-modded-dot" data-stm-marker-path="${esc(hm.path || '')}" title="${esc(hm.title || '')}"></span>`;
+    } else {
+      out += '<span class="pointed hollow"></span>';
+    }
+  }
+  return out;
+}
+
+// Helper: count occurrences of a substring
+function count(s, sub) {
+  let n = 0, i = 0;
+  while ((i = s.indexOf(sub, i)) !== -1) { n++; i += sub.length; }
+  return n;
+}
+
+// ── Backwards-compat ────────────────────────────────────────────────
+
+describe('STM #408 — shDotsWithBonus backwards compatibility', () => {
+  it('no opts → byte-identical to pre-#408 output (base + bonus dots, no marker)', () => {
+    const out = shDotsWithBonus(3, 2);
+    expect(out).toBe(
+      '<span class="pointed"></span>'.repeat(3)
+      + '<span class="pointed hollow"></span>'.repeat(2),
+    );
+    expect(out).not.toContain('stm-modded-dot');
+    expect(out).not.toContain('data-stm-marker-path');
+  });
+
+  it('opts with no filledMod/hollowMod → backwards-compat path', () => {
+    const out = shDotsWithBonus(3, 2, {});
+    expect(out).toBe(shDotsWithBonus(3, 2));
+  });
+
+  it('zero base + zero bonus + opts → empty string', () => {
+    expect(shDotsWithBonus(0, 0, { filledMod: { from: 0, to: 0, path: 'x' } })).toBe('');
+  });
+});
+
+// ── Filled mod (attributes.X.dots / skills.X.dots) ──────────────────
+
+describe('STM #408 — filled-stream mod (attributes/skills .dots)', () => {
+  it('Presence dots +2 (base 3 → final 5): dots 3..4 are marked, dots 0..2 are not', () => {
+    const out = shDotsWithBonus(5, 0, {
+      filledMod: {
+        from: 3, to: 5,
+        path: 'attributes.Presence.dots',
+        title: 'ST adjustment: Presence (dots) +2. Click for details.',
+      },
+    });
+    // 5 total filled dots, 2 of which are modded
+    expect(count(out, '<span class="pointed"></span>')).toBe(3);
+    expect(count(out, '<span class="pointed stm-modded-dot"')).toBe(2);
+    // Each modded dot carries the path attribute + title
+    expect(out).toContain('data-stm-marker-path="attributes.Presence.dots"');
+    expect(out).toContain('title="ST adjustment: Presence (dots) +2. Click for details."');
+  });
+
+  it('preserves order: unmarked dots first, modded dots after', () => {
+    const out = shDotsWithBonus(4, 0, {
+      filledMod: { from: 2, to: 4, path: 'attributes.Wits.dots', title: 'tip' },
+    });
+    const firstModded = out.indexOf('stm-modded-dot');
+    const lastUnmodded = out.lastIndexOf('<span class="pointed"></span>');
+    expect(lastUnmodded).toBeLessThan(firstModded);
+  });
+
+  it('full-range mod (base 0 → final 3): every dot is modded', () => {
+    const out = shDotsWithBonus(3, 0, {
+      filledMod: { from: 0, to: 3, path: 'attributes.Strength.dots', title: '' },
+    });
+    expect(count(out, 'stm-modded-dot')).toBe(3);
+    expect(count(out, '<span class="pointed"></span>')).toBe(0);
+  });
+});
+
+// ── Hollow mod (attributes.X.bonus / skills.X.bonus) ────────────────
+
+describe('STM #408 — hollow-stream mod (attributes/skills .bonus)', () => {
+  it('Presence bonus +3 with autoBonus 0 (base 0 → final 3): all 3 hollow dots are marked', () => {
+    // shDotsWithBonus(base_dots=0, autoBonus_plus_bonus=3, { hollowMod from 0+0 to 0+3 })
+    const out = shDotsWithBonus(0, 3, {
+      hollowMod: {
+        from: 0, to: 3,
+        path: 'attributes.Presence.bonus',
+        title: 'ST adjustment: Presence (bonus) +3 — click for details',
+      },
+    });
+    expect(count(out, '<span class="pointed hollow"></span>')).toBe(0);
+    expect(count(out, '<span class="pointed hollow stm-modded-dot"')).toBe(3);
+  });
+
+  it('attribute bonus mod with autoBonus offset (Majesty +1, bonus mod +2)', () => {
+    // c.disciplines.Majesty.dots = 1 → autoBonus = 1
+    // c.attributes.Presence.bonus before: 0; after applyStMods with delta +2: 2
+    // Call site: shDotsWithBonus(presence_dots, autoBonus + bonus, opts)
+    // Hollow stream: 3 positions = autoBonus(1) + manualBonus(2)
+    // Modded sub-range: [autoBonus + ov.base, autoBonus + ov.final) = [1, 3)
+    const out = shDotsWithBonus(2, 3, {
+      hollowMod: { from: 1, to: 3, path: 'attributes.Presence.bonus', title: 't' },
+    });
+    // 2 filled dots (unmodded), 1 hollow unmarked (autoBonus), 2 hollow modded (manual bonus mod)
+    expect(count(out, '<span class="pointed"></span>')).toBe(2);
+    expect(count(out, '<span class="pointed hollow"></span>')).toBe(1);
+    expect(count(out, '<span class="pointed hollow stm-modded-dot"')).toBe(2);
+  });
+
+  it('skill bonus mod: hollow stream layout bn first, then ptBn / mciBn — modded sub-range starts at 0', () => {
+    // sk.bonus = 2 (post-mod, was 0, delta +2)
+    // ptBn = 1, mciBn = 0
+    // Call site: shDotsWithBonus(d, bn + ptBn + mciBn) = shDotsWithBonus(d, 3)
+    // Hollow stream layout (skill convention): bn first (positions 0..1), then ptBn (position 2)
+    // Modded sub-range = [ov.base, ov.final) = [0, 2) within bn subrange
+    const out = shDotsWithBonus(2, 3, {
+      hollowMod: { from: 0, to: 2, path: 'skills.Athletics.bonus', title: 't' },
+    });
+    // 2 filled, 2 hollow modded (the bn portion), 1 hollow unmarked (ptBn)
+    expect(count(out, '<span class="pointed"></span>')).toBe(2);
+    expect(count(out, '<span class="pointed hollow stm-modded-dot"')).toBe(2);
+    expect(count(out, '<span class="pointed hollow"></span>')).toBe(1);
+  });
+});
+
+// ── Combined filled + hollow mod ────────────────────────────────────
+
+describe('STM #408 — combined filled and hollow mods', () => {
+  it('dots +2 AND bonus +1: both sub-ranges marked, rest plain', () => {
+    const out = shDotsWithBonus(5, 1, {
+      filledMod: { from: 3, to: 5, path: 'attributes.Presence.dots', title: 'd' },
+      hollowMod: { from: 0, to: 1, path: 'attributes.Presence.bonus', title: 'b' },
+    });
+    // 3 unmodded filled, 2 modded filled, 1 modded hollow
+    expect(count(out, '<span class="pointed"></span>')).toBe(3);
+    expect(count(out, '<span class="pointed stm-modded-dot"')).toBe(2);
+    expect(count(out, '<span class="pointed hollow"></span>')).toBe(0);
+    expect(count(out, '<span class="pointed hollow stm-modded-dot"')).toBe(1);
+    // Two distinct paths in the output
+    expect(out).toContain('data-stm-marker-path="attributes.Presence.dots"');
+    expect(out).toContain('data-stm-marker-path="attributes.Presence.bonus"');
+  });
+});
+
+// ── Defensive ───────────────────────────────────────────────────────
+
+describe('STM #408 — defensive', () => {
+  it('escapes HTML in title and path attributes', () => {
+    const out = shDotsWithBonus(1, 0, {
+      filledMod: { from: 0, to: 1, path: '<script>', title: '"injection"' },
+    });
+    expect(out).toContain('data-stm-marker-path="&lt;script&gt;"');
+    expect(out).toContain('title="&quot;injection&quot;"');
+    expect(out).not.toContain('<script>');
+  });
+
+  it('handles missing path/title gracefully', () => {
+    const out = shDotsWithBonus(1, 0, {
+      filledMod: { from: 0, to: 1 },
+    });
+    expect(out).toContain('data-stm-marker-path=""');
+    expect(out).toContain('title=""');
+  });
+
+  it('out-of-range mod (to > base): only marks within actual base', () => {
+    const out = shDotsWithBonus(3, 0, {
+      filledMod: { from: 1, to: 99, path: 'x', title: 't' },
+    });
+    // Only positions 1..2 are marked (within base=3)
+    expect(count(out, 'stm-modded-dot')).toBe(2);
+    expect(count(out, '<span class="pointed"></span>')).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Bundled UX polish following Peter's smoke confirming the data layer is correct (post bugfix #405). Four findings, all presentation-layer.

Closes #408 (manual close on dev-merge per `feedback_github_autoclose_dev_gap`)

## Finding 1 — Global toggle copy

The label and hint were ambiguous between "master switch for the STM system" and "apply this mod to all characters". Cost a debug round-trip during Peter's smoke.

- "Global overlay ON/OFF" → **"Show ST Mods on sheets ON/OFF"**
- Hint copy expanded to "Master switch... emergency hide-all kill-switch... mods stay in the DB"
- Parallel rephrase on the per-character toggle: "Suppress overlay for this character" → "Hide ST Mods for this character only"

## Finding 2 — Modded-dot class replaces standalone marker pip (biggest)

The pre-#408 design emitted a separate `<span class="stm-marker">` gold pip after the dot run. Visually it collided with the dots themselves — Peter's perception was "no extra dots showed" because the marker pip and the dot glyph look alike at a glance.

**Now:** the modded sub-range of dots themselves carries `.stm-modded-dot` + `data-stm-marker-path` + `title`. Gold tint + 1px gold outline ring, no motion (Peter chose static differentiation). Existing `document.body` delegated handler picks up `data-stm-marker-path` on the dot span; **no listener changes needed**.

### Implementation

`shDotsWithBonus` gains an optional `opts` third parameter:

```js
shDotsWithBonus(base, bonus, {
  filledMod: { from, to, path, title },  // marks filled-stream dots [from..to-1]
  hollowMod: { from, to, path, title },  // marks hollow-stream dots [from..to-1]
});
```

No-opts path is byte-identical to pre-#408 — all existing callers unaffected.

### Hollow-stream layout conventions

- **Attributes:** `shDotsWithBonus(dots, autoBonus + bonus, ...)`. Hollow stream is `autoBonus` first, then manual `bonus`. Modded bonus sub-range starts at hollow position `autoBonus + ovBonus.base`.
- **Skills:** `shDotsWithBonus(d, bn + ptBn + mciBn, ...)`. Hollow stream is `bn` first, then `ptBn`, then `mciBn`. Modded `skills.X.bonus` sub-range starts at hollow position `ovBonus.base` (no offset).

### Scope split

- Dot-run paths (`attributes.X.dots/bonus`, `skills.X.dots/bonus`): marked via `.stm-modded-dot` on the dot span. Standalone marker removed for these.
- Non-dot displays (`blood_potency`, `humanity`, `current.*`, `derived.*` in the stats strip): standalone `.stm-marker` pip retained — these are number displays, no dots to mark.

## Finding 3 — Tooltip enrichment

`markerFor()` title was the static string `'ST adjustment'`. Now includes the stat label (via `labelForPath`) and signed delta:

```
ST adjustment: Presence (bonus) +2. Click for details.
```

Same enrichment on dot-class titles via the `shDotsWithBonus` opts path. No em-dashes per CLAUDE.md punctuation rules (was tempted by the issue brief's `—`; used `.` instead).

## Finding 4 — Popover layout hierarchy

Pre-#408 popover read as one stream — `Base:` label on one line, `0` value on another, mod rows immediately below indistinguishable from the Base row.

**Now:**

- Explicit `<span class="stm-pop-row-lbl">` / `<span class="stm-pop-val">` pairs in Base / Final rows so flex always keeps them on one line
- New "Adjustments" sub-header above mod rows with a thin gold left-border on the mods container + indentation so the popover reads **start → adjust → result** at a glance
- Stronger separator under Base (border-bottom), more prominent gold accent border above Final

## Acceptance criteria

| AC | Status |
|----|--------|
| Global toggle relabelled (Finding 1) | ✅ |
| `.stm-marker` standalone removed from sheet dot runs; modded dots carry class + attribute (Finding 2) | ✅ |
| CSS `.stm-modded-dot`: gold tint + thin gold ring, no motion (Finding 2) | ✅ |
| Click on modded dot opens popover via existing delegated handler | ✅ structural (same `data-stm-marker-path` attribute carrier) |
| Title attribute includes stat label + signed delta (Finding 3) | ✅ |
| Popover visual hierarchy: Base / Adjustments / Final visibly distinct (Finding 4) | ✅ |
| Tests cover the polish (no UI regression) | ✅ 13 new cases |
| No regression — existing tests still pass | ✅ 995/995 |

## Test plan

- [x] Parse-check all touched modules (`node --input-type=module --check`)
- [x] Full server test suite: **995/995 passing**
- [x] New `stm-polish-408-dots.test.js`: 13 cases covering backwards-compat (no-opts byte-identical), filled-stream mod, hollow-stream mod with autoBonus offset, skill-bonus mod with bn-first layout, combined filled+hollow, defensive (HTML escape + out-of-range clamp)
- [ ] Peter's in-browser smoke: open Yusuf → see modded dots tinted gold with ring → hover for enriched tooltip → click opens popover with clear hierarchy → toggle Global on/off + Per-character on/off — copy reads unambiguous

## Files

- **modified** `public/js/data/helpers.js` — `shDotsWithBonus` gains opts param (backwards-compat preserved when opts is undefined)
- **modified** `public/js/editor/sheet.js` — attribute + skill read-mode render compute filled/hollow ranges from `c._st_mod_overlay` and pass to `shDotsWithBonus`. `markersFor` import dropped (only `markerFor` still used for non-dot displays)
- **modified** `public/js/editor/st-mod-popover.js` — `markerFor` title enriched via `labelForPath` + signed delta; popover HTML restructured with explicit label/value spans + new "Adjustments" sub-header
- **modified** `public/js/admin/st-mods-panel.js` — global + per-character toggle labels rephrased; hint copy expanded
- **modified** `public/css/components.css` — `.stm-modded-dot` rules (gold tint + 1px ring, no motion); popover CSS restructured for hierarchy (label/value flex, separators, "Adjustments" header indent + gold left-border)
- **new** `server/tests/stm-polish-408-dots.test.js` — 13 vitest cases for the dot helper opts contract

## What this PR does NOT do

- Doesn't touch any data layer code (POST/GET/applyStMods/loadStMods unchanged — bugfix #405 already nailed that down)
- Doesn't add motion to the modded-dot styling — Peter explicitly chose static gold tint + ring
- Doesn't restyle the standalone marker for non-dot displays (stats strip) — that styling is fine
- STM-5 dropdown UX is out of scope (separate issue if surfaced)