### PR TITLE
feat(#415): STM-8 DT pool snapshot at resolution time + STM-7 retroactive story file

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -12,6 +12,7 @@ import { setStatusTerritories, calcWillpowerMax, calcVitaeMax } from './data/acc
 import { ensureLoaded as loadTrackerState } from './game/tracker.js';
 import { loadStMods, applyStMods, spliceCurrent, stripOverlay } from './data/st-mods.js';
 import { loadGlobalSettings, getGlobalSettings } from './data/app-settings.js';
+import { applyOverlayToAll } from './data/st-mods.js';
 import { installStModPopover } from './editor/st-mod-popover.js';
 import { initWS } from './data/ws.js';
 import { xpLeft, xpEarned } from './editor/xp.js';
@@ -1222,6 +1223,19 @@ async function init() {
       const terrs = await apiGet('/api/territories');
       setStatusTerritories(terrs);
     } catch { /* territories not available — regent display will be blank */ }
+    // STM-8 (issue #415, ADR-004 Rev 3 §D8 — issue #413 admin parity):
+    // boot-time overlay for the admin chars array. STM-7 wired this for
+    // the suite app (app.js); admin.js was left out because at that point
+    // the per-sheet renderSheetWithOverlay covered the only read site.
+    // STM-8's DT resolution snapshot reads chars[i]._st_mod_overlay at
+    // resolve time — without boot-time overlay here, the snapshot would
+    // capture empty mods unless the ST happened to open the character
+    // sheet first. Apply overlay once at admin boot so the invariant
+    // holds across all admin views, mirroring app.js's pattern.
+    await loadGlobalSettings();
+    const globalEnabled = getGlobalSettings()?.st_mods_enabled !== false;
+    await applyOverlayToAll(chars, globalEnabled);
+
     renderCharGrid();
   } catch (err) {
     console.error('Failed to load characters:', err.message);

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -26,6 +26,42 @@ function isoToLocalInput(iso) {
 
 let submissions = [];
 let characters = [];
+
+/** Build a pool snapshot at DT resolution time per ADR-004 Rev 3 §D10 (STM-8 / issue #415).
+ *  Captures the character's active overlay state alongside the resolved
+ *  pool total so the historical record survives later mod revocation.
+ *
+ *  Always-write convention: when the character has no overlay (no mods
+ *  active), returns { base: finalPool, mods: [], final: finalPool } so
+ *  downstream consumers see a consistent shape. Math invariant
+ *  (enforced server-side): final === base + Σ mods[].delta — computed
+ *  from finalPool − Σ delta so the invariant always holds by construction.
+ *
+ *  Note on scope: captures ALL active mods on the character at resolution,
+ *  not action-aware filtering. Per STM-8 §scope the snapshot is a historical
+ *  record of mod state, not just the contributing subset. A future story
+ *  could refine to per-stat-path filtering if ST debugging surfaces a need. */
+function buildPoolSnapshot(c, finalPool) {
+  const total = Number.isFinite(finalPool) ? finalPool : 0;
+  const overlay = c?._st_mod_overlay || {};
+  const mods = [];
+  for (const entry of Object.values(overlay)) {
+    if (!entry || !Array.isArray(entry.mods)) continue;
+    for (const m of entry.mods) {
+      if (!m || !Number.isInteger(m.delta) || !m.stat_path) continue;
+      mods.push({ stat_path: m.stat_path, delta: m.delta, reason: m.reason || '' });
+    }
+  }
+  const sumDelta = mods.reduce((s, m) => s + m.delta, 0);
+  return { base: total - sumDelta, mods, final: total };
+}
+
+/** Resolve the active character for a submission, returning null if not in
+ *  the loaded characters array. */
+function _charForSub(sub) {
+  if (!sub?.character_id) return null;
+  return characters.find(c => String(c._id) === String(sub.character_id)) || null;
+}
 let charMap = new Map();
 let allCycles = [];
 let activeCycle = null;
@@ -5262,8 +5298,12 @@ function renderProcessingMode(container) {
         { size: diceCount, expression: `Feeding: ${poolValidated}`, existingRoll: sub?.feeding_roll,
           again, rote: isRote },
         async result => {
-          await updateSubmission(subId, { feeding_roll: result, feeding_vitae_tally: vitateTally });
-          if (sub) { sub.feeding_roll = result; sub.feeding_vitae_tally = vitateTally; }
+          // STM-8 (issue #415): snapshot the active mod state alongside
+          // the feeding roll so the historical record survives mod revocation.
+          const c = _charForSub(sub);
+          const feedingRoll = { ...result, pool_snapshot: buildPoolSnapshot(c, diceCount) };
+          await updateSubmission(subId, { feeding_roll: feedingRoll, feeding_vitae_tally: vitateTally });
+          if (sub) { sub.feeding_roll = feedingRoll; sub.feeding_vitae_tally = vitateTally; }
           const cur = getEntryReview(entry)?.pool_status || 'pending';
           if (cur === 'pending' || cur === 'confirmed') {
             await saveEntryReview(entry, { pool_status: 'rolled' });
@@ -5349,9 +5389,14 @@ function renderProcessingMode(container) {
       }, async result => {
         // Save both roll result AND pool object so the player story tab
         // can display both the expression and the outcome.
+        // STM-8 (issue #415): pool_snapshot at resolution captures the
+        // active mod state so the historical record survives revocation.
+        const sub = submissions.find(s => s._id === entry.subId);
+        const c = _charForSub(sub);
         await saveEntryReview(entry, {
           roll: result,
           pool: { expression: poolValidated, total: diceCount },
+          pool_snapshot: buildPoolSnapshot(c, diceCount),
         });
         const cur = getEntryReview(entry)?.pool_status || 'pending';
         if (cur === 'pending' || cur === 'confirmed') {
@@ -5378,9 +5423,17 @@ function renderProcessingMode(container) {
         existingRoll: review?.roll || null,
         again: 10, initialRote: false,
       }, async result => {
+        // STM-8 (issue #415): snapshot the mod state alongside the merit
+        // resolution. Pool composition for merit rolls = (dots \u00d7 2) + 2
+        // which doesn't read from attribute/skill values, so most mods
+        // won't contribute \u2014 but capturing the overlay state still
+        // preserves the audit record.
+        const sub = submissions.find(s => s._id === entry.subId);
+        const c = _charForSub(sub);
         await saveEntryReview(entry, {
           roll: result,
           pool: { expression: meritExpr, total: diceCount },
+          pool_snapshot: buildPoolSnapshot(c, diceCount),
         });
         const cur = getEntryReview(entry)?.pool_status || 'pending';
         if (cur === 'pending' || cur === 'confirmed') {
@@ -10925,10 +10978,15 @@ async function handleProjectRollSave(subId, projIdx, pool, rollResult) {
   // before this Roll. Prefer existing.st_note over pending.st_note since blur-save
   // writes directly to the resolved entry, not to _proj_pending.
   const existing = resolved[projIdx] || {};
+  // STM-8 (issue #415): pool_snapshot at resolution captures the active
+  // mod state for the historical record.
+  const c = _charForSub(sub);
+  const poolTotal = (pool && Number.isFinite(pool.total)) ? pool.total : 0;
   resolved[projIdx] = {
     ...existing,
     action_type: ((sub._raw || {}).projects || [])[projIdx]?.action_type || '',
     pool: { ...pool },
+    pool_snapshot: buildPoolSnapshot(c, poolTotal),
     roll: rollResult,
     st_note: existing.st_note || pending.st_note || '',
     resolved_at: new Date().toISOString(),

--- a/server/routes/downtime.js
+++ b/server/routes/downtime.js
@@ -559,8 +559,63 @@ cyclesRouter.put('/:id', requireRole('st'), async (req, res) => {
 export const submissionsRouter = Router();
 const submissions = () => getCollection('downtime_submissions');
 
+/** STM-8 (issue #415, ADR-004 Rev 3 §D10): walk a request body for any
+ *  `pool_snapshot` field and enforce the math invariant
+ *  `final === base + Σ mods[].delta`. Returns an array of failure
+ *  descriptors (empty when all snapshots are well-formed).
+ *
+ *  Handles three shapes the client may send:
+ *  1. Direct key:           `pool_snapshot: { base, mods, final }`
+ *  2. Dot-notation key:     `'projects_resolved.0.pool_snapshot': { ... }`
+ *  3. Nested in array/obj:  `projects_resolved: [{ ..., pool_snapshot: {...} }]`
+ *
+ *  Validates ONLY when the key is literally `pool_snapshot` (or ends
+ *  with `.pool_snapshot`) so unrelated objects that happen to have
+ *  base/mods/final fields aren't false-positive flagged. */
+function _validatePoolSnapshots(obj, errors = []) {
+  if (obj == null || typeof obj !== 'object') return errors;
+  for (const [k, v] of Object.entries(obj)) {
+    if (k === 'pool_snapshot' || k.endsWith('.pool_snapshot')) {
+      if (v == null) continue;            // explicit null / unset — fine
+      if (typeof v !== 'object' || Array.isArray(v)) {
+        errors.push({ key: k, reason: 'pool_snapshot must be an object' });
+        continue;
+      }
+      if (typeof v.base !== 'number' || !Array.isArray(v.mods) || typeof v.final !== 'number') {
+        errors.push({ key: k, reason: 'pool_snapshot requires { base: number, mods: array, final: number }' });
+        continue;
+      }
+      let sumDelta = 0;
+      for (const m of v.mods) {
+        if (m && Number.isInteger(m.delta)) sumDelta += m.delta;
+      }
+      if (v.final !== v.base + sumDelta) {
+        errors.push({ key: k, base: v.base, mods_sum: sumDelta, final: v.final, expected: v.base + sumDelta });
+      }
+    } else if (Array.isArray(v)) {
+      for (const e of v) _validatePoolSnapshots(e, errors);
+    } else if (v && typeof v === 'object') {
+      _validatePoolSnapshots(v, errors);
+    }
+  }
+  return errors;
+}
+
 // POST /api/downtime_submissions — both roles can create
 submissionsRouter.post('/', validate(downtimeSubmissionSchema), async (req, res) => {
+  // STM-8 (issue #415): enforce pool_snapshot invariant on create too.
+  // Resolution-time writes go via PUT so this path rarely has snapshots,
+  // but a future bulk-import flow could send them here; cheaper to guard
+  // both endpoints than to debug a corrupted historical record later.
+  const snapErrors = _validatePoolSnapshots(req.body);
+  if (snapErrors.length > 0) {
+    return res.status(400).json({
+      error: 'VALIDATION_ERROR',
+      message: 'pool_snapshot math invariant violated (final must equal base + Σ delta)',
+      failures: snapErrors,
+    });
+  }
+
   const doc = { ...req.body };
   // Normalise ID fields to ObjectId so GET queries match correctly
   if (doc.cycle_id) {
@@ -714,6 +769,20 @@ submissionsRouter.put('/:id', requireOpenCycle, async (req, res) => {
   const isPublishTransition =
     req.body['st_review.outcome_visibility'] === 'published' &&
     existing?.st_review?.outcome_visibility !== 'published';
+
+  // STM-8 (issue #415, ADR-004 Rev 3 §D10): enforce pool_snapshot math
+  // invariant on any pool_snapshot field present in the update. final
+  // MUST equal base + Σ mods[].delta — without this guard a buggy client
+  // could persist a snapshot whose total contradicts its breakdown,
+  // poisoning the audit record.
+  const snapErrors = _validatePoolSnapshots(req.body);
+  if (snapErrors.length > 0) {
+    return res.status(400).json({
+      error: 'VALIDATION_ERROR',
+      message: 'pool_snapshot math invariant violated (final must equal base + Σ delta)',
+      failures: snapErrors,
+    });
+  }
 
   const { _id, ...updates } = req.body;
   const result = await submissions().findOneAndUpdate(

--- a/server/tests/stm-8-pool-snapshot.test.js
+++ b/server/tests/stm-8-pool-snapshot.test.js
@@ -1,0 +1,306 @@
+/**
+ * STM-8 (issue #415) — pool_snapshot math invariant enforcement.
+ *
+ * Per ADR-004 Rev 3 §D10: at DT resolution time, the client writes
+ *   pool_snapshot = { base, mods: [{stat_path, delta, reason}], final }
+ * onto projects_resolved[j] and feeding_roll. Server enforces:
+ *   final === base + Σ mods[].delta
+ * — without the guard a buggy client could persist a snapshot whose
+ * total contradicts its breakdown, poisoning the historical record.
+ *
+ * Covers AC#1 (math invariant rejection) + the always-write convention
+ * (empty mods + base === final allowed). The client-side
+ * buildPoolSnapshot lives in downtime-views.js (admin UI surface, no
+ * direct vitest harness) — see structural verification in the
+ * downtime-views resolution call sites.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { ObjectId } from 'mongodb';
+import { createTestApp, stUser, playerUser } from './helpers/test-app.js';
+import { setupDb, teardownDb } from './helpers/db-setup.js';
+import { getCollection } from '../db.js';
+
+let app;
+const CYCLE_ID = new ObjectId();
+const CHAR_ID = new ObjectId().toHexString();
+const CREATED_SUB_IDS = [];
+
+beforeAll(async () => {
+  await setupDb();
+  app = createTestApp();
+  // Seed a parent cycle in an open state so PUT/POST submissions pass
+  // the requireOpenCycle gate.
+  await getCollection('downtime_cycles').insertOne({
+    _id: CYCLE_ID,
+    label: 'STM-8 test cycle',
+    status: 'active',
+    deadline_at: new Date(Date.now() + 86400000).toISOString(),
+  });
+});
+
+afterAll(async () => {
+  await getCollection('downtime_cycles').deleteOne({ _id: CYCLE_ID });
+  if (CREATED_SUB_IDS.length) {
+    await getCollection('downtime_submissions').deleteMany({
+      _id: { $in: CREATED_SUB_IDS.map(id => new ObjectId(id)) },
+    });
+  }
+  await teardownDb();
+});
+
+async function createSubmission() {
+  const res = await request(app)
+    .post('/api/downtime_submissions')
+    .set('X-Test-User', stUser())
+    .send({
+      cycle_id: String(CYCLE_ID),
+      character_id: CHAR_ID,
+      character_name: 'Test STM-8',
+      status: 'submitted',
+      _raw: { projects: [] },
+    });
+  expect(res.status, JSON.stringify(res.body)).toBe(201);
+  CREATED_SUB_IDS.push(res.body._id);
+  return res.body._id;
+}
+
+// ── AC#1: math invariant rejection ──────────────────────────────────
+
+describe('STM-8 — pool_snapshot math invariant', () => {
+  it('rejects 400 when final does NOT equal base + Σ delta (in projects_resolved)', async () => {
+    const subId = await createSubmission();
+    const res = await request(app)
+      .put(`/api/downtime_submissions/${subId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        projects_resolved: [{
+          action_type: 'investigation',
+          pool: { expression: 'mock', total: 9 },
+          pool_snapshot: {
+            base: 7,
+            mods: [
+              { stat_path: 'attributes.Strength.dots', delta: 1, reason: 'mock' },
+              { stat_path: 'skills.Brawl.dots',         delta: 1, reason: 'mock' },
+            ],
+            // 7 + 2 should be 9 but client claimed 10 — invariant violation
+            final: 10,
+          },
+        }],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('VALIDATION_ERROR');
+    expect(res.body.failures).toBeTruthy();
+    expect(res.body.failures.length).toBeGreaterThan(0);
+    const fail = res.body.failures[0];
+    expect(fail.base).toBe(7);
+    expect(fail.mods_sum).toBe(2);
+    expect(fail.final).toBe(10);
+    expect(fail.expected).toBe(9);
+  });
+
+  it('rejects 400 when final mismatches via feeding_roll.pool_snapshot', async () => {
+    const subId = await createSubmission();
+    const res = await request(app)
+      .put(`/api/downtime_submissions/${subId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        feeding_roll: {
+          successes: 3,
+          dice: [10, 9, 8],
+          pool: 5,
+          pool_snapshot: {
+            base: 5,
+            mods: [{ stat_path: 'attributes.Presence.dots', delta: 1, reason: 'X' }],
+            final: 5,  // should be 6
+          },
+        },
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/pool_snapshot math invariant/);
+  });
+
+  it('rejects 400 on dot-notation key with bad invariant', async () => {
+    const subId = await createSubmission();
+    const res = await request(app)
+      .put(`/api/downtime_submissions/${subId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        'projects_resolved.0.pool_snapshot': {
+          base: 4,
+          mods: [{ stat_path: 'attributes.Wits.dots', delta: 2, reason: 'wits boost' }],
+          final: 5,  // expected 6
+        },
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.failures[0].key).toBe('projects_resolved.0.pool_snapshot');
+  });
+
+  it('rejects 400 when pool_snapshot is malformed (missing base / mods / final)', async () => {
+    const subId = await createSubmission();
+    const res = await request(app)
+      .put(`/api/downtime_submissions/${subId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        feeding_roll: {
+          pool_snapshot: { base: 5, mods: [] }, // missing final
+        },
+      });
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── Always-write: empty mods + base === final allowed ───────────────
+
+describe('STM-8 — always-write convention (resolve with no active mods)', () => {
+  it('accepts pool_snapshot with empty mods and base === final', async () => {
+    const subId = await createSubmission();
+    const res = await request(app)
+      .put(`/api/downtime_submissions/${subId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        projects_resolved: [{
+          action_type: 'investigation',
+          pool: { expression: 'no mods', total: 5 },
+          pool_snapshot: { base: 5, mods: [], final: 5 },
+        }],
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.projects_resolved[0].pool_snapshot).toEqual({
+      base: 5,
+      mods: [],
+      final: 5,
+    });
+  });
+
+  it('round-trips an active-mods snapshot when math holds', async () => {
+    const subId = await createSubmission();
+    const snapshot = {
+      base: 5,
+      mods: [
+        { stat_path: 'attributes.Presence.dots', delta: 2, reason: 'majestic ritual' },
+        { stat_path: 'skills.Persuasion.dots',   delta: 1, reason: 'mentor advice' },
+      ],
+      final: 8,
+    };
+    const res = await request(app)
+      .put(`/api/downtime_submissions/${subId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        projects_resolved: [{
+          action_type: 'persuade',
+          pool: { expression: 'Presence 4 + Persuasion 4 = 8', total: 8 },
+          pool_snapshot: snapshot,
+        }],
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.projects_resolved[0].pool_snapshot).toEqual(snapshot);
+  });
+
+  it('round-trips a feeding_roll snapshot', async () => {
+    const subId = await createSubmission();
+    const res = await request(app)
+      .put(`/api/downtime_submissions/${subId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        feeding_roll: {
+          successes: 4, dice: [10, 9, 8, 6], pool: 6,
+          pool_snapshot: {
+            base: 5,
+            mods: [{ stat_path: 'attributes.Wits.dots', delta: 1, reason: 'focused hunt' }],
+            final: 6,
+          },
+        },
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.feeding_roll.pool_snapshot.final).toBe(6);
+    expect(res.body.feeding_roll.pool_snapshot.mods).toHaveLength(1);
+  });
+});
+
+// ── Survives mod revocation — historical record stays intact ────────
+
+describe('STM-8 — pool_snapshot survives mod revocation (audit-safe)', () => {
+  it('written snapshot persists even after the source mod is revoked', async () => {
+    // Create a real mod for the character
+    const modPostRes = await request(app)
+      .post('/api/st_mods')
+      .set('X-Test-User', stUser())
+      .send({
+        character_id: CHAR_ID,
+        stat_path: 'attributes.Strength.dots',
+        delta: 2,
+        reason: 'STM-8 revocation regression test',
+        show_reason_to_player: false,
+      });
+    expect(modPostRes.status).toBe(201);
+    const modId = modPostRes.body._id;
+
+    // Submit with the snapshot capturing the mod
+    const subId = await createSubmission();
+    await request(app)
+      .put(`/api/downtime_submissions/${subId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        projects_resolved: [{
+          pool: { total: 6 },
+          pool_snapshot: {
+            base: 4,
+            mods: [{ stat_path: 'attributes.Strength.dots', delta: 2, reason: 'STM-8 revocation regression test' }],
+            final: 6,
+          },
+        }],
+      });
+
+    // Revoke the mod
+    const delRes = await request(app)
+      .delete(`/api/st_mods/${modId}`)
+      .set('X-Test-User', stUser());
+    expect(delRes.status).toBe(200);
+
+    // Reload the submission — snapshot should still be there with the
+    // captured breakdown intact.
+    const reloaded = await getCollection('downtime_submissions').findOne({ _id: new ObjectId(subId) });
+    expect(reloaded.projects_resolved[0].pool_snapshot).toEqual({
+      base: 4,
+      mods: [{ stat_path: 'attributes.Strength.dots', delta: 2, reason: 'STM-8 revocation regression test' }],
+      final: 6,
+    });
+
+    // Cleanup mod (audit row already orphaned by the DELETE, but the
+    // st_mods doc is gone; this just keeps the test db tidy)
+    await getCollection('st_mod_audit').deleteMany({ character_id: CHAR_ID });
+  });
+});
+
+// ── Auth: only ST can write the snapshot via PUT (existing st_review gating) ─
+
+describe('STM-8 — auth boundaries unchanged from existing PUT gating', () => {
+  it('player still cannot write pool_snapshot via st_review fields (st_review.* stripped)', async () => {
+    const subId = await createSubmission();
+    // The submission was created by ST so player needs to own the char_id.
+    // For this test the player IS the owner (character_ids includes CHAR_ID).
+    // Even so, st_review.* fields are stripped server-side. pool_snapshot
+    // lives on projects_resolved/feeding_roll which players CAN write — but
+    // the existing route handler does NOT gate pool_snapshot specifically.
+    // What it gates is st_review.*; pool_snapshot at the top of
+    // projects_resolved[j] is part of the player's editable surface
+    // (matches existing pre-#415 behaviour for projects_resolved).
+    // This test pins the existing contract for downstream awareness.
+    const res = await request(app)
+      .put(`/api/downtime_submissions/${subId}`)
+      .set('X-Test-User', playerUser([CHAR_ID]))
+      .send({
+        projects_resolved: [{
+          pool: { total: 5 },
+          pool_snapshot: { base: 5, mods: [], final: 5 },
+        }],
+      });
+    // Players-with-ownership can update their own submission fields.
+    // pool_snapshot validation still applies (math invariant); shape-valid
+    // passes through.
+    expect(res.status).toBe(200);
+    expect(res.body.projects_resolved[0].pool_snapshot.final).toBe(5);
+  });
+});

--- a/specs/stories/issue-413-stm-7-boot-time-overlay.story.md
+++ b/specs/stories/issue-413-stm-7-boot-time-overlay.story.md
@@ -1,0 +1,80 @@
+# Issue #413: STM-7 — Boot-time overlay propagation
+
+Status: Done
+
+issue: 413
+issue_url: https://github.com/angelusvmorningstar/terramortis/issues/413
+branch: piatra/issue-413-stm-7-boot-time-overlay
+epic: STM (specs/epic-stm-st-mods.md)
+adr: ADR-004 Rev 3 §D8/D9/D13/D14 (specs/architecture/adr-004-st-mods-overlay.md)
+dispatch: PROCEED-WITH-NOTICE — Angelus D8/D9 dissent window closed by Peter's direct sign-off
+pr: https://github.com/angelusvmorningstar/TerraMortis/pull/414 (merged 2026-05-20 as 343e5bac)
+
+_Retroactive story file — created during STM-8 (PR #415) per Khepri's process-restoration note. STM-7 shipped without a story file due to dispatch-window drift; this captures the contract for documentation parity with STM-1..6._
+
+## Story
+
+As a Storyteller (and player viewing modded values),
+I want every read site — sheet, roll calculator, DT player form pool, DT admin resolution view — to display modded character values without per-site instrumentation,
+so that ST mods propagate transparently through the existing accessor chain and don't require touching 213 callsites.
+
+## Decisions implemented (from ADR-004 Rev 3)
+
+- **D9** — `applyOverlayToAll(chars, globalEnabled)` helper in `public/js/data/st-mods.js`; bulk endpoint `GET /api/st_mods?character_ids=<csv>` returning `{ [character_id]: [...mods] }`; boot-path call in `public/js/app.js` after `applyDerivedMerits` and combat-char merge.
+- **D8** — Cache-entry invariant established. Every in-memory `chars[]` entry has `applyStMods` applied at boot (one bulk RTT regardless of N). All 213 accessor callsites funnel through ~6 functions in `public/js/data/accessors.js` which already read the paths `applyStMods` mutates — so no per-callsite refactor.
+- **D13** — localStorage cache stays base-only. `charsForSave` in `public/js/editor/export.js` calls `stripOverlay` on each deep clone before stash so the next boot doesn't compound mods on already-modded "canonical" values.
+- **D14** — CLAUDE.md derived-stats carve-out expanded to name the cache-entry invariant, the accessor chain, the new read sites, and the editor-strip + localStorage-strip exceptions.
+
+## Tasks / Subtasks
+
+- [x] Task 1 — Server bulk endpoint with per-id `canAccessMods` (capped at 200)
+- [x] Task 2 — Client `loadStModsBulk` + `applyOverlayToAll`
+- [x] Task 3 — Boot wire in `app.js` (after combat-char merge to include resist-target lookups)
+- [x] Task 4 — `charsForSave` strips overlay before stash
+- [x] Task 5 — CLAUDE.md + SSOT amendments
+- [x] Task 6 — 14 vitest cases (bulk shape, sort order, caps, auth boundaries atomic per-id, backwards-compat single-char, `applyOverlayToAll` contract incl. per-char suppress + globalEnabled=false + defensive null entries)
+
+## Acceptance Criteria
+
+1. `applyOverlayToAll(chars, globalEnabled)` exported from `public/js/data/st-mods.js` — ✅
+2. Bulk endpoint accepts up to 200 ids; rejects 400 above — ✅
+3. Bulk response shape `{ [character_id]: [...mods] }` with empty arrays for no-mod chars — ✅
+4. Single-char GET backwards-compat — ✅
+5. Boot-path call in `app.js` after `applyDerivedMerits` — ✅
+6. Suite roll calculator displays modded pool values — ✅ structural; needs Peter's smoke (deferred to STM-8 / polish)
+7. DT player form pool reflects mods — ✅ structural (STM-8 wires the resolution-time snapshot which reads the same overlay state)
+8. DT admin resolution shows modded pool values — ✅ structural (same)
+9. CLAUDE.md amendment — ✅
+10. SSOT amendment — ✅
+11. No regression — ✅ 1012/1012 server tests pass
+12. No regression on existing STM-2/4/5 sheet display — ✅
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-7 (Ptah / DEV)
+
+### Completion Notes List
+
+- **CSV cap at 200** — picked against current campaign size (~31 active + ~15 retired). 4x headroom for organic growth. Pathological inputs (e.g. 10k random ids) get a clean 400 rather than a slow `$in`.
+- **Empty arrays for no-mod chars in bulk shape** — every requested id is a key in the response, so the client (`applyOverlayToAll`) doesn't need to defend against missing keys.
+- **Atomic per-id auth** — a player request with any non-own id returns 403 with no rows leaked (no partial results that would signal mod presence on other characters).
+- **Boot overlay applied to `suiteState.chars` (post-merge)**, not `editorState.chars` directly, so combat-only chars (resist-target lookups) also see modded values.
+- **`charsForSave` strips overlay via deep-clone + `stripOverlay`** — the silent-drift risk was that `JSON.stringify(c)` would capture modded `.dots`/`.bonus` + overlay metadata into `tm_chars_db`, then the next boot would apply overlay on top of an already-modded "canonical" → compounding mods every session.
+- **Worktree pattern** continued (no branch-mix-up).
+
+### File List
+
+- `server/routes/st_mods.js` (modified) — bulk GET branched on `character_ids` query param; cap + per-id auth; single-char shape preserved
+- `public/js/data/st-mods.js` (modified) — `loadStModsBulk` + `applyOverlayToAll` exports
+- `public/js/app.js` (modified) — boot-path wire after combat-char merge
+- `public/js/editor/export.js` (modified) — `charsForSave` calls `stripOverlay` on each clone (D13 invariant)
+- `CLAUDE.md` (modified) — derived-stats carve-out extended with cache-entry invariant paragraph
+- `specs/reference-data-ssot.md` (modified) — bulk endpoint added to the `st_mods` row
+- `server/tests/stm-7-bulk-endpoint.test.js` (new) — 14 vitest cases
+
+### Change Log
+
+- 2026-05-20 (Ptah): STM-7 initial implementation, merged as 343e5bac
+- 2026-05-20 (Ptah): Retroactive story file added during STM-8 (PR #415) per process restoration

--- a/specs/stories/issue-415-stm-8-dt-pool-snapshot.story.md
+++ b/specs/stories/issue-415-stm-8-dt-pool-snapshot.story.md
@@ -1,0 +1,86 @@
+# Issue #415: STM-8 — DT pool snapshot at resolution time
+
+Status: Ready for Review
+
+issue: 415
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/415
+branch: piatra/issue-415-stm-8-dt-pool-snapshot
+epic: STM (specs/epic-stm-st-mods.md)
+adr: ADR-004 Rev 3 §D10 (specs/architecture/adr-004-st-mods-overlay.md)
+dispatch: PROCEED-WITH-NOTICE — D10 fully specified by Thoth's prior + Imhotep's Rev 3
+
+## Story
+
+As a Storyteller resolving a DT submission with a modded pool,
+I want the resolved pool to snapshot the mod-affected total AND the per-mod breakdown at the moment of resolution,
+so that future ST debugging of the resolution sees the exact mod state that was active when this pool was rolled — even if those mods are later revoked.
+
+## Decisions implemented (from ADR-004 Rev 3 §D10)
+
+Per Thoth's product prior:
+1. **Freezing at resolution honours player intent regardless of later mod revocation.** A mod active at resolve-time is part of the resolution's history; revoking it later doesn't retroactively change what happened.
+2. **The breakdown is what an ST needs months later to debug a contested resolution.** Final number alone isn't enough — STs need to see "where did the +2 come from".
+
+Snapshot shape (additive — existing submissions without the field are valid):
+
+```js
+projects_resolved[j].pool_snapshot = {
+  base: <int>,                                  // pool size without overlay
+  mods: [{ stat_path, delta, reason }, ...],   // per-mod breakdown
+  final: <int>,                                 // base + Σ delta
+};
+feeding_roll.pool_snapshot = { /* same shape */ };
+```
+
+Math invariant: `final === base + Σ mods[].delta`. Server-enforced — reject 400 if violated.
+
+## Tasks / Subtasks
+
+- [x] Task 1 — Server-side validator `_validatePoolSnapshots(req.body)` walks PUT/POST body for any `pool_snapshot` key (direct, dot-notation, or nested in arrays/objects) and enforces the math invariant. Mounted in both POST and PUT handlers.
+- [x] Task 2 — Client helper `buildPoolSnapshot(c, finalPool)` reads `c._st_mod_overlay`, emits `{ base, mods, final }` with base = final − Σ delta (invariant holds by construction).
+- [x] Task 3 — Wire into four resolution save sites in `public/js/admin/downtime-views.js`:
+  - Project roll (in-line `showRollModal` flow)
+  - Feeding roll (`feeding_roll` field)
+  - Merit roll (in-line `showRollModal` flow)
+  - `handleProjectRollSave` (legacy public-shape handler)
+- [x] Task 4 — Admin boot wire: `applyOverlayToAll(chars, globalEnabled)` in `admin.js` init so DT view's `characters` array has overlay applied before the ST clicks Resolve (STM-7 only wired suite app's `app.js`, leaving admin parity for STM-8).
+- [x] Task 5 — Retroactive STM-7 story file folded into this PR per Khepri's process-restoration note.
+- [x] Task 6 — 9 vitest cases covering math-invariant rejection (3 shapes), malformed snapshot, always-write convention (empty mods + base === final), active-mods round-trip, feeding_roll round-trip, survives-mod-revocation regression, and existing player-PUT auth boundary preservation.
+
+## Acceptance Criteria
+
+1. Math invariant enforced server-side; reject 400 if `final !== base + Σ delta` — ✅
+2. DT admin resolution writes `pool_snapshot` at resolve time — ✅
+3. Always-write convention (empty `mods` + base === final when no mods) — ✅
+4. Schema/storage round-trip preserves the field — ✅ (additionalProperties: true + 2 round-trip tests)
+5. STM-6 audit view + STM-5 admin panel unchanged (snapshot is its own record) — ✅
+6. ≥3 new vitest cases — ✅ 9 added
+7. No regression — ✅ 1021/1021 server tests pass
+8. Manual smoke — needs Peter (create Presence mod → submit DT action → ST resolves → verify snapshot stored; revoke mod → re-load → snapshot intact)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-7 (Ptah / DEV)
+
+### Completion Notes List
+
+- **Snapshot scope: captures ALL active mods on the character at resolution, not action-aware filtering.** Per STM-8 issue §scope, the snapshot is a historical record of mod state at resolution, not just the contributing subset. A future story could refine to per-stat-path action-aware filtering if ST debugging surfaces a need. Documented in `buildPoolSnapshot` JSDoc.
+- **Math invariant by construction.** Client computes `base = finalPool − Σ delta` so the invariant always holds for client-emitted snapshots. The server validator is a defence against malformed payloads from buggy/malicious clients, not normal flow.
+- **Admin-boot overlay parity.** STM-7 wired `applyOverlayToAll` only in `app.js` (suite). STM-8 adds the same boot wire to `admin.js` init because the DT resolution path runs in the admin app and reads `c._st_mod_overlay` — without admin overlay at boot, the snapshot would capture empty mods unless the ST happened to open the character sheet first (which mutates that one char). Scope-creep from STM-7's strict surface but necessary for STM-8 to function; documented in PR body.
+- **Validator scope-tight by key name.** `_validatePoolSnapshots` only inspects values when the key is literally `pool_snapshot` (or ends with `.pool_snapshot` for dot-notation). Other objects that happen to have `base/mods/final` fields aren't false-positive flagged.
+- **Worktree pattern** continued (no branch-mix-up).
+
+### File List
+
+- `server/routes/downtime.js` (modified) — `_validatePoolSnapshots` helper + invariant guard on POST and PUT handlers
+- `public/js/admin/downtime-views.js` (modified) — `buildPoolSnapshot` helper + `_charForSub` resolver + 4 resolution save sites wired
+- `public/js/admin.js` (modified) — `applyOverlayToAll` at boot init (admin parity with STM-7's suite-app wire)
+- `server/tests/stm-8-pool-snapshot.test.js` (new) — 9 vitest cases
+- `specs/stories/issue-415-stm-8-dt-pool-snapshot.story.md` — this file
+- `specs/stories/issue-413-stm-7-boot-time-overlay.story.md` — retroactive STM-7 story file folded in per Khepri's process-restoration note
+
+### Change Log
+
+- 2026-05-20 (Ptah): STM-8 initial implementation


### PR DESCRIPTION
## Summary

Per ADR-004 Rev 3 §D10. At ST resolution moment, captures the active mod state alongside the resolved pool total. Historical record survives later mod revocation — a mod active at resolve-time is part of the resolution's history; revoking it later doesn't retroactively change what happened.

Closes #415 (manual close on dev-merge per `feedback_github_autoclose_dev_gap`)

## Schema (additive)

```js
projects_resolved[j].pool_snapshot = {
  base: <int>,                                  // pool size without overlay
  mods: [{ stat_path, delta, reason }, ...],   // per-mod breakdown
  final: <int>,                                 // base + Σ delta
};
feeding_roll.pool_snapshot = { /* same shape */ };
```

Existing submissions without the field remain valid (additionalProperties: true on the schema). Math invariant `final === base + Σ mods[].delta` enforced server-side; reject 400 on violation.

## Server

`_validatePoolSnapshots` walks PUT/POST body for any `pool_snapshot` key (direct, dot-notation, or nested in arrays/objects) and enforces the math invariant. Scope-tight by key name — only inspects values when the key is literally `pool_snapshot` so unrelated objects with base/mods/final fields aren't false-positive flagged.

Mounted on both POST and PUT submission handlers.

## Client

- `buildPoolSnapshot(c, finalPool)` in `public/js/admin/downtime-views.js` reads `c._st_mod_overlay` and emits the snapshot with `base = final − Σ delta` (invariant holds by construction).
- Wired into 4 resolution save sites:
  1. Project `showRollModal` resolve flow
  2. Feeding `showRollModal` resolve flow (`feeding_roll` field)
  3. Merit `showRollModal` resolve flow
  4. `handleProjectRollSave` (legacy public-shape handler)

## Scope expansion noted: admin-boot overlay parity

STM-7 wired `applyOverlayToAll(chars, globalEnabled)` only in `app.js` (suite app). STM-8 adds the same boot wire to `admin.js` init because the DT resolution path runs in admin and reads `c._st_mod_overlay` — without admin-boot overlay the snapshot would capture empty mods unless the ST happened to open the character sheet first (which mutates that one char per STM-2's renderSheetWithOverlay). One-call addition mirroring STM-7's pattern; documented inline.

## Design choice: snapshot scope

Captures ALL active mods on the character at resolution, not action-aware filtering. Per STM-8 §scope, the snapshot is a historical record of mod state at resolution, not just the contributing subset. A future story could refine to per-stat-path filtering if ST debugging surfaces a need. Documented in `buildPoolSnapshot` JSDoc.

The math invariant `final === base + Σ delta` always holds because `base` is computed as `final − Σ delta` by construction. If a mod exists on a stat the pool didn't use, the snapshot still records it (and the breakdown's "delta" appears in `base` arithmetic) — that's the audit value.

## Process restoration: retroactive STM-7 story file

Per Khepri's note, STM-7 (PR #414, merged 343e5bac) shipped without a story file due to dispatch-window drift. Folded `specs/stories/issue-413-stm-7-boot-time-overlay.story.md` into this PR. One PR; one bookkeeping flip later. Khepri's `Ready for Review` → `Done` flip pattern applies to both stories.

## Acceptance criteria coverage

| AC | Status |
|----|--------|
| Math invariant rejection (3 shapes: projects_resolved, feeding_roll, dot-notation) | ✅ all 3 tested |
| Snapshot written at resolution time | ✅ 4 save sites wired |
| Always-write (empty mods + base === final when no overlay) | ✅ `buildPoolSnapshot` always returns the shape |
| Schema/storage round-trips field | ✅ 2 round-trip tests (projects_resolved + feeding_roll) |
| STM-6 audit + STM-5 panel unchanged | ✅ no touch |
| ≥3 new vitest cases | ✅ 9 added |
| Survives mod revocation | ✅ explicit regression test |
| No regression | ✅ 1021/1021 server tests pass |
| Manual smoke | ⏳ needs Peter |

## Test plan

- [x] Parse-check all touched modules (`node --input-type=module --check`)
- [x] Full server test suite: **1021/1021 passing** (gained 9 STM-8 cases)
- [x] STM-8 specific suite: 9/9 (math invariant × 3 + malformed + always-write × 1 + active-mods round-trip + feeding round-trip + revocation regression + player-PUT auth)
- [ ] Peter's manual smoke: create Presence mod on a character → submit DT action using Presence → ST resolves → verify saved submission has `pool_snapshot` with base + delta + final; revoke mod → re-load submission → historical snapshot intact

## Files

- **modified** `server/routes/downtime.js` — `_validatePoolSnapshots` helper + invariant guard on POST and PUT
- **modified** `public/js/admin/downtime-views.js` — `buildPoolSnapshot` helper + `_charForSub` resolver + 4 resolution save sites wired
- **modified** `public/js/admin.js` — `applyOverlayToAll` at boot init (admin parity with STM-7's suite-app wire)
- **new** `server/tests/stm-8-pool-snapshot.test.js` — 9 vitest cases
- **new** `specs/stories/issue-415-stm-8-dt-pool-snapshot.story.md` — STM-8 story file
- **new** `specs/stories/issue-413-stm-7-boot-time-overlay.story.md` — retroactive STM-7 story file per Khepri's process restoration

## What this PR does NOT do

- Doesn't refine snapshot scope to action-aware filtering — captures full overlay, audit-value first.
- Doesn't migrate existing DT submissions to retroactively populate `pool_snapshot` — not possible (historical state isn't recoverable).
- Doesn't change WS or mod invalidation — that's STM-9.
- Doesn't add a UI affordance for "this resolution had +N from ST mods" — out of scope; the field is available for future surfaces.