### PR TITLE
chore(stm-8): flip story status to Done

### DIFF
--- a/specs/stories/issue-415-stm-8-dt-pool-snapshot.story.md
+++ b/specs/stories/issue-415-stm-8-dt-pool-snapshot.story.md
@@ -1,6 +1,6 @@
 # Issue #415: STM-8 — DT pool snapshot at resolution time
 
-Status: Ready for Review
+Status: Done
 
 issue: 415
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/415


### PR DESCRIPTION
Tiny bookkeeping flip after PR #417 (STM-8 + retroactive STM-7 story file) merged as 96c0b28b.

STM-7's story file shipped with Status: Done already in #417, so no flip there. Just STM-8 needed the Ready-for-Review → Done flip.

No code change, no test impact.