### PR TITLE
chore(stm-9): flip story status to Done — Epic STM complete

### DIFF
--- a/specs/stories/issue-416-stm-9-ws-mod-sync.story.md
+++ b/specs/stories/issue-416-stm-9-ws-mod-sync.story.md
@@ -1,6 +1,6 @@
 # Issue #416: STM-9 — WS-driven mod invalidation
 
-Status: Ready for Review
+Status: Done
 
 issue: 416
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/416


### PR DESCRIPTION
Final bookkeeping flip after PR #419 (STM-9 WS-driven mod invalidation) merged as d21966c6.

This closes Epic STM. All 9 stories shipped to dev: STM-1 backend → STM-2 overlay → STM-3 settings → STM-4 sheet UX → STM-5 admin panel → STM-6 audit view → STM-7 boot-time propagation → STM-8 DT pool snapshot → STM-9 WS sync. Plus mid-flight bugfix #405 (closure drift), auth-relax #410 (player read), UX polish #408 (gold-tint marker bundle).

Pending: Peter's cross-client and player browser smokes + main-merge cadence at his discretion.