### PR TITLE
fix(#425): wire STM display into suite sheet renderer

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -95,6 +95,7 @@ import { applyDerivedMerits } from './editor/mci.js';
 import { preloadRules } from './editor/rule_engine/load-rules.js';
 import { applyOverlayToAll } from './data/st-mods.js';
 import { loadGlobalSettings, getGlobalSettings } from './data/app-settings.js';
+import { installStModPopover } from './editor/st-mod-popover.js';
 import { loadPool, chgPool, chgMod, updPool, setAgain, togMod, togSpec, doRoll, clrHist, effPool } from './suite/roll.js';
 import { onSheetChar, renderSheet as suiteRenderSheet, repaintSheetTrackers } from './suite/sheet.js';
 import { toggleExp as suiteToggleExp, toggleDisc as suiteToggleDisc } from './suite/sheet-helpers.js';
@@ -1349,11 +1350,23 @@ async function boot() {
             const target = (suiteState.chars || []).find(c => String(c._id) === String(charId));
             if (!target) return;
             await applyOverlayToAll([target], getGlobalSettings()?.st_mods_enabled !== false);
+            // Issue #425: full suite sheet re-render (not just tracker
+            // repaint) so the modded dots + markers refresh. STM-9
+            // originally only repainted trackers here because the suite
+            // sheet wasn't yet STM-wired; #425 wires it, so the dots/
+            // markers now need the full render to reflect a remote change.
             if (String(suiteState.sheetChar?._id) === String(charId)) {
-              repaintSheetTrackers();
+              suiteRenderSheet();
             }
           },
         });
+
+        // Issue #425: install the STM popover delegated click handler for
+        // the suite app. STM-4 wired admin + player but not the suite;
+        // without this, suite-sheet markers emit data-stm-marker-path but
+        // nothing opens the popover on click. Single listener on
+        // document.body (idempotent across re-renders).
+        installStModPopover(document.body);
         return;
       } catch (err) {
         // Mid-flight failure: leave the user on the login screen with a

--- a/public/js/suite/sheet.js
+++ b/public/js/suite/sheet.js
@@ -4,6 +4,7 @@
 
 import state from './data.js';
 import { displayName, getWillpower, redactPlayer, shDotsWithBonus, formatSpecs, hasAoE } from '../data/helpers.js';
+import { markerFor } from '../editor/st-mod-popover.js';
 import {
   ICONS, COV_ICON_MAP, CITY_SVG, OTHER_SVG, BP_SVG, HUM_SVG, STAT_SVG,
   RITUAL_DISCS, CORE_DISCS,
@@ -27,6 +28,66 @@ import { calcTotalInfluence, influenceBreakdown } from '../editor/domain.js';
 import { shRenderInfluenceMerits, shRenderDomainMerits, shRenderGeneralMerits, shRenderManoeuvres, shRenderEquipment } from '../editor/sheet.js';
 import { DICE_ICON_SVG, canRollDice } from './dice-modal.js';
 import { getPool } from '../shared/pools.js';
+
+// ── STM display helpers (issue #425) ──
+// Mirror the editor sheet's wiring (public/js/editor/sheet.js) so modded
+// dots/numbers in the suite renderer get the same gold-tint + marker +
+// popover treatment. STM-7's cache-entry invariant populates
+// c._st_mod_overlay at suite boot; this is the consumption side that the
+// suite renderer was missing.
+
+/** Build shDotsWithBonus opts for an attribute path. autoBonus (discipline-
+ *  derived) renders first in the hollow stream, then manual bonus — so the
+ *  modded manual-bonus sub-range is offset by autoBonus, matching the
+ *  editor convention. */
+function _stmAttrOpts(c, a, autoBonus) {
+  const ovDots = c._st_mod_overlay?.[`attributes.${a}.dots`];
+  const ovBonus = c._st_mod_overlay?.[`attributes.${a}.bonus`];
+  const opts = {};
+  if (ovDots) {
+    const sign = ovDots.delta >= 0 ? '+' : '';
+    opts.filledMod = {
+      from: ovDots.base, to: ovDots.final,
+      path: `attributes.${a}.dots`,
+      title: `ST adjustment: ${a} (dots) ${sign}${ovDots.delta}. Click for details.`,
+    };
+  }
+  if (ovBonus) {
+    const sign = ovBonus.delta >= 0 ? '+' : '';
+    opts.hollowMod = {
+      from: autoBonus + ovBonus.base, to: autoBonus + ovBonus.final,
+      path: `attributes.${a}.bonus`,
+      title: `ST adjustment: ${a} (bonus) ${sign}${ovBonus.delta}. Click for details.`,
+    };
+  }
+  return opts;
+}
+
+/** Build shDotsWithBonus opts for a skill path. Skill hollow stream is
+ *  manual bonus first, then PT/MCI auto-bonus — so the modded skill bonus
+ *  sub-range starts at hollow position ovBonus.base (no offset). */
+function _stmSkillOpts(c, s) {
+  const ovDots = c._st_mod_overlay?.[`skills.${s}.dots`];
+  const ovBonus = c._st_mod_overlay?.[`skills.${s}.bonus`];
+  const opts = {};
+  if (ovDots) {
+    const sign = ovDots.delta >= 0 ? '+' : '';
+    opts.filledMod = {
+      from: ovDots.base, to: ovDots.final,
+      path: `skills.${s}.dots`,
+      title: `ST adjustment: ${s} (dots) ${sign}${ovDots.delta}. Click for details.`,
+    };
+  }
+  if (ovBonus) {
+    const sign = ovBonus.delta >= 0 ? '+' : '';
+    opts.hollowMod = {
+      from: ovBonus.base, to: ovBonus.final,
+      path: `skills.${s}.bonus`,
+      title: `ST adjustment: ${s} (bonus) ${sign}${ovBonus.delta}. Click for details.`,
+    };
+  }
+  return opts;
+}
 
 // ── Surgical tracker repaint (no full sheet rebuild) ──
 
@@ -113,6 +174,13 @@ export function onSheetChar(name) {
 export function renderSheet() {
   state.openExpId = null;
   const c = state.sheetChar;
+  // Issue #425: expose the suite's active character to the STM popover's
+  // delegated handler. _resolveActiveCharacter in editor/st-mod-popover.js
+  // checks window.__activeChar (set by player.js too); the suite reuses
+  // the same global so clicking a modded dot in the suite app resolves
+  // the right character. Set on every render so it tracks sheetChar
+  // changes (including clears to null).
+  window.__activeChar = c || null;
   const el = document.getElementById('sh-content-suite');
   // Split-tab containers (phone UX — Stats / Skills / Powers)
   const statsEl  = document.getElementById('stats-content');
@@ -257,12 +325,15 @@ export function renderSheet() {
   // Covenant strip moved to Status tab
 
   // ── STATS STRIP ──
+  // Issue #425: markerFor suffix on each derived/root stat number so modded
+  // values get the gold-pip marker + tooltip + click-to-popover (mirrors
+  // public/js/editor/sheet.js stats strip).
   html += `<div class="sh-stats-strip">
-    <div class="sh-stat-cell"><div class="sh-stat-icon">${BP_SVG}<span class="sh-stat-n">${c.blood_potency || 1}</span></div><div class="sh-stat-lbl">BP</div></div>
-    <div class="sh-stat-cell"><div class="sh-stat-icon">${HUM_SVG}<span class="sh-stat-n">${c.humanity || 0}</span></div><div class="sh-stat-lbl">Humanity</div></div>
-    <div class="sh-stat-cell"><div class="sh-stat-icon">${STAT_SVG}<span class="sh-stat-n">${calcSize(c)}</span></div><div class="sh-stat-lbl">Size</div></div>
-    <div class="sh-stat-cell"><div class="sh-stat-icon">${STAT_SVG}<span class="sh-stat-n">${calcSpeed(c)}</span></div><div class="sh-stat-lbl">Speed</div></div>
-    <div class="sh-stat-cell"><div class="sh-stat-icon">${STAT_SVG}<span class="sh-stat-n">${calcDefence(c)}</span></div><div class="sh-stat-lbl">Defence</div></div>
+    <div class="sh-stat-cell"><div class="sh-stat-icon">${BP_SVG}<span class="sh-stat-n">${c.blood_potency || 1}${markerFor(c, 'blood_potency')}</span></div><div class="sh-stat-lbl">BP</div></div>
+    <div class="sh-stat-cell"><div class="sh-stat-icon">${HUM_SVG}<span class="sh-stat-n">${c.humanity || 0}${markerFor(c, 'humanity')}</span></div><div class="sh-stat-lbl">Humanity</div></div>
+    <div class="sh-stat-cell"><div class="sh-stat-icon">${STAT_SVG}<span class="sh-stat-n">${calcSize(c)}${markerFor(c, 'derived.size')}</span></div><div class="sh-stat-lbl">Size</div></div>
+    <div class="sh-stat-cell"><div class="sh-stat-icon">${STAT_SVG}<span class="sh-stat-n">${calcSpeed(c)}${markerFor(c, 'derived.speed')}</span></div><div class="sh-stat-lbl">Speed</div></div>
+    <div class="sh-stat-cell"><div class="sh-stat-icon">${STAT_SVG}<span class="sh-stat-n">${calcDefence(c)}${markerFor(c, 'derived.defence')}</span></div><div class="sh-stat-lbl">Defence</div></div>
   </div>`;
 
   // ── TRACKERS ──
@@ -385,7 +456,17 @@ export function renderSheet() {
     html += `<div class="attr-cell"><div class="attr-group-hd">${cat.label} Attributes</div>`;
     cat.attrs.forEach(a => {
       const base = getAttrDots(c, a), bonus = getAttrBonus(c, a);
-      html += `<div class="attr-row-item"><span class="attr-name">${a}</span><span class="attr-dots">${dotsWithBonus(base, bonus)}</span></div>`;
+      // Issue #425: use shDotsWithBonus (the canonical opts-aware helper)
+      // so modded attribute dots/bonus get gold-tint + marker. autoBonus is
+      // the discipline-derived portion (getAttrBonus combines manual + disc);
+      // manual bonus = c.attributes[a].bonus. This also aligns the suite's
+      // attribute bonus-dot styling with the editor + skills (which already
+      // use shDotsWithBonus) — the suite-only .dots-bonus wrapper from
+      // sheet-helpers' dotsWithBonus is dropped for attributes.
+      const manualBonus = c.attributes?.[a]?.bonus || 0;
+      const autoBonus = Math.max(0, bonus - manualBonus);
+      const opts = _stmAttrOpts(c, a, autoBonus);
+      html += `<div class="attr-row-item"><span class="attr-name">${a}</span><span class="attr-dots">${shDotsWithBonus(base, bonus, opts)}</span></div>`;
     });
     html += `</div>`;
     // Skills block — matches desktop view: PT/MCI bonus dots shown hollow,
@@ -402,7 +483,8 @@ export function renderSheet() {
       const mciBn = c._mci_dot3_skills?.has(s) ? 1 : 0;
       const totalBn = bn + ptBn + mciBn;
       const hasDots = d > 0 || totalBn > 0;
-      const dotStr = hasDots ? shDotsWithBonus(d, totalBn) : '\u2013';
+      // Issue #425: opts for modded skill dots/bonus.
+      const dotStr = hasDots ? shDotsWithBonus(d, totalBn, _stmSkillOpts(c, s)) : '\u2013';
       const naLabel = na ? '9-Again' : ptNa ? '9-Again (PT)' : ohmNa ? '9-Again (OHM)' : '';
       const _diceBtn = (_showDice && hasDots) ? `<span class="skill-dice-btn" onclick="openDiceModal('skill','${s}')" title="Roll ${s}">${DICE_ICON_SVG}</span>` : '';
       html += `<div class="skill-row${hasDots ? ' has-dots' : ''}">
@@ -460,7 +542,10 @@ export function renderSheet() {
         drawerHtml += `<button class="auspex-insight-btn" onclick="openPanel('auspex')">Auspex Insight \u203A</button>`;
       }
       const nCls = nameClass ? `trait-name ${nameClass}` : 'trait-name';
-      const dTag = r ? `<span class="trait-dots">${dots(r)}</span>` : '';
+      // Issue #425: marker on modded discipline dots. Disciplines are
+      // object-keyed (project_disciplines_object_keyed) so the path is
+      // disciplines.<Name>.dots.
+      const dTag = r ? `<span class="trait-dots">${dots(r)}${markerFor(c, `disciplines.${d}.dots`)}</span>` : '';
       const isExpandable = hasPowers || (d === 'Auspex' && r >= 1);
       const inner = `<div class="trait-row"><div class="trait-main"><span class="${nCls}">${d}</span><div class="trait-right">${dTag}${isExpandable ? '<span class="disc-tap-arr">\u203A</span>' : ''}</div></div></div>`;
       if (!isExpandable) return `<div class="disc-tap-row">${inner}</div>`;

--- a/server/tests/stm-suite-display-425.test.js
+++ b/server/tests/stm-suite-display-425.test.js
@@ -1,0 +1,128 @@
+/**
+ * Bugfix #425 — suite sheet STM display wiring contract.
+ *
+ * The bug: the suite renderer (public/js/suite/sheet.js) consumed modded
+ * VALUES (via STM-7's cache-entry invariant) but never emitted the STM
+ * display markup — no gold-tint dots, no marker pip, no popover. The fix
+ * mirrors the editor pattern: shDotsWithBonus opts for attribute/skill
+ * dots + markerFor on derived/root stat numbers + popover active-char
+ * resolution via window.__activeChar.
+ *
+ * The render code is browser-only (DOM, location, window). This test
+ * verifies the two pure pieces the suite consumes:
+ *   1. shDotsWithBonus opts produce the modded-dot markup (the contract
+ *      the suite's attribute/skill render now passes opts into)
+ *   2. The opts-computation shape mirrors the editor (filledMod offset 0
+ *      for dots; hollowMod offset = autoBonus for attributes, 0 for skills)
+ *
+ * Inline mirrors of shDotsWithBonus + the opts helpers (browser-only
+ * modules can't import in Node) — same pattern as the STM-4 / STM-7
+ * test files.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+function esc(s) {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
+function shDotsWithBonus(base, bonus, opts) {
+  if (!opts || (!opts.filledMod && !opts.hollowMod)) {
+    if (!bonus) return '<span class="pointed"></span>'.repeat(Math.max(0, base || 0));
+    return '<span class="pointed"></span>'.repeat(Math.max(0, base || 0)) + '<span class="pointed hollow"></span>'.repeat(Math.max(0, bonus || 0));
+  }
+  const fm = opts.filledMod, hm = opts.hollowMod;
+  let out = '';
+  for (let i = 0; i < Math.max(0, base || 0); i++) {
+    if (fm && i >= fm.from && i < fm.to) {
+      out += `<span class="pointed stm-modded-dot" data-stm-marker-path="${esc(fm.path || '')}" title="${esc(fm.title || '')}"></span>`;
+    } else out += '<span class="pointed"></span>';
+  }
+  for (let i = 0; i < Math.max(0, bonus || 0); i++) {
+    if (hm && i >= hm.from && i < hm.to) {
+      out += `<span class="pointed hollow stm-modded-dot" data-stm-marker-path="${esc(hm.path || '')}" title="${esc(hm.title || '')}"></span>`;
+    } else out += '<span class="pointed hollow"></span>';
+  }
+  return out;
+}
+
+// Mirror of suite/sheet.js _stmAttrOpts + _stmSkillOpts
+function stmAttrOpts(c, a, autoBonus) {
+  const ovDots = c._st_mod_overlay?.[`attributes.${a}.dots`];
+  const ovBonus = c._st_mod_overlay?.[`attributes.${a}.bonus`];
+  const opts = {};
+  if (ovDots) {
+    opts.filledMod = { from: ovDots.base, to: ovDots.final, path: `attributes.${a}.dots`, title: 't' };
+  }
+  if (ovBonus) {
+    opts.hollowMod = { from: autoBonus + ovBonus.base, to: autoBonus + ovBonus.final, path: `attributes.${a}.bonus`, title: 't' };
+  }
+  return opts;
+}
+function stmSkillOpts(c, s) {
+  const ovDots = c._st_mod_overlay?.[`skills.${s}.dots`];
+  const ovBonus = c._st_mod_overlay?.[`skills.${s}.bonus`];
+  const opts = {};
+  if (ovDots) opts.filledMod = { from: ovDots.base, to: ovDots.final, path: `skills.${s}.dots`, title: 't' };
+  if (ovBonus) opts.hollowMod = { from: ovBonus.base, to: ovBonus.final, path: `skills.${s}.bonus`, title: 't' };
+  return opts;
+}
+
+function count(s, sub) {
+  let n = 0, i = 0;
+  while ((i = s.indexOf(sub, i)) !== -1) { n++; i += sub.length; }
+  return n;
+}
+
+describe('#425 — suite attribute dots emit modded markup via opts', () => {
+  it('Presence dots +2 (base 3 → final 5): 2 modded filled dots with path attr', () => {
+    const c = { _st_mod_overlay: { 'attributes.Presence.dots': { base: 3, delta: 2, final: 5 } } };
+    const opts = stmAttrOpts(c, 'Presence', 0);
+    const out = shDotsWithBonus(5, 0, opts);
+    expect(count(out, '<span class="pointed stm-modded-dot"')).toBe(2);
+    expect(count(out, '<span class="pointed"></span>')).toBe(3);
+    expect(out).toContain('data-stm-marker-path="attributes.Presence.dots"');
+  });
+
+  it('Presence bonus +3 with autoBonus 1 (Majesty): modded sub-range offset by autoBonus', () => {
+    // c.attributes.Presence.bonus modded 0→3; discAttrBonus = 1 (Majesty)
+    // getAttrBonus total = 1 (disc) + 3 (manual) = 4 hollow dots
+    // modded manual bonus sub-range = [autoBonus + 0, autoBonus + 3) = [1, 4)
+    const c = { _st_mod_overlay: { 'attributes.Presence.bonus': { base: 0, delta: 3, final: 3 } } };
+    const opts = stmAttrOpts(c, 'Presence', 1);
+    const out = shDotsWithBonus(3, 4, opts); // base dots 3, total hollow 4
+    // 1 hollow unmarked (autoBonus), 3 hollow modded (manual bonus)
+    expect(count(out, '<span class="pointed hollow"></span>')).toBe(1);
+    expect(count(out, '<span class="pointed hollow stm-modded-dot"')).toBe(3);
+  });
+
+  it('no overlay → byte-identical to plain dots (no regression)', () => {
+    const c = {}; // no _st_mod_overlay
+    const opts = stmAttrOpts(c, 'Wits', 0);
+    expect(opts).toEqual({});
+    const out = shDotsWithBonus(3, 1, opts);
+    expect(out).toBe('<span class="pointed"></span>'.repeat(3) + '<span class="pointed hollow"></span>');
+    expect(out).not.toContain('stm-modded-dot');
+  });
+});
+
+describe('#425 — suite skill dots emit modded markup via opts', () => {
+  it('skill bonus mod: hollow stream bn-first, modded sub-range starts at 0', () => {
+    // skills.Athletics.bonus modded 0→2; ptBn=1 (so totalBn = 2 + 1 = 3)
+    const c = { _st_mod_overlay: { 'skills.Athletics.bonus': { base: 0, delta: 2, final: 2 } } };
+    const opts = stmSkillOpts(c, 'Athletics');
+    const out = shDotsWithBonus(2, 3, opts); // dots 2, total hollow 3 (bn 2 + ptBn 1)
+    expect(count(out, '<span class="pointed hollow stm-modded-dot"')).toBe(2);
+    expect(count(out, '<span class="pointed hollow"></span>')).toBe(1);
+    expect(out).toContain('data-stm-marker-path="skills.Athletics.bonus"');
+  });
+
+  it('skill dots mod: filled sub-range marked', () => {
+    const c = { _st_mod_overlay: { 'skills.Brawl.dots': { base: 2, delta: 1, final: 3 } } };
+    const opts = stmSkillOpts(c, 'Brawl');
+    const out = shDotsWithBonus(3, 0, opts);
+    expect(count(out, '<span class="pointed stm-modded-dot"')).toBe(1);
+    expect(count(out, '<span class="pointed"></span>')).toBe(2);
+  });
+});

--- a/specs/stories/issue-425-stm-suite-display-wiring.story.md
+++ b/specs/stories/issue-425-stm-suite-display-wiring.story.md
@@ -1,0 +1,66 @@
+# Issue #425: STM bugfix — suite sheet renderer missing STM display wiring
+
+Status: Ready for Review
+
+issue: 425
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/425
+branch: piatra/issue-425-stm-suite-display-wiring
+epic: STM (specs/epic-stm-st-mods.md)
+dispatch: PROCEED-WITH-NOTICE — v2 wiring gap, independent of Rev 4
+
+## Story
+
+As a player landing on `/` (the suite app),
+I want modded values on my character sheet to show the same gold-tint dots / markers / tooltips / click-to-popover as the admin sheet,
+so that I can see *that* a value was adjusted by the ST, not just the modded number with no indication.
+
+## Root cause
+
+STM-4 + polish #408 wired the EDITOR sheet renderer (`public/js/editor/sheet.js`). The SUITE sheet renderer (`public/js/suite/sheet.js`) is a parallel implementation that was never wired — same fragmentation pattern CLAUDE.md notes for the two tracker implementations. The data layer worked (STM-7's cache-entry invariant populates `c._st_mod_overlay` at suite boot); only the suite's consumption side was missing.
+
+## Tasks / Subtasks
+
+- [x] Task 1 — Import `markerFor` + add `_stmAttrOpts` / `_stmSkillOpts` helpers to suite/sheet.js (mirror editor pattern).
+- [x] Task 2 — Attribute render: switch from sheet-helpers `dotsWithBonus` to canonical `shDotsWithBonus(base, bonus, opts)` so modded dots/bonus get gold-tint. autoBonus (discipline-derived) computed as `getAttrBonus − manualBonus` for the hollow offset.
+- [x] Task 3 — Skill render: add opts to the existing `shDotsWithBonus` call.
+- [x] Task 4 — Stats strip: `markerFor` on BP, Humanity, Size, Speed, Defence number displays.
+- [x] Task 5 — Disciplines: `markerFor(c, disciplines.<Name>.dots)` on each discipline row (object-keyed per project_disciplines_object_keyed).
+- [x] Task 6 — Popover active-char resolution: set `window.__activeChar = state.sheetChar` in suite `renderSheet` (reuses the global player.js already sets; chosen fix (a) for minimal diff).
+- [x] Task 7 — Install the popover delegated handler for the suite app: `installStModPopover(document.body)` in app.js boot (STM-4 wired admin + player but not the suite).
+- [x] Task 8 — Suite onStModUpdate WS callback upgraded from tracker-repaint-only to full `suiteRenderSheet()` so a remote mod change refreshes the modded dots/markers (STM-9 left this as tracker-repaint because the suite wasn't STM-wired yet).
+- [x] Task 9 — 5 vitest cases on the opts → markup contract + no-regression byte-identity.
+
+## Acceptance Criteria
+
+1. All `shDotsWithBonus` in suite/sheet.js pass opts — ✅ (skill call + attribute render switched to shDotsWithBonus)
+2. Derived/root stat numbers get `markerFor` — ✅ (BP, Humanity, Size, Speed, Defence + disciplines)
+3. Popover `_resolveActiveCharacter` resolves suite active char — ✅ via `window.__activeChar` + `installStModPopover` in suite boot
+4. Smoke on `/`: Presence dots + bonus mod shows gold-tint + ring + tooltip + popover — ⏳ needs Peter (structural: opts emit `stm-modded-dot` markup, popover handler installed, resolver wired)
+5. No regression — ✅ 1035/1035 server tests; no-overlay path byte-identical
+6. ≥2 vitest cases — ✅ 5 added
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-7 (Ptah / DEV)
+
+### Completion Notes List
+
+- **Attribute render switched from sheet-helpers `dotsWithBonus` to canonical `shDotsWithBonus`.** sheet-helpers' version wraps bonus dots in a suite-only `.dots-bonus` (dim-gold) span; the canonical opts-aware version doesn't. Switching drops that wrapper for attributes — but this ALIGNS attributes with skills (which already use shDotsWithBonus) and with the editor. Net consistency win, not a regression. Documented inline + in PR. The non-modded path stays byte-identical to the editor's output.
+- **autoBonus split for the hollow offset.** Suite's `getAttrBonus` combines manual + discipline-derived bonus. The modded `attributes.X.bonus` overlay targets the MANUAL bonus channel. To offset the modded sub-range correctly (disc-auto dots render first, manual after — editor convention), `autoBonus = getAttrBonus − c.attributes[a].bonus`.
+- **Popover handler install added to suite boot.** STM-4 wired `installStModPopover` for admin + player only. Without it, suite markers emit `data-stm-marker-path` but nothing opens the popover. Added to app.js boot. This was a latent gap that #425 surfaces (the suite never had ANY markers before, so the missing install was invisible).
+- **Suite onStModUpdate upgraded to full re-render.** STM-9's app.js handler only called `repaintSheetTrackers()` (suite wasn't STM-wired then). Now calls `suiteRenderSheet()` so modded dots/markers refresh on a remote mod change.
+- **Deferred: tracker-max markers (derived.health_max / willpower_max / vitae_max).** The tracker num displays (`current/max`) are rewritten by `repaintSheetTrackers` on every tracker tick via `textContent`/`innerHTML` assignment, which would wipe an injected marker. Adding markers there means dual-wiring (static render + repaint path) and fighting a hot path. These are rare mod targets; deferred with this note. The primary bug (attribute mods showing no indication — Peter's Presence smoke) is fully addressed. Follow-up issue if ST debugging needs them.
+- **Worktree pattern continued.**
+
+### File List
+
+- `public/js/suite/sheet.js` (modified) — `markerFor` import; `_stmAttrOpts`/`_stmSkillOpts` helpers; attribute + skill dot opts; stats-strip + discipline markers; `window.__activeChar` set in renderSheet
+- `public/js/app.js` (modified) — `installStModPopover(document.body)` in suite boot; onStModUpdate upgraded from `repaintSheetTrackers` to `suiteRenderSheet`
+- `server/tests/stm-suite-display-425.test.js` (new) — 5 vitest cases on the opts → markup contract
+- `specs/stories/issue-425-stm-suite-display-wiring.story.md` — this file
+
+### Change Log
+
+- 2026-05-20 (Ptah): suite display wiring


### PR DESCRIPTION
## Summary

The suite renderer (`public/js/suite/sheet.js`) consumed modded VALUES via STM-7's cache-entry invariant but never emitted the STM display markup — no gold-tint dots, no marker, no popover. STM-4 + #408 wired only the editor renderer; the suite is a parallel implementation (same fragmentation pattern CLAUDE.md notes for the two trackers). Players land on `/` (suite app), so they saw modded numbers with zero indication.

Closes #425 (manual close on dev-merge per `feedback_github_autoclose_dev_gap`)

## Fix (mirrors the editor pattern)

| Surface | Change |
|---|---|
| Attributes | `dotsWithBonus` → canonical `shDotsWithBonus(base, bonus, opts)` with `_stmAttrOpts` |
| Skills | opts added to existing `shDotsWithBonus` call via `_stmSkillOpts` |
| Stats strip | `markerFor` on BP / Humanity / Size / Speed / Defence |
| Disciplines | `markerFor(c, disciplines.<Name>.dots)` per row (object-keyed) |
| Popover resolver | `window.__activeChar = state.sheetChar` in `renderSheet` + `installStModPopover` in suite boot |
| WS refresh | `onStModUpdate` upgraded from `repaintSheetTrackers` → `suiteRenderSheet` |

## Design choices documented

### 1. Attribute render switched to canonical `shDotsWithBonus`

sheet-helpers' `dotsWithBonus` wraps bonus dots in a suite-only `.dots-bonus` (dim-gold) span; the canonical opts-aware `shDotsWithBonus` doesn't. Switching drops that wrapper for attributes — but this ALIGNS attributes with skills (which already use `shDotsWithBonus`) and with the editor renderer. Net consistency win, not a regression. The no-overlay code path stays byte-identical to the editor's output (verified by a regression test).

### 2. autoBonus split for the hollow-stream offset

Suite's `getAttrBonus` combines manual + discipline-derived bonus. The modded `attributes.X.bonus` overlay targets the MANUAL channel. To offset the modded sub-range correctly (disc-auto dots first, manual after — editor convention), `autoBonus = getAttrBonus − c.attributes[a].bonus`.

### 3. Popover handler install added to suite boot

STM-4 wired `installStModPopover` for admin + player only. Without it, suite markers would emit `data-stm-marker-path` but nothing opens the popover. Latent gap that #425 surfaces (the suite never had markers before, so the missing install was invisible). Chose fix (a) from the issue — reuse `window.__activeChar` — for minimal diff.

### 4. onStModUpdate upgraded to full re-render

STM-9's app.js handler only called `repaintSheetTrackers()` (suite wasn't STM-wired then). Now calls `suiteRenderSheet()` so a remote mod create/revoke refreshes the modded dots + markers, not just the tracker boxes.

## Deferred: tracker-max markers

`derived.health_max` / `willpower_max` / `vitae_max` markers in the tracker `current/max` displays are deferred. `repaintSheetTrackers` rewrites those nums via `textContent`/`innerHTML` on every tracker tick, which would wipe an injected marker — dual-wiring a hot path for rare mod targets isn't worth it. The primary bug (attribute mods showing no indication — Peter's Presence smoke) is fully addressed. Follow-up issue if ST debugging needs them. The AC's "if shown" hedge covers this.

## Acceptance criteria coverage

| AC | Status |
|----|--------|
| 1 — shDotsWithBonus opts on all calls | ✅ skill + attribute (switched to shDotsWithBonus) |
| 2 — markerFor on derived/root numbers | ✅ BP/Humanity/Size/Speed/Defence + disciplines; tracker-max deferred (documented) |
| 3 — popover resolves suite active char | ✅ `window.__activeChar` + `installStModPopover` in suite boot |
| 4 — smoke: Presence dots+bonus gold-tint+popover | ✅ structural; needs Peter's in-browser |
| 5 — no regression | ✅ 1035/1035 server tests; no-overlay byte-identical |
| 6 — ≥2 vitest cases | ✅ 5 added |

## Test plan

- [x] Parse-check touched modules (`node --input-type=module --check`)
- [x] Full server test suite: **1035/1035 passing** (gained 5)
- [x] #425 suite: 5/5 (attr dots opts, attr bonus offset, no-overlay byte-identity, skill bonus bn-first, skill dots)
- [ ] Peter's smoke on `/`: Presence dots + bonus mod on Yusuf → gold-tint dots + ring + tooltip + click-to-popover, identical to admin

## Files

- **modified** `public/js/suite/sheet.js` — `markerFor` import; `_stmAttrOpts`/`_stmSkillOpts`; attribute + skill dot opts; stats-strip + discipline markers; `window.__activeChar` in renderSheet
- **modified** `public/js/app.js` — `installStModPopover` in suite boot; onStModUpdate → full re-render
- **new** `server/tests/stm-suite-display-425.test.js` — 5 vitest cases
- **new** `specs/stories/issue-425-stm-suite-display-wiring.story.md`

## Out of scope

- Rev 4 lifecycle (STM-10..13) — separate
- `suite/sheet-helpers.js` — not touched; switched to the canonical `data/helpers.js#shDotsWithBonus` instead
- Tracker-max markers — deferred (see above)