### PR TITLE
fix(#433): suite chevron-expand — namespace suite toggle handlers

### DIFF
--- a/public/js/suite/sheet-helpers.js
+++ b/public/js/suite/sheet-helpers.js
@@ -194,7 +194,7 @@ export function toggleDisc(id) {
 // ── Build expandable row HTML ──
 
 export function expRow(id, lbl, val, bodyHtml) {
-  return `<div class="exp-row" id="exp-row-${id}" onclick="toggleExp('${id}')">
+  return `<div class="exp-row" id="exp-row-${id}" onclick="suiteToggleExp('${id}')">
     ${lbl ? `<span class="exp-lbl labeled">${lbl}</span>` : ''}
     <span class="exp-val">${val}</span>
     <span class="exp-arr">\u203A</span>
@@ -203,5 +203,10 @@ export function expRow(id, lbl, val, bodyHtml) {
 }
 
 // ── Expose to inline onclick handlers in rendered HTML ──
-window.toggleExp = toggleExp;
-window.toggleDisc = toggleDisc;
+// Issue #433: suite-namespaced globals. The suite app page also hosts the
+// editor sheet (Sheets tab); app.js binds the EDITOR toggleExp/toggleDisc to
+// the unprefixed window globals, which clobbered the suite versions formerly
+// assigned here — silently no-opping suite chevrons. Namespacing removes the
+// collision: each renderer's onclick targets its own function.
+window.suiteToggleExp = toggleExp;
+window.suiteToggleDisc = toggleDisc;

--- a/public/js/suite/sheet.js
+++ b/public/js/suite/sheet.js
@@ -549,7 +549,7 @@ export function renderSheet() {
       const isExpandable = hasPowers || (d === 'Auspex' && r >= 1);
       const inner = `<div class="trait-row"><div class="trait-main"><span class="${nCls}">${d}</span><div class="trait-right">${dTag}${isExpandable ? '<span class="disc-tap-arr">\u203A</span>' : ''}</div></div></div>`;
       if (!isExpandable) return `<div class="disc-tap-row">${inner}</div>`;
-      return `<div class="disc-tap-row" id="disc-row-${id}" onclick="toggleDisc('${id}')">${inner}</div>
+      return `<div class="disc-tap-row" id="disc-row-${id}" onclick="suiteToggleDisc('${id}')">${inner}</div>
         <div class="disc-drawer" id="disc-drawer-${id}">${drawerHtml}</div>`;
     }
 
@@ -575,7 +575,7 @@ export function renderSheet() {
         const _devHasRoll = _devPool && !_devPool.noRoll && _devPool.total !== undefined;
         const _devDice = (_showDice && _devHasRoll) ? `<span class="disc-power-dice" onclick="event.stopPropagation();openDiceModal('power','${_devName}')" title="Roll ${_devName}">${DICE_ICON_SVG}</span>` : '';
         const inner = `<div class="trait-row"><div class="trait-main"><span class="trait-name secondary">${p.name || ''}</span>${_devDice}<div class="trait-right"><span class="disc-tap-arr">\u203A</span></div></div></div>`;
-        html += `<div class="disc-tap-row" id="disc-row-${gid}" onclick="toggleDisc('${gid}')">${inner}</div>
+        html += `<div class="disc-tap-row" id="disc-row-${gid}" onclick="suiteToggleDisc('${gid}')">${inner}</div>
           <div class="disc-drawer" id="disc-drawer-${gid}"><div class="disc-power">
             ${p.stats ? `<div class="disc-power-stats">${p.stats}</div>` : ''}
             <div class="disc-power-effect">${p.effect || ''}</div>
@@ -604,7 +604,7 @@ export function renderSheet() {
         const levelDots = p.level ? `<span class="trait-dots">${dots(p.level)}</span>` : '';
         const tradSub = p.tradition ? `<div class="trait-sub"><span class="trait-qual dim">${p.tradition}</span></div>` : '';
         const inner = `<div class="trait-row"><div class="trait-main"><span class="trait-name secondary">${p.name}</span>${_riteDice}<div class="trait-right">${levelDots}<span class="disc-tap-arr">\u203A</span></div></div>${tradSub}</div>`;
-        html += `<div class="disc-tap-row" id="disc-row-${gid}" onclick="toggleDisc('${gid}')">${inner}</div>
+        html += `<div class="disc-tap-row" id="disc-row-${gid}" onclick="suiteToggleDisc('${gid}')">${inner}</div>
           <div class="disc-drawer" id="disc-drawer-${gid}"><div class="disc-power">
             ${p.stats ? `<div class="disc-power-stats">${p.stats}</div>` : ''}
             <div class="disc-power-effect">${p.effect || ''}</div>
@@ -624,7 +624,7 @@ export function renderSheet() {
         const _pactHasRoll = _pactPool && !_pactPool.noRoll && _pactPool.total !== undefined;
         const _pactDice = (_showDice && _pactHasRoll) ? `<span class="disc-power-dice" onclick="event.stopPropagation();openDiceModal('power','${_pactName}')" title="Roll ${_pactName}">${DICE_ICON_SVG}</span>` : '';
         const inner = `<div class="trait-row"><div class="trait-main"><span class="trait-name secondary">${p.name}</span>${_pactDice}<div class="trait-right"><span class="disc-tap-arr">\u203A</span></div></div></div>`;
-        html += `<div class="disc-tap-row" id="disc-row-${gid}" onclick="toggleDisc('${gid}')">${inner}</div>
+        html += `<div class="disc-tap-row" id="disc-row-${gid}" onclick="suiteToggleDisc('${gid}')">${inner}</div>
           <div class="disc-drawer" id="disc-drawer-${gid}"><div class="disc-power">
             ${p.stats ? `<div class="disc-power-stats">${p.stats}</div>` : ''}
             <div class="disc-power-effect">${p.effect || ''}</div>
@@ -693,7 +693,7 @@ export function renderSheet() {
       const qualSub = qualifier ? `<div class="trait-sub"><span class="trait-qual">${qualifier}</span></div>` : '';
       const standInner = `<div class="trait-row"><div class="trait-main"><span class="trait-name">${m.name}</span><div class="trait-right"><span class="trait-dots">${dots(m.rating || 0)}</span>${drawerHtml ? '<span class="disc-tap-arr">\u203A</span>' : ''}</div></div>${qualSub}</div>`;
       if (drawerHtml) {
-        html += `<div class="disc-tap-row" id="disc-row-${sid}" onclick="toggleDisc('${sid}')">${standInner}</div>
+        html += `<div class="disc-tap-row" id="disc-row-${sid}" onclick="suiteToggleDisc('${sid}')">${standInner}</div>
           <div class="disc-drawer" id="disc-drawer-${sid}">${drawerHtml}</div>`;
       } else {
         html += `<div class="disc-tap-row" style="cursor:default">${standInner}</div>`;

--- a/server/tests/suite-chevron-binding-433.test.js
+++ b/server/tests/suite-chevron-binding-433.test.js
@@ -1,0 +1,64 @@
+/**
+ * Bugfix #433 — suite chevron-expand binding contract.
+ *
+ * The bug: the suite app page hosts BOTH the editor sheet (Sheets tab)
+ * and the suite sheet. app.js binds the EDITOR toggleExp/toggleDisc to
+ * the unprefixed window globals; the suite sheet's inline onclick called
+ * the same unprefixed names, so the editor functions ran against suite-
+ * convention element IDs and silently no-opped.
+ *
+ * Fix: namespace the suite handlers — suite onclick calls
+ * suiteToggleExp/suiteToggleDisc, which app.js + sheet-helpers expose
+ * separately from the editor's toggleExp/toggleDisc.
+ *
+ * The toggle functions are browser-only (DOM + window). This source-
+ * contract test pins the binding so a future edit that reverts the
+ * onclick namespace (or re-introduces the window.toggleExp collision in
+ * sheet-helpers) fails here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, resolve } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..', '..');
+const sheetJs = readFileSync(resolve(repoRoot, 'public/js/suite/sheet.js'), 'utf8');
+const helpersJs = readFileSync(resolve(repoRoot, 'public/js/suite/sheet-helpers.js'), 'utf8');
+
+describe('#433 — suite sheet onclick uses the namespaced suite handlers', () => {
+  it('suite/sheet.js has no unprefixed toggleDisc/toggleExp onclick (would resolve to editor version)', () => {
+    expect(sheetJs).not.toMatch(/onclick="toggleDisc\(/);
+    expect(sheetJs).not.toMatch(/onclick="toggleExp\(/);
+  });
+
+  it('suite/sheet.js disc rows call suiteToggleDisc', () => {
+    const count = (sheetJs.match(/onclick="suiteToggleDisc\(/g) || []).length;
+    expect(count).toBeGreaterThanOrEqual(5); // disciplines / devotions / rites / rituals / standing
+  });
+});
+
+describe('#433 — sheet-helpers exposes namespaced globals + emits namespaced onclick', () => {
+  it('expRow emits suiteToggleExp, not the unprefixed toggleExp', () => {
+    expect(helpersJs).toMatch(/onclick="suiteToggleExp\(/);
+    expect(helpersJs).not.toMatch(/onclick="toggleExp\(/);
+  });
+
+  it('window exposure is namespaced (no collision with editor window.toggleExp/toggleDisc)', () => {
+    // The collision-causing lines must be gone:
+    expect(helpersJs).not.toMatch(/window\.toggleExp\s*=/);
+    expect(helpersJs).not.toMatch(/window\.toggleDisc\s*=/);
+    // Replaced with namespaced exposure:
+    expect(helpersJs).toMatch(/window\.suiteToggleExp\s*=/);
+    expect(helpersJs).toMatch(/window\.suiteToggleDisc\s*=/);
+  });
+
+  it('the toggle functions themselves still operate on suite-convention IDs', () => {
+    // toggleDisc targets disc-row-/disc-drawer-; toggleExp targets exp-row-/exp-body-
+    expect(helpersJs).toMatch(/disc-row-/);
+    expect(helpersJs).toMatch(/disc-drawer-/);
+    expect(helpersJs).toMatch(/exp-row-/);
+    expect(helpersJs).toMatch(/exp-body-/);
+  });
+});

--- a/specs/stories/issue-433-suite-chevron-expand-bug.story.md
+++ b/specs/stories/issue-433-suite-chevron-expand-bug.story.md
@@ -1,0 +1,65 @@
+# Issue #433: Suite app chevron-expand no-ops (wrong toggleDisc wired)
+
+Status: Ready for Review
+
+issue: 433
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/433
+branch: piatra/issue-433-suite-chevron-expand
+dispatch: PROCEED-WITH-NOTICE — small wiring bug, unrelated to Rev 4
+
+## Story
+
+As a player on the suite app (`/`),
+I want clicking a discipline-power / devotion / rite / ritual / pact / merit chevron to expand the rule elaboration drawer,
+so that I can read the rule clarification I most need — instead of a chevron that does nothing.
+
+## Root cause
+
+The suite app page hosts BOTH the editor sheet (Sheets tab) and the suite sheet. `app.js` binds the EDITOR `toggleExp`/`toggleDisc` to the unprefixed `window.toggleExp`/`window.toggleDisc` (app.js:1081-1082). The suite sheet emitted inline `onclick="toggleDisc('disc-row-N')"` — same unprefixed names — so the editor functions ran against suite-convention element IDs (`disc-row-`/`disc-drawer-`, which the editor's toggleDisc doesn't use) and silently no-opped.
+
+`app.js` already exposed `window.suiteToggleDisc`/`window.suiteToggleExp` (Object.assign at 1183-1184), and `suite/sheet-helpers.js` also self-assigned `window.toggleExp`/`window.toggleDisc` to the suite versions at module load — but that assignment was clobbered by app.js's later editor binding. The suite onclick strings just needed to call the namespaced names.
+
+## Fix choice: (a) per-app namespacing
+
+Picked (a) over (b) smart-router and (c) delegated-routing because both sheets coexist on the same page — namespace separation is the cleanest contract (each renderer's onclick targets its own function, no runtime renderer-detection). (c) would be the principled long-term cleanup but is a bigger diff than this focused bugfix warrants.
+
+## Tasks / Subtasks
+
+- [x] Task 1 — suite/sheet.js: 5 `onclick="toggleDisc(...)"` → `onclick="suiteToggleDisc(...)"` (disciplines / devotions / rites / rituals / standing-merit drawers).
+- [x] Task 2 — suite/sheet-helpers.js: `expRow` emits `suiteToggleExp`; window self-exposure changed from the collision-causing `window.toggleExp`/`window.toggleDisc` to `window.suiteToggleExp`/`window.suiteToggleDisc`.
+- [x] Task 3 — Source-contract vitest pinning the binding (no unprefixed onclick in suite/sheet.js; namespaced window exposure; suite-convention IDs intact).
+
+No app.js change needed — it already exposes `window.suiteToggleDisc`/`window.suiteToggleExp`; the bug was purely the suite onclick calling the unprefixed names.
+
+## Acceptance Criteria
+
+1. Suite disc-power chevron expands the drawer — ✅ structural (onclick → suiteToggleDisc, exposed)
+2. Click again collapses — ✅ (toggleDisc toggles the visible class)
+3. Devotions / rites / rituals / pacts / merits — ✅ (the 5 suiteToggleDisc sites cover the drawer types; merit info rows via expRow now use suiteToggleExp; editor-rendered merit blocks use the editor toggleExp which shares the exp-row convention and is correctly bound)
+4. Editor sheet unchanged — ✅ (window.toggleExp/toggleDisc still editor versions; admin + player.html untouched)
+5. No console errors — ✅ (both globals defined)
+6. ≥1 vitest binding contract — ✅ 5 cases
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-7 (Ptah / DEV)
+
+### Completion Notes List
+
+- **Issue's "dead import" analysis was slightly off.** It claimed app.js:101's suite-toggle imports were "never exposed to window" — but app.js DOES expose them via the Object.assign at 1183-1184. The actual bug was the suite onclick strings calling the unprefixed `toggleDisc`/`toggleExp` (which app.js binds to the EDITOR versions). Fix = correct the onclick names; app.js needs no change.
+- **Removed the collision-causing lines in sheet-helpers.** `window.toggleExp = toggleExp` / `window.toggleDisc = toggleDisc` at module load were always going to be clobbered by app.js's editor binding — pointless and misleading. Changed to `window.suiteToggleExp`/`window.suiteToggleDisc` so sheet-helpers self-exposes the namespaced globals (defensive — works even if app.js's Object.assign is ever refactored).
+- **Source-contract test** rather than a behavioural one because the toggle functions are browser-only (DOM + window). The test greps for the binding contract: no unprefixed onclick in suite/sheet.js, namespaced window exposure, suite-convention IDs intact. Catches any regression that reverts the namespace.
+- **Worktree pattern continued.**
+
+### File List
+
+- `public/js/suite/sheet.js` (modified) — 5 disc-row onclick → suiteToggleDisc
+- `public/js/suite/sheet-helpers.js` (modified) — expRow onclick → suiteToggleExp; window exposure namespaced
+- `server/tests/suite-chevron-binding-433.test.js` (new) — 5 source-contract cases
+- `specs/stories/issue-433-suite-chevron-expand-bug.story.md` — this file
+
+### Change Log
+
+- 2026-05-20 (Ptah): suite chevron binding fix


### PR DESCRIPTION
## Summary

On the suite app (`/`, player-facing default), clicking discipline-power / devotion / rite / ritual / pact / merit chevrons did nothing. The editor sheet (admin) worked. Players, who most need the rule clarification, saw dead chevrons.

Closes #433 (manual close on dev-merge per `feedback_github_autoclose_dev_gap`)

## Root cause

The suite app page hosts BOTH the editor sheet (Sheets tab) and the suite sheet. `app.js:1081-1082` binds the EDITOR `toggleExp`/`toggleDisc` to the unprefixed `window` globals. The suite sheet emitted `onclick="toggleDisc('disc-row-N')"` — same unprefixed names — so the editor functions ran against suite-convention element IDs (`disc-row-`/`disc-drawer-`, which the editor's toggleDisc doesn't target) and silently no-opped.

**Correction to the issue's analysis:** it claimed app.js's suite-toggle imports were "never exposed to window". They ARE — `app.js:1183-1184` exposes `window.suiteToggleDisc`/`window.suiteToggleExp` via Object.assign. The actual bug was the suite onclick strings calling the *unprefixed* names. So app.js needs no change; the fix is correcting the onclick names.

## Fix: (a) per-app namespacing

Picked (a) over (b) smart-router and (c) delegated-routing: both sheets coexist on the same page, so namespace separation is the cleanest contract — each renderer's onclick targets its own function with no runtime renderer-detection. (c) would be the principled long-term cleanup but is a bigger diff than this focused bugfix warrants.

- `suite/sheet.js`: 5 disc-row `onclick="toggleDisc(...)"` → `onclick="suiteToggleDisc(...)"`
- `suite/sheet-helpers.js`: `expRow` emits `suiteToggleExp`; the module-load window self-exposure changed from the collision-causing `window.toggleExp`/`window.toggleDisc` (always clobbered by app.js's later editor binding) to `window.suiteToggleExp`/`window.suiteToggleDisc`

## Acceptance criteria coverage

| AC | Status |
|----|--------|
| Disc-power chevron expands | ✅ onclick → suiteToggleDisc (exposed) |
| Click again collapses | ✅ toggleDisc toggles visible class |
| Devotions/rites/rituals/pacts/merits | ✅ 5 suiteToggleDisc sites cover drawer types; expRow info rows → suiteToggleExp |
| Editor sheet unchanged | ✅ window.toggleExp/toggleDisc still editor versions |
| No console errors | ✅ both globals defined |
| ≥1 vitest binding contract | ✅ 5 source-contract cases |

## Test plan

- [x] Parse-check touched modules (`node --input-type=module --check`)
- [x] Full server test suite: **1040/1040 passing** (gained 5)
- [x] Source-contract test: no unprefixed onclick remains in suite/sheet.js; window exposure namespaced; suite-convention IDs intact (regression guard against reverting the namespace)
- [ ] Peter's smoke on `/`: click a discipline-power chevron → drawer expands; click again → collapses; same for devotions/rites/merits

## Files

- **modified** `public/js/suite/sheet.js` — 5 disc-row onclick → suiteToggleDisc
- **modified** `public/js/suite/sheet-helpers.js` — expRow onclick → suiteToggleExp; window exposure namespaced
- **new** `server/tests/suite-chevron-binding-433.test.js` — 5 source-contract cases
- **new** `specs/stories/issue-433-suite-chevron-expand-bug.story.md`

## Note on test shape

The toggle functions are browser-only (DOM + window), so a behavioural test would need jsdom. The source-contract test pins the binding (no unprefixed onclick, namespaced exposure, suite IDs intact) — catches any future edit that reverts the namespace, which is the regression that would re-break this.