### PR TITLE
chore(#433): flip story status to Done

### DIFF
--- a/specs/stories/issue-433-suite-chevron-expand-bug.story.md
+++ b/specs/stories/issue-433-suite-chevron-expand-bug.story.md
@@ -1,6 +1,6 @@
 # Issue #433: Suite app chevron-expand no-ops (wrong toggleDisc wired)
 
-Status: Ready for Review
+Status: Done
 
 issue: 433
 issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/433


### PR DESCRIPTION
Tiny bookkeeping flip after PR #435 (suite chevron-expand fix) merged.

No code change, no test impact.