### PR TITLE
feat(#434): STM-10 lifecycle backend (active + toggle + tombstone-delete + event stream)

### DIFF
--- a/public/js/data/st-mods.js
+++ b/public/js/data/st-mods.js
@@ -130,10 +130,16 @@ export function applyStMods(c, mods, overlayEnabled) {
     return c;
   }
 
-  // Group by path, summing deltas, retaining each contributing mod
+  // Group by path, summing deltas, retaining each contributing mod.
+  // STM-10 (issue #434, ADR-004 Rev 4 §D16): skip INACTIVE mods. The
+  // bulk/single GET returns all mods (active + inactive) so STM-11's
+  // audit view and STM-12's panel can show the full set; the overlay
+  // only composes active ones. `active !== false` treats a missing field
+  // as active (D19 backfill-independence for pre-Rev 4 docs).
   const byPath = new Map();
   for (const m of mods) {
     if (!m || typeof m.stat_path !== 'string' || !Number.isInteger(m.delta)) continue;
+    if (m.active === false) continue;
     let entry = byPath.get(m.stat_path);
     if (!entry) {
       entry = { delta: 0, mods: [] };
@@ -141,6 +147,13 @@ export function applyStMods(c, mods, overlayEnabled) {
     }
     entry.delta += m.delta;
     entry.mods.push(m);
+  }
+
+  // If every mod was inactive, byPath is empty — strip any prior overlay
+  // and return so a freshly-deactivated mod reverts the displayed value.
+  if (byPath.size === 0) {
+    stripOverlay(c);
+    return c;
   }
 
   // Restore any prior overlay before re-applying — successive renders pile

--- a/server/routes/st_mods.js
+++ b/server/routes/st_mods.js
@@ -81,6 +81,37 @@ function creatorFromUser(user) {
   };
 }
 
+/** STM-10 (issue #434, ADR-004 Rev 4 §D17): build a lifecycle audit-event
+ *  row. The audit collection is now an immutable event stream:
+ *  created / activated / deactivated / deleted.
+ *
+ *  Field naming: the Rev 4 schema names the actor `by` and the timestamp
+ *  `at`. STM-6's existing audit reader (GET /api/st_mod_audit sort +
+ *  the admin audit page) consumes `created_by` / `created_at`. To avoid
+ *  breaking that surface during the STM-10 → STM-11 window (STM-11 owns
+ *  the audit-view migration to the new names), this dual-stamps BOTH —
+ *  same actor object + same timestamp string under both names. STM-11
+ *  migrates the reader to by/at and drops the created_* aliases.
+ *
+ *  `mod` is the (possibly partial) mod doc: needs _id, character_id,
+ *  stat_path, delta, reason. delta + reason are captured AT THE EVENT
+ *  so a later edit/revoke can't rewrite history. */
+function buildAuditEvent(mod, event, who, when) {
+  return {
+    st_mod_id: mod._id,
+    character_id: String(mod.character_id),
+    stat_path: mod.stat_path,
+    delta: mod.delta,
+    reason: mod.reason,
+    event,
+    by: who,
+    at: when,
+    // Back-compat aliases (see JSDoc) — same values, STM-6 reader consumes these.
+    created_by: who,
+    created_at: when,
+  };
+}
+
 // ─── POST /api/st_mods ───────────────────────────────────────────────
 // Creates an st_mod and a paired st_mod_audit row in the same handler.
 // Sequential write with best-effort rollback on audit failure (no Mongo
@@ -111,6 +142,9 @@ router.post('/', requireRole('st'), async (req, res) => {
     delta,
     reason: trimmedReason,
     show_reason_to_player: !!show_reason_to_player,
+    // STM-10 (issue #434, ADR-004 Rev 4 §D15): lifecycle field. Mods are
+    // now persistent + toggleable; `active` defaults true on create.
+    active: true,
     created_by: createdBy,
     created_at: createdAt,
   };
@@ -118,17 +152,9 @@ router.post('/', requireRole('st'), async (req, res) => {
   const modResult = await mods().insertOne(modDoc);
   const modId = modResult.insertedId;
 
-  // Audit row mirrors the mod (minus show_reason_to_player, per AC#2) and
-  // references the mod by st_mod_id so revoke-time matching is trivial.
-  const auditDoc = {
-    st_mod_id: modId,
-    character_id: String(character_id),
-    stat_path,
-    delta,
-    reason: trimmedReason,
-    created_by: createdBy,
-    created_at: createdAt,
-  };
+  // STM-10 (§D17): the audit row is now a lifecycle EVENT (event: 'created')
+  // rather than the implicit creation-only row from STM-1.
+  const auditDoc = buildAuditEvent({ _id: modId, character_id, stat_path, delta, reason: trimmedReason }, 'created', createdBy, createdAt);
 
   try {
     await audit().insertOne(auditDoc);
@@ -142,10 +168,9 @@ router.post('/', requireRole('st'), async (req, res) => {
   }
 
   // STM-9 (issue #416, ADR-004 Rev 3 §D11): broadcast the create event
-  // AFTER both inserts succeed. Connected clients (admin / player / suite)
-  // receive `{ type: 'st_mod', op: 'create', character_id, st_mod_id }`
-  // and refetch + re-overlay for the affected character. The originating
-  // client deduplicates via markLocalWrite (mirrors tracker.js pattern).
+  // AFTER both inserts succeed. STM-10 (§D18) widened the op set; 'create'
+  // unchanged. Connected clients refetch + re-overlay for the affected
+  // character; the originating client deduplicates via markLocalWrite.
   broadcastStModUpdate(String(character_id), 'create', String(modId));
 
   const created = await mods().findOne({ _id: modId });
@@ -239,21 +264,101 @@ router.get('/', async (req, res) => {
   res.json(docs);
 });
 
+// ─── PATCH /api/st_mods/:id ──────────────────────────────────────────
+// STM-10 (issue #434, ADR-004 Rev 4 §D16): toggle a mod's active state.
+// Body { active: boolean }. Writes an `activated` / `deactivated` audit
+// event and broadcasts the matching WS op. Reason is captured from the
+// mod's current reason (optional override via body.reason); by + at are
+// always server-stamped. Returns the updated mod doc.
+router.patch('/:id', requireRole('st'), async (req, res) => {
+  const oid = parseId(req.params.id);
+  if (!oid) return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid ID' });
+
+  const { active } = req.body || {};
+  if (typeof active !== 'boolean') {
+    return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'active must be boolean' });
+  }
+
+  const existing = await mods().findOne({ _id: oid });
+  if (!existing) return res.status(404).json({ error: 'NOT_FOUND' });
+
+  // Flip the active flag, then write the lifecycle event. Reason captured
+  // at the event (override allowed; defaults to the mod's creation reason).
+  const overrideReason = typeof req.body?.reason === 'string' && req.body.reason.trim()
+    ? req.body.reason.trim()
+    : existing.reason;
+  const who = creatorFromUser(req.user);
+  const when = nowIso();
+  const event = active ? 'activated' : 'deactivated';
+
+  await mods().updateOne({ _id: oid }, { $set: { active } });
+
+  const auditDoc = buildAuditEvent(
+    { _id: oid, character_id: existing.character_id, stat_path: existing.stat_path, delta: existing.delta, reason: overrideReason },
+    event, who, when,
+  );
+  try {
+    await audit().insertOne(auditDoc);
+  } catch (err) {
+    // Roll back the flag so the audit ledger and mod state stay consistent
+    // (mirrors STM-1's create rollback). The ledger is the source of truth
+    // for "what happened"; a flag change with no audit row would lie.
+    try { await mods().updateOne({ _id: oid }, { $set: { active: existing.active !== false } }); } catch { /* best-effort */ }
+    console.error('[st_mods] PATCH audit insert failed, rolled back active flag:', err);
+    return res.status(500).json({ error: 'INTERNAL_ERROR', message: 'Failed to write audit row' });
+  }
+
+  // STM-10 (§D18): op set widened. activate / deactivate are new ops.
+  broadcastStModUpdate(String(existing.character_id), active ? 'activate' : 'deactivate', String(oid));
+
+  const updated = await mods().findOne({ _id: oid });
+  res.json(updated);
+});
+
 // ─── DELETE /api/st_mods/:id ─────────────────────────────────────────
-// Hard-delete the mod. Audit row is intentionally LEFT IN PLACE.
+// STM-10 (issue #434, ADR-004 Rev 4 §D17 — HALT-DAR LOAD-BEARING):
+// tombstone-before-destroy. The `deleted` audit event MUST be written
+// BEFORE the mod doc is removed. If the tombstone insert fails, the
+// delete does NOT proceed (return 500). The audit ledger is immutable
+// and outlives the mod doc — Position B retention contract: mod
+// definitions are deletable for list cleanliness; the accountability
+// ledger is permanent.
 router.delete('/:id', requireRole('st'), async (req, res) => {
   const oid = parseId(req.params.id);
   if (!oid) return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid ID' });
-  // Resolve the doc BEFORE deletion so we know which character to
-  // broadcast against (the deleted row has the character_id we need).
-  // STM-9 (issue #416): the broadcast hook fires only after the delete
-  // succeeds — clients shouldn't be told a mod was revoked if it wasn't.
+
+  // Resolve the doc first — its fields populate the tombstone, and we need
+  // the character_id for the broadcast.
   const existing = await mods().findOne({ _id: oid });
-  const result = await mods().deleteOne({ _id: oid });
-  if (!result.deletedCount) return res.status(404).json({ error: 'NOT_FOUND' });
-  if (existing?.character_id) {
-    broadcastStModUpdate(String(existing.character_id), 'revoke', String(oid));
+  if (!existing) return res.status(404).json({ error: 'NOT_FOUND' });
+
+  // 1. Write the tombstone BEFORE destroying the mod doc.
+  const who = creatorFromUser(req.user);
+  const when = nowIso();
+  const tombstone = buildAuditEvent(
+    { _id: oid, character_id: existing.character_id, stat_path: existing.stat_path, delta: existing.delta, reason: existing.reason },
+    'deleted', who, when,
+  );
+  try {
+    await audit().insertOne(tombstone);
+  } catch (err) {
+    // Tombstone failed → do NOT delete. The mod survives, no ledger entry.
+    // This is the HALT-DAR contract: never destroy without the tombstone.
+    console.error('[st_mods] DELETE tombstone insert failed, aborting delete:', err);
+    return res.status(500).json({ error: 'INTERNAL_ERROR', message: 'Failed to write tombstone; delete aborted' });
   }
+
+  // 2. Tombstone is durable — now destroy the mod doc.
+  const result = await mods().deleteOne({ _id: oid });
+  if (!result.deletedCount) {
+    // Extremely rare (doc vanished between findOne and deleteOne). The
+    // tombstone stays (immutable ledger); report the inconsistency.
+    console.warn('[st_mods] DELETE: tombstone written but deleteOne removed 0 docs for', String(oid));
+    return res.status(404).json({ error: 'NOT_FOUND' });
+  }
+
+  // STM-10 (§D18): 'revoke' op retired → 'delete'.
+  broadcastStModUpdate(String(existing.character_id), 'delete', String(oid));
   res.json({ deleted: true });
 });
 
@@ -329,6 +434,9 @@ auditRouter.get('/', requireRole('st'), async (req, res) => {
   const decorated = rows.map(r => ({
     ...r,
     active: r.st_mod_id != null && aliveSet.has(String(r.st_mod_id)),
+    // STM-10 (§D19 backfill-independence): pre-Rev 4 audit rows have no
+    // `event` field — they were all creation rows, so default to 'created'.
+    event: r.event ?? 'created',
   }));
 
   res.json({ rows: decorated, total, page, page_size: pageSize });

--- a/server/tests/api-st-mods.test.js
+++ b/server/tests/api-st-mods.test.js
@@ -427,8 +427,14 @@ describe('STM-6 — GET /api/st_mod_audit filter + pagination + active decoratio
       .get(`/api/st_mod_audit?character_id=${STM6_CHAR_A}`)
       .set('X-Test-User', stUser());
     expect(resA.status).toBe(200);
-    expect(resA.body.total).toBe(3);
+    // STM-10 (issue #434): the setup revokes one of CHAR_A's 3 mods, and
+    // DELETE now writes a `deleted` tombstone audit row (tombstone-before-
+    // destroy). So CHAR_A's audit stream = 3 'created' + 1 'deleted' = 4.
+    // Pre-STM-10 the revoke left only the 3 creation rows.
+    expect(resA.body.total).toBe(4);
     expect(resA.body.rows.every(r => r.character_id === STM6_CHAR_A)).toBe(true);
+    expect(resA.body.rows.filter(r => r.event === 'created').length).toBe(3);
+    expect(resA.body.rows.filter(r => r.event === 'deleted').length).toBe(1);
 
     const resB = await request(app)
       .get(`/api/st_mod_audit?character_id=${STM6_CHAR_B}`)

--- a/server/tests/stm-10-lifecycle.test.js
+++ b/server/tests/stm-10-lifecycle.test.js
@@ -1,0 +1,281 @@
+/**
+ * STM-10 (issue #434) — lifecycle backend.
+ *
+ * ADR-004 Rev 4 §D15-D20: persistent toggleable mods. Covers:
+ *   - active:true default on create + 'created' audit event
+ *   - PATCH activate/deactivate → flag flip + audit event + WS op
+ *   - overlay skips inactive mods (active !== false)
+ *   - DELETE tombstone-before-destroy (HALT-DAR LOAD-BEARING merge gate)
+ *   - DELETE rollback when tombstone insert fails → mod survives
+ *   - backwards-compat audit read: pre-Rev4 row without `event` reads 'created'
+ *   - WS op set: create / activate / deactivate / delete ('revoke' retired)
+ */
+
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import request from 'supertest';
+import { ObjectId } from 'mongodb';
+import { createTestApp, stUser } from './helpers/test-app.js';
+import { setupDb, teardownDb } from './helpers/db-setup.js';
+import { getCollection } from '../db.js';
+import * as dbModule from '../db.js';
+import * as wsModule from '../ws.js';
+
+let app;
+const CHAR_ID = new ObjectId().toHexString();
+const CREATED_IDS = [];
+let broadcastSpy;
+
+beforeAll(async () => {
+  await setupDb();
+  app = createTestApp();
+  await getCollection('st_mods').deleteMany({ character_id: CHAR_ID });
+  await getCollection('st_mod_audit').deleteMany({ character_id: CHAR_ID });
+  broadcastSpy = vi.spyOn(wsModule, 'broadcastStModUpdate');
+});
+
+afterAll(async () => {
+  await getCollection('st_mods').deleteMany({ character_id: CHAR_ID });
+  await getCollection('st_mod_audit').deleteMany({ character_id: CHAR_ID });
+  broadcastSpy.mockRestore();
+  await teardownDb();
+});
+
+async function createMod(stat_path = 'attributes.Presence.dots', delta = 1) {
+  const res = await request(app).post('/api/st_mods').set('X-Test-User', stUser()).send({
+    character_id: CHAR_ID, stat_path, delta, reason: 'lifecycle test', show_reason_to_player: false,
+  });
+  expect(res.status).toBe(201);
+  CREATED_IDS.push(res.body._id);
+  return res.body;
+}
+
+// ── create: active default + 'created' event ────────────────────────
+
+describe('STM-10 — POST sets active:true + writes created event', () => {
+  it('mod doc has active:true', async () => {
+    const mod = await createMod();
+    expect(mod.active).toBe(true);
+  });
+
+  it('audit row has event:created (+ by/at + back-compat created_by/created_at)', async () => {
+    const mod = await createMod();
+    const auditRow = await getCollection('st_mod_audit').findOne({ st_mod_id: new ObjectId(mod._id), event: 'created' });
+    expect(auditRow).toBeTruthy();
+    expect(auditRow.event).toBe('created');
+    expect(auditRow.by).toMatchObject({ discord_id: 'test-st-001' });
+    expect(typeof auditRow.at).toBe('string');
+    // Back-compat aliases for STM-6 reader
+    expect(auditRow.created_by).toMatchObject({ discord_id: 'test-st-001' });
+    expect(auditRow.created_at).toBe(auditRow.at);
+  });
+
+  it('POST broadcasts create op', async () => {
+    broadcastSpy.mockClear();
+    const mod = await createMod();
+    expect(broadcastSpy).toHaveBeenCalledWith(CHAR_ID, 'create', String(mod._id));
+  });
+});
+
+// ── PATCH: activate / deactivate ────────────────────────────────────
+
+describe('STM-10 — PATCH toggles active + writes lifecycle event + WS op', () => {
+  it('PATCH { active: false } → mod inactive + deactivated audit + deactivate broadcast', async () => {
+    const mod = await createMod();
+    broadcastSpy.mockClear();
+    const res = await request(app)
+      .patch(`/api/st_mods/${mod._id}`)
+      .set('X-Test-User', stUser())
+      .send({ active: false });
+    expect(res.status).toBe(200);
+    expect(res.body.active).toBe(false);
+
+    const stored = await getCollection('st_mods').findOne({ _id: new ObjectId(mod._id) });
+    expect(stored.active).toBe(false);
+
+    const auditRow = await getCollection('st_mod_audit').findOne({ st_mod_id: new ObjectId(mod._id), event: 'deactivated' });
+    expect(auditRow).toBeTruthy();
+    expect(auditRow.delta).toBe(1);     // captured at the event
+    expect(auditRow.reason).toBe('lifecycle test');
+
+    expect(broadcastSpy).toHaveBeenCalledWith(CHAR_ID, 'deactivate', String(mod._id));
+  });
+
+  it('PATCH { active: true } on a deactivated mod → reactivated + activated audit + activate broadcast', async () => {
+    const mod = await createMod();
+    await request(app).patch(`/api/st_mods/${mod._id}`).set('X-Test-User', stUser()).send({ active: false });
+    broadcastSpy.mockClear();
+    const res = await request(app)
+      .patch(`/api/st_mods/${mod._id}`)
+      .set('X-Test-User', stUser())
+      .send({ active: true });
+    expect(res.status).toBe(200);
+    expect(res.body.active).toBe(true);
+
+    const auditRow = await getCollection('st_mod_audit').findOne({ st_mod_id: new ObjectId(mod._id), event: 'activated' });
+    expect(auditRow).toBeTruthy();
+    expect(broadcastSpy).toHaveBeenCalledWith(CHAR_ID, 'activate', String(mod._id));
+  });
+
+  it('PATCH 400 on non-boolean active', async () => {
+    const mod = await createMod();
+    const res = await request(app).patch(`/api/st_mods/${mod._id}`).set('X-Test-User', stUser()).send({ active: 'yes' });
+    expect(res.status).toBe(400);
+  });
+
+  it('PATCH 404 on unknown id', async () => {
+    const res = await request(app).patch(`/api/st_mods/${new ObjectId().toHexString()}`).set('X-Test-User', stUser()).send({ active: false });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ── Overlay skips inactive (client-side filter, asserted via shape) ──
+
+describe('STM-10 — GET returns all mods (active + inactive)', () => {
+  it('single GET returns both active and inactive mods', async () => {
+    const charB = new ObjectId().toHexString();
+    const m1 = await request(app).post('/api/st_mods').set('X-Test-User', stUser()).send({
+      character_id: charB, stat_path: 'attributes.Wits.dots', delta: 1, reason: 'a',
+    });
+    const m2 = await request(app).post('/api/st_mods').set('X-Test-User', stUser()).send({
+      character_id: charB, stat_path: 'attributes.Wits.bonus', delta: 1, reason: 'b',
+    });
+    await request(app).patch(`/api/st_mods/${m2.body._id}`).set('X-Test-User', stUser()).send({ active: false });
+
+    const res = await request(app).get(`/api/st_mods?character_id=${charB}`).set('X-Test-User', stUser());
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    const byId = Object.fromEntries(res.body.map(m => [String(m._id), m]));
+    expect(byId[String(m1.body._id)].active).toBe(true);
+    expect(byId[String(m2.body._id)].active).toBe(false);
+
+    await getCollection('st_mods').deleteMany({ character_id: charB });
+    await getCollection('st_mod_audit').deleteMany({ character_id: charB });
+  });
+});
+
+// ── DELETE tombstone-before-destroy (HALT-DAR merge gate) ───────────
+
+describe('STM-10 — DELETE tombstone-before-destroy (HALT-DAR LOAD-BEARING)', () => {
+  it('tombstone audit row SURVIVES the permanent delete of the mod doc', async () => {
+    const mod = await createMod();
+    broadcastSpy.mockClear();
+
+    const delRes = await request(app).delete(`/api/st_mods/${mod._id}`).set('X-Test-User', stUser());
+    expect(delRes.status).toBe(200);
+
+    // Mod doc is gone
+    const modDoc = await getCollection('st_mods').findOne({ _id: new ObjectId(mod._id) });
+    expect(modDoc).toBeNull();
+
+    // Tombstone survives — THE merge gate
+    const tombstone = await getCollection('st_mod_audit').findOne({ st_mod_id: new ObjectId(mod._id), event: 'deleted' });
+    expect(tombstone).toBeTruthy();
+    expect(tombstone.event).toBe('deleted');
+    expect(tombstone.stat_path).toBe('attributes.Presence.dots');
+    expect(tombstone.delta).toBe(1);
+
+    // The 'created' audit row also survives (full lifecycle ledger intact)
+    const created = await getCollection('st_mod_audit').findOne({ st_mod_id: new ObjectId(mod._id), event: 'created' });
+    expect(created).toBeTruthy();
+
+    // 'delete' op broadcast (not the retired 'revoke')
+    expect(broadcastSpy).toHaveBeenCalledWith(CHAR_ID, 'delete', String(mod._id));
+  });
+
+  it('rollback: when tombstone insert fails, the mod doc is NOT deleted', async () => {
+    const mod = await createMod();
+
+    // getCollection returns a fresh Collection per call, so spying a single
+    // instance won't catch the route's call. Spy getCollection itself and
+    // return a Proxy that rejects st_mod_audit.insertOne once, delegating
+    // everything else to the real collection.
+    let failNextAuditInsert = true;
+    const realGet = dbModule.getCollection;
+    const gcSpy = vi.spyOn(dbModule, 'getCollection').mockImplementation((name) => {
+      const coll = realGet(name);
+      if (name !== 'st_mod_audit') return coll;
+      return new Proxy(coll, {
+        get(target, prop) {
+          if (prop === 'insertOne' && failNextAuditInsert) {
+            failNextAuditInsert = false;
+            return () => Promise.reject(new Error('simulated tombstone failure'));
+          }
+          const v = target[prop];
+          return typeof v === 'function' ? v.bind(target) : v;
+        },
+      });
+    });
+
+    const delRes = await request(app).delete(`/api/st_mods/${mod._id}`).set('X-Test-User', stUser());
+    expect(delRes.status).toBe(500);
+
+    gcSpy.mockRestore();
+
+    // The mod doc MUST still exist — destroy never proceeded
+    const modDoc = await getCollection('st_mods').findOne({ _id: new ObjectId(mod._id) });
+    expect(modDoc).toBeTruthy();
+    expect(modDoc.active).toBe(true);
+
+    // No tombstone was written (the insert was rejected)
+    const tombstone = await getCollection('st_mod_audit').findOne({ st_mod_id: new ObjectId(mod._id), event: 'deleted' });
+    expect(tombstone).toBeNull();
+  });
+
+  it('DELETE 404 on unknown id (no tombstone written)', async () => {
+    const fakeId = new ObjectId().toHexString();
+    const res = await request(app).delete(`/api/st_mods/${fakeId}`).set('X-Test-User', stUser());
+    expect(res.status).toBe(404);
+    const tombstone = await getCollection('st_mod_audit').findOne({ st_mod_id: new ObjectId(fakeId), event: 'deleted' });
+    expect(tombstone).toBeNull();
+  });
+});
+
+// ── Backwards-compat: pre-Rev4 audit row without `event` ────────────
+
+describe('STM-10 — backwards-compat audit read (event ?? created)', () => {
+  it('audit GET surfaces a pre-Rev4 row (no event field) as event:created', async () => {
+    const charC = new ObjectId().toHexString();
+    // Insert a legacy-shaped audit row directly (no `event` field) —
+    // mimics a pre-Rev4 STM-1 creation row.
+    const legacyMod = new ObjectId();
+    await getCollection('st_mods').insertOne({
+      _id: legacyMod, character_id: charC, stat_path: 'attributes.Resolve.dots',
+      delta: 1, reason: 'legacy', created_by: { discord_id: 'x', discord_name: 'Legacy ST' },
+      created_at: new Date().toISOString(),
+      // note: no `active` field — pre-Rev4 doc
+    });
+    await getCollection('st_mod_audit').insertOne({
+      st_mod_id: legacyMod, character_id: charC, stat_path: 'attributes.Resolve.dots',
+      delta: 1, reason: 'legacy', created_by: { discord_id: 'x', discord_name: 'Legacy ST' },
+      created_at: new Date().toISOString(),
+      // note: no `event` field
+    });
+
+    const res = await request(app).get(`/api/st_mod_audit?character_id=${charC}`).set('X-Test-User', stUser());
+    expect(res.status).toBe(200);
+    const row = res.body.rows.find(r => String(r.st_mod_id) === String(legacyMod));
+    expect(row).toBeTruthy();
+    expect(row.event).toBe('created');   // defaulted from missing field
+
+    await getCollection('st_mods').deleteMany({ character_id: charC });
+    await getCollection('st_mod_audit').deleteMany({ character_id: charC });
+  });
+
+  it('legacy mod with no active field still composes into overlay (active !== false)', async () => {
+    // The overlay filter is client-side (applyStMods); this asserts the
+    // server returns the legacy doc so the client can include it.
+    const charD = new ObjectId().toHexString();
+    const legacyMod = new ObjectId();
+    await getCollection('st_mods').insertOne({
+      _id: legacyMod, character_id: charD, stat_path: 'attributes.Stamina.dots',
+      delta: 2, reason: 'legacy active', created_at: new Date().toISOString(),
+      // no `active` field
+    });
+    const res = await request(app).get(`/api/st_mods?character_id=${charD}`).set('X-Test-User', stUser());
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].active).toBeUndefined();   // missing → client treats as active
+
+    await getCollection('st_mods').deleteMany({ character_id: charD });
+  });
+});

--- a/server/tests/stm-9-ws-broadcast.test.js
+++ b/server/tests/stm-9-ws-broadcast.test.js
@@ -118,7 +118,9 @@ describe('STM-9 — DELETE /api/st_mods/:id emits broadcastStModUpdate(revoke)',
     expect(broadcastSpy).toHaveBeenCalledTimes(1);
     const call = broadcastSpy.mock.calls[0];
     expect(call[0]).toBe(CHAR_ID);
-    expect(call[1]).toBe('revoke');
+    // STM-10 (issue #434, §D18): DELETE now emits 'delete' (the 'revoke'
+    // op string is retired). Updated from the STM-9 assertion.
+    expect(call[1]).toBe('delete');
     expect(call[2]).toBe(String(modId));
   });
 
@@ -183,7 +185,7 @@ describe('STM-9 — client dedupe blocks echo of own write', () => {
     // Multiple frames within the window — all suppressed because they
     // all match the same constant 'st_mod' key.
     handleStModMsg({ characterId: CHAR_ID, op: 'create', st_mod_id: 'id-1' }, onUpdate);
-    handleStModMsg({ characterId: CHAR_ID, op: 'revoke', st_mod_id: 'id-2' }, onUpdate);
+    handleStModMsg({ characterId: CHAR_ID, op: 'delete', st_mod_id: 'id-2' }, onUpdate);
     expect(onUpdate).not.toHaveBeenCalled();
   });
 

--- a/server/ws.js
+++ b/server/ws.js
@@ -81,8 +81,13 @@ export function broadcastTrackerUpdate(characterId, fields) {
  * unique-mutation token (mirrors how tracker frames use per-field keys).
  *
  * @param {string} characterId
- * @param {'create' | 'revoke'} op
- * @param {string} stModId — the mod doc _id (or revoked doc id)
+ * @param {'create' | 'activate' | 'deactivate' | 'delete'} op
+ *   STM-10 (issue #434, ADR-004 Rev 4 §D18) widened the op set. The
+ *   `revoke` op from STM-9 is retired — DELETE now emits `delete`, and
+ *   the PATCH toggle emits `activate` / `deactivate`. Clients treat the
+ *   op as advisory and refetch the character's mods regardless, so an
+ *   unknown op degrades gracefully to "refetch".
+ * @param {string} stModId — the affected mod doc _id
  */
 export function broadcastStModUpdate(characterId, op, stModId) {
   if (!_wss) return;

--- a/specs/stories/issue-434-stm-10-lifecycle-backend.story.md
+++ b/specs/stories/issue-434-stm-10-lifecycle-backend.story.md
@@ -1,0 +1,80 @@
+# Issue #434: STM-10 — lifecycle backend (active + toggle + tombstone-delete + event stream)
+
+Status: Ready for Review
+
+issue: 434
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/434
+branch: piatra/issue-434-stm-10-lifecycle-backend
+epic: STM (specs/epic-stm-st-mods.md)
+adr: ADR-004 Rev 4 §D15-D20 (specs/architecture/adr-004-st-mods-overlay.md)
+dispatch: PROCEED-WITH-NOTICE (D16 dissent window closed by Angelus sign-off). Tombstone-before-destroy is HALT-DAR-pinned LOAD-BEARING.
+
+## Story
+
+As a Storyteller,
+I want ST mods to be persistent and toggleable (create → active ↔ inactive → permanently deleted) with an immutable audit event stream,
+so that mods can be paused without losing them, permanently removed for list cleanliness, and every lifecycle event stays accountable even after the mod doc is destroyed.
+
+## Decisions implemented (ADR-004 Rev 4 §D15-D20)
+
+- **D15** — `active: boolean` on st_mods, defaults `true` on create.
+- **D16** — `PATCH /api/st_mods/:id { active }` toggle, writes `activated`/`deactivated` audit event, broadcasts matching WS op.
+- **D17** — audit collection is now a lifecycle event stream (`event: created|activated|deactivated|deleted`). DELETE writes a `deleted` tombstone BEFORE destroying the mod doc.
+- **D18** — WS op set widened: `create` / `activate` / `deactivate` / `delete`. The STM-9 `revoke` op is retired.
+- **D19** — backfill-independence: `active !== false` (missing field = active) + `event ?? 'created'` (missing field = created). No hard migration needed; STM-13 ships the idempotent backfill separately.
+- **D20** / Position B — mod docs deletable for list cleanliness; audit ledger immutable.
+
+## Tasks / Subtasks
+
+- [x] Task 1 — POST: `active: true` on create + `created` lifecycle audit event (replaces STM-1's implicit creation row).
+- [x] Task 2 — PATCH `/api/st_mods/:id`: flip active, write `activated`/`deactivated` event (delta + reason captured at event), broadcast, roll back the flag if the audit insert fails.
+- [x] Task 3 — DELETE: **tombstone-before-destroy** (HALT-DAR). Write `deleted` audit row first; if it fails, abort the delete (500). Then deleteOne. Broadcast `delete` (retiring `revoke`).
+- [x] Task 4 — Overlay filter: `applyStMods` skips `active === false` mods (the bulk/single GET still returns all so STM-11/12 see the full set).
+- [x] Task 5 — `event ?? 'created'` decoration on the audit GET for pre-Rev4 rows.
+- [x] Task 6 — WS `broadcastStModUpdate` JSDoc op-set widening; grep confirmed no `=== 'revoke'` consumer (the panel's `action === 'revoke'` is a UI action name, not the WS op; updated the STM-9 test's `revoke` assertion to `delete`).
+- [x] Task 7 — 13 vitest cases (5 required + 8 extra: PATCH 400/404, GET-returns-all, DELETE 404, legacy-active-field overlay).
+
+## Acceptance Criteria
+
+1. st_mods stores `active`, defaults true — ✅
+2. **HALT-DAR: tombstone-before-destroy + rollback on tombstone failure** — ✅ explicit vitest gate (tombstone survives permanent delete; rollback leaves mod intact when tombstone insert fails)
+3. PATCH deactivate flips + audit + WS deactivate — ✅
+4. PATCH activate flips + audit + WS activate — ✅
+5. POST writes `created` event — ✅
+6. Overlay skips inactive — ✅ (applyStMods filter)
+7. GET returns all mods (active + inactive) — ✅
+8. Audit GET returns full lifecycle stream; legacy rows read `created` — ✅
+9. WS ops: create/activate/deactivate/delete; `revoke` retired — ✅
+10. Grep `=== 'revoke'` — ✅ none found (WS op); STM-9 test updated
+11. ≥5 vitest cases — ✅ 13
+12. No regression — ✅ 1053/1053 (STM-6 filter-by-character test updated: revoke now adds a tombstone row, so CHAR_A's audit stream is 4 = 3 created + 1 deleted)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-7 (Ptah / DEV)
+
+### Completion Notes List
+
+- **Audit field naming: dual-stamp.** Rev 4 names the actor `by` and timestamp `at`. STM-6's audit reader (GET sort by `created_at` + admin page reading `created_by.discord_name`) is out of scope for STM-10 (STM-11 owns the audit-view migration). To avoid breaking the merged STM-6 surface during the STM-10→STM-11 window, `buildAuditEvent` writes BOTH `by`/`at` (canonical Rev 4) AND `created_by`/`created_at` (back-compat aliases, same values). STM-11 migrates the reader to by/at and drops the aliases. Documented in the helper JSDoc + PR.
+- **Tombstone-before-destroy ordering (HALT-DAR).** DELETE: resolve doc → write `deleted` tombstone → (if tombstone insert throws) abort with 500, mod survives, no ledger entry → else deleteOne → broadcast. The merge-gate vitest spies `getCollection` (not a single collection instance — the driver returns a fresh Collection per call) with a Proxy that rejects `st_mod_audit.insertOne` once, asserting the mod doc remains.
+- **PATCH rollback symmetry.** If the activated/deactivated audit insert fails, the active flag is rolled back to its prior value (mirrors STM-1's create rollback) — the ledger is the source of truth; a flag flip with no audit row would lie.
+- **delta + reason captured AT the event** (not referenced live) so a later edit/revoke can't rewrite history. Matches the DT-snapshot principle from STM-8.
+- **Overlay filter is client-side** (`applyStMods` skips `active === false`); the server GET returns all mods so STM-11's audit view and STM-12's panel can show active + inactive. `active !== false` treats missing field as active (D19).
+- **`revoke` retirement.** Grep found the WS op only at the DELETE call site (changed to `delete`) + the STM-9 test (updated) + JSDoc (widened). No `=== 'revoke'` consumer exists — the panel's `data-stm-action="revoke"` / `action === 'revoke'` is a UI action label routing to DELETE, unrelated to the WS op string. STM-12 will rework the panel UI (toggle / delete-permanent); for STM-10 the panel's revoke button still maps to DELETE which now tombstones.
+- **Worktree pattern continued.**
+
+### File List
+
+- `server/routes/st_mods.js` (modified) — `buildAuditEvent` helper; POST active+created event; new PATCH toggle; DELETE tombstone-before-destroy; audit GET `event ?? 'created'` decoration; DELETE op `revoke`→`delete`
+- `server/ws.js` (modified) — `broadcastStModUpdate` JSDoc op-set widened
+- `public/js/data/st-mods.js` (modified) — `applyStMods` skips `active === false`; strips overlay when all mods inactive
+- `server/tests/stm-10-lifecycle.test.js` (new) — 13 vitest cases incl. the tombstone-before-destroy + rollback merge gates
+- `server/tests/stm-9-ws-broadcast.test.js` (modified) — DELETE op assertion `revoke`→`delete`; dedupe sample op updated
+- `server/tests/api-st-mods.test.js` (modified) — STM-6 filter-by-character total 3→4 (revoke now writes a tombstone)
+- `specs/stories/issue-434-stm-10-lifecycle-backend.story.md` — this file
+
+### Change Log
+
+- 2026-05-20 (Ptah): STM-10 lifecycle backend


### PR DESCRIPTION
## Summary

ADR-004 Rev 4 §D15-D20. Pivots STM from ephemeral mods to **persistent toggleable mods**: create → active ↔ inactive → permanently deleted, with an immutable audit event stream. Foundation backend for STM-11/12/13.

Closes #434 (manual close on dev-merge per `feedback_github_autoclose_dev_gap`)

## HALT-DAR LOAD-BEARING: tombstone-before-destroy

DELETE writes the `deleted` audit row **BEFORE** removing the mod doc:
1. Resolve the doc (fields populate the tombstone)
2. Insert the `deleted` tombstone audit row
3. **If the tombstone insert throws → abort with 500, mod survives, no ledger entry**
4. Else `deleteOne` the mod
5. Broadcast `delete`

The merge-gate vitest (`tombstone audit row SURVIVES the permanent delete`) asserts the tombstone persists after the mod doc is gone. A second gate (`rollback: when tombstone insert fails, the mod doc is NOT deleted`) spies `getCollection` with a Proxy rejecting `st_mod_audit.insertOne` once and asserts the mod survives. Position B retention: mod docs deletable for list cleanliness; audit ledger immutable.

## Decisions

| § | Decision | Implementation |
|---|---|---|
| D15 | `active: boolean` on st_mods, default true | POST sets `active: true` |
| D16 | PATCH toggle | `PATCH /api/st_mods/:id { active }` → flip + audit + WS op + flag-rollback-on-audit-failure |
| D17 | audit lifecycle event stream | `event ∈ {created, activated, deactivated, deleted}`; DELETE tombstone-before-destroy |
| D18 | WS op set widened | `create` / `activate` / `deactivate` / `delete`; `revoke` retired |
| D19 | backfill-independence | `active !== false` + `event ?? 'created'`; STM-13 ships backfill |
| D20 / Position B | mod docs deletable, ledger immutable | tombstone survives delete |

## Design choices documented for review

### 1. Audit field naming — dual-stamp (back-compat seam)

Rev 4 names the actor `by` and timestamp `at`. STM-6's audit reader (GET sort by `created_at`, admin page reading `created_by.discord_name`) is out of scope for STM-10 — STM-11 owns the audit-view migration. To keep the merged STM-6 surface working through the STM-10→STM-11 window, `buildAuditEvent` writes BOTH `by`/`at` (canonical Rev 4) AND `created_by`/`created_at` (back-compat aliases, identical values). STM-11 migrates the reader to `by`/`at` and drops the aliases.

### 2. Overlay filter is client-side

`applyStMods` skips `active === false`. The server GET (single + bulk) returns ALL mods so STM-11's audit view and STM-12's panel can show active + inactive. `active !== false` treats a missing field as active (D19 — pre-Rev4 docs compose normally without a backfill).

### 3. `revoke` retirement — grep clean

Per ADR Concerns #13, grep'd for `=== 'revoke'`. The WS op `'revoke'` existed only at the DELETE call site (→ `delete`), the STM-9 test (updated), and the JSDoc (widened). The panel's `data-stm-action="revoke"` / `action === 'revoke'` is a UI action label routing to DELETE — unrelated to the WS op string, untouched (STM-12 reworks the panel UI). The client `_handleStModMsg` is op-agnostic (refetches regardless), so retiring `revoke` doesn't break client handling.

### 4. PATCH rollback symmetry

If the activated/deactivated audit insert fails, the `active` flag is rolled back to its prior value (mirrors STM-1's create rollback). The ledger is the source of truth; a flag flip with no audit row would misrepresent history.

### 5. delta + reason captured at the event

PATCH/DELETE audit rows capture the mod's delta + reason at event time (not referenced live), so a later edit can't rewrite history — same principle as STM-8's DT snapshot.

## Acceptance criteria coverage

| AC | Status |
|----|--------|
| active stored, default true | ✅ |
| **HALT-DAR tombstone-before-destroy + rollback** | ✅ 2 explicit gates |
| PATCH deactivate (flip + audit + WS) | ✅ |
| PATCH activate (flip + audit + WS) | ✅ |
| POST writes `created` event | ✅ |
| overlay skips inactive | ✅ applyStMods filter |
| GET returns all mods | ✅ |
| audit GET full stream; legacy → `created` | ✅ |
| WS ops create/activate/deactivate/delete; revoke retired | ✅ |
| grep `=== 'revoke'` | ✅ none (WS op); STM-9 test updated |
| ≥5 vitest cases | ✅ 13 |
| no regression | ✅ 1053/1053 |

## Test plan

- [x] Parse-check touched modules
- [x] Full server suite: **1053/1053 passing** (gained 13 STM-10; STM-6 filter test updated for the tombstone row; STM-9 op assertion `revoke`→`delete`)
- [x] STM-10 suite: 13/13 incl. both tombstone gates
- [ ] Peter's smoke: create a mod (active) → deactivate (sheet reverts to base, mod still in panel) → reactivate (modded again) → delete-permanent (gone from list, audit shows the full created/deactivated/activated/deleted stream)

## Files

- **modified** `server/routes/st_mods.js` — `buildAuditEvent`; POST active+created; PATCH toggle; DELETE tombstone-before-destroy; audit GET event-default; DELETE op `revoke`→`delete`
- **modified** `server/ws.js` — `broadcastStModUpdate` JSDoc op-set widened
- **modified** `public/js/data/st-mods.js` — `applyStMods` skips inactive
- **new** `server/tests/stm-10-lifecycle.test.js` — 13 cases incl. tombstone gates
- **modified** `server/tests/stm-9-ws-broadcast.test.js` — DELETE op `revoke`→`delete`
- **modified** `server/tests/api-st-mods.test.js` — STM-6 filter total 3→4 (revoke writes tombstone)
- **new** `specs/stories/issue-434-stm-10-lifecycle-backend.story.md`

## Out of scope (next stories)

- STM-11 audit-view lifecycle stream display (+ migrate reader to by/at, drop created_* aliases)
- STM-12 panel UI: toggle / delete-permanent / filter / muted-inactive / reactivate-existing / soft-warn on inactive-path
- STM-13 idempotent backfill (active:true for pre-Rev4 mods)