### PR TITLE
STM-11: audit view migrates to lifecycle event stream (#439)

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -5834,19 +5834,37 @@ html:not([data-theme="dark"]) .char-picker__pill { font-weight: 600; }
 .stm-audit-row-reason { margin-top: 4px; color: var(--txt2); font-size: 12px; }
 .stm-audit-empty, .stm-audit-loading { padding: 18px; color: var(--txt3); font-style: italic; text-align: center; }
 
-.stm-badge {
+/* A deleted (tombstone) event row reads as terminal — dimmed, struck. */
+.stm-audit-row--deleted { opacity: .68; }
+.stm-audit-row--deleted .stm-audit-char,
+.stm-audit-row--deleted .stm-audit-path { text-decoration: line-through; }
+
+/* STM-11: per-event-type lifecycle badge. */
+.stm-ev-badge {
   font-size: 10px;
   letter-spacing: .5px;
   text-transform: uppercase;
   padding: 1px 8px;
   border-radius: 2px;
+  min-width: 78px;
+  text-align: center;
 }
-.stm-badge--active {
+.stm-ev--created {
+  background: var(--surf2);
+  color: var(--txt2);
+  border: 1px solid var(--bdr2);
+}
+.stm-ev--activated {
   background: var(--green2-4, rgba(110,160,90,.35));
   color: var(--green, #6EA05A);
   border: 1px solid var(--green, #6EA05A);
 }
-.stm-badge--revoked {
+.stm-ev--deactivated {
+  background: var(--surf);
+  color: var(--txt3);
+  border: 1px solid var(--bdr);
+}
+.stm-ev--deleted {
   background: var(--crim-a25, rgba(139,0,0,.25));
   color: var(--crim, #8B0000);
   border: 1px solid var(--crim, #8B0000);

--- a/public/js/admin/st-mods-audit.js
+++ b/public/js/admin/st-mods-audit.js
@@ -1,9 +1,12 @@
-/* ST Mods audit view (Epic STM, issue #379).
+/* ST Mods audit view (Epic STM, issue #379; lifecycle migration #439).
  *
- * Read-only paginated list of every st_mod_audit row, sorted newest first.
- * Filterable by character, ST (creator), and date range. Active/revoked
- * badge per row decided server-side via the GET /api/st_mod_audit
- * { active: bool } decoration.
+ * Read-only paginated lifecycle event stream, sorted newest first. Each
+ * row is an event — created / activated / deactivated / deleted — rendered
+ * with a distinct badge. STM-11 (issue #439) migrated this from the STM-6
+ * creation-rows-with-derived-revoked-marker model to the true event stream:
+ * reads canonical `by`/`at`/`event` fields (the server coalesces legacy
+ * created_by/created_at/missing-event for pre-STM-11 rows, so no dependence
+ * on STM-13's backfill). Filterable by character, ST, date range, and event.
  *
  * Delegated routing (per memory feedback_listener_routing_static_blind_spot):
  * filter dropdowns, date inputs, pagination buttons all listen via a single
@@ -19,13 +22,21 @@ import { esc, displayName, sortName } from '../data/helpers.js';
 
 const PAGE_SIZE = 50;
 
+// STM-11: per-event-type visual treatment + human label.
+const EVENT_META = {
+  created:     { label: 'Created',     cls: 'stm-ev--created' },
+  activated:   { label: 'Activated',   cls: 'stm-ev--activated' },
+  deactivated: { label: 'Deactivated', cls: 'stm-ev--deactivated' },
+  deleted:     { label: 'Deleted',     cls: 'stm-ev--deleted' },
+};
+
 // ── Module-level state ───────────────────────────────────────────────
 // Single render pass owns the displayed slice; filters mutate state then
 // trigger a refetch + repaint.
 const state = {
   characters: [], // {_id, name} pairs for the dropdown — populated lazily
   initialized: false,
-  filters: { character_id: '', st: '', from: '', to: '' },
+  filters: { character_id: '', st: '', from: '', to: '', event: '' },
   page: 1,
   total: 0,
   rows: [],
@@ -66,7 +77,7 @@ function renderScaffold() {
     <div class="stm-audit-root">
       <header class="stm-audit-head">
         <h2>ST Mods — Audit Log</h2>
-        <p class="stm-audit-sub">Every mod creation event, including revoked mods. Sorted newest first.</p>
+        <p class="stm-audit-sub">Full lifecycle event stream: creations, activations, deactivations, and deletions. Sorted newest first.</p>
       </header>
       <div class="stm-audit-filters" data-stm-filters>
         <label>Character
@@ -77,6 +88,15 @@ function renderScaffold() {
         <label>ST
           <select data-stm-filter="st">
             <option value="">All STs</option>
+          </select>
+        </label>
+        <label>Event
+          <select data-stm-filter="event">
+            <option value="">All events</option>
+            <option value="created">Created</option>
+            <option value="activated">Activated</option>
+            <option value="deactivated">Deactivated</option>
+            <option value="deleted">Deleted</option>
           </select>
         </label>
         <label>From
@@ -136,7 +156,7 @@ function _attachDelegatedHandlers(root) {
     if (!(t instanceof HTMLElement)) return;
     const action = t.dataset.stmAction;
     if (action === 'clear') {
-      state.filters = { character_id: '', st: '', from: '', to: '' };
+      state.filters = { character_id: '', st: '', from: '', to: '', event: '' };
       state.page = 1;
       // Reset the visible controls
       root.querySelectorAll('[data-stm-filter]').forEach(el => { el.value = ''; });
@@ -164,6 +184,7 @@ async function _refetchAndRender() {
   const qs = new URLSearchParams();
   if (state.filters.character_id) qs.set('character_id', state.filters.character_id);
   if (state.filters.st) qs.set('st', state.filters.st);
+  if (state.filters.event) qs.set('event', state.filters.event);
   if (state.filters.from) qs.set('from', state.filters.from);
   if (state.filters.to) qs.set('to', state.filters.to);
   qs.set('page', String(state.page));
@@ -178,7 +199,7 @@ async function _refetchAndRender() {
     // doesn't make the option disappear mid-session.
     const seen = new Set(state.stOptions);
     for (const r of state.rows) {
-      const n = r?.created_by?.discord_name;
+      const n = r?.by?.discord_name;
       if (n && !seen.has(n)) { seen.add(n); state.stOptions.push(n); }
     }
     state.stOptions.sort();
@@ -213,17 +234,19 @@ function _renderBody() {
   const rowsHtml = state.rows.map(r => {
     const charName = charNameMap.get(String(r.character_id)) || `Character ${r.character_id}`;
     const deltaSign = r.delta > 0 ? '+' : '';
-    const stName = r?.created_by?.discord_name || 'unknown';
-    const when = r.created_at ? r.created_at.replace('T', ' ').replace(/\..*$/, '') : '';
-    const badgeClass = r.active ? 'stm-badge--active' : 'stm-badge--revoked';
-    const badgeText = r.active ? 'active' : 'revoked';
+    const stName = r?.by?.discord_name || 'unknown';
+    const when = r.at ? r.at.replace('T', ' ').replace(/\..*$/, '') : '';
+    const meta = EVENT_META[r.event] || { label: r.event || 'event', cls: 'stm-ev--created' };
+    // A 'deleted' event is terminal — the mod no longer exists, so the
+    // current-active state of the doc is irrelevant; the row is the gravestone.
+    const eventClass = r.event === 'deleted' ? 'stm-audit-row--deleted' : '';
     return `
-      <article class="stm-audit-row">
+      <article class="stm-audit-row ${eventClass}">
         <div class="stm-audit-row-head">
+          <span class="stm-ev-badge ${meta.cls}">${esc(meta.label)}</span>
           <span class="stm-audit-char">${esc(charName)}</span>
           <span class="stm-audit-path">${esc(labelForPath(r.stat_path))}</span>
           <span class="stm-audit-delta">${esc(deltaSign + String(r.delta))}</span>
-          <span class="stm-badge ${badgeClass}">${badgeText}</span>
         </div>
         <div class="stm-audit-row-meta">
           <span>by ${esc(stName)}</span>

--- a/server/routes/st_mods.js
+++ b/server/routes/st_mods.js
@@ -82,16 +82,13 @@ function creatorFromUser(user) {
 }
 
 /** STM-10 (issue #434, ADR-004 Rev 4 §D17): build a lifecycle audit-event
- *  row. The audit collection is now an immutable event stream:
+ *  row. The audit collection is an immutable event stream:
  *  created / activated / deactivated / deleted.
  *
- *  Field naming: the Rev 4 schema names the actor `by` and the timestamp
- *  `at`. STM-6's existing audit reader (GET /api/st_mod_audit sort +
- *  the admin audit page) consumes `created_by` / `created_at`. To avoid
- *  breaking that surface during the STM-10 → STM-11 window (STM-11 owns
- *  the audit-view migration to the new names), this dual-stamps BOTH —
- *  same actor object + same timestamp string under both names. STM-11
- *  migrates the reader to by/at and drops the created_* aliases.
+ *  STM-11 (issue #439): `by` (actor) + `at` (timestamp) are now the ONLY
+ *  field names. The STM-10 dual-stamp aliases (`created_by`/`created_at`)
+ *  are dropped — the audit GET reader migrated to by/at (with an $ifNull
+ *  fallback to the legacy fields for pre-STM-11 rows already in the DB).
  *
  *  `mod` is the (possibly partial) mod doc: needs _id, character_id,
  *  stat_path, delta, reason. delta + reason are captured AT THE EVENT
@@ -106,9 +103,6 @@ function buildAuditEvent(mod, event, who, when) {
     event,
     by: who,
     at: when,
-    // Back-compat aliases (see JSDoc) — same values, STM-6 reader consumes these.
-    created_by: who,
-    created_at: when,
   };
 }
 
@@ -369,28 +363,37 @@ export default router;
 // stays clean (POST/GET/DELETE /api/st_mods + GET /api/st_mod_audit).
 //
 // STM-6 (issue #379): extended with optional filters + pagination.
-// Backwards-compatible breaking change in response shape: returns
-// { rows, total, page, page_size } wrapper instead of a bare array.
-// STM-2 had no consumer; the STM-6 admin page is the first consumer.
+// STM-11 (issue #439): migrated to the lifecycle event-stream shape.
+// Response: { rows, total, page, page_size }, each row carrying the
+// canonical `event` / `by` / `at` fields.
+//
+// Aggregation coalesces legacy pre-STM-11 rows (which carry
+// `created_by`/`created_at` and no `event`) into the canonical fields
+// via $ifNull, so the reader is uniform across old + new rows WITHOUT
+// depending on STM-13's backfill running first (ADR Rev 4 §D19):
+//   at    = at    ?? created_at
+//   by    = by    ?? created_by
+//   event = event ?? 'created'
 //
 // Query params (all optional):
 //   character_id — exact match
-//   st           — match against created_by.discord_name
-//   from / to    — ISO date range, inclusive, applied to created_at
+//   st           — match against by.discord_name (coalesced)
+//   event        — filter by event type (created/activated/deactivated/deleted)
+//   from / to    — ISO date range, inclusive, applied to at (coalesced)
 //   page         — 1-indexed (default 1)
 //   page_size    — default 50, clamped to [1, 100]
 //
 // Each returned row is decorated with { ...auditRow, active: <bool> }
 // where active === (st_mods document with _id === auditRow.st_mod_id exists).
-// The active lookup is batched into a single $in query — explicitly NOT
-// N+1 — per ADR §"Concerns" Item 2 sibling concern about query shape.
+// The active lookup is batched into a single $in query (not N+1).
 export const auditRouter = Router();
 
 const DEFAULT_PAGE_SIZE = 50;
 const MAX_PAGE_SIZE = 100;
+const AUDIT_EVENT_TYPES = ['created', 'activated', 'deactivated', 'deleted'];
 
 auditRouter.get('/', requireRole('st'), async (req, res) => {
-  const { character_id, st, from, to } = req.query;
+  const { character_id, st, from, to, event } = req.query;
 
   // Parse pagination — clamp to safe bounds. Bad input falls back to defaults
   // rather than 400, matching the "filters are optional" spirit.
@@ -400,28 +403,46 @@ auditRouter.get('/', requireRole('st'), async (req, res) => {
     Math.max(1, parseInt(req.query.page_size, 10) || DEFAULT_PAGE_SIZE),
   );
 
-  // Build the Mongo filter from non-empty params
-  const filter = {};
-  if (character_id) filter.character_id = String(character_id);
-  if (st) filter['created_by.discord_name'] = String(st);
+  // Coalesce legacy fields → canonical so old + new rows filter/sort uniformly.
+  const coalesce = {
+    $addFields: {
+      at: { $ifNull: ['$at', '$created_at'] },
+      by: { $ifNull: ['$by', '$created_by'] },
+      event: { $ifNull: ['$event', 'created'] },
+    },
+  };
+
+  // Build the post-coalesce match.
+  const match = {};
+  if (character_id) match.character_id = String(character_id);
+  if (st) match['by.discord_name'] = String(st);
+  if (event && AUDIT_EVENT_TYPES.includes(String(event))) match.event = String(event);
   if (from || to) {
-    filter.created_at = {};
-    if (from) filter.created_at.$gte = String(from);
-    if (to) filter.created_at.$lte = String(to);
+    match.at = {};
+    if (from) match.at.$gte = String(from);
+    if (to) match.at.$lte = String(to);
   }
 
-  const total = await audit().countDocuments(filter);
-  const rows = await audit()
-    .find(filter)
-    .sort({ created_at: -1 })
-    .skip((page - 1) * pageSize)
-    .limit(pageSize)
-    .toArray();
+  // Single aggregation: coalesce → match → facet { rows (sort/skip/limit), total }.
+  const agg = await audit().aggregate([
+    coalesce,
+    { $match: match },
+    {
+      $facet: {
+        rows: [
+          { $sort: { at: -1 } },
+          { $skip: (page - 1) * pageSize },
+          { $limit: pageSize },
+        ],
+        total: [{ $count: 'n' }],
+      },
+    },
+  ]).toArray();
 
-  // Batched active-check: one $in query against st_mods regardless of
-  // page size. Collect st_mod_ids from this page, find which still exist,
-  // map back to a boolean per row. Audit rows from a future writer that
-  // didn't populate st_mod_id (none today) safely default to inactive.
+  const rows = agg[0]?.rows || [];
+  const total = agg[0]?.total?.[0]?.n || 0;
+
+  // Batched active-check: one $in query against st_mods regardless of page size.
   const stModIds = rows.map(r => r.st_mod_id).filter(id => id != null);
   let aliveSet = new Set();
   if (stModIds.length) {
@@ -434,9 +455,6 @@ auditRouter.get('/', requireRole('st'), async (req, res) => {
   const decorated = rows.map(r => ({
     ...r,
     active: r.st_mod_id != null && aliveSet.has(String(r.st_mod_id)),
-    // STM-10 (§D19 backfill-independence): pre-Rev 4 audit rows have no
-    // `event` field — they were all creation rows, so default to 'created'.
-    event: r.event ?? 'created',
   }));
 
   res.json({ rows: decorated, total, page, page_size: pageSize });

--- a/server/tests/api-st-mods.test.js
+++ b/server/tests/api-st-mods.test.js
@@ -443,13 +443,17 @@ describe('STM-6 — GET /api/st_mod_audit filter + pagination + active decoratio
     expect(resB.body.rows.every(r => r.character_id === STM6_CHAR_B)).toBe(true);
   });
 
-  it('AC#4 — filter-by-st narrows on created_by.discord_name', async () => {
+  it('AC#4 — filter-by-st narrows on by.discord_name', async () => {
     const res = await request(app)
       .get('/api/st_mod_audit?st=Alice')
       .set('X-Test-User', stUser());
     expect(res.status).toBe(200);
-    expect(res.body.rows.every(r => r.created_by?.discord_name === 'Alice')).toBe(true);
-    // Alice has 3 audit rows
+    // STM-11: reader migrated to canonical `by`; server coalesces legacy
+    // created_by → by, so the filter + the returned field are both `by`.
+    expect(res.body.rows.every(r => r.by?.discord_name === 'Alice')).toBe(true);
+    // Alice authored 3 'created' events plus the 'deleted' tombstone on
+    // STM6_MOD_IDS[0] (the DELETE in setup is performed as the default ST
+    // user, NOT Alice), so filter-by-Alice yields exactly the 3 creations.
     expect(res.body.rows.filter(r => r.character_id === STM6_CHAR_A).length).toBe(3);
   });
 
@@ -505,12 +509,110 @@ describe('STM-6 — GET /api/st_mod_audit filter + pagination + active decoratio
     expect(res.body.page_size).toBe(100);
   });
 
-  it('sorts by created_at descending (newest first)', async () => {
+  it('sorts by at descending (newest first)', async () => {
     const res = await request(app)
       .get(`/api/st_mod_audit?character_id=${STM6_CHAR_A}`)
       .set('X-Test-User', stUser());
-    const timestamps = res.body.rows.map(r => r.created_at);
+    const timestamps = res.body.rows.map(r => r.at);
+    expect(timestamps.every(Boolean)).toBe(true);
     const sorted = [...timestamps].sort().reverse();
     expect(timestamps).toEqual(sorted);
+  });
+});
+
+// ── STM-11: lifecycle event-stream (issue #439) ──────────────────────
+// STM-6 surfaced creation rows with a derived revoked marker. STM-11 turns
+// the audit view into a true lifecycle stream: every create / activate /
+// deactivate / delete is its own row carrying canonical `by`/`at`/`event`,
+// and the reader coalesces legacy created_by/created_at/no-event rows so the
+// stream is uniform without depending on STM-13's backfill.
+describe('STM-11 — audit lifecycle event stream', () => {
+  const STM11_CHAR = new ObjectId().toHexString();
+  let MOD_ID;
+
+  beforeAll(async () => {
+    await getCollection('st_mods').deleteMany({ character_id: STM11_CHAR });
+    await getCollection('st_mod_audit').deleteMany({ character_id: STM11_CHAR });
+    // Create → deactivate → reactivate, producing created/deactivated/activated.
+    const createRes = await request(app)
+      .post('/api/st_mods')
+      .set('X-Test-User', stUser())
+      .send({ character_id: STM11_CHAR, stat_path: 'attributes.Stamina.dots', delta: 1, reason: 'lifecycle' });
+    MOD_ID = createRes.body._id;
+    await request(app).patch(`/api/st_mods/${MOD_ID}`).set('X-Test-User', stUser()).send({ active: false });
+    await request(app).patch(`/api/st_mods/${MOD_ID}`).set('X-Test-User', stUser()).send({ active: true });
+  });
+
+  afterAll(async () => {
+    await getCollection('st_mods').deleteMany({ character_id: STM11_CHAR });
+    await getCollection('st_mod_audit').deleteMany({ character_id: STM11_CHAR });
+  });
+
+  it('records a row per lifecycle event with canonical by/at/event fields', async () => {
+    const res = await request(app)
+      .get(`/api/st_mod_audit?character_id=${STM11_CHAR}`)
+      .set('X-Test-User', stUser());
+    expect(res.status).toBe(200);
+    expect(res.body.total).toBe(3);
+    const events = res.body.rows.map(r => r.event).sort();
+    expect(events).toEqual(['activated', 'created', 'deactivated']);
+    // Canonical fields populated on every row; legacy aliases gone.
+    expect(res.body.rows.every(r => r.by?.discord_name && r.at)).toBe(true);
+    expect(res.body.rows.every(r => r.created_by === undefined && r.created_at === undefined)).toBe(true);
+  });
+
+  it('filters by event type', async () => {
+    const res = await request(app)
+      .get(`/api/st_mod_audit?character_id=${STM11_CHAR}&event=deactivated`)
+      .set('X-Test-User', stUser());
+    expect(res.body.total).toBe(1);
+    expect(res.body.rows[0].event).toBe('deactivated');
+    expect(String(res.body.rows[0].st_mod_id)).toBe(String(MOD_ID));
+    // The mod was reactivated, so the live st_mods doc exists → active:true
+    // even on the historical 'deactivated' row (decoration reflects current
+    // doc state, not the event).
+    expect(res.body.rows[0].active).toBe(true);
+  });
+
+  it('ignores an unknown event filter value (returns full stream)', async () => {
+    const res = await request(app)
+      .get(`/api/st_mod_audit?character_id=${STM11_CHAR}&event=bogus`)
+      .set('X-Test-User', stUser());
+    expect(res.body.total).toBe(3);
+  });
+
+  it('coalesces legacy created_by/created_at/no-event rows into canonical fields', async () => {
+    const LEGACY_CHAR = new ObjectId().toHexString();
+    const legacyId = new ObjectId();
+    // Simulate a pre-STM-11 audit row: only created_by/created_at, no event.
+    await getCollection('st_mod_audit').insertOne({
+      st_mod_id: legacyId,
+      character_id: LEGACY_CHAR,
+      stat_path: 'attributes.Strength.dots',
+      delta: 2,
+      reason: 'legacy grant',
+      created_by: { discord_id: 'legacy-st', discord_name: 'LegacyST' },
+      created_at: '2026-01-01T00:00:00.000Z',
+    });
+    try {
+      const res = await request(app)
+        .get(`/api/st_mod_audit?character_id=${LEGACY_CHAR}`)
+        .set('X-Test-User', stUser());
+      expect(res.body.total).toBe(1);
+      const row = res.body.rows[0];
+      expect(row.event).toBe('created');
+      expect(row.by?.discord_name).toBe('LegacyST');
+      expect(row.at).toBe('2026-01-01T00:00:00.000Z');
+      // Legacy row's mod was never persisted → active:false.
+      expect(row.active).toBe(false);
+
+      // The coalesced `by` is also filterable + the coalesced `at` sortable.
+      const filtered = await request(app)
+        .get(`/api/st_mod_audit?character_id=${LEGACY_CHAR}&st=LegacyST`)
+        .set('X-Test-User', stUser());
+      expect(filtered.body.total).toBe(1);
+    } finally {
+      await getCollection('st_mod_audit').deleteMany({ character_id: LEGACY_CHAR });
+    }
   });
 });

--- a/server/tests/stm-10-lifecycle.test.js
+++ b/server/tests/stm-10-lifecycle.test.js
@@ -57,16 +57,18 @@ describe('STM-10 — POST sets active:true + writes created event', () => {
     expect(mod.active).toBe(true);
   });
 
-  it('audit row has event:created (+ by/at + back-compat created_by/created_at)', async () => {
+  it('audit row has event:created with canonical by/at and no legacy aliases', async () => {
     const mod = await createMod();
     const auditRow = await getCollection('st_mod_audit').findOne({ st_mod_id: new ObjectId(mod._id), event: 'created' });
     expect(auditRow).toBeTruthy();
     expect(auditRow.event).toBe('created');
     expect(auditRow.by).toMatchObject({ discord_id: 'test-st-001' });
     expect(typeof auditRow.at).toBe('string');
-    // Back-compat aliases for STM-6 reader
-    expect(auditRow.created_by).toMatchObject({ discord_id: 'test-st-001' });
-    expect(auditRow.created_at).toBe(auditRow.at);
+    // STM-11 (issue #439) closed the dual-stamp transition window: new rows
+    // write canonical by/at ONLY. The STM-6 reader was migrated to coalesce
+    // legacy created_by/created_at, so the write-side aliases are gone.
+    expect(auditRow.created_by).toBeUndefined();
+    expect(auditRow.created_at).toBeUndefined();
   });
 
   it('POST broadcasts create op', async () => {

--- a/specs/stories/issue-439-stm-11-audit-lifecycle-view.story.md
+++ b/specs/stories/issue-439-stm-11-audit-lifecycle-view.story.md
@@ -1,0 +1,72 @@
+# Issue #439: STM-11 — audit view migrates to lifecycle event stream (by/at canonical, drop dual-stamp aliases)
+
+Status: Ready for Review
+
+issue: 439
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/439
+branch: piatra/issue-439-stm-11-audit-lifecycle-view
+epic: STM (specs/epic-stm-st-mods.md)
+adr: ADR-004 Rev 4 §D16-D19 (specs/architecture/adr-004-st-mods-overlay.md)
+dispatch: PROCEED-WITH-NOTICE. Closes the STM-10 dual-stamp transition window while STM-10 is still in HEAD.
+
+## Story
+
+As a Storyteller,
+I want the ST Mods audit view to read as a true lifecycle event stream (created / activated / deactivated / deleted) rather than creation rows with a derived active-vs-revoked marker,
+so that every lifecycle event is individually accountable and visually distinct, and the transitional dual-stamp audit fields are retired in favour of the canonical `by` / `at` shape.
+
+## Decisions implemented (ADR-004 Rev 4 §D16-D19)
+
+- **D16/D17** — the audit reader consumes the lifecycle event stream directly. Each row is one event with its own per-event-type badge; the STM-6 active/revoked badge derived from st_mods doc-presence retires.
+- **Dual-stamp window closed** — `buildAuditEvent` drops the back-compat `created_by`/`created_at` aliases STM-10 wrote during the transition. New audit rows carry canonical `by`/`at`/`event` only.
+- **D19 backfill-independence** — the reader does not depend on STM-13 running first. The GET aggregation coalesces legacy rows (`created_by`/`created_at`, no `event`) into canonical fields via `$ifNull` (`at = at ?? created_at`, `by = by ?? created_by`, `event = event ?? 'created'`), so old and new rows filter/sort uniformly.
+
+## Tasks / Subtasks
+
+- [x] Task 1 — `buildAuditEvent`: drop `created_by`/`created_at` aliases; write `by`/`at`/`event` only.
+- [x] Task 2 — audit GET migrated to an aggregation pipeline: `$addFields` coalesce (legacy → canonical) → `$match` (character / by.discord_name / event / date-range on coalesced `at`) → `$facet` { rows: sort `at` desc + skip + limit, total: count }. Batched `$in` active-decoration preserved (not N+1).
+- [x] Task 3 — optional `event` filter param (created/activated/deactivated/deleted); unknown values ignored (full stream returned).
+- [x] Task 4 — client `st-mods-audit.js`: read `by.discord_name` + `at`; render per-event-type badge; deleted rows rendered as dimmed/struck tombstones; active/revoked badge retired; ST-dropdown built from `by.discord_name`.
+- [x] Task 5 — event-type filter affordance added to the filter bar (the recommended-but-optional AC item).
+- [x] Task 6 — CSS: retire `.stm-badge--active`/`--revoked` (unused, grep-confirmed); add `.stm-ev-badge` + per-event-type modifiers + `.stm-audit-row--deleted` tombstone treatment.
+- [x] Task 7 — tests: migrate stale `created_by`/`created_at` assertions to `by`/`at`; update the STM-10 created-event test (aliases now absent); add 4 new event-stream vitest cases.
+
+## Acceptance Criteria
+
+1. Rows render by `event` type with distinct treatment (created neutral / activated gold / deactivated muted / deleted tombstone) — ✅
+2. Sort defaults to `at` descending — ✅ (aggregation `$sort: { at: -1 }`)
+3. Row reads use `by.discord_name` + `at`; legacy `created_by`/`created_at` reads removed — ✅
+4. Backend writes drop dual-stamp aliases; legacy rows without `event` still readable (`event ?? 'created'`) — ✅
+5. Filter UI works against event-stream shape: ST → `by.discord_name`, date → `at`, plus new event-type filter — ✅
+6. Active/revoked badge retires; per-row event type replaces doc-presence derivation — ✅
+7. ≥3 new vitest cases (event-rendering shape, by/at-not-created_by/created_at, filter-by-event) — ✅ 4 added
+8. No regression — ✅ 1057/1057
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-7 (Ptah / DEV)
+
+### Completion Notes List
+
+- **Reader as aggregation, not find().** Coalescing legacy → canonical must happen BEFORE match/sort so that filter-by-ST, date-range, and sort all see one field regardless of row vintage. A plain `find()` can't `$ifNull`, so the endpoint moved to a `$addFields → $match → $facet` pipeline. `$facet` returns rows + total in one round-trip; total reads `agg[0].total[0].n` (empty result → 0).
+- **Active decoration kept, but no longer drives the badge.** The server still returns `active` (batched `$in` against st_mods presence) — cheap, and the STM-6 AC#6 test still asserts it. But the CLIENT no longer renders an active/revoked badge; each row's visual state now comes from its own `event` type. This is the cleaner realization of the AC ("read the event, not doc-presence"): every row IS an event, so per-row event rendering needs no most-recent-event lookup. `active` survives as decoration metadata, not display state.
+- **Deleted rows are gravestones.** A `deleted` event is terminal; the underlying mod no longer exists, so its current-active state is meaningless. The row is dimmed + struck (`.stm-audit-row--deleted`) and the badge reads "Deleted". The decoration `active:false` on these rows is incidental, not displayed.
+- **Event filter is forgiving.** Unknown `?event=` values are ignored (full stream returned) rather than 400 — matches the STM-6 "filters are optional" spirit; bad input never errors the page.
+- **Dual-stamp window closed in the right order.** STM-10's note said "STM-11 migrates the reader to by/at, then drops the alias writes." Done in that order within this branch: reader migrated (aggregation coalesce handles BOTH old alias-only legacy rows AND new canonical rows) FIRST, so dropping the write-side aliases in `buildAuditEvent` cannot strand the reader. The STM-10 created-event test that asserted the aliases were present is inverted to assert they are absent.
+- **CSS cleanup.** `.stm-badge`/`--active`/`--revoked` had no remaining consumers after the client migration (grep-confirmed across `public/js` + html) — removed rather than left as dead rules.
+- **Worktree pattern continued** (`/tmp/tm-ptah/stm-11`, node_modules symlinked from main for the test run).
+
+### File List
+
+- `server/routes/st_mods.js` (modified) — `buildAuditEvent` drops `created_by`/`created_at`; audit GET rewritten as coalesce → match → facet aggregation with event filter + `at`-desc sort, batched `$in` active-decoration preserved
+- `public/js/admin/st-mods-audit.js` (modified) — reads `by`/`at`; per-event-type badge render; deleted-tombstone rows; event-type filter affordance; ST-dropdown from `by.discord_name`
+- `public/css/components.css` (modified) — retired `.stm-badge*`; added `.stm-ev-badge` + per-event-type modifiers + `.stm-audit-row--deleted`
+- `server/tests/api-st-mods.test.js` (modified) — migrated `created_by`/`created_at` assertions to `by`/`at`; new STM-11 describe block (4 cases: event-stream shape, event filter, unknown-event-ignored, legacy coalesce)
+- `server/tests/stm-10-lifecycle.test.js` (modified) — created-event test inverted to assert aliases absent
+- `specs/stories/issue-439-stm-11-audit-lifecycle-view.story.md` — this file
+
+### Change Log
+
+- 2026-05-20 (Ptah): STM-11 audit lifecycle view migration


### PR DESCRIPTION
## Summary

STM-11 (issue #439, ADR-004 Rev 4 §D16-D19). Migrates the ST Mods audit **read** side from the STM-6 "creation rows + derived active/revoked marker" model to a true **lifecycle event stream**, and closes the STM-10 dual-stamp transition window.

- **`buildAuditEvent`** drops the transitional `created_by`/`created_at` aliases. New audit rows carry canonical `by` / `at` / `event` only.
- **Audit GET** rewritten as an aggregation: `$addFields` coalesce (`at = at ?? created_at`, `by = by ?? created_by`, `event = event ?? 'created'`) → `$match` → `$facet` { rows: sort `at` desc + page, total: count }. Coalesce runs **before** match/sort so legacy alias-only rows and new canonical rows filter/sort uniformly — no dependence on the STM-13 backfill (§D19). The batched `$in` active-decoration is preserved (not N+1). New optional `event` filter param.
- **Client `st-mods-audit.js`** reads `by.discord_name` + `at`; renders a per-event-type badge (created neutral / activated gold / deactivated muted / deleted tombstone); deleted rows are dimmed + struck; ST dropdown sourced from `by.discord_name`; event-type filter affordance added.
- **CSS** retires the now-unused `.stm-badge*` rules (grep-confirmed no consumers); adds `.stm-ev-badge` + per-event modifiers + `.stm-audit-row--deleted`.

## Design notes

- **Active decoration kept, but no longer the badge.** Server still returns `active` (cheap batched `$in`, still asserted by STM-6 AC#6), but the UI badge now comes from each row's own `event` — every row IS an event, so no most-recent-event lookup is needed. This is the cleaner reading of the AC's "read the event, not doc-presence."
- **Window closed in the correct order.** Reader migrated first (the coalesce handles BOTH legacy and canonical shapes), THEN the write-side aliases dropped — so dropping the aliases can't strand the reader. The STM-10 test that asserted the aliases were present is inverted to assert they are absent.
- **Forgiving event filter.** Unknown `?event=` values are ignored (full stream returned), matching the STM-6 "filters are optional" spirit.

## Tests

- Migrated the two stale audit assertions (`created_by`→`by`, `created_at`→`at`).
- Inverted the STM-10 created-event test to assert the aliases are gone.
- +4 new STM-11 cases: per-event-type stream shape, event filter, unknown-event-ignored, and legacy-row coalesce (raw-inserted `created_by`/`created_at`/no-`event` row surfaces with populated `by`/`at`/`event` and is filterable/sortable).
- **1057/1057 pass.** No regression.

## Test plan

- [ ] Admin → ST Mods → Audit Log: create, deactivate, reactivate, delete a mod; confirm four distinctly-badged rows appear newest-first.
- [ ] Deleted row renders as a dimmed/struck tombstone.
- [ ] Filter by ST, by date range, and by event type each narrow correctly; Clear resets all four.
- [ ] Pre-STM-11 audit rows (if any in dev DB) still render with creator + timestamp.

Closes #439