### PR TITLE
STM-13: idempotent active:true backfill script (#441)

### DIFF
--- a/server/scripts/stm-13-backfill-active.js
+++ b/server/scripts/stm-13-backfill-active.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+/**
+ * STM-13 (issue #441, ADR-004 Rev 4 §D19) — idempotent cleanliness backfill.
+ *
+ * Sets `active: true` on every pre-Rev 4 `st_mods` document that lacks the
+ * field. Correctness does NOT depend on this running — the live query uses
+ * `active !== false` and the audit reader uses `event ?? 'created'`, so
+ * pre-Rev 4 docs already behave correctly. This script is purely cosmetic:
+ * it makes the stored shape uniform so the DB matches the Rev 4 schema.
+ *
+ * Shipped separately from STM-10's lifecycle backend (Imhotep's discipline)
+ * so it is independently revertible: if the backfill surfaces an issue it can
+ * be rolled back without disturbing the merged lifecycle logic.
+ *
+ * IDEMPOTENT — the filter is `{ active: { $exists: false } }`, so a second
+ * run matches zero documents and updates nothing.
+ *
+ * WRITES ARE LIVE BY DEFAULT. Pass --dry-run to preview without writing.
+ *
+ * Usage:
+ *   # preview first (no writes):
+ *   node server/scripts/stm-13-backfill-active.js --dry-run
+ *   # then apply (writes active:true to st_mods):
+ *   node server/scripts/stm-13-backfill-active.js
+ *   # also backfill the audit event field (event ?? 'created') on legacy rows:
+ *   node server/scripts/stm-13-backfill-active.js --audit
+ *   node server/scripts/stm-13-backfill-active.js --audit --dry-run
+ *
+ * Production (Render one-off shell): run the exact command above against the
+ * Render service shell — the script reads MONGODB_URI from the environment,
+ * so no code modification is needed to point it at Atlas.
+ */
+
+// Load env before db.js/config.js resolve MONGODB_URI. Locally, run from the
+// server/ dir so this picks up server/.env; on Render the env vars are already
+// set in the process, so this is a no-op there.
+import 'dotenv/config';
+import { pathToFileURL } from 'url';
+import { connectDb, getCollection, closeDb } from '../db.js';
+
+/**
+ * Backfill a single collection: $set the given field on docs that lack it.
+ * Idempotent — the filter targets only missing-field docs, so a second run
+ * matches zero. Returns { scanned, updated, skipped }.
+ *
+ * @param {string} collName
+ * @param {object} missingFilter — selects docs lacking the field, e.g. { active: { $exists: false } }
+ * @param {object} setDoc — the $set payload, e.g. { active: true }
+ * @param {{ dryRun?: boolean, log?: boolean }} [opts]
+ */
+export async function backfill(collName, missingFilter, setDoc, opts = {}) {
+  const { dryRun = false, log = true } = opts;
+  const coll = getCollection(collName);
+  const scanned = await coll.countDocuments({});
+  const needing = await coll.countDocuments(missingFilter);
+  const skipped = scanned - needing;
+
+  let updated = 0;
+  if (dryRun) {
+    updated = needing; // would-update count
+  } else if (needing > 0) {
+    const res = await coll.updateMany(missingFilter, { $set: setDoc });
+    updated = res.modifiedCount;
+  }
+
+  if (log) {
+    const verb = dryRun ? '[DRY RUN] would update' : 'updated';
+    console.log(
+      `  ${collName}: scanned ${scanned}, ${verb} ${updated}, ` +
+      `skipped ${skipped} (field already present)`,
+    );
+  }
+  return { scanned, updated, skipped };
+}
+
+export async function main({ dryRun, withAudit } = {}) {
+  const t0 = Date.now();
+  console.log(`Mode: ${dryRun ? 'DRY RUN (read only)' : 'LIVE (writing)'}`);
+  console.log(`Targets: st_mods${withAudit ? ' + st_mod_audit' : ''}\n`);
+
+  await connectDb();
+  try {
+    await backfill('st_mods', { active: { $exists: false } }, { active: true }, { dryRun });
+
+    if (withAudit) {
+      // Pre-Rev 4 audit rows were all creation rows (no lifecycle events
+      // existed yet), so the canonical event for a missing field is 'created'
+      // (matches the reader's `event ?? 'created'` default, §D19).
+      await backfill('st_mod_audit', { event: { $exists: false } }, { event: 'created' }, { dryRun });
+    }
+  } finally {
+    await closeDb();
+  }
+
+  console.log(`\nDone in ${((Date.now() - t0) / 1000).toFixed(2)}s.`);
+}
+
+// Auto-run only when invoked directly (not when imported by a test).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main({
+    dryRun: process.argv.includes('--dry-run'),
+    withAudit: process.argv.includes('--audit'),
+  }).catch(err => { console.error(err); process.exit(1); });
+}

--- a/server/tests/stm-13-backfill.test.js
+++ b/server/tests/stm-13-backfill.test.js
@@ -1,0 +1,97 @@
+/**
+ * STM-13 (issue #441) — idempotent active:true backfill script.
+ *
+ * Exercises the exported `backfill()` helper from
+ * server/scripts/stm-13-backfill-active.js against the test DB. Filters are
+ * scoped to a per-test character_id so the assertions stay deterministic even
+ * when other test files run in parallel and mutate the shared st_mods /
+ * st_mod_audit collections.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ObjectId } from 'mongodb';
+import { setupDb, teardownDb } from './helpers/db-setup.js';
+import { getCollection } from '../db.js';
+import { backfill } from '../scripts/stm-13-backfill-active.js';
+
+const CHAR = new ObjectId().toHexString();
+const MISSING = { character_id: CHAR, active: { $exists: false } };
+
+beforeAll(async () => {
+  await setupDb();
+  await getCollection('st_mods').deleteMany({ character_id: CHAR });
+  await getCollection('st_mod_audit').deleteMany({ character_id: CHAR });
+});
+
+afterAll(async () => {
+  await getCollection('st_mods').deleteMany({ character_id: CHAR });
+  await getCollection('st_mod_audit').deleteMany({ character_id: CHAR });
+  await teardownDb();
+});
+
+describe('STM-13 — st_mods active backfill', () => {
+  it('sets active:true on missing-field docs, leaves explicit active untouched', async () => {
+    const mods = getCollection('st_mods');
+    await mods.insertMany([
+      // pre-Rev 4: no active field
+      { character_id: CHAR, stat_path: 'attributes.Strength.dots', delta: 1 },
+      { character_id: CHAR, stat_path: 'attributes.Wits.dots', delta: 1 },
+      // already migrated
+      { character_id: CHAR, stat_path: 'attributes.Stamina.dots', delta: 1, active: true },
+      // explicitly deactivated — must NOT be flipped to true
+      { character_id: CHAR, stat_path: 'attributes.Resolve.dots', delta: 1, active: false },
+    ]);
+
+    const res = await backfill('st_mods', MISSING, { active: true }, { log: false });
+    expect(res.updated).toBe(2);
+
+    // The two legacy docs are now active:true; the explicit false survives.
+    const missingAfter = await mods.countDocuments(MISSING);
+    expect(missingAfter).toBe(0);
+    const stillFalse = await mods.countDocuments({ character_id: CHAR, active: false });
+    expect(stillFalse).toBe(1);
+    const nowTrue = await mods.countDocuments({ character_id: CHAR, active: true });
+    expect(nowTrue).toBe(3); // 2 backfilled + 1 pre-existing
+  });
+
+  it('is idempotent — a second run updates zero', async () => {
+    const res = await backfill('st_mods', MISSING, { active: true }, { log: false });
+    expect(res.updated).toBe(0);
+  });
+
+  it('--dry-run reports the would-update count without writing', async () => {
+    const mods = getCollection('st_mods');
+    await mods.insertOne({ character_id: CHAR, stat_path: 'attributes.Dexterity.dots', delta: 1 });
+
+    const res = await backfill('st_mods', MISSING, { active: true }, { dryRun: true, log: false });
+    expect(res.updated).toBe(1);            // would update the one new legacy doc
+    expect(await mods.countDocuments(MISSING)).toBe(1); // but it was NOT written
+
+    // a real run then clears it
+    const live = await backfill('st_mods', MISSING, { active: true }, { log: false });
+    expect(live.updated).toBe(1);
+    expect(await mods.countDocuments(MISSING)).toBe(0);
+  });
+});
+
+describe('STM-13 — st_mod_audit event backfill (--audit)', () => {
+  const AUDIT_MISSING = { character_id: CHAR, event: { $exists: false } };
+
+  it('sets event:created on legacy rows lacking the field', async () => {
+    const audit = getCollection('st_mod_audit');
+    await audit.insertMany([
+      { character_id: CHAR, stat_path: 'attributes.Strength.dots', delta: 1, created_at: '2026-01-01T00:00:00.000Z' },
+      { character_id: CHAR, stat_path: 'attributes.Wits.dots', delta: 1, event: 'created' }, // already has event
+    ]);
+
+    const res = await backfill('st_mod_audit', AUDIT_MISSING, { event: 'created' }, { log: false });
+    expect(res.updated).toBe(1);
+    expect(await audit.countDocuments(AUDIT_MISSING)).toBe(0);
+    expect(await audit.countDocuments({ character_id: CHAR, event: 'created' })).toBe(2);
+  });
+
+  it('is idempotent — a second audit run updates zero', async () => {
+    const res = await backfill('st_mod_audit', AUDIT_MISSING, { event: 'created' }, { log: false });
+    expect(res.updated).toBe(0);
+  });
+});

--- a/specs/stories/issue-441-stm-13-backfill-active.story.md
+++ b/specs/stories/issue-441-stm-13-backfill-active.story.md
@@ -1,0 +1,67 @@
+# Issue #441: STM-13 — idempotent backfill (active:true on pre-Rev 4 mods, separately revertible)
+
+Status: Ready for Review
+
+issue: 441
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/441
+branch: piatra/issue-441-stm-13-backfill-active
+epic: STM (specs/epic-stm-st-mods.md)
+adr: ADR-004 Rev 4 §D19 (specs/architecture/adr-004-st-mods-overlay.md)
+dispatch: PROCEED-WITH-NOTICE. Separately revertible per Imhotep's discipline — does NOT bundle into STM-10.
+
+## Story
+
+As a Storyteller / operator,
+I want an idempotent, dry-runnable script that stamps `active: true` on pre-Rev 4 st_mods documents lacking the field,
+so that the stored data shape matches the Rev 4 schema for cleanliness, without the lifecycle backend's correctness ever depending on the backfill having run.
+
+## Decisions implemented (ADR-004 Rev 4 §D19)
+
+- **Backfill-independence.** Correctness is already guaranteed without this script (the live query uses `active !== false`, the audit reader uses `event ?? 'created'`). This backfill is purely cosmetic — it makes the stored shape uniform.
+- **Separately revertible.** Shipped as a standalone script, not bundled into STM-10's backend, so a problem with the backfill can be rolled back without disturbing the merged lifecycle logic.
+
+## Tasks / Subtasks
+
+- [x] Task 1 — `server/scripts/stm-13-backfill-active.js`: connect via the db.js pattern (`connectDb` / `getCollection` / `closeDb`, which carry the Atlas ssl-strip + tls config). `$set: { active: true }` on `{ active: { $exists: false } }`.
+- [x] Task 2 — idempotency: the filter targets only missing-field docs, so a second run matches zero. Verified by test.
+- [x] Task 3 — `--dry-run` flag: counts the would-update set, writes nothing. Default is LIVE (writes), per the issue (run `--dry-run` first to preview).
+- [x] Task 4 — logging: scanned, updated (or would-update), skipped (field already present), elapsed time.
+- [x] Task 5 — optional `--audit` flag: sibling backfill for `st_mod_audit` rows lacking `event` (`$set: { event: 'created' }`, matching the reader's §D19 default). Same idempotency + dry-run shape. Kept in-file behind an opt-in flag so the default run stays narrow (st_mods only).
+- [x] Task 6 — Render-invocable without code edits: env comes from the process (Render env vars) or `server/.env` when run locally from `server/`. `import 'dotenv/config'` loads the latter before config.js resolves the URI.
+- [x] Task 7 — vitest coverage (exported `backfill()` helper; auto-run guarded by an `import.meta.url === argv[1]` entry-point check so importing the module in a test does not connect/exit).
+
+## Acceptance Criteria
+
+1. Script exists and runs against MongoDB Atlas — ✅ (dry-run executed end-to-end against the real connection)
+2. No-arg run writes `active: true` to pre-Rev 4 mods; idempotent (second run = 0) — ✅ test
+3. `--dry-run` identifies the same set, skips writes — ✅ test
+4. Logs scanned / updated / skipped / elapsed — ✅
+5. Render one-off shell invocable without code modification — ✅ (env from process; dotenv no-ops when the file is absent)
+6. No regression — ✅ 1058/1058 (1053 base + 5 new; base predates the STM-11 merge — STM-13 touches disjoint files)
+7. Optional audit event-field backfill — ✅ `--audit` flag, mirrored idempotency + dry-run
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-7 (Ptah / DEV)
+
+### Completion Notes List
+
+- **Dry-run default is OFF (writes live), per the issue** — opposite of some older repo scripts that default to dry-run + require `--apply`. The issue explicitly specifies live-by-default with `--dry-run` to preview, so the script header tells the operator to run `--dry-run` first.
+- **db.js reuse vs the cwd-relative dotenv convention.** The issue asked to mirror `server/db.js`'s connection pattern — `connectDb()` carries the legacy-`ssl=`-strip + `tls: true` Atlas handling that the bare-`MongoClient` scripts re-implement ad hoc, so reusing it is the more faithful + correct choice. But config.js resolves its `.env` at the repo root, whereas the env file lives at `server/.env`; the established scripts load env cwd-relative via `import 'dotenv/config'` (run from `server/`). I added `import 'dotenv/config'` as the FIRST import so, run locally from `server/`, it populates `process.env.MONGODB_URI` from `server/.env` before config.js reads it (dotenv never overwrites an already-set var). On Render the env vars are pre-set, so the dotenv load is a harmless no-op.
+- **Entry-point guard for testability.** The script exports `backfill()` and `main()` and only auto-runs `main()` when invoked directly (`import.meta.url === pathToFileURL(process.argv[1]).href`). This lets the vitest suite import and exercise `backfill()` without triggering a real connect + `process.exit`.
+- **Test isolation under serial-but-shared DB.** vitest runs integration files serially against a shared `tm_suite_test` connection, but other files mutate `st_mods` / `st_mod_audit`. The test scopes its filters to a per-test `character_id` so `updated`/`skipped` assertions are deterministic regardless of concurrent residue.
+- **Explicit `active: false` is never flipped.** The filter is `{ $exists: false }`, so a deliberately-deactivated mod is left alone — only truly field-less (pre-Rev 4) docs are touched. Asserted in the test.
+- **Verified live (read-only).** Ran `--dry-run --audit` against a real Mongo connection end-to-end (connect → count → report → close) to confirm the connection pattern works; no writes performed. The actual production run is Peter-triggered post-merge (out of scope).
+- **Worktree pattern continued** (`/tmp/tm-ptah/stm-13`, node_modules + server/.env symlinked from main).
+
+### File List
+
+- `server/scripts/stm-13-backfill-active.js` (new) — idempotent active:true backfill; `--dry-run` + optional `--audit`; exported `backfill()`/`main()` with entry-point guard
+- `server/tests/stm-13-backfill.test.js` (new) — 5 vitest cases: backfill correctness, explicit-false untouched, idempotency, dry-run, audit event backfill + its idempotency
+- `specs/stories/issue-441-stm-13-backfill-active.story.md` — this file
+
+### Change Log
+
+- 2026-05-20 (Ptah): STM-13 idempotent backfill script


### PR DESCRIPTION
## Summary

STM-13 (issue #441, ADR-004 Rev 4 §D19). Ships a standalone, idempotent cleanliness backfill: `server/scripts/stm-13-backfill-active.js` stamps `active: true` on pre-Rev 4 `st_mods` documents that lack the field.

Correctness never depends on this running — the live query uses `active !== false` and the audit reader uses `event ?? 'created'`, so pre-Rev 4 docs already behave correctly. This only makes the stored shape uniform. Shipped standalone (not bundled into STM-10) so it is **independently revertible**.

- **Idempotent** — the filter is `{ active: { $exists: false } }`, so a second run matches zero. An explicit `active: false` is never flipped to true.
- **Writes live by default**; `--dry-run` previews (counts the would-update set, writes nothing). Run `--dry-run` first.
- **Optional `--audit`** — sibling backfill for `st_mod_audit` rows lacking `event` (`$set: { event: 'created' }`), same idempotency + dry-run shape. In-file behind an opt-in flag so the default run stays narrow (st_mods only).

## Design notes

- **Reuses `db.js` `connectDb()`** rather than a bare `MongoClient` — it carries the Atlas legacy-`ssl=`-strip + `tls: true` handling that the older scripts re-implement ad hoc. `import 'dotenv/config'` is the first import so a local run from `server/` populates `MONGODB_URI` from `server/.env` before config.js resolves it; on Render the env vars are pre-set, so it is a no-op there (AC: Render-invocable without code edits).
- **Entry-point guard** — exports `backfill()` / `main()` and only auto-runs `main()` when invoked directly (`import.meta.url === pathToFileURL(process.argv[1]).href`), so the test can import and exercise `backfill()` without connecting or calling `process.exit`.
- **Verified live (read-only)** — ran `--dry-run --audit` end-to-end against a real Mongo connection (connect → count → report → close); no writes. The actual production run is Peter-triggered post-merge (out of scope).

## Tests

5 vitest cases against the real test DB (`tm_suite_test`), filters scoped to a per-test `character_id` for determinism under the shared serial connection:
- backfill sets `active:true` on missing-field docs; explicit `active:false` untouched; pre-existing `active:true` untouched
- idempotency — second run updates zero
- `--dry-run` reports the count without writing
- audit event backfill + its idempotency

**1058/1058 pass** (1053 base + 5 new; this base predates the STM-11 merge — STM-13 touches disjoint files).

## Test plan

- [ ] `cd server && node scripts/stm-13-backfill-active.js --dry-run` against staging — confirm scanned/would-update counts look right.
- [ ] Run live, then re-run — second run reports `updated 0` (idempotent).
- [ ] `--audit --dry-run` previews the `st_mod_audit` event backfill.

Closes #441