### PR TITLE
STM-12: panel lifecycle UI (filter / muted-inactive / reactivate / soft-warn) (#440)

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -5750,19 +5750,95 @@ html:not([data-theme="dark"]) .char-picker__pill { font-weight: 600; }
   letter-spacing: .5px;
   text-transform: uppercase;
 }
-.stm-mod-revoke {
+.stm-mod-glyph { color: var(--gold2); font-size: 12px; line-height: 1; }
+.stm-mod-actions { display: flex; gap: 6px; }
+.stm-mod-btn {
   padding: 4px 10px;
   background: transparent;
-  border: 1px solid var(--crim, #8B0000);
-  color: var(--crim, #8B0000);
+  border: 1px solid var(--bdr2);
+  color: var(--txt2);
   border-radius: 3px;
   font-size: 11px;
   cursor: pointer;
 }
-.stm-mod-revoke:hover { background: var(--crim, #8B0000); color: var(--txt-on-dark, #fff); }
+.stm-mod-btn:hover { background: var(--surf3, var(--surf2)); color: var(--txt); }
+.stm-mod-btn--reactivate { border-color: var(--green, #6EA05A); color: var(--green, #6EA05A); }
+.stm-mod-btn--reactivate:hover { background: var(--green, #6EA05A); color: var(--txt-on-dark, #fff); }
+.stm-mod-btn--delete { border-color: var(--crim, #8B0000); color: var(--crim, #8B0000); }
+.stm-mod-btn--delete:hover { background: var(--crim, #8B0000); color: var(--txt-on-dark, #fff); }
 .stm-mod-reason { margin: 4px 0 2px; color: var(--txt2); font-size: 12px; }
 .stm-mod-meta { font-size: 11px; color: var(--txt3); margin: 0; }
 .stm-list-empty { color: var(--txt3); font-style: italic; }
+
+/* — STM-12 lifecycle: filter bar, inactive (muted) group, modal, banner — */
+.stm-list-group { margin-bottom: 14px; }
+.stm-list-group h3 { margin: 6px 0; }
+.stm-list-filters { display: flex; gap: 8px; margin: 4px 0 10px; }
+.stm-view-btn {
+  padding: 4px 12px;
+  background: transparent;
+  border: 1px solid var(--bdr2);
+  color: var(--txt3);
+  border-radius: 3px;
+  font-size: 12px;
+  cursor: pointer;
+}
+.stm-view-btn:hover { color: var(--txt); }
+.stm-view-btn.is-active { background: var(--gold2-a25, rgba(122,82,8,.25)); color: var(--gold2); border-color: var(--gold2); }
+
+/* Inactive rows render muted: no gold border-glow, dimmed, outline glyph. */
+.stm-mod-row--inactive {
+  border-left-color: var(--bdr2);
+  opacity: .6;
+}
+.stm-mod-row--inactive .stm-mod-glyph,
+.stm-mod-row--inactive .stm-mod-delta { color: var(--txt3); }
+.stm-list-group--inactive > h3 { color: var(--txt3); }
+
+/* Soft-duplicate (dormant) warning banner. */
+.stm-dormant-banner {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 8px 0;
+  padding: 8px 12px;
+  background: var(--gold2-a25, rgba(122,82,8,.18));
+  border: 1px solid var(--gold2);
+  border-radius: 3px;
+}
+.stm-dormant-text { flex: 1; color: var(--txt); font-size: 12px; }
+.stm-dormant-dismiss {
+  background: transparent;
+  border: none;
+  color: var(--txt3);
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+.stm-dormant-dismiss:hover { color: var(--txt); }
+
+/* Delete confirmation modal. */
+.stm-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+.stm-modal {
+  background: var(--surf2);
+  border: 1px solid var(--bdr2);
+  border-radius: 4px;
+  padding: 20px 24px;
+  max-width: 440px;
+  width: calc(100% - 48px);
+}
+.stm-modal h3 { margin: 0 0 10px; color: var(--crim, #8B0000); font-family: var(--fh); }
+.stm-modal p { color: var(--txt2); font-size: 13px; margin: 6px 0; }
+.stm-modal-note { color: var(--txt3); font-size: 12px; }
+.stm-modal-actions { display: flex; gap: 10px; justify-content: flex-end; margin-top: 16px; }
 
 /* — STM-6 audit page polish (issue #379 styling) — */
 .stm-audit-root { padding: 18px 24px; font-family: var(--fl); color: var(--txt); }

--- a/public/js/admin/st-mods-panel-logic.js
+++ b/public/js/admin/st-mods-panel-logic.js
@@ -1,0 +1,47 @@
+/* ST Mods panel — pure logic helpers (Epic STM, STM-12 issue #440).
+ *
+ * Extracted from st-mods-panel.js so they carry NO browser-only imports
+ * (no window/location/api), which lets vitest import + unit-test them
+ * directly in Node. The panel imports these for partitioning, filtering,
+ * and the soft-duplicate (dormant) match.
+ *
+ * Active semantics (ADR-004 Rev 4 §D15/D19): a mod is active unless its
+ * `active` field is explicitly false. A missing field (pre-Rev 4 doc) is
+ * treated as active.
+ */
+
+export function isActive(m) {
+  return !!m && m.active !== false;
+}
+
+/** Split mods into { active, inactive }, preserving input order within each. */
+export function partitionMods(mods) {
+  const active = [];
+  const inactive = [];
+  for (const m of mods || []) {
+    (isActive(m) ? active : inactive).push(m);
+  }
+  return { active, inactive };
+}
+
+/** Apply the panel's view filter. view ∈ {'all','active','inactive'}. */
+export function filterMods(mods, view) {
+  const { active, inactive } = partitionMods(mods);
+  if (view === 'active') return { active, inactive: [] };
+  if (view === 'inactive') return { active: [], inactive };
+  return { active, inactive };
+}
+
+/**
+ * Soft-duplicate match for the create form (load-bearing AC, STM-12).
+ *
+ * Returns the first INACTIVE mod on this character whose stat_path equals
+ * the form's path, or null. Active-path matches return null on purpose:
+ * stacking multiple active mods on one path is by design (ADR Rev 1 §D4),
+ * so the create form must stay silent for them. The warning only nudges
+ * the ST to reactivate a dormant mod instead of creating a near-duplicate.
+ */
+export function findDormantMatch(mods, statPath) {
+  if (!statPath) return null;
+  return (mods || []).find(m => !isActive(m) && m.stat_path === statPath) || null;
+}

--- a/public/js/admin/st-mods-panel.js
+++ b/public/js/admin/st-mods-panel.js
@@ -1,15 +1,24 @@
-/* ST Mods admin panel (Epic STM, issue #386).
+/* ST Mods admin panel (Epic STM, issue #386; lifecycle UI #440).
  *
  * Per-character workbench: header + global kill-switch toggle +
- * per-character override toggle + create form + active-mods list with
- * revoke buttons. Consumes STM-1 (POST/GET/DELETE /api/st_mods),
- * STM-3 (/api/settings, /api/characters/:id/st_mods_suppressed),
- * and STM-6's label helper + categorised dropdown structure.
+ * per-character override toggle + create form + a lifecycle mod list.
+ * STM-12 (issue #440) evolves the list from "active mods + revoke" into
+ * an active/inactive lifecycle view: active mods (Deactivate/Delete) and
+ * a visually-muted inactive group (Reactivate/Delete), an All/Active/
+ * Inactive filter, a delete-confirmation modal with tombstone copy, and
+ * a soft-duplicate warning that fires only when the create form's path
+ * matches an INACTIVE mod (active-path stacking stays silent per Rev 1 §D4).
+ *
+ * Consumes STM-1/STM-10 (POST/GET/PATCH/DELETE /api/st_mods), STM-3
+ * (/api/settings, /api/characters/:id/st_mods_suppressed), STM-6's label
+ * helper + categorised dropdown, and the pure helpers in
+ * st-mods-panel-logic.js.
  *
  * Delegated event routing throughout (per memory
  * feedback_listener_routing_static_blind_spot):
- *   - one `change` listener for filter inputs + toggles
- *   - one `click` listener for buttons (Save, Revoke, etc.)
+ *   - one `change` listener for filter inputs + toggles + form fields
+ *   - one `click` listener for buttons (Save, Deactivate, Reactivate,
+ *     Delete, filter views, modal confirm/cancel, dormant reactivate)
  * dispatching on data-stm-* attributes.
  */
 
@@ -21,17 +30,21 @@ import {
   getGlobalSettings,
   loadGlobalSettings,
 } from '../data/app-settings.js';
+import { partitionMods, filterMods, findDormantMatch } from './st-mods-panel-logic.js';
 
 // Module-level state for the active panel.
 const state = {
   character: null,
-  mods: [],          // GET /api/st_mods rows for active character
+  mods: [],          // GET /api/st_mods rows for active character (active + inactive)
+  view: 'all',       // list filter: 'all' | 'active' | 'inactive'
   form: {
     stat_path: '',
     delta: 1,
     reason: '',
     show_reason_to_player: false,
   },
+  dormantDismissedPath: null, // path the ST dismissed the dormant banner for
+  pendingDelete: null,        // mod id awaiting delete confirmation (modal open)
   error: null,
   saving: false,
   loading: false,
@@ -64,6 +77,9 @@ export async function initStModsPanel(rootEl, character, onMutate) {
   state.form.delta = 1;
   state.form.reason = '';
   state.form.show_reason_to_player = false;
+  state.view = 'all';
+  state.dormantDismissedPath = null;
+  state.pendingDelete = null;
   state.error = null;
 
   if (!state.initialized) {
@@ -130,6 +146,7 @@ function _renderScaffold() {
             Show reason to player
           </label>
         </div>
+        <div class="stm-dormant-banner-slot" data-stm-dormant-banner>${_renderDormantBanner()}</div>
         <div class="stm-form-actions">
           <button data-stm-action="save" ${state.saving ? 'disabled' : ''}>Save mod</button>
           ${state.error ? `<span class="stm-form-error">${esc(state.error)}</span>` : ''}
@@ -137,41 +154,128 @@ function _renderScaffold() {
       </section>
 
       <section class="stm-panel-list">
-        <h3>Active mods</h3>
+        <div class="stm-list-filters" data-stm-filters>
+          <button data-stm-view="all" class="stm-view-btn ${state.view === 'all' ? 'is-active' : ''}">All</button>
+          <button data-stm-view="active" class="stm-view-btn ${state.view === 'active' ? 'is-active' : ''}">Active only</button>
+          <button data-stm-view="inactive" class="stm-view-btn ${state.view === 'inactive' ? 'is-active' : ''}">Inactive only</button>
+        </div>
         <div class="stm-list-body" data-stm-list-body>
-          ${state.loading ? '<p>Loading…</p>' : _renderModRows()}
+          ${state.loading ? '<p>Loading…</p>' : _renderLists()}
         </div>
       </section>
+      ${_renderDeleteModal()}
     </div>
   `;
 }
 
-function _renderModRows() {
+// Render the active + inactive sections per the current view filter. The
+// inactive group is only shown when it has rows (in 'all' view) so an
+// all-active character isn't cluttered with an empty "Inactive" heading.
+function _renderLists() {
   if (!state.mods.length) {
-    return '<p class="stm-list-empty">No active mods. Create one above.</p>';
+    return '<p class="stm-list-empty">No mods yet. Create one above.</p>';
   }
-  return state.mods.map(m => {
-    const sign = m.delta >= 0 ? '+' : '';
-    const when = m.created_at ? m.created_at.replace('T', ' ').replace(/\..*$/, '') : '';
-    const creator = m?.created_by?.discord_name || 'unknown';
-    return `
-      <article class="stm-mod-row">
-        <header class="stm-mod-row-head">
-          <span class="stm-mod-label">${esc(labelForPath(m.stat_path))}</span>
-          <span class="stm-mod-delta">${esc(sign + String(m.delta))}</span>
-          ${m.show_reason_to_player ? '<span class="stm-mod-public">shown to player</span>' : ''}
-          <button class="stm-mod-revoke" data-stm-action="revoke" data-stm-mod-id="${esc(String(m._id))}">Revoke</button>
-        </header>
-        ${m.reason ? `<p class="stm-mod-reason"><em>${esc(m.reason)}</em></p>` : ''}
-        <p class="stm-mod-meta">${esc(creator)} · ${esc(when)}</p>
-      </article>
-    `;
-  }).join('');
+  const { active, inactive } = filterMods(state.mods, state.view);
+  const counts = partitionMods(state.mods);
+  const parts = [];
+
+  if (state.view !== 'inactive') {
+    const body = active.length
+      ? active.map(m => _renderRow(m, true)).join('')
+      : '<p class="stm-list-empty">No active mods.</p>';
+    parts.push(`<div class="stm-list-group"><h3>Active mods (${counts.active.length})</h3>${body}</div>`);
+  }
+
+  if (state.view === 'inactive') {
+    const body = inactive.length
+      ? inactive.map(m => _renderRow(m, false)).join('')
+      : '<p class="stm-list-empty">No inactive mods.</p>';
+    parts.push(`<div class="stm-list-group"><h3>Inactive mods (${counts.inactive.length})</h3>${body}</div>`);
+  } else if (counts.inactive.length) {
+    // 'all' view: append the muted inactive group when any exist.
+    const body = inactive.map(m => _renderRow(m, false)).join('');
+    parts.push(`<div class="stm-list-group stm-list-group--inactive"><h3>Inactive mods (${counts.inactive.length})</h3>${body}</div>`);
+  }
+
+  return parts.join('');
+}
+
+function _renderRow(m, isActiveRow) {
+  const sign = m.delta >= 0 ? '+' : '';
+  const when = m.created_at ? m.created_at.replace('T', ' ').replace(/\..*$/, '') : '';
+  const creator = m?.created_by?.discord_name || 'unknown';
+  const id = esc(String(m._id));
+  const glyph = isActiveRow ? '●' : '◌';
+  const toggleBtn = isActiveRow
+    ? `<button class="stm-mod-btn" data-stm-action="deactivate" data-stm-mod-id="${id}">Deactivate</button>`
+    : `<button class="stm-mod-btn stm-mod-btn--reactivate" data-stm-action="reactivate" data-stm-mod-id="${id}">Reactivate</button>`;
+  return `
+    <article class="stm-mod-row ${isActiveRow ? '' : 'stm-mod-row--inactive'}">
+      <header class="stm-mod-row-head">
+        <span class="stm-mod-glyph">${glyph}</span>
+        <span class="stm-mod-label">${esc(labelForPath(m.stat_path))}</span>
+        <span class="stm-mod-delta">${esc(sign + String(m.delta))}</span>
+        ${m.show_reason_to_player ? '<span class="stm-mod-public">shown to player</span>' : ''}
+        <span class="stm-mod-actions">
+          ${toggleBtn}
+          <button class="stm-mod-btn stm-mod-btn--delete" data-stm-action="delete" data-stm-mod-id="${id}">Delete</button>
+        </span>
+      </header>
+      ${m.reason ? `<p class="stm-mod-reason"><em>${esc(m.reason)}</em></p>` : ''}
+      <p class="stm-mod-meta">${esc(creator)} · ${esc(when)}</p>
+    </article>
+  `;
+}
+
+// Soft-duplicate banner: shown only when the create form's path matches an
+// INACTIVE mod and the ST hasn't dismissed it for that path. Active-path
+// matches are silent on purpose (multi-mod stacking is by design, Rev 1 §D4).
+function _renderDormantBanner() {
+  const path = (state.form.stat_path || '').trim();
+  if (!path || state.dormantDismissedPath === path) return '';
+  const match = findDormantMatch(state.mods, path);
+  if (!match) return '';
+  const sign = match.delta >= 0 ? '+' : '';
+  const label = `${labelForPath(match.stat_path)} ${sign}${match.delta}`;
+  return `
+    <div class="stm-dormant-banner" role="status">
+      <span class="stm-dormant-text">A dormant '${esc(label)}' already exists for this character. Reactivate it instead?</span>
+      <button class="stm-mod-btn stm-mod-btn--reactivate" data-stm-action="reactivate-dormant" data-stm-mod-id="${esc(String(match._id))}">Reactivate dormant</button>
+      <button class="stm-dormant-dismiss" data-stm-action="dismiss-dormant" aria-label="Dismiss">&times;</button>
+    </div>
+  `;
+}
+
+// Delete confirmation modal — explicit "permanently delete" + tombstone copy.
+function _renderDeleteModal() {
+  if (!state.pendingDelete) return '';
+  const m = state.mods.find(x => String(x._id) === String(state.pendingDelete));
+  if (!m) return '';
+  const sign = m.delta >= 0 ? '+' : '';
+  const label = `${labelForPath(m.stat_path)} ${sign}${m.delta}`;
+  return `
+    <div class="stm-modal-overlay" data-stm-modal-overlay>
+      <div class="stm-modal" role="dialog" aria-modal="true">
+        <h3>Permanently delete this mod?</h3>
+        <p>You are about to permanently delete <strong>${esc(label)}</strong>.</p>
+        <p class="stm-modal-note">The audit log will record this deletion as a tombstone; the mod itself will be gone and cannot be reactivated. To pause it instead, cancel and use <em>Deactivate</em>.</p>
+        <div class="stm-modal-actions">
+          <button class="stm-mod-btn stm-mod-btn--delete" data-stm-action="confirm-delete" data-stm-mod-id="${esc(String(m._id))}">Permanently delete</button>
+          <button class="stm-mod-btn" data-stm-action="cancel-delete">Cancel</button>
+        </div>
+      </div>
+    </div>
+  `;
 }
 
 function _renderListBody() {
   const el = _rootEl?.querySelector('[data-stm-list-body]');
-  if (el) el.innerHTML = state.loading ? '<p>Loading…</p>' : _renderModRows();
+  if (el) el.innerHTML = state.loading ? '<p>Loading…</p>' : _renderLists();
+}
+
+function _renderDormantBannerSlot() {
+  const el = _rootEl?.querySelector('[data-stm-dormant-banner]');
+  if (el) el.innerHTML = _renderDormantBanner();
 }
 
 function _renderError() {
@@ -205,19 +309,49 @@ function _attachDelegatedHandlers(root) {
       if (key === 'delta') state.form.delta = parseInt(t.value, 10) || 0;
       else if (key === 'show_reason_to_player') state.form.show_reason_to_player = t.checked;
       else state.form[key] = t.value;
+      // Changing the stat path resets the dormant-dismissal and re-evaluates
+      // the soft-duplicate banner against the new path.
+      if (key === 'stat_path') {
+        state.dormantDismissedPath = null;
+        _renderDormantBannerSlot();
+      }
     }
   });
 
   root.addEventListener('click', (e) => {
     const t = e.target;
     if (!(t instanceof HTMLElement)) return;
-    const action = t.dataset.stmAction;
-    if (action === 'save') {
-      _onSaveClick();
-    } else if (action === 'revoke') {
-      _onRevokeClick(t.dataset.stmModId);
+    const btn = t.closest('[data-stm-action], [data-stm-view]');
+    if (!(btn instanceof HTMLElement)) {
+      // Click on the modal backdrop (outside the dialog) cancels the delete.
+      if (t.matches('[data-stm-modal-overlay]')) _cancelDelete();
+      return;
     }
+    const view = btn.dataset.stmView;
+    if (view) { _onViewChange(view); return; }
+    const action = btn.dataset.stmAction;
+    const modId = btn.dataset.stmModId;
+    if (action === 'save') _onSaveClick();
+    else if (action === 'deactivate') _onToggleClick(modId, false);
+    else if (action === 'reactivate') _onToggleClick(modId, true);
+    else if (action === 'reactivate-dormant') _onReactivateDormant(modId);
+    else if (action === 'dismiss-dormant') _onDismissDormant();
+    else if (action === 'delete') _onDeleteClick(modId);
+    else if (action === 'confirm-delete') _onConfirmDelete(modId);
+    else if (action === 'cancel-delete') _cancelDelete();
   });
+}
+
+// ── View filter ──────────────────────────────────────────────────────
+
+function _onViewChange(view) {
+  if (view !== 'all' && view !== 'active' && view !== 'inactive') return;
+  state.view = view;
+  // Update the active-button styling + list body without a full scaffold redraw.
+  _rootEl?.querySelectorAll('[data-stm-view]').forEach(b => {
+    b.classList.toggle('is-active', b.dataset.stmView === view);
+  });
+  _renderListBody();
 }
 
 // ── Toggle handlers ──────────────────────────────────────────────────
@@ -307,21 +441,78 @@ async function _onSaveClick() {
   }
 }
 
-// ── Revoke ───────────────────────────────────────────────────────────
+// ── Lifecycle: deactivate / reactivate (PATCH active) ────────────────
 
-async function _onRevokeClick(modId) {
+async function _onToggleClick(modId, active) {
   if (!modId) return;
-  if (!confirm('Revoke this mod? The audit log will still record the creation event.')) return;
   try {
-    // STM-9 (issue #416): same dedupe shape as POST — mark before DELETE.
+    // STM-9 (issue #416): mark the local write before PATCH so the WS echo
+    // is suppressed — the panel refreshes itself via _refetchMods.
     if (state.character?._id) markLocalWrite(String(state.character._id), { st_mod: true });
-    await apiDelete(`/api/st_mods/${modId}`);
+    await apiPatch(`/api/st_mods/${modId}`, { active });
     await _refetchMods();
     _renderListBody();
+    _renderDormantBannerSlot();   // (de)activation can change dormant-match state
     if (_onMutateCallback) _onMutateCallback();
   } catch (err) {
-    console.error('[stm-panel] revoke failed:', err);
+    console.error('[stm-panel] toggle failed:', err);
   }
+}
+
+async function _onReactivateDormant(modId) {
+  // Reactivate the dormant match from the soft-duplicate banner, then clear
+  // the form path so the banner retires.
+  await _onToggleClick(modId, true);
+  state.form.stat_path = '';
+  state.dormantDismissedPath = null;
+  _renderScaffold();
+}
+
+function _onDismissDormant() {
+  state.dormantDismissedPath = (state.form.stat_path || '').trim() || null;
+  _renderDormantBannerSlot();
+}
+
+// ── Delete (tombstone) with confirmation modal ───────────────────────
+
+function _onDeleteClick(modId) {
+  if (!modId) return;
+  state.pendingDelete = modId;
+  _renderModal();
+}
+
+function _cancelDelete() {
+  state.pendingDelete = null;
+  _renderModal();
+}
+
+async function _onConfirmDelete(modId) {
+  if (!modId) return;
+  try {
+    // STM-9 (issue #416): same dedupe shape as PATCH/POST — mark before DELETE.
+    if (state.character?._id) markLocalWrite(String(state.character._id), { st_mod: true });
+    await apiDelete(`/api/st_mods/${modId}`);
+    state.pendingDelete = null;
+    await _refetchMods();
+    _renderModal();
+    _renderListBody();
+    _renderDormantBannerSlot();
+    if (_onMutateCallback) _onMutateCallback();
+  } catch (err) {
+    console.error('[stm-panel] delete failed:', err);
+    state.pendingDelete = null;
+    _renderModal();
+  }
+}
+
+// Mount/refresh the modal at the panel root (it lives just inside the root,
+// outside the list body, so list re-renders don't clobber it).
+function _renderModal() {
+  const root = _rootEl?.querySelector('[data-stm-panel-root]');
+  if (!root) return;
+  const existing = root.querySelector('[data-stm-modal-overlay]');
+  if (existing) existing.remove();
+  if (state.pendingDelete) root.insertAdjacentHTML('beforeend', _renderDeleteModal());
 }
 
 // ── Fetch helpers ────────────────────────────────────────────────────

--- a/server/tests/stm-12-panel-logic.test.js
+++ b/server/tests/stm-12-panel-logic.test.js
@@ -1,0 +1,101 @@
+/**
+ * STM-12 (issue #440) — panel lifecycle logic.
+ *
+ * Unit tests for the pure helpers in
+ * public/js/admin/st-mods-panel-logic.js. These carry no browser-only
+ * imports, so they import + run directly in Node under vitest. They cover
+ * the two load-bearing ACs (soft-warn fires on inactive-path match;
+ * active-path stacking is silent) plus the active/inactive partitioning
+ * that drives the "reactivate moves the row to the active section" UI.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  isActive,
+  partitionMods,
+  filterMods,
+  findDormantMatch,
+} from '../../public/js/admin/st-mods-panel-logic.js';
+
+const STR = 'attributes.Strength.dots';
+const DEX = 'attributes.Dexterity.dots';
+
+const activeStr   = { _id: '1', stat_path: STR, delta: 2, active: true };
+const inactiveStr = { _id: '2', stat_path: STR, delta: 1, active: false };
+const legacyStr   = { _id: '3', stat_path: STR, delta: 3 };           // no active field
+const inactiveDex = { _id: '4', stat_path: DEX, delta: -1, active: false };
+
+describe('STM-12 — isActive / partitionMods', () => {
+  it('treats a missing active field as active (pre-Rev 4 docs)', () => {
+    expect(isActive(legacyStr)).toBe(true);
+    expect(isActive(activeStr)).toBe(true);
+    expect(isActive(inactiveStr)).toBe(false);
+  });
+
+  it('partitions active vs inactive', () => {
+    const { active, inactive } = partitionMods([activeStr, inactiveStr, legacyStr, inactiveDex]);
+    expect(active.map(m => m._id)).toEqual(['1', '3']);
+    expect(inactive.map(m => m._id)).toEqual(['2', '4']);
+  });
+});
+
+describe('STM-12 — filterMods view', () => {
+  const mods = [activeStr, inactiveStr, inactiveDex];
+  it('all → both groups', () => {
+    const r = filterMods(mods, 'all');
+    expect(r.active).toHaveLength(1);
+    expect(r.inactive).toHaveLength(2);
+  });
+  it('active → only active', () => {
+    const r = filterMods(mods, 'active');
+    expect(r.active).toHaveLength(1);
+    expect(r.inactive).toHaveLength(0);
+  });
+  it('inactive → only inactive', () => {
+    const r = filterMods(mods, 'inactive');
+    expect(r.active).toHaveLength(0);
+    expect(r.inactive).toHaveLength(2);
+  });
+});
+
+describe('STM-12 — findDormantMatch (soft-duplicate warning)', () => {
+  it('AC: fires when the form path matches an INACTIVE mod', () => {
+    const match = findDormantMatch([inactiveStr, inactiveDex], STR);
+    expect(match).toBe(inactiveStr);
+  });
+
+  it('AC negative: silent when the path matches only an ACTIVE mod (stacking is by design)', () => {
+    // Strength has an active mod but no inactive one → no dormant warning.
+    expect(findDormantMatch([activeStr, inactiveDex], STR)).toBeNull();
+  });
+
+  it('silent when the path matches only a legacy (active-by-default) mod', () => {
+    expect(findDormantMatch([legacyStr], STR)).toBeNull();
+  });
+
+  it('prefers the inactive match even when an active mod shares the path', () => {
+    // Mixed: an active AND an inactive mod on Strength → the dormant one is
+    // the reactivation target, so it must be returned.
+    const match = findDormantMatch([activeStr, inactiveStr], STR);
+    expect(match).toBe(inactiveStr);
+  });
+
+  it('returns null for an empty path', () => {
+    expect(findDormantMatch([inactiveStr], '')).toBeNull();
+    expect(findDormantMatch([inactiveStr], null)).toBeNull();
+  });
+});
+
+describe('STM-12 — reactivate updates the UI grouping', () => {
+  it('a reactivated mod moves from the inactive group to the active group', () => {
+    const mods = [activeStr, inactiveStr];
+    // Before: inactiveStr is in the inactive group.
+    expect(partitionMods(mods).inactive.map(m => m._id)).toContain('2');
+
+    // Simulate the PATCH { active: true } result the panel re-fetches.
+    const reactivated = mods.map(m => (m._id === '2' ? { ...m, active: true } : m));
+    const { active, inactive } = partitionMods(reactivated);
+    expect(active.map(m => m._id)).toEqual(['1', '2']);
+    expect(inactive).toHaveLength(0);
+  });
+});

--- a/specs/stories/issue-440-stm-12-panel-lifecycle-ui.story.md
+++ b/specs/stories/issue-440-stm-12-panel-lifecycle-ui.story.md
@@ -1,0 +1,74 @@
+# Issue #440: STM-12 — panel UI for persistent toggleable mods (filter / muted-inactive / reactivate / soft-warn)
+
+Status: Ready for Review
+
+issue: 440
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/440
+branch: piatra/issue-440-stm-12-panel-lifecycle
+epic: STM (specs/epic-stm-st-mods.md)
+adr: ADR-004 Rev 4 §D15/D17 + Rev 1 §D4 (specs/architecture/adr-004-st-mods-overlay.md)
+dispatch: PROCEED-WITH-NOTICE. PRD Rev 4 ACs are verbatim; this story implements them. Last piece of the Rev 4 chapter.
+
+## Story
+
+As a Storyteller,
+I want the ST Mods panel to show active AND inactive mods (inactive visually muted, each with a Reactivate affordance), with All/Active/Inactive filtering, per-row Deactivate/Reactivate/Delete, a delete-confirmation modal that names the tombstone behaviour, and a soft-duplicate warning that fires only when my new mod's path matches a dormant mod,
+so that I can pause/resume mods without losing them, permanently delete for list cleanliness with a clear warning, and avoid accidentally re-creating a mod that is merely dormant.
+
+## Decisions implemented
+
+- **Load-bearing AC 1** — inactive mods stay visible, rendered muted (reduced opacity, no gold border-glow, `◌` outline glyph, dimmed text) with a Reactivate button on every inactive row.
+- **Load-bearing AC 2** — the soft-duplicate warning fires ONLY when the create form's path matches an INACTIVE mod on this character. Active-path stacking is silent (multi-mod stacking is by design, ADR Rev 1 §D4). The banner names the specific dormant match and offers to reactivate it.
+- **§D15/D17** — Deactivate/Reactivate call `PATCH /api/st_mods/:id { active }`; Delete calls `DELETE` (STM-10's tombstone-before-destroy).
+
+## Tasks / Subtasks
+
+- [x] Task 1 — pure-logic module `public/js/admin/st-mods-panel-logic.js` (`isActive`, `partitionMods`, `filterMods`, `findDormantMatch`), import-free so vitest exercises it directly in Node.
+- [x] Task 2 — panel render expansion: All/Active/Inactive filter bar; Active group (Deactivate/Delete); muted Inactive group (Reactivate/Delete), shown in `all` view only when non-empty.
+- [x] Task 3 — soft-duplicate banner in the create form, re-evaluated on stat-path change; dismissible per-path; "Reactivate dormant" button targets the specific match.
+- [x] Task 4 — delete confirmation modal with "permanently delete" copy + explicit tombstone wording ("the audit log will record this deletion; the mod itself will be gone"); backdrop-click + Cancel dismiss.
+- [x] Task 5 — delegated routing: one `change` listener (toggles + form fields), one `click` listener (save / deactivate / reactivate / delete / confirm / cancel / filter views / dormant reactivate+dismiss). No per-row addEventListener. `markLocalWrite` + `onMutate` on every mutation.
+- [x] Task 6 — CSS: muted-inactive row, filter buttons, dormant banner, modal overlay.
+- [x] Task 7 — 11 vitest cases (the 3 required + 8 supporting).
+
+## Acceptance Criteria
+
+1. Panel renders active + inactive, inactive muted — ✅
+2. Reactivate on every inactive row → PATCH active:true → moves to active, WS broadcast — ✅ (markLocalWrite before PATCH; STM-10 broadcasts `activate`)
+3. Deactivate on every active row → PATCH active:false → moves to inactive — ✅
+4. Delete → confirmation modal → DELETE → row gone; `deleted` tombstone created — ✅ (modal copy names the tombstone; STM-10 writes it)
+5. Soft warning fires on inactive-path match; active-path silent; dismissible — ✅ (`findDormantMatch`, unit-tested both ways)
+6. Filter All/Active/Inactive; defaults to All on open — ✅
+7. All handlers via delegated routing on the panel root — ✅
+8. Cross-client smoke — ⚠️ not run (OAuth-gated admin; see notes). WS path unchanged from STM-9/10.
+9. No regression — ✅ 1068/1068; STM-5 create/list/global-toggle/suppress paths untouched
+10. ≥3 vitest cases (dormant fires / active-path silent / reactivate updates UI) — ✅ all three present (+8 more)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-7 (Ptah / DEV)
+
+### Completion Notes List
+
+- **Pure-logic split for testability.** The soft-warn and partition rules are the load-bearing logic, so they live in `st-mods-panel-logic.js` with NO browser imports — vitest imports them directly (the panel itself can't be imported in Node because of its api/ws/app-settings deps). This is the "pure-function units where possible" the issue asked for; the three required cases are pure-function assertions.
+- **Soft-warn semantics.** `findDormantMatch` returns the first INACTIVE mod sharing the form's path, else null. An active mod on the same path returns null (silent) — even when an active AND inactive mod both exist on that path, the inactive one is the reactivation target and is returned. A pre-Rev 4 mod with no `active` field counts as active (silent), matching §D19.
+- **Inactive group visibility.** In `all` view the muted Inactive group is shown only when non-empty, so an all-active character isn't cluttered with an empty heading. In `inactive` view the empty-state message shows.
+- **Delete is a real modal, not `confirm()`.** The issue requires a confirmation modal with tombstone copy; native `confirm()` can't carry that wording. The modal mounts at the panel root (outside the list body) via `_renderModal()` so list re-renders don't clobber it; backdrop-click and Cancel both dismiss. STM-5's `revoke` button + native confirm are retired.
+- **Delegated routing discipline** (memory feedback_listener_routing_static_blind_spot). Click handlers are in the `click` listener and change handlers in the `change` listener — never crossed. The click handler resolves the acted element via `t.closest('[data-stm-action],[data-stm-view]')` so clicks on button text/icons still route. Filter-view switching repaints only the list body + button states (no full scaffold redraw); the dormant banner has its own slot re-render so a stat-path change updates it without rebuilding the form.
+- **WS dedupe unchanged.** `markLocalWrite(charId, { st_mod: true })` fires before every PATCH/DELETE (same shape as STM-9's POST path), so the originating client's WS echo is suppressed and the panel refreshes via its own `_refetchMods`.
+- **Browser smoke NOT performed.** The admin panel is behind Discord OAuth + requires a selected character; it can't be exercised end-to-end in this session. Per CLAUDE.md I am flagging this rather than claiming success. Mitigations: 11 passing units on the load-bearing logic, parse-checks on both modules, and correctly-separated delegated listeners (the specific failure mode the listener-routing memory warns about — click handlers registered inside a `change` listener — is not present here). Recommend a QA browser pass for the cross-client (AC#8) and modal/banner interaction.
+- **Worktree pattern continued** (`/tmp/tm-ptah/stm-12`, node_modules + server/.env symlinked from main; base forked from dev tip 47b5b6b7 which already includes STM-11).
+
+### File List
+
+- `public/js/admin/st-mods-panel-logic.js` (new) — pure helpers: isActive / partitionMods / filterMods / findDormantMatch
+- `public/js/admin/st-mods-panel.js` (modified) — lifecycle render (active/inactive/filter), Deactivate/Reactivate/Delete handlers, delete modal, dormant soft-warn banner; STM-5 revoke + native confirm retired
+- `public/css/components.css` (modified) — muted-inactive row, filter bar, dormant banner, delete modal; retired unused `.stm-mod-revoke`
+- `server/tests/stm-12-panel-logic.test.js` (new) — 11 vitest cases
+- `specs/stories/issue-440-stm-12-panel-lifecycle-ui.story.md` — this file
+
+### Change Log
+
+- 2026-05-20 (Ptah): STM-12 panel lifecycle UI


### PR DESCRIPTION
## Summary

STM-12 (issue #440). The ST Mods admin panel evolves from "active mods + revoke" into a full lifecycle view on top of STM-10's backend. Last piece of the Rev 4 chapter.

- **Active group** (Deactivate / Delete) + a **visually-muted Inactive group** (Reactivate / Delete) — `◌` outline glyph, reduced opacity, no gold border-glow.
- **All / Active only / Inactive only** filter; defaults to All on open. In `all` view the Inactive group shows only when non-empty.
- **Delete confirmation modal** with "permanently delete" copy and explicit tombstone wording ("the audit log will record this deletion; the mod itself will be gone"). Replaces the STM-5 revoke button + native `confirm()`.
- **Soft-duplicate warning** fires ONLY when the create form's path matches an **inactive** mod (active-path stacking stays silent per ADR Rev 1 §D4). The banner names the dormant match and offers "Reactivate dormant"; dismissible per-path.
- Deactivate/Reactivate → `PATCH /api/st_mods/:id { active }`; Delete → `DELETE`. `markLocalWrite` fires before each so the originating client's WS echo is suppressed; `onMutate` triggers the sheet re-render.

## Design notes

- **Pure-logic split.** The load-bearing rules live in a new `public/js/admin/st-mods-panel-logic.js` with no browser imports, so vitest exercises them directly in Node (the panel itself can't be imported in Node due to its api/ws/app-settings deps). `findDormantMatch` returns the first **inactive** mod sharing the path, else null — an active-only match returns null (silent), and when both an active and inactive mod share a path the inactive one (the reactivation target) is returned. A missing `active` field counts as active (§D19).
- **Delete is a real modal, not `confirm()`** — native confirm can't carry the tombstone copy. It mounts at the panel root outside the list body so list re-renders don't clobber it; backdrop-click + Cancel dismiss.
- **Delegated routing** (memory: listener-routing blind spot). Click handlers in the `click` listener, change handlers in the `change` listener — never crossed. Filter switching repaints only the list body + button states; the dormant banner has its own slot re-render.

## Tests

11 vitest cases on the pure logic (the 3 required + 8 supporting): dormant soft-warn fires on inactive-path match; active-path stacking is silent (negative case); reactivate moves the row to the active group; partition/filter/missing-active-field edge cases. **1073/1073 pass.**

## Browser smoke — NOT performed (flagged)

The admin panel is behind Discord OAuth and requires a selected character, so it could not be exercised end-to-end in this session. Per CLAUDE.md I'm flagging this rather than claiming success. Mitigations: 11 passing units on the load-bearing logic, parse-checks on both modules, and correctly-separated delegated listeners (the exact failure mode the listener-routing memory warns about is not present). **Recommend a QA browser pass** for AC#8 (cross-client) and the modal/banner interactions.

## Test plan

- [ ] Open a character's ST Mods panel: active mods listed; create one, deactivate it → it moves to a muted Inactive group with a Reactivate button.
- [ ] Reactivate → moves back to Active. Open STM-11's audit view in another tab → `activated`/`deactivated` events appear.
- [ ] Delete → confirmation modal names the tombstone behaviour → confirm → row gone; audit shows a `deleted` tombstone.
- [ ] In the create form pick a stat path that has a dormant mod → soft-warn banner appears; pick a path with only an active mod → no banner. Dismiss works.
- [ ] All / Active only / Inactive only filter narrows correctly.
- [ ] Two STs on the same panel: one reactivates → the other sees it within ~1s.

Closes #440