### PR TITLE
fix(downtime): mobile escape hatch instead of dead /player link

### DIFF
--- a/public/css/suite.css
+++ b/public/css/suite.css
@@ -1397,7 +1397,13 @@ details.city-section[open] > .city-section-hd::before { transform: rotate(90deg)
   font-family: var(--ft); font-size: 13px; color: var(--txt2); line-height: 1.6;
   background: var(--surf2); border: 1px solid var(--bdr); border-radius: 8px; margin: 16px;
 }
-.dt-mobile-notice-link { color: var(--accent); text-decoration: underline; }
+.dt-mobile-notice-text { margin: 0 0 14px; }
+.dt-mobile-show-anyway {
+  font-family: var(--ft); font-size: 13px; cursor: pointer;
+  padding: 10px 18px; border-radius: 6px;
+  background: var(--accent); color: var(--bg, #0D0B09); border: 1px solid var(--accent);
+}
+.dt-mobile-show-anyway:hover { filter: brightness(1.08); }
 
 /* Nav badge (used by More tab and app icons — Story 3.3) */
 .nav-badge {

--- a/public/js/tabs/downtime-tab.js
+++ b/public/js/tabs/downtime-tab.js
@@ -90,7 +90,20 @@ export async function initDowntimeTab(el, char, territories = []) {
     // The mobile notice still applies for non-ST, non-localhost on small screens.
     const forceForm = location.hostname === 'localhost' || isST;
     if (!forceForm && window.innerWidth <= 600) {
-      currentZone.innerHTML = '<div class="dt-mobile-notice">This form works best on desktop. <a href="/player" class="dt-mobile-notice-link">Open Player Portal</a></div>';
+      // Small-screen heads-up. The previous "Open Player Portal" link pointed
+      // at /player, which is now a legacy stub that redirects back to / — so
+      // mobile players were bounced in a loop with no way to reach the form.
+      // Offer an explicit escape hatch instead: render the form in place.
+      currentZone.innerHTML = `<div class="dt-mobile-notice">
+        <p class="dt-mobile-notice-text">This form is designed for desktop and may be awkward on a small screen.</p>
+        <button type="button" class="dt-mobile-show-anyway" data-dt-show-form>Show the form anyway</button>
+      </div>`;
+      const showBtn = currentZone.querySelector('[data-dt-show-form]');
+      if (showBtn) {
+        showBtn.addEventListener('click', () => {
+          renderDowntimeTab(currentZone, char, territories, { singleColumn: true, skipFreshFetch: true });
+        });
+      }
     } else {
       // Issue #259 (perf): char + territories come from suiteState which
       // was loaded at boot — skip the redundant fresh-fetch pair.


### PR DESCRIPTION
## Summary

iPhone (and any ≤600px) players reported being unable to submit downtimes: the Downtime tab showed "best accessed on desktop" and the only affordance — "Open Player Portal" → `/player` — redirected back to `/` over and over, leaving "no option at all."

**Root cause (two compounding pieces):**
1. `public/js/tabs/downtime-tab.js` — the small-screen notice linked to `/player`.
2. `public/player.html` is now a legacy stub that unconditionally `window.location.replace('/')` (the player portal was merged into the unified `index.html`). So `/player` → `/` → same app → Downtime tab → same notice → loop.

It is **not** a User-Agent/iPhone check — the gate is `window.innerWidth <= 600`, so "Request Desktop Site" can't break the loop (the redirect is unconditional JS).

## Fix

Replace the dead link with a **"Show the form anyway"** button that renders the downtime form in place — the exact `renderDowntimeTab(...)` call ST and localhost already use successfully — bypassing the width gate. The desktop heads-up text stays.

The button is created and bound on render, and clicking it replaces the notice entirely, so this is **not** the listener-routing-on-re-render blind spot (no re-rendering `change` listener wipes the binding).

## Files
- `public/js/tabs/downtime-tab.js` — notice copy + "Show the form anyway" button + click handler; dead `/player` link removed
- `public/css/suite.css` — button styling; retired the now-unused `.dt-mobile-notice-link`

## Testing / limitations
- Parse-checked (`node --input-type=module --check`).
- **Not browser-smoked:** this path is gated behind player Discord OAuth + an active downtime cycle + a ≤600px viewport, which I can't reproduce locally (no frontend test framework). Per CLAUDE.md I'm flagging this rather than claiming success.
- **Recommend a real-device pass after dev deploy:** on an iPhone, open Downtime → tap "Show the form anyway" → confirm the form renders and a submission goes through.

## Side note (not this bug)
`public/_redirects` currently has a dev maintenance-mode block redirecting `/` and `/player.html` to `/maintenance.html`. That's device-independent and a dev-branch artifact, separate from this fix.

## Test plan
- [ ] iPhone Safari: Downtime tab shows the notice with a "Show the form anyway" button (no dead portal link).
- [ ] Tapping it renders the downtime form; a submission saves.
- [ ] Desktop (>600px) still renders the form directly with no notice.
- [ ] ST / localhost still bypass the notice as before.