### PR TITLE
feat(#458): DT Story merit summary — blocking list + Dismiss/Undismiss

### DIFF
--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -6957,6 +6957,38 @@ html:not([data-theme="dark"]) .roll-btn-save:hover { border-color: var(--success
 }
 .dt-story-complete-badge { color: var(--result-succ); }
 .dt-story-pending-note { color: var(--txt3); font-style: italic; }
+/* ── Issue #458: merit summary dismiss/override ──────────────────── */
+.dt-story-complete-badge.dt-story-complete-overridden { color: var(--gold2); }
+.dt-merit-blocking-list {
+  margin-top: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.dt-merit-blocking-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+.dt-merit-blocking-item-label { color: var(--txt2); font-weight: 500; }
+.dt-merit-blocking-reason { color: var(--txt3); font-style: italic; flex: 1; }
+.dt-merit-dismiss-btn {
+  font-size: 11px;
+  padding: 2px 7px;
+  border: 1px solid var(--bdr);
+  border-radius: 3px;
+  background: var(--surf2);
+  color: var(--txt2);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.dt-merit-dismiss-btn:hover { border-color: var(--gold2); color: var(--gold2); }
+.dt-merit-dismiss-btn--active {
+  border-color: var(--gold2);
+  color: var(--gold2);
+  background: var(--surf3);
+}
 
 /* Sign-off panel */
 .dt-story-sign-off {

--- a/public/js/admin/downtime-story.js
+++ b/public/js/admin/downtime-story.js
@@ -289,6 +289,10 @@ export async function initDtStory(cycleId) {
     const feedApproveBtn = e.target.closest('.dt-feed-val-approve-btn');
     if (feedApproveBtn) { handleFeedingApproval(feedApproveBtn); return; }
 
+    // Merit summary dismiss / undismiss
+    const dismissBtn = e.target.closest('.dt-merit-dismiss-btn');
+    if (dismissBtn) { _handleMeritSummaryDismiss(dismissBtn); return; }
+
     // Save Draft
     const saveDraftBtn = e.target.closest('.dt-story-save-draft-btn');
     if (saveDraftBtn && !saveDraftBtn.disabled) {
@@ -376,6 +380,32 @@ function _showStoryAutosaveStatus(el, state) {
     return;
   }
   if (state === 'error') { el.textContent = 'Save failed'; }
+}
+
+async function _handleMeritSummaryDismiss(btn) {
+  if (!_currentSub) return;
+  const sub = _currentSub;
+  const idx = parseInt(btn.dataset.actionIdx, 10);
+  if (isNaN(idx)) return;
+
+  const current = Array.isArray(sub.st_narrative?.merit_summary_overrides)
+    ? [...sub.st_narrative.merit_summary_overrides]
+    : [];
+
+  const updated = current.includes(idx)
+    ? current.filter(i => i !== idx)
+    : [...current, idx].sort((a, b) => a - b);
+
+  try {
+    await saveNarrativeField(sub._id, { 'st_narrative.merit_summary_overrides': updated });
+  } catch (err) {
+    return;
+  }
+  (sub.st_narrative ??= {}).merit_summary_overrides = updated;
+
+  const char = getCharForSub(sub);
+  const view = document.getElementById('dt-story-char-view');
+  if (view) view.innerHTML = renderCharacterView(char, sub);
 }
 
 async function _handleStoryTaBlur(ta) {
@@ -2244,12 +2274,14 @@ function actionResponsesComplete(sub, categories) {
 }
 
 function meritSummaryComplete(sub) {
-  const actions  = sub?.merit_actions || [];
-  const resolved = sub?.merit_actions_resolved || [];
-  const acqRes   = sub?.acquisitions_resolved  || [];
+  const actions   = sub?.merit_actions || [];
+  const resolved  = sub?.merit_actions_resolved || [];
+  const acqRes    = sub?.acquisitions_resolved  || [];
+  const overrides = new Set(sub?.st_narrative?.merit_summary_overrides || []);
 
   for (let i = 0; i < actions.length; i++) {
     if (_isDeletedMeritAction(sub, i)) continue;
+    if (overrides.has(i)) continue;
     const rev = resolved[i] || {};
     if ((rev.pool_status || '') === 'skipped') continue;
     if (deriveMeritCategory(actions[i].merit_type) === 'resources') {
@@ -2328,24 +2360,63 @@ function renderMeritSummary(char, sub) {
     }
   }
 
+  // Build the list of all blocking items (ignoring overrides — overrides determine display only)
+  const acqRes    = sub?.acquisitions_resolved || [];
+  const overrides = new Set(sub?.st_narrative?.merit_summary_overrides || []);
+
+  const blockingItems = [];
+  actions.forEach((a, i) => {
+    if (_isDeletedMeritAction(sub, i)) return;
+    const rev = resolved[i] || {};
+    if ((rev.pool_status || '') === 'skipped') return;
+    const cat = deriveMeritCategory(a.merit_type);
+    if (cat === 'resources') {
+      const revStatus = resolved[i]?.pool_status || '';
+      if (revStatus === 'validated' || revStatus === 'skipped') return;
+      const acqStatus = acqRes[0]?.pool_status || '';
+      if (acqStatus === 'validated' || acqStatus === 'skipped') return;
+      const { label, qualifier } = getMeritDetails(char, a);
+      const displayLabel = qualifier ? `${label} (${qualifier})` : label;
+      blockingItems.push({ idx: i, label: displayLabel || 'Resources', reason: 'acquisition outcome pending' });
+    } else {
+      if (rev.outcome_summary?.trim()) return;
+      const { label, qualifier } = getMeritDetails(char, a);
+      const displayLabel = qualifier ? `${label} (${qualifier})` : label;
+      blockingItems.push({ idx: i, label: displayLabel || a.merit_type || 'Merit', reason: 'outcome not yet recorded' });
+    }
+  });
+
+  const remainingBlocks = blockingItems.filter(item => !overrides.has(item.idx));
+  const dismissedBlocks = blockingItems.filter(item =>  overrides.has(item.idx));
+  const genuinelyComplete = blockingItems.length === 0;
+
   h += `<div class="dt-story-section-actions">`;
-  if (complete) {
+  if (genuinelyComplete) {
     h += `<span class="dt-story-complete-badge">&#10003; All outcomes recorded</span>`;
+  } else if (remainingBlocks.length === 0) {
+    const n = dismissedBlocks.length;
+    h += `<span class="dt-story-complete-badge dt-story-complete-overridden">&#10003; Overridden (${n} dismissed)</span>`;
   } else {
-    const acqRes  = sub?.acquisitions_resolved || [];
-    const missing = actions.filter((a, i) => {
-      const rev = resolved[i] || {};
-      if (rev.pool_status === 'skipped') return false;
-      if (deriveMeritCategory(a.merit_type) === 'resources') {
-        const revStatus = resolved[i]?.pool_status || '';
-        if (revStatus === 'validated' || revStatus === 'skipped') return false;
-        const acqStatus = acqRes[0]?.pool_status || '';
-        return acqStatus !== 'validated' && acqStatus !== 'skipped';
-      }
-      return !rev.outcome_summary?.trim();
-    }).length;
-    h += `<span class="dt-story-pending-note">${missing} outcome${missing !== 1 ? 's' : ''} still to record in DT Processing</span>`;
+    const n = remainingBlocks.length;
+    h += `<span class="dt-story-pending-note">${n} outcome${n !== 1 ? 's' : ''} still to record in DT Processing</span>`;
   }
+
+  const allDisplayed = [...remainingBlocks, ...dismissedBlocks];
+  if (allDisplayed.length) {
+    h += `<div class="dt-merit-blocking-list">`;
+    for (const item of allDisplayed) {
+      const isDismissed = overrides.has(item.idx);
+      const btnClass = isDismissed ? 'dt-merit-dismiss-btn dt-merit-dismiss-btn--active' : 'dt-merit-dismiss-btn';
+      const btnLabel = isDismissed ? 'Undismiss' : 'Dismiss';
+      h += `<div class="dt-merit-blocking-item">`;
+      h += `<span class="dt-merit-blocking-item-label">${esc(item.label)}</span>`;
+      h += `<span class="dt-merit-blocking-reason">— ${esc(item.reason)}</span>`;
+      h += `<button class="${btnClass}" data-action-idx="${item.idx}">${btnLabel}</button>`;
+      h += `</div>`;
+    }
+    h += `</div>`;
+  }
+
   h += `</div>`;
   h += `</div></div>`;
   return h;

--- a/specs/stories/feat.458.dt-story-merit-summary-dismiss.story.md
+++ b/specs/stories/feat.458.dt-story-merit-summary-dismiss.story.md
@@ -1,0 +1,438 @@
+---
+title: 'DT Story: expand merit summary incomplete list with names, reasons, and per-action dismiss'
+type: 'feature'
+issue: 458
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/458
+branch: ms/issue-458-dt-story-merit-summary-dismiss
+created: '2026-05-21'
+status: review
+recommended_model: 'sonnet — five touch-points all in downtime-story.js + one CSS block; no schema migration required'
+context:
+  - public/js/admin/downtime-story.js
+  - public/css/admin-layout.css
+---
+
+## Intent
+
+**Problem:** When a submission's Allies & Asset Summary section is blocked ("N outcomes still to
+record in DT Processing"), the ST can see the count but has no way to know *which* actions are
+blocking or *why*. If the ST decides that data entry for a particular action is genuinely
+unneeded — e.g. the player's Contacts action was a no-show and there is nothing to narrate — they
+must enter dummy text just to satisfy the completeness check.
+
+**Desired behaviour:**
+
+1. The blocking message expands to list each incomplete action by name and reason.
+2. Each blocking item has a Dismiss button. Dismissing an item writes its index to
+   `st_narrative.merit_summary_overrides` and removes it from the count.
+3. When all blocks are dismissed, the section shows an amber "Overridden (N dismissed)" badge
+   instead of the green "All outcomes recorded" badge, and the completion dot goes green (the
+   section no longer gates sign-off).
+4. Dismissed items show an Undismiss button — clicking again removes the override.
+5. Overrides persist across page loads via `saveNarrativeField`.
+
+## Critical: sync dev before starting
+
+**This branch was cut from Morningstar before fix #456 was merged to dev.** The current file on
+this branch has the pre-fix-456 `meritSummaryComplete` (no resources-specific logic) and the
+pre-fix-456 `renderMeritSummary` footer (no T2/T3 fixes).
+
+Before implementing any task, run:
+
+```
+git fetch origin && git merge origin/dev
+```
+
+Resolve the only expected conflict site (`specs/stories/sprint-status.yaml`) by keeping all
+entries from both sides, then proceed.
+
+After the merge the file will have the fix-456 versions of `meritSummaryComplete` (lines
+~2233–2249) and `renderMeritSummary` (lines ~2257–2325). The tasks below describe changes
+relative to those post-merge versions.
+
+## State of key functions after dev merge
+
+**`meritSummaryComplete` (post-fix-456, lines ~2233–2249):**
+
+```js
+function meritSummaryComplete(sub) {
+  const actions  = sub?.merit_actions || [];
+  const resolved = sub?.merit_actions_resolved || [];
+  const acqRes   = sub?.acquisitions_resolved  || [];
+
+  for (let i = 0; i < actions.length; i++) {
+    const rev = resolved[i] || {};
+    if ((rev.pool_status || '') === 'skipped') continue;
+    if (deriveMeritCategory(actions[i].merit_type) === 'resources') {
+      const revStatus = resolved[i]?.pool_status || '';
+      if (revStatus === 'validated' || revStatus === 'skipped') continue;
+      const acqStatus = acqRes[0]?.pool_status || '';
+      if (acqStatus !== 'validated' && acqStatus !== 'skipped') return false;
+      continue;
+    }
+    if (!rev.outcome_summary?.trim()) return false;
+  }
+  return true;
+}
+```
+
+**`renderMeritSummary` footer section (post-fix-456, lines ~2306–2323):**
+
+```js
+h += `<div class="dt-story-section-actions">`;
+if (complete) {
+  h += `<span class="dt-story-complete-badge">&#10003; All outcomes recorded</span>`;
+} else {
+  const acqRes  = sub?.acquisitions_resolved || [];
+  const missing = actions.filter((a, i) => {
+    const rev = resolved[i] || {};
+    if (rev.pool_status === 'skipped') return false;
+    if (deriveMeritCategory(a.merit_type) === 'resources') {
+      const revStatus = resolved[i]?.pool_status || '';
+      if (revStatus === 'validated' || revStatus === 'skipped') return false;
+      const acqStatus = acqRes[0]?.pool_status || '';
+      return acqStatus !== 'validated' && acqStatus !== 'skipped';
+    }
+    return !rev.outcome_summary?.trim();
+  }).length;
+  h += `<span class="dt-story-pending-note">${missing} outcome${missing !== 1 ? 's' : ''} still to record in DT Processing</span>`;
+}
+h += `</div>`;
+h += `</div></div>`;
+return h;
+```
+
+**Click dispatch (lines ~270–331):** delegated `e.target.closest()` checks on the panel element.
+
+**`saveNarrativeField(submissionId, patch)` (line ~362):** persists via `apiPut`; updates
+`_currentSub` in-memory with the caller's memUpdate pattern.
+
+**Re-render pattern (line ~1213):**
+```js
+const char = getCharForSub(_currentSub);
+view.innerHTML = renderCharacterView(char, _currentSub);
+```
+
+## Tasks
+
+### T1 — `meritSummaryComplete`: honour overrides
+
+Replace the body of `meritSummaryComplete` (the entire function from the opening `{` to closing
+`}`). Add `overrides` extraction and skip any action whose index is in the override set:
+
+```js
+function meritSummaryComplete(sub) {
+  const actions   = sub?.merit_actions || [];
+  const resolved  = sub?.merit_actions_resolved || [];
+  const acqRes    = sub?.acquisitions_resolved  || [];
+  const overrides = new Set(sub?.st_narrative?.merit_summary_overrides || []);
+
+  for (let i = 0; i < actions.length; i++) {
+    if (overrides.has(i)) continue;
+    const rev = resolved[i] || {};
+    if ((rev.pool_status || '') === 'skipped') continue;
+    if (deriveMeritCategory(actions[i].merit_type) === 'resources') {
+      const revStatus = resolved[i]?.pool_status || '';
+      if (revStatus === 'validated' || revStatus === 'skipped') continue;
+      const acqStatus = acqRes[0]?.pool_status || '';
+      if (acqStatus !== 'validated' && acqStatus !== 'skipped') return false;
+      continue;
+    }
+    if (!rev.outcome_summary?.trim()) return false;
+  }
+  return true;
+}
+```
+
+### T2 — `renderMeritSummary`: blocking list + dismiss buttons + overridden badge
+
+Replace the entire footer section (from `h += '<div class="dt-story-section-actions">';` to
+and including the `h += '</div></div>'; return h;` lines) with the new implementation below.
+
+Key logic:
+
+1. Build `blockingItems[]` — all actions that are incomplete ignoring overrides. Each entry is
+   `{ idx, label, reason }`.
+2. Split into `remainingBlocks` (not overridden) and `dismissedBlocks` (overridden).
+3. Dot class: `complete` (from `meritSummaryComplete`, which already respects overrides) →
+   `dt-story-dot-complete` vs `dt-story-dot-pending`. No change to dot derivation is needed.
+
+Replacement (full footer + closing tags):
+
+```js
+  // Build the list of all blocking items (ignoring overrides — overrides determine display)
+  const acqRes    = sub?.acquisitions_resolved || [];
+  const overrides = new Set(sub?.st_narrative?.merit_summary_overrides || []);
+
+  const blockingItems = [];
+  actions.forEach((a, i) => {
+    const rev = resolved[i] || {};
+    if ((rev.pool_status || '') === 'skipped') return;
+    const cat = deriveMeritCategory(a.merit_type);
+    if (cat === 'resources') {
+      const revStatus = resolved[i]?.pool_status || '';
+      if (revStatus === 'validated' || revStatus === 'skipped') return;
+      const acqStatus = acqRes[0]?.pool_status || '';
+      if (acqStatus === 'validated' || acqStatus === 'skipped') return;
+      const { label, qualifier } = getMeritDetails(char, a);
+      const displayLabel = label + (qualifier ? ` (${qualifier})` : '');
+      blockingItems.push({ idx: i, label: displayLabel || 'Resources', reason: 'acquisition outcome pending' });
+    } else {
+      if (rev.outcome_summary?.trim()) return;
+      const { label, qualifier } = getMeritDetails(char, a);
+      const displayLabel = label + (qualifier ? ` (${qualifier})` : '');
+      blockingItems.push({ idx: i, label: displayLabel || a.merit_type || 'Merit', reason: 'outcome not yet recorded' });
+    }
+  });
+
+  const remainingBlocks = blockingItems.filter(item => !overrides.has(item.idx));
+  const dismissedBlocks = blockingItems.filter(item =>  overrides.has(item.idx));
+  const genuinelyComplete = blockingItems.length === 0;
+
+  h += `<div class="dt-story-section-actions">`;
+  if (genuinelyComplete) {
+    h += `<span class="dt-story-complete-badge">&#10003; All outcomes recorded</span>`;
+  } else if (remainingBlocks.length === 0) {
+    // All blocks dismissed
+    const n = dismissedBlocks.length;
+    h += `<span class="dt-story-complete-badge dt-story-complete-overridden">&#10003; Overridden (${n} dismissed)</span>`;
+  } else {
+    const n = remainingBlocks.length;
+    h += `<span class="dt-story-pending-note">${n} outcome${n !== 1 ? 's' : ''} still to record in DT Processing</span>`;
+  }
+
+  // Render blocking list — remaining (dismissable) first, then dismissed (undismissable)
+  const allDisplayed = [...remainingBlocks, ...dismissedBlocks];
+  if (allDisplayed.length) {
+    h += `<div class="dt-merit-blocking-list">`;
+    for (const item of allDisplayed) {
+      const isDismissed = overrides.has(item.idx);
+      const btnClass = isDismissed ? 'dt-merit-dismiss-btn dt-merit-dismiss-btn--active' : 'dt-merit-dismiss-btn';
+      const btnLabel = isDismissed ? 'Undismiss' : 'Dismiss';
+      h += `<div class="dt-merit-blocking-item">`;
+      h += `<span class="dt-merit-blocking-item-label">${esc(item.label)}</span>`;
+      h += `<span class="dt-merit-blocking-reason">— ${esc(item.reason)}</span>`;
+      h += `<button class="${btnClass}" data-action-idx="${item.idx}">${btnLabel}</button>`;
+      h += `</div>`;
+    }
+    h += `</div>`;
+  }
+
+  h += `</div>`;
+  h += `</div></div>`;
+  return h;
+```
+
+**Important — `char` must be in scope.** The current `renderMeritSummary` signature is
+`function renderMeritSummary(char, sub)` — `char` is already the first parameter, so
+`getMeritDetails(char, a)` works without changes.
+
+### T3 — `_handleMeritSummaryDismiss(btn)` handler
+
+Add this async function near `_handleStoryTaBlur` (around line 381) or adjacent to other
+`_handle*` helpers:
+
+```js
+async function _handleMeritSummaryDismiss(btn) {
+  if (!_currentSub) return;
+  const sub = _currentSub;
+  const idx = parseInt(btn.dataset.actionIdx, 10);
+  if (isNaN(idx)) return;
+
+  const current = Array.isArray(sub.st_narrative?.merit_summary_overrides)
+    ? [...sub.st_narrative.merit_summary_overrides]
+    : [];
+
+  const updated = current.includes(idx)
+    ? current.filter(i => i !== idx)
+    : [...current, idx].sort((a, b) => a - b);
+
+  await saveNarrativeField(sub._id, { 'st_narrative.merit_summary_overrides': updated });
+  (sub.st_narrative ??= {}).merit_summary_overrides = updated;
+
+  const char = getCharForSub(sub);
+  const view = document.getElementById('dt-story-char-view');
+  if (view) view.innerHTML = renderCharacterView(char, sub);
+}
+```
+
+### T4 — Wire dismiss handler into click dispatch
+
+In the click dispatch listener (lines ~270–331), add a new handler guard. Insert it immediately
+after the `feedApproveBtn` block (line ~291) and before the `saveDraftBtn` block (line ~293):
+
+```js
+    // Merit summary dismiss / undismiss
+    const dismissBtn = e.target.closest('.dt-merit-dismiss-btn');
+    if (dismissBtn) { _handleMeritSummaryDismiss(dismissBtn); return; }
+```
+
+### T5 — CSS: new classes for blocking list and overridden badge
+
+Append to the merit summary block in `public/css/admin-layout.css` (after line 6959,
+`.dt-story-pending-note { color: var(--txt3); font-style: italic; }`):
+
+```css
+/* ── Issue #458: merit summary dismiss/override ──────────────────── */
+.dt-story-complete-badge.dt-story-complete-overridden { color: var(--gold2); }
+.dt-merit-blocking-list {
+  margin-top: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.dt-merit-blocking-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+}
+.dt-merit-blocking-item-label { color: var(--txt2); font-weight: 500; }
+.dt-merit-blocking-reason { color: var(--txt3); font-style: italic; flex: 1; }
+.dt-merit-dismiss-btn {
+  font-size: 11px;
+  padding: 2px 7px;
+  border: 1px solid var(--bdr);
+  border-radius: 3px;
+  background: var(--surf2);
+  color: var(--txt2);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.dt-merit-dismiss-btn:hover { border-color: var(--gold2); color: var(--gold2); }
+.dt-merit-dismiss-btn--active {
+  border-color: var(--gold2);
+  color: var(--gold2);
+  background: var(--surf3);
+}
+```
+
+### T6 — Playwright spec
+
+File: `tests/feat-458-dt-story-merit-summary-dismiss.spec.js`
+
+Use the `fake-test-token` auth pattern from
+`tests/fix-432-checklist-merit-star-icon.spec.js` (mock `/api/auth/me`, mock
+`/api/downtime_cycles`, mock `/api/downtime_submissions/:id`, set `merit_actions` directly on
+the submission fixture to bypass `buildMeritActions`).
+
+**Fixtures:**
+
+```js
+const baseSub = (id) => ({
+  _id: id,
+  character_id: 'char-test',
+  character_name: 'Test Character',
+  cycle_id: 'cycle-test',
+  cycle_name: 'Test Cycle',
+  responses: {},
+  _raw: { sphere_actions: [], contact_actions: { requests: [] }, retainer_actions: { actions: [] } },
+  merit_actions: [],
+  merit_actions_resolved: [],
+  acquisitions_resolved: [],
+  st_narrative: {},
+  st_review: {},
+  projects_resolved: [],
+  feeding_validation: {},
+});
+
+// One blocking contacts action, no outcome_summary
+const SUB_ONE_MISSING = {
+  ...baseSub('sub-458-one'),
+  merit_actions: [{ merit_type: 'Contacts (Church)', action_type: 'misc', desired_outcome: 'Info from Church' }],
+  merit_actions_resolved: [{ pool_status: 'confirmed', outcome_summary: '' }],
+};
+
+// Two blocking actions
+const SUB_TWO_MISSING = {
+  ...baseSub('sub-458-two'),
+  merit_actions: [
+    { merit_type: 'Allies 3 (Police)', action_type: 'misc', desired_outcome: 'Police help' },
+    { merit_type: 'Contacts (Church)', action_type: 'misc', desired_outcome: 'Church info' },
+  ],
+  merit_actions_resolved: [
+    { pool_status: 'confirmed', outcome_summary: '' },
+    { pool_status: 'confirmed', outcome_summary: '' },
+  ],
+};
+
+// One missing, already dismissed (overrides: [0])
+const SUB_DISMISSED = {
+  ...baseSub('sub-458-dismissed'),
+  merit_actions: [{ merit_type: 'Contacts (Church)', action_type: 'misc', desired_outcome: 'Church info' }],
+  merit_actions_resolved: [{ pool_status: 'confirmed', outcome_summary: '' }],
+  st_narrative: { merit_summary_overrides: [0] },
+};
+
+// All outcomes genuinely complete
+const SUB_COMPLETE = {
+  ...baseSub('sub-458-complete'),
+  merit_actions: [{ merit_type: 'Allies 2 (Police)', action_type: 'misc', desired_outcome: 'Police help' }],
+  merit_actions_resolved: [{ pool_status: 'confirmed', outcome_summary: 'Police network maintained.' }],
+};
+```
+
+**Tests to write (AC-1 through AC-6):**
+
+```
+AC-1: SUB_ONE_MISSING → "1 outcome still to record in DT Processing" visible; action name
+      "Contacts (Church)" visible in blocking list; reason "outcome not yet recorded" visible.
+
+AC-2: SUB_ONE_MISSING → Dismiss button present with text "Dismiss".
+
+AC-3: SUB_TWO_MISSING → count text says "2 outcomes still to record"; both action names
+      visible in blocking list.
+
+AC-4: SUB_DISMISSED → section dot is green (dt-story-dot-complete); "Overridden (1 dismissed)"
+      badge present; Undismiss button visible; no "still to record" text.
+
+AC-5: SUB_DISMISSED → clicking Undismiss fires PATCH to /api/downtime_submissions/:id;
+      after re-render, "1 outcome still to record" text re-appears and Dismiss button shown.
+      (Mock the PATCH endpoint and assert it was called with merit_summary_overrides: [].)
+
+AC-6: SUB_COMPLETE → "All outcomes recorded" badge visible; no blocking list rendered;
+      dot is green; no "Dismiss" button.
+```
+
+**Pattern for checking dot class:**
+
+```js
+const dot = await page.locator('[data-section="merit_summary"] .dt-story-completion-dot');
+await expect(dot).toHaveClass(/dt-story-dot-complete/);
+```
+
+## Acceptance Criteria
+
+- [x] AC-1: When merit summary is incomplete, each blocking action is listed by name and reason below the count message
+- [x] AC-2: Each blocking item has a Dismiss button
+- [x] AC-3: Clicking Dismiss saves `merit_summary_overrides` via `saveNarrativeField` and immediately re-renders the section
+- [x] AC-4: When all blocking items are dismissed, the section shows "Overridden (N dismissed)" in amber and the dot turns green
+- [x] AC-5: Dismissed items show an Undismiss button; clicking it removes the override and re-renders
+- [x] AC-6: Submissions with all outcomes genuinely present show only the green "All outcomes recorded" badge with no blocking list
+
+## Dev Agent Record
+
+_To be completed by the implementing agent._
+
+### Tasks Completed
+- [x] T1 — `meritSummaryComplete` override check
+- [x] T2 — `renderMeritSummary` blocking list + overridden badge
+- [x] T3 — `_handleMeritSummaryDismiss` handler
+- [x] T4 — Click dispatch wire-up
+- [x] T5 — CSS
+- [x] T6 — Playwright spec (6 tests: AC-1 through AC-6)
+
+### Notes
+
+Root cause discovered during AC-5 debugging: Playwright glob pattern `**/api/downtime_submissions*`
+does not match URLs with additional path segments (e.g. `.../downtime_submissions/sub-id`) because
+Playwright's `*` wildcard does not cross `/` boundaries. Route mock in the spec was changed to use
+a regex (`/\/api\/downtime_submissions/`) so both the list endpoint (GET) and ID endpoint (PUT)
+are intercepted correctly.
+
+### File List
+- `public/js/admin/downtime-story.js` — T1–T4: `meritSummaryComplete`, `renderMeritSummary`, `_handleMeritSummaryDismiss`, click dispatch
+- `public/css/admin-layout.css` — T5: new CSS classes
+- `tests/feat-458-dt-story-merit-summary-dismiss.spec.js` — T6: 6 Playwright tests
+- `specs/stories/feat.458.dt-story-merit-summary-dismiss.story.md` — story file (this file)
+- `specs/stories/sprint-status.yaml` — status updated to `review`

--- a/specs/stories/sprint-status.yaml
+++ b/specs/stories/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-15
-# last_updated: 2026-05-21 (fix-452: buildMeritActions actionVal guard implemented + 4 Playwright tests)
+# last_updated: 2026-05-21 (feat-458: merit summary dismiss/override — 6 Playwright tests, all passing)
 # project: TM Suite
 # project_key: NOKEY
 # tracking_system: file-system
@@ -799,3 +799,4 @@ development_status:
   fix-452-dt-story-actionval-guard: review                  # buildMeritActions flat-response loop: add actionVal guard — phantom sphere slots (merit set, action empty) now silently excluded; 6 Playwright tests pass
   fix-454-dt-story-status-loop-guard: review                # status loop missing actionVal guard (same phantom-slot bug as #452 sphere loop); deriveMeritCategory regex /mystery cult initiate/ misses "Mystery Cult Initiation" — fix: /mystery cult initiat/; 6 Playwright tests passing
   fix-456-dt-story-resources-acq-complete: review   # meritSummaryComplete checks acquisitions_resolved[0] but DT Processing writes to merit_actions_resolved[i]; resources acquisition validated in Processing stays pending in Story; fix: check resolved[i].pool_status first; T3: row shows notes_thread as outcome
+  feat-458-dt-story-merit-summary-dismiss: review   # expand merit summary blocking message: list each incomplete action by name+reason; per-action Dismiss button; overrides persist to st_narrative.merit_summary_overrides; amber Overridden badge when all dismissed

--- a/tests/feat-458-dt-story-merit-summary-dismiss.spec.js
+++ b/tests/feat-458-dt-story-merit-summary-dismiss.spec.js
@@ -302,6 +302,79 @@ test.describe('feat.458: merit summary dismiss/override', () => {
     await expect(page.locator('.dt-merit-dismiss-btn').first()).toHaveText('Dismiss');
   });
 
+  // QA-1 ─────────────────────────────────────────────────────────────────────
+
+  test('QA-1: clicking Dismiss fires PUT with index in overrides and re-renders overridden badge', async ({ page }) => {
+    await setup(page, [SUB_ONE_MISSING]);
+
+    // Initial state: Dismiss button (not active)
+    const dismissBtn = page.locator('.dt-merit-dismiss-btn').first();
+    await expect(dismissBtn).toBeVisible();
+    await expect(dismissBtn).toHaveText('Dismiss');
+
+    const putPromise = page.waitForRequest(
+      req => req.url().includes('/api/downtime_submissions/') && req.method() === 'PUT',
+      { timeout: 5000 }
+    );
+
+    await dismissBtn.click();
+
+    const putRequest = await putPromise;
+    const body = JSON.parse(putRequest.postData());
+    expect(body['st_narrative.merit_summary_overrides']).toEqual([0]);
+
+    await page.waitForTimeout(1000);
+
+    // After re-render: overridden badge shown, no pending note
+    const html = await getMeritSectionHtml(page, 'merit_summary');
+    expect(html).toContain('Overridden (1 dismissed)');
+    expect(html).not.toContain('still to record in DT Processing');
+
+    // Dot turns green
+    const dot = page.locator('[data-section="merit_summary"] .dt-story-completion-dot');
+    await expect(dot).toHaveClass(/dt-story-dot-complete/);
+
+    // Button flips to Undismiss
+    await expect(page.locator('.dt-merit-dismiss-btn--active')).toHaveText('Undismiss');
+  });
+
+  // QA-2 ─────────────────────────────────────────────────────────────────────
+
+  test('QA-2: partial dismiss (2 items, dismiss 1) — dot stays pending, one Dismiss one Undismiss', async ({ page }) => {
+    await setup(page, [SUB_TWO_MISSING]);
+
+    // Both Dismiss buttons present; click the first (Allies, idx=0)
+    const btns = page.locator('.dt-merit-dismiss-btn');
+    await expect(btns).toHaveCount(2);
+
+    const putPromise = page.waitForRequest(
+      req => req.url().includes('/api/downtime_submissions/') && req.method() === 'PUT',
+      { timeout: 5000 }
+    );
+
+    await btns.first().click();
+
+    const putRequest = await putPromise;
+    const body = JSON.parse(putRequest.postData());
+    expect(body['st_narrative.merit_summary_overrides']).toEqual([0]);
+
+    await page.waitForTimeout(1000);
+
+    // Still one remaining block → "1 outcome still to record"
+    const html = await getMeritSectionHtml(page, 'merit_summary');
+    expect(html).toContain('1 outcome still to record in DT Processing');
+    expect(html).not.toContain('Overridden');
+
+    // Dot stays pending because one un-dismissed block remains
+    const dot = page.locator('[data-section="merit_summary"] .dt-story-completion-dot');
+    await expect(dot).toHaveClass(/dt-story-dot-pending/);
+
+    // One Dismiss (remaining) + one Undismiss (dismissed) visible
+    await expect(page.locator('.dt-merit-dismiss-btn')).toHaveCount(2);
+    await expect(page.locator('.dt-merit-dismiss-btn--active')).toHaveCount(1);
+    await expect(page.locator('.dt-merit-dismiss-btn--active')).toHaveText('Undismiss');
+  });
+
   // AC-6 ──────────────────────────────────────────────────────────────────────
 
   test('AC-6: all outcomes present → green check badge, no blocking list', async ({ page }) => {

--- a/tests/feat-458-dt-story-merit-summary-dismiss.spec.js
+++ b/tests/feat-458-dt-story-merit-summary-dismiss.spec.js
@@ -1,0 +1,322 @@
+/**
+ * Tests for feat #458 — merit summary dismiss/override.
+ *
+ * Feature: When the merit summary section has incomplete outcomes, each
+ * blocking action is now listed by name and reason. An ST can Dismiss
+ * individual actions to override the block. When all blocks are dismissed,
+ * an amber "Overridden (N dismissed)" badge replaces the pending note and
+ * the section dot turns green.
+ *
+ * AC-1: Blocking action name + reason listed below count message
+ * AC-2: Dismiss button present on each blocking item
+ * AC-3: Two blocking actions → "2 outcomes still to record"; both names visible
+ * AC-4: Pre-dismissed submission → "Overridden (1 dismissed)" badge, dot green
+ * AC-5: Clicking Undismiss fires PUT to /api/downtime_submissions/:id;
+ *        re-render shows pending note + Dismiss button
+ * AC-6: All outcomes genuinely present → green check badge, no blocking list
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Shared fixtures ───────────────────────────────────────────────────────────
+
+const ST_USER = {
+  id: '123000458', username: 'test_st_458', global_name: 'Test ST 458',
+  avatar: null, role: 'st', player_id: 'p-458', character_ids: [], is_dual_role: false,
+};
+
+const ACTIVE_CYCLE = {
+  _id: 'cycle-458', cycle_number: 3, status: 'active',
+  phase_signoff: {}, confirmed_ambience: {},
+};
+
+const CHAR = {
+  _id: 'char-458',
+  name: 'Test Kindred', moniker: null, honorific: null,
+  clan: 'Daeva', covenant: 'Invictus', player: 'Test Player',
+  blood_potency: 2, humanity: 6, humanity_base: 7, court_title: null,
+  home_territory: null, retired: false,
+  status: { city: 1, clan: 1, covenant: { Invictus: 1 } },
+  attributes: {
+    Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+    Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+    Presence: { dots: 3, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: {}, disciplines: {},
+  merits: [
+    { name: 'Allies',   category: 'general', dots: 2 },
+    { name: 'Contacts', category: 'general', dots: 2 },
+  ],
+  powers: [], ordeals: [],
+};
+
+// ── Submission builders ───────────────────────────────────────────────────────
+
+function baseSub(id) {
+  return {
+    _id: id,
+    cycle_id: 'cycle-458',
+    character_id: 'char-458',
+    character_name: 'Test Kindred',
+    player_name: 'Test Player',
+    status: 'submitted',
+    responses: {},
+    _raw: { sphere_actions: [], contact_actions: { requests: [] }, retainer_actions: { actions: [] } },
+    projects_resolved: [],
+    merit_actions_resolved: [],
+    acquisitions_resolved: [],
+    st_review: {},
+    st_narrative: { story_moment: { status: 'complete' } },
+    feeding_review: { pool_status: 'no_feed' },
+  };
+}
+
+// AC-1 + AC-2: one Allies sphere action with no outcome_summary → one blocking item.
+// Uses flat-response path: buildMeritActions reads sphere_1_merit + sphere_1_action keys
+// when _raw.sphere_actions is empty.
+const SUB_ONE_MISSING = {
+  ...baseSub('sub-458-one'),
+  responses: {
+    sphere_1_merit:   'Allies 2 (Police)',
+    sphere_1_action:  'misc',
+    sphere_1_outcome: 'Police network maintained',
+  },
+  merit_actions_resolved: [
+    { pool_status: 'confirmed', outcome_summary: '' },
+  ],
+};
+
+// AC-3: two sphere actions, both missing outcome_summary.
+const SUB_TWO_MISSING = {
+  ...baseSub('sub-458-two'),
+  responses: {
+    sphere_1_merit:   'Allies 2 (Police)',
+    sphere_1_action:  'misc',
+    sphere_1_outcome: 'Police help',
+    sphere_2_merit:   'Contacts (Church)',
+    sphere_2_action:  'misc',
+    sphere_2_outcome: 'Church info',
+  },
+  merit_actions_resolved: [
+    { pool_status: 'confirmed', outcome_summary: '' },
+    { pool_status: 'confirmed', outcome_summary: '' },
+  ],
+};
+
+// AC-4: one Allies action, no outcome, already dismissed via overrides.
+// meritSummaryComplete returns true → dot green; footer shows overridden badge.
+const SUB_DISMISSED = {
+  ...baseSub('sub-458-dismissed'),
+  responses: {
+    sphere_1_merit:   'Allies 2 (Police)',
+    sphere_1_action:  'misc',
+    sphere_1_outcome: 'Police network',
+  },
+  merit_actions_resolved: [
+    { pool_status: 'confirmed', outcome_summary: '' },
+  ],
+  st_narrative: {
+    story_moment: { status: 'complete' },
+    merit_summary_overrides: [0],
+  },
+};
+
+// AC-6: all outcomes genuinely present → green check, no blocking list.
+const SUB_COMPLETE = {
+  ...baseSub('sub-458-complete'),
+  responses: {
+    sphere_1_merit:   'Allies 2 (Police)',
+    sphere_1_action:  'misc',
+    sphere_1_outcome: 'Police network maintained',
+  },
+  merit_actions_resolved: [
+    { pool_status: 'confirmed', outcome_summary: 'Police network maintained.' },
+  ],
+};
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+async function setup(page, submissions, { interceptPut } = {}) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER });
+
+  await page.route('**/api/auth/me', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(ST_USER) })
+  );
+  await page.route(/\/api\/characters$/, route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([CHAR]) })
+  );
+  await page.route('**/api/characters/names', route =>
+    route.fulfill({ status: 200, contentType: 'application/json',
+      body: JSON.stringify([{ _id: CHAR._id, name: CHAR.name, moniker: CHAR.moniker, honorific: CHAR.honorific }]) })
+  );
+  await page.route('**/api/downtime_cycles*', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([ACTIVE_CYCLE]) })
+  );
+  // Route covers both ?query-param GETs and /id PUT/PATCH paths
+  await page.route(/\/api\/downtime_submissions/, route => {
+    const method = route.request().method();
+    if (method === 'PUT' || method === 'PATCH' || method === 'POST') {
+      if (interceptPut) interceptPut(route.request());
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+    }
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(submissions) });
+  });
+  await page.route('**/api/territories*', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+  );
+  await page.route('**/api/game_sessions*', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+  );
+  await page.route('**/api/session_logs*', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+  );
+  await page.route('**/api/st_mods*', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+  );
+
+  await page.goto('/admin.html');
+  await page.waitForSelector('#admin-app', { state: 'visible', timeout: 10000 });
+  await page.click('[data-domain="downtime"]');
+  await page.waitForSelector('button[data-phase="story"]', { state: 'visible', timeout: 10000 });
+  await page.click('button[data-phase="story"]');
+  await page.waitForSelector('#dt-story-nav-rail', { timeout: 10000 });
+  await page.click('.dt-story-pill');
+  await page.waitForSelector('.dt-story-char-content', { timeout: 5000 });
+  await page.waitForTimeout(300);
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function getMeritSectionHtml(page, sectionKey) {
+  return page.evaluate((key) => {
+    const el = document.querySelector(`.dt-story-section[data-section="${key}"]`);
+    return el ? el.innerHTML : null;
+  }, sectionKey);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('feat.458: merit summary dismiss/override', () => {
+
+  // AC-1 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-1: blocking action name and reason visible below count message', async ({ page }) => {
+    await setup(page, [SUB_ONE_MISSING]);
+    const html = await getMeritSectionHtml(page, 'merit_summary');
+    expect(html).not.toBeNull();
+    // Pending note still present
+    expect(html).toContain('still to record in DT Processing');
+    // Action name (from getMeritDetails on 'Allies 2 (Police)' → label 'Allies', qualifier 'Police')
+    expect(html).toContain('Allies (Police)');
+    // Reason
+    expect(html).toContain('outcome not yet recorded');
+    // No overridden badge
+    expect(html).not.toContain('Overridden');
+  });
+
+  // AC-2 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-2: Dismiss button present on blocking item', async ({ page }) => {
+    await setup(page, [SUB_ONE_MISSING]);
+    const dismissBtn = page.locator('.dt-merit-dismiss-btn').first();
+    await expect(dismissBtn).toBeVisible();
+    await expect(dismissBtn).toHaveText('Dismiss');
+    // Must not have active styling yet
+    await expect(dismissBtn).not.toHaveClass(/dt-merit-dismiss-btn--active/);
+  });
+
+  // AC-3 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-3: two blocking actions → count says "2 outcomes", both names visible', async ({ page }) => {
+    await setup(page, [SUB_TWO_MISSING]);
+    const html = await getMeritSectionHtml(page, 'merit_summary');
+    expect(html).not.toBeNull();
+    expect(html).toContain('2 outcomes still to record in DT Processing');
+    // Both action names visible
+    expect(html).toContain('Allies (Police)');
+    expect(html).toContain('Contacts (Church)');
+    // Two Dismiss buttons
+    const dismissBtns = page.locator('.dt-merit-dismiss-btn');
+    await expect(dismissBtns).toHaveCount(2);
+  });
+
+  // AC-4 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-4: pre-dismissed submission → overridden badge visible, dot green', async ({ page }) => {
+    await setup(page, [SUB_DISMISSED]);
+    const html = await getMeritSectionHtml(page, 'merit_summary');
+    expect(html).not.toBeNull();
+    // Overridden badge shown (not the green check)
+    expect(html).toContain('Overridden (1 dismissed)');
+    expect(html).not.toContain('All outcomes recorded');
+    expect(html).not.toContain('still to record in DT Processing');
+    // Dot is green (meritSummaryComplete returns true when all overridden)
+    const dot = page.locator('[data-section="merit_summary"] .dt-story-completion-dot');
+    await expect(dot).toHaveClass(/dt-story-dot-complete/);
+    // Undismiss button present
+    const undismissBtn = page.locator('.dt-merit-dismiss-btn--active');
+    await expect(undismissBtn).toBeVisible();
+    await expect(undismissBtn).toHaveText('Undismiss');
+  });
+
+  // AC-5 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-5: clicking Undismiss fires PUT and re-renders with pending note', async ({ page }) => {
+    // Capture PUT bodies for assertion
+    const putBodies = [];
+    await setup(page, [SUB_DISMISSED], {
+      interceptPut: (req) => { try { putBodies.push(req.postData()); } catch (_) {} },
+    });
+
+    // Initial state: overridden badge + Undismiss button
+    await expect(page.locator('.dt-merit-dismiss-btn--active')).toBeVisible();
+
+    // Wait for PUT request to be made first
+    const putPromise = page.waitForRequest(
+      req => req.url().includes('/api/downtime_submissions/') && req.method() === 'PUT',
+      { timeout: 5000 }
+    );
+
+    // Click Undismiss
+    await page.locator('.dt-merit-dismiss-btn--active').click();
+
+    // Assert PUT fired with empty overrides array
+    const putRequest = await putPromise;
+    const body = JSON.parse(putRequest.postData());
+    // Key contains a literal dot — use bracket notation, not toHaveProperty (which splits on '.')
+    expect(body['st_narrative.merit_summary_overrides']).toEqual([]);
+
+    // Give the async handler time to complete the re-render
+    await page.waitForTimeout(1000);
+
+    // After re-render: pending note shown, no overridden badge
+    const html = await getMeritSectionHtml(page, 'merit_summary');
+    expect(html).toContain('still to record in DT Processing');
+    expect(html).not.toContain('Overridden');
+
+    // Dismiss button (not active/Undismiss) is shown for the re-blocked item
+    await expect(page.locator('.dt-merit-dismiss-btn').first()).toHaveText('Dismiss');
+  });
+
+  // AC-6 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-6: all outcomes present → green check badge, no blocking list', async ({ page }) => {
+    await setup(page, [SUB_COMPLETE]);
+    const html = await getMeritSectionHtml(page, 'merit_summary');
+    expect(html).not.toBeNull();
+    expect(html).toContain('All outcomes recorded');
+    expect(html).not.toContain('Overridden');
+    expect(html).not.toContain('still to record in DT Processing');
+    // No blocking list rendered
+    const blockingList = page.locator('.dt-merit-blocking-list');
+    await expect(blockingList).toHaveCount(0);
+    // No dismiss buttons
+    const dismissBtns = page.locator('.dt-merit-dismiss-btn');
+    await expect(dismissBtns).toHaveCount(0);
+  });
+
+});


### PR DESCRIPTION
## Summary

- Expands the "N outcomes still to record" message in the Allies & Asset Summary section to list each incomplete action by name and reason, so STs know exactly what is outstanding
- Adds per-action Dismiss/Undismiss buttons that persist overrides to `st_narrative.merit_summary_overrides` via `saveNarrativeField`
- When all blocking items are dismissed, the section shows an amber "Overridden (N dismissed)" badge and the completion dot turns green — sign-off is no longer blocked
- Fixes a Playwright test bug: glob pattern `**/api/downtime_submissions*` does not match `/id` PUT paths (glob `*` doesn't cross `/`); changed to regex

## Closes

- Closes #458

## Story

- specs/stories/feat.458.dt-story-merit-summary-dismiss.story.md

## Test plan

- [ ] `npx playwright test tests/feat-458-dt-story-merit-summary-dismiss.spec.js` — 8 tests pass (AC-1 through AC-6 + QA-1 Dismiss forward path + QA-2 partial dismiss)
- [ ] CI green
- [ ] Manual: open DT Story tab, find a character with incomplete merit outcomes — confirm blocking list renders, Dismiss persists on reload, Overridden badge shows when all dismissed

## Branch flow

- From: `ms/issue-458-dt-story-merit-summary-dismiss`
- Into: `dev`