### PR TITLE
fix(#464): deduplicate Story Moment in Archive tab

### DIFF
--- a/public/js/tabs/story-tab.js
+++ b/public/js/tabs/story-tab.js
@@ -435,10 +435,19 @@ export function renderOutcomeWithCards(sub, opts = {}) {
 
   // ── Sections 1-2: Story Moment + Home Report (above main narrative) ──
   let h = '<div class="story-narrative">';
-  h += renderStoryMoment(sub, { editable });
-  h += renderHomeReportSection(sub, { editable });
+  const smHtml = renderStoryMoment(sub, { editable });
+  const hrHtml = renderHomeReportSection(sub, { editable });
+  h += smHtml;
+  h += hrHtml;
+  // If a dedicated renderer produced output, skip the same heading in
+  // published_outcome to prevent the section appearing twice (fix #464).
+  const _renderedKeys = new Set();
+  if (smHtml) _renderedKeys.add('story_moment');
+  if (hrHtml) _renderedKeys.add('home_report');
   for (const sec of sections) {
     if (sec.heading) {
+      const secKey = _flagSectionKeyForHeading(sec.heading);
+      if (secKey && _renderedKeys.has(secKey)) continue;
       const isMech = sec.heading === 'Mechanical Outcomes';
       // Match the parsed heading to a project card to find its index. When
       // editable, the heading section is treated as the editable surface for

--- a/specs/stories/fix.464.archive-story-moment-dedup.story.md
+++ b/specs/stories/fix.464.archive-story-moment-dedup.story.md
@@ -1,0 +1,238 @@
+---
+issue: 464
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/464
+branch: ms/issue-464-archive-story-moment-duplicate
+status: review
+date: 2026-05-22
+---
+
+# fix.464 — Archive tab: Story Moment deduplication guard
+
+## Story
+
+As a player viewing the Archive tab,
+I want the Story Moment section to appear exactly once per downtime report,
+so that I am not confused by duplicated narrative content.
+
+## Background
+
+`renderOutcomeWithCards` (story-tab.js) has two independent render paths that both produce a
+"Story Moment" block:
+
+1. **Dedicated renderer** — `renderStoryMoment(sub)` at line 438, reading from
+   `st_narrative.story_moment.response` (the consolidated field written by the admin tool from
+   DT3 onwards).
+2. **Section loop** — `parseOutcomeSections(sub.published_outcome)` at line 380 parses the raw
+   `published_outcome` text; when the push text contains a `## Story Moment` heading (which it
+   does for DT3), the loop at lines 440-486 renders that heading as a second Story Moment block.
+
+DT1-2 escaped the bug because `story_moment` was never set — `renderStoryMoment` returned `''`,
+so only the sections loop path fired. DT3 introduced the structured `story_moment` field, and now
+both paths fire simultaneously, producing an identical duplicate.
+
+The same latent issue exists for `renderHomeReportSection` / `## Home Report`.
+
+## Acceptance Criteria
+
+- [ ] AC1: A DT3 submission with `st_narrative.story_moment.response` set shows exactly **one**
+  Story Moment block in `renderOutcomeWithCards` output.
+- [ ] AC2: A legacy submission with **only** `published_outcome` text (no `st_narrative.story_moment`,
+  no `personal_story`, no `letter_from_home`, no `touchstone`) still shows Story Moment from the
+  parsed `## Story Moment` heading in `published_outcome`.
+- [ ] AC3: Home Report does not duplicate under the same conditions — same guard applies.
+- [ ] AC4: Legacy `letter_from_home`-only and `touchstone`-only submissions render their Story Moment
+  section unchanged (single block, no regression).
+
+---
+
+## Dev Notes
+
+### File to modify — ONE file, no others
+
+**`public/js/tabs/story-tab.js`** — function `renderOutcomeWithCards` (line ~378).
+
+Do **not** touch: `_storyNarrSection`, `renderStoryMoment`, `renderHomeReportSection`,
+`_flagSectionKeyForHeading`, `parseOutcomeSections`, or any other helper. The fix is
+entirely local to the control flow inside `renderOutcomeWithCards`.
+
+### Exact fix — minimal change
+
+**Before the section loop**, compute the dedicated section HTML first and track which
+section keys were rendered:
+
+```js
+// ── Sections 1-2: Story Moment + Home Report (above main narrative) ──
+let h = '<div class="story-narrative">';
+const smHtml = renderStoryMoment(sub, { editable });
+const hrHtml = renderHomeReportSection(sub, { editable });
+h += smHtml;
+h += hrHtml;
+// Skip published_outcome headings already handled by dedicated renderers.
+const _renderedKeys = new Set();
+if (smHtml) _renderedKeys.add('story_moment');
+if (hrHtml) _renderedKeys.add('home_report');
+
+for (const sec of sections) {
+  if (sec.heading) {
+    const secKey = _flagSectionKeyForHeading(sec.heading);
+    if (secKey && _renderedKeys.has(secKey)) continue;   // ← guard
+    // ... rest of loop unchanged ...
+  }
+}
+```
+
+**The loop body is unchanged.** Only the `continue` guard line is added.
+
+### Why `_flagSectionKeyForHeading` is the right hook
+
+`_flagSectionKeyForHeading` already maps:
+- `'story moment'` → `'story_moment'`
+- `'home report'` → `'home_report'`
+
+Using it is idiomatic — it's already the canonical heading → key resolver in this file
+(used for flag affordances at line 462). No new string comparison needed.
+
+### Why `renderStoryMoment` returns `''` on legacy-only submissions
+
+```js
+function renderStoryMoment(sub, opts = {}) {
+  const smText = sub.st_narrative?.story_moment?.response;
+  if (smText) return _storyNarrSection(...);          // early return for DT3+
+
+  const psText = sub.st_narrative?.personal_story?.response;
+  if (psText) return _storyNarrSection(...);           // early return
+
+  const letter    = sub.st_narrative?.letter_from_home?.response;
+  const touchstone = sub.st_narrative?.touchstone?.response;
+  if (!letter && !touchstone) return '';              // ← returns '' here
+  // ... legacy dual-block path for DT1-2
+}
+```
+
+A submission with **only** a `## Story Moment` heading in `published_outcome` (and no structured
+`st_narrative` fields) will return `''` → `_renderedKeys` will NOT have `'story_moment'` → the
+loop will render the heading as normal. AC2 is satisfied by this logic automatically.
+
+### What NOT to do
+
+- Do NOT modify `renderStoryMoment` or `renderHomeReportSection` — they are correct.
+- Do NOT call `renderStoryMoment` twice.
+- Do NOT try to strip headings from `published_outcome` — historical data exists; this would be
+  destructive and wrong.
+- Do NOT add a `compiled_sections_already_rendered` flag or similar module-level state. The
+  `_renderedKeys` Set is local to `renderOutcomeWithCards` and is all that's needed.
+
+### Key line numbers (as of branch base — verify before editing)
+
+| Line | What |
+|------|------|
+| 378  | `export function renderOutcomeWithCards(sub, opts = {})` |
+| 380  | `const sections = parseOutcomeSections(sub.published_outcome)` |
+| 436  | `// ── Sections 1-2: Story Moment + Home Report` comment |
+| 437  | `let h = '<div class="story-narrative">'` |
+| 438  | `h += renderStoryMoment(sub, { editable })` |
+| 439  | `h += renderHomeReportSection(sub, { editable })` |
+| 440  | `for (const sec of sections) {` |
+| 462  | `const headingKey = _flagSectionKeyForHeading(sec.heading)` |
+
+---
+
+## Tasks / Subtasks
+
+- [x] T1: Add `_renderedKeys` Set and `continue` guard to `renderOutcomeWithCards` in `story-tab.js`
+  - [x] Capture `renderStoryMoment` return value before appending; add to `_renderedKeys` if non-empty
+  - [x] Capture `renderHomeReportSection` return value before appending; add to `_renderedKeys` if non-empty
+  - [x] Add `if (secKey && _renderedKeys.has(secKey)) continue;` at top of the section loop's `if (sec.heading)` block
+  - [x] Parse-check: `node --check --input-type=module < public/js/tabs/story-tab.js`
+- [x] T2: Write Playwright tests for the four ACs (file: `tests/fix-464-archive-story-moment-dedup.spec.js`)
+  - [x] AC1: structured `story_moment` + published_outcome with `## Story Moment` → exactly one `.story-section-head` containing "Story Moment"
+  - [x] AC2: no structured fields + published_outcome with `## Story Moment` → exactly one `.story-section-head` containing "Story Moment"
+  - [x] AC3: structured `home_report` + published_outcome with `## Home Report` → exactly one `.story-section-head` containing "Home Report"
+  - [x] AC4: legacy `letter_from_home`-only submission → exactly one Story Moment block
+- [x] T3: Run tests and confirm all pass
+
+---
+
+## Testing Approach
+
+Tests import `renderOutcomeWithCards` directly from `story-tab.js` via Playwright's
+`page.evaluate` + `page.addScriptTag`, OR use the `page.goto` + fixture interception pattern
+used throughout this test suite.
+
+The simplest approach is **pure unit style** within Playwright — create a minimal HTML page,
+inject the module, call `renderOutcomeWithCards` with stub data, and count `.story-section-head`
+elements. See `tests/issue-321-dt-story-cycle-resolver.spec.js` for the API-stub pattern used
+in this repo.
+
+Stub shapes needed for each AC:
+
+```js
+// AC1 — structured story_moment + published_outcome heading
+const sub_ac1 = {
+  _id: 'sub-ac1', character_id: 'char-1', cycle_id: 'cycle-1',
+  published_outcome: '## Story Moment\n\nThe letter content from push text.',
+  st_narrative: { story_moment: { response: 'The structured story moment.', status: 'complete' } },
+  responses: {},
+};
+// Expected: exactly 1 h4 with text "Story Moment"
+
+// AC2 — no structured fields, only published_outcome
+const sub_ac2 = {
+  _id: 'sub-ac2', character_id: 'char-1', cycle_id: 'cycle-1',
+  published_outcome: '## Story Moment\n\nContent from push text only.',
+  st_narrative: {},
+  responses: {},
+};
+// Expected: exactly 1 h4 with text "Story Moment"
+
+// AC3 — home report dedup
+const sub_ac3 = {
+  _id: 'sub-ac3', character_id: 'char-1', cycle_id: 'cycle-1',
+  published_outcome: '## Home Report\n\nThe home report in push text.',
+  st_narrative: { home_report: { response: 'The structured home report.', status: 'complete' } },
+  responses: {},
+};
+// Expected: exactly 1 h4 with text "Home Report"
+
+// AC4 — legacy letter_from_home only
+const sub_ac4 = {
+  _id: 'sub-ac4', character_id: 'char-1', cycle_id: 'cycle-1',
+  published_outcome: null,
+  st_narrative: { letter_from_home: { response: 'Legacy letter content.', status: 'complete' } },
+  responses: {},
+};
+// Expected: exactly 1 h4 with text "Story Moment" (from legacy path)
+```
+
+---
+
+## File List
+
+- `public/js/tabs/story-tab.js` — UPDATE
+- `tests/fix-464-archive-story-moment-dedup.spec.js` — CREATE
+
+---
+
+## Dev Agent Record
+
+### Completion Notes
+
+T1: In `renderOutcomeWithCards` (story-tab.js), replaced the two inline `h +=` calls for dedicated
+section renderers with captured variables (`smHtml`, `hrHtml`). Built a `_renderedKeys` Set from
+whichever ones returned non-empty string. Added `if (secKey && _renderedKeys.has(secKey)) continue`
+at the top of the `if (sec.heading)` block in the published_outcome sections loop. This prevents
+the same section appearing twice when structured `st_narrative` data and a matching `## Heading`
+both exist in `published_outcome`. The existing `_flagSectionKeyForHeading` function was the
+correct hook — it already maps `'story moment'` → `'story_moment'` and `'home report'` →
+`'home_report'`.
+
+T2: 5 Playwright tests via the game app Archive tab. AC4 required `published_outcome` to be a
+truthy string (archive-tab.js:65 filters out submissions without it); a non-heading body string
+was used so the legacy `letter_from_home` path still fires without competition.
+
+All 5 tests pass. Parse check clean.
+
+### Change Log
+
+- fix(#464): renderOutcomeWithCards — dedup guard for dedicated section renderers (2026-05-22)
+- test(#464): 5 Playwright tests via Archive tab (AC1-AC4 + content integrity) (2026-05-22)

--- a/tests/fix-464-archive-story-moment-dedup.spec.js
+++ b/tests/fix-464-archive-story-moment-dedup.spec.js
@@ -1,0 +1,206 @@
+/**
+ * fix-464: Archive tab — Story Moment section renders twice when published_outcome
+ * also contains a ## Story Moment heading.
+ *
+ * Root cause: renderOutcomeWithCards called renderStoryMoment() (reads structured
+ * st_narrative.story_moment) AND the sections loop parsed ## Story Moment from
+ * published_outcome text, producing a duplicate block. Fixed by tracking which
+ * section keys the dedicated renderers have already handled and skipping matching
+ * headings in the loop.
+ *
+ * Tests:
+ *   AC1: structured story_moment + published_outcome heading → exactly 1 Story Moment
+ *   AC2: no structured fields, published_outcome heading only → exactly 1 Story Moment
+ *   AC3: structured home_report + published_outcome heading → exactly 1 Home Report
+ *   AC4: legacy letter_from_home only (no published_outcome) → exactly 1 Story Moment
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Shared identity ─────────────────────────────────────────────────────────────
+
+const PLAYER_USER = {
+  id: '464000001', username: 'test_player_464', global_name: 'Test Player 464',
+  avatar: null, role: 'player', player_id: 'p-464',
+  character_ids: ['char-464'], is_dual_role: false,
+};
+
+const CHAR_464 = {
+  _id: 'char-464', name: 'Archive Test Char', moniker: null, honorific: null,
+  clan: 'Mekhet', covenant: 'Ordo Dracul', player: 'Test Player 464',
+  blood_potency: 2, humanity: 6, humanity_base: 7, court_title: null,
+  regent_territory: null, retired: false,
+  status: {
+    city: 1, clan: 0,
+    covenant: { 'Carthian Movement': 0, 'Circle of the Crone': 0, 'Invictus': 0, 'Lancea et Sanctum': 0, 'Ordo Dracul': 1 },
+  },
+  attributes: {
+    Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+    Intelligence: { dots: 3, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+    Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: {}, disciplines: { Auspex: { dots: 2 } }, merits: [], powers: [], ordeals: [],
+};
+
+const CYCLE_464 = {
+  _id: 'cycle-464', label: 'Downtime 3', cycle_number: 3, status: 'closed',
+  game_number: 3, confirmed_ambience: {}, narrative_notes: '',
+};
+
+// AC1: structured story_moment + ## Story Moment in published_outcome
+// Bug: without the fix, Story Moment appears twice.
+const SUB_AC1 = {
+  _id: 'sub-464-ac1',
+  character_id: 'char-464',
+  cycle_id: 'cycle-464',
+  published_outcome: '## Story Moment\n\nThe narrative moment written by the ST in the push text.',
+  st_narrative: {
+    story_moment: { response: 'The structured story moment text from admin tool.', status: 'complete' },
+  },
+  responses: {},
+  projects_resolved: [],
+  merit_actions_resolved: [],
+  section_flags: [],
+};
+
+// AC2: no structured fields at all — published_outcome heading is the only source.
+// The heading must still render (not be swallowed).
+const SUB_AC2 = {
+  _id: 'sub-464-ac2',
+  character_id: 'char-464',
+  cycle_id: 'cycle-464',
+  published_outcome: '## Story Moment\n\nContent from push text only — no structured field.',
+  st_narrative: {},
+  responses: {},
+  projects_resolved: [],
+  merit_actions_resolved: [],
+  section_flags: [],
+};
+
+// AC3: structured home_report + ## Home Report in published_outcome.
+const SUB_AC3 = {
+  _id: 'sub-464-ac3',
+  character_id: 'char-464',
+  cycle_id: 'cycle-464',
+  published_outcome: '## Home Report\n\nThe home report in push text.',
+  st_narrative: {
+    home_report: { response: 'The structured home report from admin tool.', status: 'complete' },
+  },
+  responses: {},
+  projects_resolved: [],
+  merit_actions_resolved: [],
+  section_flags: [],
+};
+
+// AC4: legacy letter_from_home only — published_outcome has NO Story Moment heading.
+// The archive tab requires a truthy published_outcome to list the submission.
+// renderStoryMoment's legacy path handles this; must produce exactly 1 block.
+const SUB_AC4 = {
+  _id: 'sub-464-ac4',
+  character_id: 'char-464',
+  cycle_id: 'cycle-464',
+  published_outcome: 'Some general narrative text with no section headings.',
+  st_narrative: {
+    letter_from_home: { response: 'Dear Alice,\n\nLegacy letter content here.', status: 'complete' },
+  },
+  responses: {},
+  projects_resolved: [],
+  merit_actions_resolved: [],
+  section_flags: [],
+};
+
+// ── Setup helper ────────────────────────────────────────────────────────────────
+
+async function setup(page, submissions) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: PLAYER_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url = route.request().url();
+    const method = route.request().method();
+    const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+
+    if (method === 'POST' || method === 'PUT' || method === 'PATCH') return ok({ ok: true });
+    if (url.includes('/api/auth/me'))              return ok(PLAYER_USER);
+    if (url.includes('/api/downtime_cycles'))      return ok([CYCLE_464]);
+    if (url.includes('/api/downtime_submissions')) return ok(submissions);
+    if (url.includes('/api/archive_documents'))    return ok([]);
+    if (url.includes('/api/characters/names'))     return ok([{ _id: CHAR_464._id, name: CHAR_464.name, moniker: null, honorific: null }]);
+    if (url.includes('/api/characters'))           return ok([CHAR_464]);
+    if (url.includes('/api/territories'))          return ok([]);
+    if (url.includes('/api/game_sessions'))        return ok([]);
+    if (url.includes('/api/session_logs'))         return ok([]);
+    if (url.includes('/api/st_mods'))              return ok([]);
+    if (url.includes('/api/ordeal-responses'))     return ok([]);
+    return ok([]);
+  });
+
+  await page.goto('/');
+  await page.waitForSelector('#app', { state: 'visible', timeout: 15000 });
+  await page.waitForFunction(() => typeof window.goTab === 'function', { timeout: 8000 });
+  await page.evaluate(() => window.goTab('archive'));
+  await page.waitForTimeout(800);
+}
+
+async function openFirstDtItem(page) {
+  // Wait for archive list to populate with a downtime entry.
+  await page.waitForSelector('.arc-doc-item[data-sub-id]', { timeout: 8000 });
+  await page.click('.arc-doc-item[data-sub-id]');
+  // Wait for the detail view to render with story-narrative.
+  await page.waitForSelector('.story-narrative', { timeout: 5000 });
+  await page.waitForTimeout(300);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────────
+
+test.describe('fix-464: Archive tab Story Moment deduplication', () => {
+
+  test('AC1: structured story_moment + published_outcome heading → exactly one Story Moment block', async ({ page }) => {
+    await setup(page, [SUB_AC1]);
+    await openFirstDtItem(page);
+
+    const heads = page.locator('.story-section-head');
+    const storyMomentHeads = heads.filter({ hasText: 'Story Moment' });
+    await expect(storyMomentHeads).toHaveCount(1);
+  });
+
+  test('AC2: no structured fields, published_outcome heading only → exactly one Story Moment block', async ({ page }) => {
+    await setup(page, [SUB_AC2]);
+    await openFirstDtItem(page);
+
+    const heads = page.locator('.story-section-head');
+    const storyMomentHeads = heads.filter({ hasText: 'Story Moment' });
+    await expect(storyMomentHeads).toHaveCount(1);
+  });
+
+  test('AC3: structured home_report + published_outcome heading → exactly one Home Report block', async ({ page }) => {
+    await setup(page, [SUB_AC3]);
+    await openFirstDtItem(page);
+
+    const heads = page.locator('.story-section-head');
+    const homeReportHeads = heads.filter({ hasText: 'Home Report' });
+    await expect(homeReportHeads).toHaveCount(1);
+  });
+
+  test('AC4: legacy letter_from_home only → exactly one Story Moment block (no regression)', async ({ page }) => {
+    await setup(page, [SUB_AC4]);
+    await openFirstDtItem(page);
+
+    const heads = page.locator('.story-section-head');
+    const storyMomentHeads = heads.filter({ hasText: 'Story Moment' });
+    await expect(storyMomentHeads).toHaveCount(1);
+  });
+
+  test('AC1 content integrity: structured story_moment text is what renders', async ({ page }) => {
+    await setup(page, [SUB_AC1]);
+    await openFirstDtItem(page);
+
+    // The structured field should be preferred over the published_outcome text.
+    const narrative = page.locator('.story-narrative');
+    await expect(narrative).toContainText('The structured story moment text from admin tool.');
+  });
+
+});

--- a/tests/fix-464-archive-story-moment-dedup.spec.js
+++ b/tests/fix-464-archive-story-moment-dedup.spec.js
@@ -92,7 +92,7 @@ const SUB_AC3 = {
   section_flags: [],
 };
 
-// AC4: legacy letter_from_home only — published_outcome has NO Story Moment heading.
+// AC4a: legacy letter_from_home only — published_outcome has NO Story Moment heading.
 // The archive tab requires a truthy published_outcome to list the submission.
 // renderStoryMoment's legacy path handles this; must produce exactly 1 block.
 const SUB_AC4 = {
@@ -102,6 +102,40 @@ const SUB_AC4 = {
   published_outcome: 'Some general narrative text with no section headings.',
   st_narrative: {
     letter_from_home: { response: 'Dear Alice,\n\nLegacy letter content here.', status: 'complete' },
+  },
+  responses: {},
+  projects_resolved: [],
+  merit_actions_resolved: [],
+  section_flags: [],
+};
+
+// AC4b: legacy touchstone only + ## Story Moment in published_outcome.
+// renderStoryMoment returns non-empty (touchstone path), so the loop must skip
+// the published_outcome heading — same guard, different legacy trigger.
+const SUB_AC4B = {
+  _id: 'sub-464-ac4b',
+  character_id: 'char-464',
+  cycle_id: 'cycle-464',
+  published_outcome: '## Story Moment\n\nThe push text story moment.',
+  st_narrative: {
+    touchstone: { response: 'Touchstone vignette content.', status: 'complete' },
+  },
+  responses: {},
+  projects_resolved: [],
+  merit_actions_resolved: [],
+  section_flags: [],
+};
+
+// Combined: both story_moment AND home_report set; published_outcome has both headings.
+// Guard must fire independently for each — no cross-contamination.
+const SUB_COMBINED = {
+  _id: 'sub-464-combined',
+  character_id: 'char-464',
+  cycle_id: 'cycle-464',
+  published_outcome: '## Story Moment\n\nStory push text.\n\n## Home Report\n\nHome report push text.',
+  st_narrative: {
+    story_moment: { response: 'Structured story moment.', status: 'complete' },
+    home_report:  { response: 'Structured home report.', status: 'complete' },
   },
   responses: {},
   projects_resolved: [],
@@ -201,6 +235,24 @@ test.describe('fix-464: Archive tab Story Moment deduplication', () => {
     // The structured field should be preferred over the published_outcome text.
     const narrative = page.locator('.story-narrative');
     await expect(narrative).toContainText('The structured story moment text from admin tool.');
+  });
+
+  test('AC4b: legacy touchstone only + published_outcome heading → exactly one Story Moment block', async ({ page }) => {
+    await setup(page, [SUB_AC4B]);
+    await openFirstDtItem(page);
+
+    const heads = page.locator('.story-section-head');
+    const storyMomentHeads = heads.filter({ hasText: 'Story Moment' });
+    await expect(storyMomentHeads).toHaveCount(1);
+  });
+
+  test('Combined: story_moment + home_report + both headings in published_outcome → one of each', async ({ page }) => {
+    await setup(page, [SUB_COMBINED]);
+    await openFirstDtItem(page);
+
+    const heads = page.locator('.story-section-head');
+    await expect(heads.filter({ hasText: 'Story Moment' })).toHaveCount(1);
+    await expect(heads.filter({ hasText: 'Home Report' })).toHaveCount(1);
   });
 
 });


### PR DESCRIPTION
## Summary

- `renderOutcomeWithCards` in `story-tab.js` had two independent render paths both producing a Story Moment block: the dedicated `renderStoryMoment()` function (reads `st_narrative.story_moment`) and the sections loop that parsed `## Story Moment` from `published_outcome` text. From DT3 onwards both fired simultaneously, showing the section twice.
- Fix: capture each dedicated renderer's HTML into a variable first, build a `_renderedKeys` Set, and add a `continue` guard at the top of the sections loop using the existing `_flagSectionKeyForHeading` hook. Same guard covers Home Report.
- 7 Playwright tests via Archive tab: AC1–AC4 + content integrity + touchstone regression + combined scenario.

## Test plan

- [x] AC1: structured `story_moment` + `## Story Moment` in push text → exactly one block
- [x] AC2: no structured fields, push text heading only → still renders once (guard doesn't swallow)
- [x] AC3: Home Report dedup works symmetrically
- [x] AC4a: legacy `letter_from_home` path unaffected
- [x] AC4b: legacy `touchstone` path unaffected
- [x] Combined: both `story_moment` + `home_report` with both headings → one of each
- [x] Content integrity: structured field preferred over push text content

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)