### PR TITLE
fix: DT player report rendering — line breaks, ST note heading, feedback italic

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -4458,12 +4458,13 @@ html:not([data-theme="dark"]) .sk-spec-row  span { color: var(--crim) !important
 }
 .proj-card-feedback-label {
   font-family: var(--fl);
-  font-size: 10px;
-  letter-spacing: 0.07em;
+  font-size: 11px;
+  letter-spacing: 0.06em;
   text-transform: uppercase;
   display: block;
-  margin-bottom: 3px;
-  color: var(--txt3);
+  margin: 0 0 6px;
+  color: var(--txt2);
+  font-weight: normal;
 }
 .proj-card-withheld-msg {
   font-size: 12px;

--- a/public/css/suite.css
+++ b/public/css/suite.css
@@ -759,7 +759,7 @@ body.desktop-mode .sh-powers-grid > .sh-sec{break-inside:avoid;}
 .proj-card-roll-fail{color:var(--crim);}
 .proj-card-dice{font-family:var(--fl);font-size:11px;color:var(--txt3);margin-top:2px;}
 .proj-card-feedback{margin-top:10px;padding:6px 0 0 10px;border-top:none;border-left:2px solid var(--bdr2);font-family:var(--ft);font-size:13px;color:var(--txt3);line-height:1.6;}
-.proj-card-feedback-label{font-family:var(--fl);font-size:10px;font-style:italic;letter-spacing:.04em;text-transform:none;display:block;margin-bottom:4px;color:var(--txt3);}
+.proj-card-feedback-label{font-family:var(--fl);font-size:11px;letter-spacing:.06em;text-transform:uppercase;display:block;margin:0 0 6px;color:var(--txt2);font-weight:normal;}
 .proj-card-withheld-msg{font-family:var(--ft);font-size:13px;color:var(--txt3);font-style:italic;margin:6px 0 0;}
 .placeholder-msg{color:var(--txt3);font-size:14px;padding:24px 16px;text-align:center;}
 .dtl-wrap{padding:12px 16px;}

--- a/public/js/tabs/story-tab.js
+++ b/public/js/tabs/story-tab.js
@@ -435,10 +435,19 @@ export function renderOutcomeWithCards(sub, opts = {}) {
 
   // ── Sections 1-2: Story Moment + Home Report (above main narrative) ──
   let h = '<div class="story-narrative">';
-  h += renderStoryMoment(sub, { editable });
-  h += renderHomeReportSection(sub, { editable });
+  const smHtml = renderStoryMoment(sub, { editable });
+  const hrHtml = renderHomeReportSection(sub, { editable });
+  h += smHtml;
+  h += hrHtml;
+  // If a dedicated renderer produced output, skip the same heading in
+  // published_outcome to prevent the section appearing twice (fix #464).
+  const _renderedKeys = new Set();
+  if (smHtml) _renderedKeys.add('story_moment');
+  if (hrHtml) _renderedKeys.add('home_report');
   for (const sec of sections) {
     if (sec.heading) {
+      const secKey = _flagSectionKeyForHeading(sec.heading);
+      if (secKey && _renderedKeys.has(secKey)) continue;
       const isMech = sec.heading === 'Mechanical Outcomes';
       // Match the parsed heading to a project card to find its index. When
       // editable, the heading section is treated as the editable surface for

--- a/public/js/tabs/story-tab.js
+++ b/public/js/tabs/story-tab.js
@@ -223,8 +223,8 @@ function _storyNarrSection(label, text, opts = {}) {
   if (sub && sectionKey) h += renderFlagAffordance(sub, sectionKey);
   h += '</div>';
   h += '<div class="story-section-body">';
-  const paras = text.trim().split(/\n{2,}/).filter(Boolean);
-  h += paras.map(p => `<p>${esc(p.replace(/\n/g, ' '))}</p>`).join('');
+  const paras = text.trim().split(/\n/).filter(Boolean);
+  h += paras.map(p => `<p>${esc(p)}</p>`).join('');
   h += '</div></div>';
   return h;
 }
@@ -300,13 +300,13 @@ function renderStoryMoment(sub, opts = {}) {
   h += '</div>';
   h += '<div class="story-section-body">';
   if (touchstone) {
-    const paras = touchstone.trim().split(/\n{2,}/).filter(Boolean);
-    h += paras.map(p => `<p>${esc(p.replace(/\n/g, ' '))}</p>`).join('');
+    const paras = touchstone.trim().split(/\n/).filter(Boolean);
+    h += paras.map(p => `<p>${esc(p)}</p>`).join('');
   }
   if (letter) {
     if (touchstone) h += '<hr class="story-moment-divider">';
-    const paras = letter.trim().split(/\n{2,}/).filter(Boolean);
-    h += paras.map(p => `<p>${esc(p.replace(/\n/g, ' '))}</p>`).join('');
+    const paras = letter.trim().split(/\n/).filter(Boolean);
+    h += paras.map(p => `<p>${esc(p)}</p>`).join('');
   }
   h += '</div></div>';
   return h;
@@ -424,7 +424,7 @@ export function renderOutcomeWithCards(sub, opts = {}) {
       }
 
       const note = rev.player_facing_note || '';
-      if (note) cardHtml += `<div class="proj-card-feedback"><span class="proj-card-feedback-label">ST Note</span>${esc(note)}</div>`;
+      if (note) cardHtml += `<div class="proj-card-feedback"><h4 class="proj-card-feedback-label">ST Note</h4><em>${esc(note)}</em></div>`;
 
       cardHtml += '</div>';
     }
@@ -477,8 +477,8 @@ export function renderOutcomeWithCards(sub, opts = {}) {
       if (isMech) {
         h += `<pre class="story-pre">${esc(body)}</pre>`;
       } else {
-        const paras = body.split(/\n{2,}/).filter(Boolean);
-        h += paras.map(p => `<p>${esc(p.replace(/\n/g, ' '))}</p>`).join('');
+        const paras = body.split(/\n/).filter(Boolean);
+        h += paras.map(p => `<p>${esc(p)}</p>`).join('');
       }
       h += '</div></div>';
 
@@ -489,8 +489,8 @@ export function renderOutcomeWithCards(sub, opts = {}) {
       }
     } else {
       const body = sec.lines.join('\n').trim();
-      const paras = body.split(/\n{2,}/).filter(Boolean);
-      h += paras.map(p => `<p>${esc(p.replace(/\n/g, ' '))}</p>`).join('');
+      const paras = body.split(/\n/).filter(Boolean);
+      h += paras.map(p => `<p>${esc(p)}</p>`).join('');
     }
   }
   h += '</div>';

--- a/specs/stories/fix.464.archive-story-moment-dedup.story.md
+++ b/specs/stories/fix.464.archive-story-moment-dedup.story.md
@@ -1,0 +1,238 @@
+---
+issue: 464
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/464
+branch: ms/issue-464-archive-story-moment-duplicate
+status: review
+date: 2026-05-22
+---
+
+# fix.464 — Archive tab: Story Moment deduplication guard
+
+## Story
+
+As a player viewing the Archive tab,
+I want the Story Moment section to appear exactly once per downtime report,
+so that I am not confused by duplicated narrative content.
+
+## Background
+
+`renderOutcomeWithCards` (story-tab.js) has two independent render paths that both produce a
+"Story Moment" block:
+
+1. **Dedicated renderer** — `renderStoryMoment(sub)` at line 438, reading from
+   `st_narrative.story_moment.response` (the consolidated field written by the admin tool from
+   DT3 onwards).
+2. **Section loop** — `parseOutcomeSections(sub.published_outcome)` at line 380 parses the raw
+   `published_outcome` text; when the push text contains a `## Story Moment` heading (which it
+   does for DT3), the loop at lines 440-486 renders that heading as a second Story Moment block.
+
+DT1-2 escaped the bug because `story_moment` was never set — `renderStoryMoment` returned `''`,
+so only the sections loop path fired. DT3 introduced the structured `story_moment` field, and now
+both paths fire simultaneously, producing an identical duplicate.
+
+The same latent issue exists for `renderHomeReportSection` / `## Home Report`.
+
+## Acceptance Criteria
+
+- [ ] AC1: A DT3 submission with `st_narrative.story_moment.response` set shows exactly **one**
+  Story Moment block in `renderOutcomeWithCards` output.
+- [ ] AC2: A legacy submission with **only** `published_outcome` text (no `st_narrative.story_moment`,
+  no `personal_story`, no `letter_from_home`, no `touchstone`) still shows Story Moment from the
+  parsed `## Story Moment` heading in `published_outcome`.
+- [ ] AC3: Home Report does not duplicate under the same conditions — same guard applies.
+- [ ] AC4: Legacy `letter_from_home`-only and `touchstone`-only submissions render their Story Moment
+  section unchanged (single block, no regression).
+
+---
+
+## Dev Notes
+
+### File to modify — ONE file, no others
+
+**`public/js/tabs/story-tab.js`** — function `renderOutcomeWithCards` (line ~378).
+
+Do **not** touch: `_storyNarrSection`, `renderStoryMoment`, `renderHomeReportSection`,
+`_flagSectionKeyForHeading`, `parseOutcomeSections`, or any other helper. The fix is
+entirely local to the control flow inside `renderOutcomeWithCards`.
+
+### Exact fix — minimal change
+
+**Before the section loop**, compute the dedicated section HTML first and track which
+section keys were rendered:
+
+```js
+// ── Sections 1-2: Story Moment + Home Report (above main narrative) ──
+let h = '<div class="story-narrative">';
+const smHtml = renderStoryMoment(sub, { editable });
+const hrHtml = renderHomeReportSection(sub, { editable });
+h += smHtml;
+h += hrHtml;
+// Skip published_outcome headings already handled by dedicated renderers.
+const _renderedKeys = new Set();
+if (smHtml) _renderedKeys.add('story_moment');
+if (hrHtml) _renderedKeys.add('home_report');
+
+for (const sec of sections) {
+  if (sec.heading) {
+    const secKey = _flagSectionKeyForHeading(sec.heading);
+    if (secKey && _renderedKeys.has(secKey)) continue;   // ← guard
+    // ... rest of loop unchanged ...
+  }
+}
+```
+
+**The loop body is unchanged.** Only the `continue` guard line is added.
+
+### Why `_flagSectionKeyForHeading` is the right hook
+
+`_flagSectionKeyForHeading` already maps:
+- `'story moment'` → `'story_moment'`
+- `'home report'` → `'home_report'`
+
+Using it is idiomatic — it's already the canonical heading → key resolver in this file
+(used for flag affordances at line 462). No new string comparison needed.
+
+### Why `renderStoryMoment` returns `''` on legacy-only submissions
+
+```js
+function renderStoryMoment(sub, opts = {}) {
+  const smText = sub.st_narrative?.story_moment?.response;
+  if (smText) return _storyNarrSection(...);          // early return for DT3+
+
+  const psText = sub.st_narrative?.personal_story?.response;
+  if (psText) return _storyNarrSection(...);           // early return
+
+  const letter    = sub.st_narrative?.letter_from_home?.response;
+  const touchstone = sub.st_narrative?.touchstone?.response;
+  if (!letter && !touchstone) return '';              // ← returns '' here
+  // ... legacy dual-block path for DT1-2
+}
+```
+
+A submission with **only** a `## Story Moment` heading in `published_outcome` (and no structured
+`st_narrative` fields) will return `''` → `_renderedKeys` will NOT have `'story_moment'` → the
+loop will render the heading as normal. AC2 is satisfied by this logic automatically.
+
+### What NOT to do
+
+- Do NOT modify `renderStoryMoment` or `renderHomeReportSection` — they are correct.
+- Do NOT call `renderStoryMoment` twice.
+- Do NOT try to strip headings from `published_outcome` — historical data exists; this would be
+  destructive and wrong.
+- Do NOT add a `compiled_sections_already_rendered` flag or similar module-level state. The
+  `_renderedKeys` Set is local to `renderOutcomeWithCards` and is all that's needed.
+
+### Key line numbers (as of branch base — verify before editing)
+
+| Line | What |
+|------|------|
+| 378  | `export function renderOutcomeWithCards(sub, opts = {})` |
+| 380  | `const sections = parseOutcomeSections(sub.published_outcome)` |
+| 436  | `// ── Sections 1-2: Story Moment + Home Report` comment |
+| 437  | `let h = '<div class="story-narrative">'` |
+| 438  | `h += renderStoryMoment(sub, { editable })` |
+| 439  | `h += renderHomeReportSection(sub, { editable })` |
+| 440  | `for (const sec of sections) {` |
+| 462  | `const headingKey = _flagSectionKeyForHeading(sec.heading)` |
+
+---
+
+## Tasks / Subtasks
+
+- [x] T1: Add `_renderedKeys` Set and `continue` guard to `renderOutcomeWithCards` in `story-tab.js`
+  - [x] Capture `renderStoryMoment` return value before appending; add to `_renderedKeys` if non-empty
+  - [x] Capture `renderHomeReportSection` return value before appending; add to `_renderedKeys` if non-empty
+  - [x] Add `if (secKey && _renderedKeys.has(secKey)) continue;` at top of the section loop's `if (sec.heading)` block
+  - [x] Parse-check: `node --check --input-type=module < public/js/tabs/story-tab.js`
+- [x] T2: Write Playwright tests for the four ACs (file: `tests/fix-464-archive-story-moment-dedup.spec.js`)
+  - [x] AC1: structured `story_moment` + published_outcome with `## Story Moment` → exactly one `.story-section-head` containing "Story Moment"
+  - [x] AC2: no structured fields + published_outcome with `## Story Moment` → exactly one `.story-section-head` containing "Story Moment"
+  - [x] AC3: structured `home_report` + published_outcome with `## Home Report` → exactly one `.story-section-head` containing "Home Report"
+  - [x] AC4: legacy `letter_from_home`-only submission → exactly one Story Moment block
+- [x] T3: Run tests and confirm all pass
+
+---
+
+## Testing Approach
+
+Tests import `renderOutcomeWithCards` directly from `story-tab.js` via Playwright's
+`page.evaluate` + `page.addScriptTag`, OR use the `page.goto` + fixture interception pattern
+used throughout this test suite.
+
+The simplest approach is **pure unit style** within Playwright — create a minimal HTML page,
+inject the module, call `renderOutcomeWithCards` with stub data, and count `.story-section-head`
+elements. See `tests/issue-321-dt-story-cycle-resolver.spec.js` for the API-stub pattern used
+in this repo.
+
+Stub shapes needed for each AC:
+
+```js
+// AC1 — structured story_moment + published_outcome heading
+const sub_ac1 = {
+  _id: 'sub-ac1', character_id: 'char-1', cycle_id: 'cycle-1',
+  published_outcome: '## Story Moment\n\nThe letter content from push text.',
+  st_narrative: { story_moment: { response: 'The structured story moment.', status: 'complete' } },
+  responses: {},
+};
+// Expected: exactly 1 h4 with text "Story Moment"
+
+// AC2 — no structured fields, only published_outcome
+const sub_ac2 = {
+  _id: 'sub-ac2', character_id: 'char-1', cycle_id: 'cycle-1',
+  published_outcome: '## Story Moment\n\nContent from push text only.',
+  st_narrative: {},
+  responses: {},
+};
+// Expected: exactly 1 h4 with text "Story Moment"
+
+// AC3 — home report dedup
+const sub_ac3 = {
+  _id: 'sub-ac3', character_id: 'char-1', cycle_id: 'cycle-1',
+  published_outcome: '## Home Report\n\nThe home report in push text.',
+  st_narrative: { home_report: { response: 'The structured home report.', status: 'complete' } },
+  responses: {},
+};
+// Expected: exactly 1 h4 with text "Home Report"
+
+// AC4 — legacy letter_from_home only
+const sub_ac4 = {
+  _id: 'sub-ac4', character_id: 'char-1', cycle_id: 'cycle-1',
+  published_outcome: null,
+  st_narrative: { letter_from_home: { response: 'Legacy letter content.', status: 'complete' } },
+  responses: {},
+};
+// Expected: exactly 1 h4 with text "Story Moment" (from legacy path)
+```
+
+---
+
+## File List
+
+- `public/js/tabs/story-tab.js` — UPDATE
+- `tests/fix-464-archive-story-moment-dedup.spec.js` — CREATE
+
+---
+
+## Dev Agent Record
+
+### Completion Notes
+
+T1: In `renderOutcomeWithCards` (story-tab.js), replaced the two inline `h +=` calls for dedicated
+section renderers with captured variables (`smHtml`, `hrHtml`). Built a `_renderedKeys` Set from
+whichever ones returned non-empty string. Added `if (secKey && _renderedKeys.has(secKey)) continue`
+at the top of the `if (sec.heading)` block in the published_outcome sections loop. This prevents
+the same section appearing twice when structured `st_narrative` data and a matching `## Heading`
+both exist in `published_outcome`. The existing `_flagSectionKeyForHeading` function was the
+correct hook — it already maps `'story moment'` → `'story_moment'` and `'home report'` →
+`'home_report'`.
+
+T2: 5 Playwright tests via the game app Archive tab. AC4 required `published_outcome` to be a
+truthy string (archive-tab.js:65 filters out submissions without it); a non-heading body string
+was used so the legacy `letter_from_home` path still fires without competition.
+
+All 5 tests pass. Parse check clean.
+
+### Change Log
+
+- fix(#464): renderOutcomeWithCards — dedup guard for dedicated section renderers (2026-05-22)
+- test(#464): 5 Playwright tests via Archive tab (AC1-AC4 + content integrity) (2026-05-22)

--- a/specs/stories/fix.466.dt-report-rendering-bugs.story.md
+++ b/specs/stories/fix.466.dt-report-rendering-bugs.story.md
@@ -1,0 +1,242 @@
+---
+issue: 466
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/466
+branch: ms/issue-466-dt-report-rendering
+status: review
+date: 2026-05-22
+---
+
+# fix.466 — DT player report: ST notes heading, line breaks, feedback italic
+
+## Story
+
+As a player viewing my downtime report,
+I want the ST notes to have a clear heading, paragraph breaks to render as distinct
+paragraphs, and the ST's feedback note to appear in italic,
+so that the report is readable and its sections are visually distinct.
+
+## Background
+
+Three rendering defects observed in Anichka's DT 3 player report, all in
+`public/js/tabs/story-tab.js`:
+
+1. **ST notes missing heading** — `player_facing_note` renders inside a `.proj-card-feedback`
+   div after the project narrative section. The `proj-card-feedback-label` span ("ST Note") is
+   styled at 10px in suite.css (`text-transform:none`, `color:var(--txt3)`) — effectively
+   invisible on the parchment theme. No visual boundary separates the narrative prose from the
+   ST note.
+
+2. **Line breaks not rendering** — `_storyNarrSection` splits text on `/\n{2,}/` (two or more
+   newlines). If the ST wrote single `\n` between paragraphs (one Enter, not two), all lines
+   collapse into a single `<p>` wall of text. The same pattern appears in the inline section
+   loop in `renderOutcomeWithCards` and in the legacy `renderStoryMoment` paths.
+
+3. **Player feedback not italicised** — The note text after the label is rendered as
+   `${esc(note)}` (plain escaped text) with no `<em>` wrapper.
+
+## Acceptance Criteria
+
+- [ ] AC1: A visible "ST Note" heading (styled like a section label, not hidden small text)
+  appears before the `player_facing_note` text in the project card, clearly separated from the
+  project narrative above it.
+- [ ] AC2: Single `\n` line breaks in narrative text (story moment, project outcome sections)
+  render as distinct `<p>` elements — "A dream" and the paragraph below it appear as two blocks,
+  not one wall.
+- [ ] AC3: `player_facing_note` text is rendered in italic.
+- [ ] AC4: No regression — existing reports with `\n\n` paragraph breaks still render correctly;
+  legacy `letter_from_home` / `touchstone` paths are unaffected.
+
+---
+
+## Dev Notes
+
+### Files to modify
+
+| File | Change |
+|------|--------|
+| `public/js/tabs/story-tab.js` | Bug 2: split fix in `_storyNarrSection`; Bug 3+1: label + italic in proj-card-feedback HTML |
+| `public/css/components.css` | Bug 1: restyle `.proj-card-feedback-label` |
+| `public/css/suite.css` | Bug 1: restyle `.proj-card-feedback-label` override |
+
+Do NOT touch: `parseOutcomeSections`, `renderStoryMoment`, `renderHomeReportSection`,
+`renderFlagAffordance`, or anything else. All three bugs are contained to the lines below.
+
+---
+
+### Bug 2 fix — line-break split (story-tab.js)
+
+**Current pattern (appears in four places):**
+```js
+const paras = text.trim().split(/\n{2,}/).filter(Boolean);
+h += paras.map(p => `<p>${esc(p.replace(/\n/g, ' '))}</p>`).join('');
+```
+
+**Replacement (same four places):**
+```js
+const paras = text.trim().split(/\n/).filter(Boolean);
+h += paras.map(p => `<p>${esc(p)}</p>`).join('');
+```
+
+**Why this is safe:** `filter(Boolean)` removes empty strings, so `\n\n` (double newline)
+produces an empty string between the two splits which is filtered out. Both `\n\n`- and
+`\n`-separated content produce the same result: one `<p>` per non-empty line. The
+`p.replace(/\n/g, ' ')` is redundant after splitting on `/\n/` (no `\n` remain in `p`), so
+remove it.
+
+**The five locations to update (DT narrative paths only):**
+
+| Line | Function | String to find |
+|------|----------|----------------|
+| 226 | `_storyNarrSection` | `text.trim().split(/\n{2,}/)` |
+| 303 | `renderStoryMoment` (legacy touchstone path) | `touchstone.trim().split(/\n{2,}/)` |
+| 308 | `renderStoryMoment` (legacy letter path) | `letter.trim().split(/\n{2,}/)` |
+| 480 | `renderOutcomeWithCards` section loop body | `body.split(/\n{2,}/)` |
+| 492 | `renderOutcomeWithCards` headingless section | `body.split(/\n{2,}/)` |
+
+Use `grep -n 'split.*\\\\n{2,}' public/js/tabs/story-tab.js` to find them — you will see SIX
+results. The sixth at line 846 is in the character doc-history renderer (unrelated to DT reports)
+— leave it unchanged for this story.
+
+---
+
+### Bug 1 + Bug 3 fix — proj-card-feedback HTML (story-tab.js:427)
+
+**Current (line 427):**
+```js
+if (note) cardHtml += `<div class="proj-card-feedback"><span class="proj-card-feedback-label">ST Note</span>${esc(note)}</div>`;
+```
+
+**Replacement:**
+```js
+if (note) cardHtml += `<div class="proj-card-feedback"><h4 class="proj-card-feedback-label">ST Note</h4><em>${esc(note)}</em></div>`;
+```
+
+Changes: `<span>` → `<h4>` for semantic heading weight; `${esc(note)}` → `<em>${esc(note)}</em>` for italic.
+
+---
+
+### Bug 1 fix — CSS restyling (components.css + suite.css)
+
+**components.css** — current `.proj-card-feedback-label` block (around line 4459):
+```css
+.proj-card-feedback-label {
+  font-family: var(--fl);
+  font-size: 10px;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+  display: block;
+  margin-bottom: 3px;
+  color: var(--txt3);
+}
+```
+Update to:
+```css
+.proj-card-feedback-label {
+  font-family: var(--fl);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  display: block;
+  margin: 0 0 6px;
+  color: var(--txt2);
+  font-weight: normal;
+}
+```
+Key changes: `color: var(--txt2)` (more visible than `--txt3`), `margin` reset to prevent h4 browser defaults pushing layout, `font-weight: normal` (h4 defaults to bold, which we don't want here).
+
+**suite.css** — current `.proj-card-feedback-label` override (line 762):
+```css
+.proj-card-feedback-label{font-family:var(--fl);font-size:10px;font-style:italic;letter-spacing:.04em;text-transform:none;display:block;margin-bottom:4px;color:var(--txt3);}
+```
+Update to:
+```css
+.proj-card-feedback-label{font-family:var(--fl);font-size:11px;letter-spacing:.06em;text-transform:uppercase;display:block;margin:0 0 6px;color:var(--txt2);font-weight:normal;}
+```
+Key changes: remove `font-style:italic` (the `<em>` on the note body handles italic now); change `text-transform:none` → `uppercase`; change `color:var(--txt3)` → `var(--txt2)`; reset margin.
+
+---
+
+### What NOT to do
+
+- Do NOT change `parseOutcomeSections` — the split fix is in the render layer, not the parser.
+- Do NOT add a new CSS class — reuse `.proj-card-feedback-label` on the `<h4>`.
+- Do NOT apply the split fix to `renderRumoursSection` — it renders lists, not paragraphs.
+- Do NOT add `font-weight: bold` to the label — it should look like a label, not a full heading.
+- Do NOT modify the `published_outcome` assembly in `downtime-views.js` — it is not involved in these bugs.
+
+---
+
+### Parse check (required)
+
+After all edits:
+```
+node --check --input-type=module < public/js/tabs/story-tab.js
+```
+Must exit 0.
+
+---
+
+## Tasks / Subtasks
+
+- [x] T1: Fix line-break split in all five occurrences in `story-tab.js`
+  - [x] Line 226 — `_storyNarrSection`
+  - [x] Line 303 — `renderStoryMoment` touchstone path
+  - [x] Line 308 — `renderStoryMoment` letter path
+  - [x] Line 480 — `renderOutcomeWithCards` section body
+  - [x] Line 492 — `renderOutcomeWithCards` headingless section
+- [x] T2: Update `proj-card-feedback` HTML at line 427 — `<span>` → `<h4>`, add `<em>` around note text
+- [x] T3: Update `.proj-card-feedback-label` CSS in `components.css` (line ~4459)
+- [x] T4: Update `.proj-card-feedback-label` CSS in `suite.css` (line ~762)
+- [x] T5: Parse check: `node --check --input-type=module < public/js/tabs/story-tab.js`
+
+---
+
+## Testing Approach
+
+No automated tests are needed for this story — all three bugs are rendering-only changes in
+well-isolated code paths. Verify manually:
+
+1. Open the player portal (player.html) → Story tab → Anichka's DT 3 report.
+2. Confirm STORY MOMENT shows paragraph breaks between "A dream" and the long paragraph.
+3. Confirm the last project section's proj-card shows "ST NOTE" as a visible label above the
+   italic note text.
+4. Confirm no visual regression in earlier DTs (DT1/DT2) — story moment, home report, feeding
+   sections should look the same as before.
+
+If local dev is not available, the parse check (T5) is the minimum gate.
+
+---
+
+## File List
+
+- `public/js/tabs/story-tab.js` — UPDATE (5× split fix + 1× proj-card HTML)
+- `public/css/components.css` — UPDATE (`.proj-card-feedback-label` restyle)
+- `public/css/suite.css` — UPDATE (`.proj-card-feedback-label` override restyle)
+
+---
+
+## Dev Agent Record
+
+### Completion Notes
+
+T1: Changed `split(/\n{2,}/)` → `split(/\n/)` and removed `p.replace(/\n/g, ' ')` at all five DT
+narrative render sites in `story-tab.js` (lines 226, 303, 308, 480, 492). Line 846 (doc-history
+renderer) left unchanged per story scope. Single and double newlines now both produce distinct `<p>`
+elements via `filter(Boolean)`.
+
+T2: Changed `proj-card-feedback` HTML at line 427 — `<span>` → `<h4>` on the label, `${esc(note)}`
+→ `<em>${esc(note)}</em>` on the note text. Handles Bug 1 (visible heading) and Bug 3 (italic) in
+one line.
+
+T3+T4: Updated `.proj-card-feedback-label` in both `components.css` and `suite.css` — bumped to
+11px, removed `font-style:italic` (now on the `<em>`), changed `text-transform:none` → `uppercase`
+in suite.css, changed `color:var(--txt3)` → `var(--txt2)` for visibility, added `font-weight:normal`
+to suppress h4 browser bold default, reset margin to 0 0 6px.
+
+Parse check: exit 0.
+
+### Change Log
+
+- fix(#466): story-tab.js — split single newlines as paragraph breaks across all 5 DT render sites (2026-05-22)
+- fix(#466): story-tab.js — proj-card-feedback label promoted to h4, note wrapped in em (2026-05-22)
+- fix(#466): components.css + suite.css — proj-card-feedback-label visible heading style (2026-05-22)

--- a/tests/fix-464-archive-story-moment-dedup.spec.js
+++ b/tests/fix-464-archive-story-moment-dedup.spec.js
@@ -1,0 +1,206 @@
+/**
+ * fix-464: Archive tab — Story Moment section renders twice when published_outcome
+ * also contains a ## Story Moment heading.
+ *
+ * Root cause: renderOutcomeWithCards called renderStoryMoment() (reads structured
+ * st_narrative.story_moment) AND the sections loop parsed ## Story Moment from
+ * published_outcome text, producing a duplicate block. Fixed by tracking which
+ * section keys the dedicated renderers have already handled and skipping matching
+ * headings in the loop.
+ *
+ * Tests:
+ *   AC1: structured story_moment + published_outcome heading → exactly 1 Story Moment
+ *   AC2: no structured fields, published_outcome heading only → exactly 1 Story Moment
+ *   AC3: structured home_report + published_outcome heading → exactly 1 Home Report
+ *   AC4: legacy letter_from_home only (no published_outcome) → exactly 1 Story Moment
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Shared identity ─────────────────────────────────────────────────────────────
+
+const PLAYER_USER = {
+  id: '464000001', username: 'test_player_464', global_name: 'Test Player 464',
+  avatar: null, role: 'player', player_id: 'p-464',
+  character_ids: ['char-464'], is_dual_role: false,
+};
+
+const CHAR_464 = {
+  _id: 'char-464', name: 'Archive Test Char', moniker: null, honorific: null,
+  clan: 'Mekhet', covenant: 'Ordo Dracul', player: 'Test Player 464',
+  blood_potency: 2, humanity: 6, humanity_base: 7, court_title: null,
+  regent_territory: null, retired: false,
+  status: {
+    city: 1, clan: 0,
+    covenant: { 'Carthian Movement': 0, 'Circle of the Crone': 0, 'Invictus': 0, 'Lancea et Sanctum': 0, 'Ordo Dracul': 1 },
+  },
+  attributes: {
+    Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+    Intelligence: { dots: 3, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+    Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: {}, disciplines: { Auspex: { dots: 2 } }, merits: [], powers: [], ordeals: [],
+};
+
+const CYCLE_464 = {
+  _id: 'cycle-464', label: 'Downtime 3', cycle_number: 3, status: 'closed',
+  game_number: 3, confirmed_ambience: {}, narrative_notes: '',
+};
+
+// AC1: structured story_moment + ## Story Moment in published_outcome
+// Bug: without the fix, Story Moment appears twice.
+const SUB_AC1 = {
+  _id: 'sub-464-ac1',
+  character_id: 'char-464',
+  cycle_id: 'cycle-464',
+  published_outcome: '## Story Moment\n\nThe narrative moment written by the ST in the push text.',
+  st_narrative: {
+    story_moment: { response: 'The structured story moment text from admin tool.', status: 'complete' },
+  },
+  responses: {},
+  projects_resolved: [],
+  merit_actions_resolved: [],
+  section_flags: [],
+};
+
+// AC2: no structured fields at all — published_outcome heading is the only source.
+// The heading must still render (not be swallowed).
+const SUB_AC2 = {
+  _id: 'sub-464-ac2',
+  character_id: 'char-464',
+  cycle_id: 'cycle-464',
+  published_outcome: '## Story Moment\n\nContent from push text only — no structured field.',
+  st_narrative: {},
+  responses: {},
+  projects_resolved: [],
+  merit_actions_resolved: [],
+  section_flags: [],
+};
+
+// AC3: structured home_report + ## Home Report in published_outcome.
+const SUB_AC3 = {
+  _id: 'sub-464-ac3',
+  character_id: 'char-464',
+  cycle_id: 'cycle-464',
+  published_outcome: '## Home Report\n\nThe home report in push text.',
+  st_narrative: {
+    home_report: { response: 'The structured home report from admin tool.', status: 'complete' },
+  },
+  responses: {},
+  projects_resolved: [],
+  merit_actions_resolved: [],
+  section_flags: [],
+};
+
+// AC4: legacy letter_from_home only — published_outcome has NO Story Moment heading.
+// The archive tab requires a truthy published_outcome to list the submission.
+// renderStoryMoment's legacy path handles this; must produce exactly 1 block.
+const SUB_AC4 = {
+  _id: 'sub-464-ac4',
+  character_id: 'char-464',
+  cycle_id: 'cycle-464',
+  published_outcome: 'Some general narrative text with no section headings.',
+  st_narrative: {
+    letter_from_home: { response: 'Dear Alice,\n\nLegacy letter content here.', status: 'complete' },
+  },
+  responses: {},
+  projects_resolved: [],
+  merit_actions_resolved: [],
+  section_flags: [],
+};
+
+// ── Setup helper ────────────────────────────────────────────────────────────────
+
+async function setup(page, submissions) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: PLAYER_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url = route.request().url();
+    const method = route.request().method();
+    const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+
+    if (method === 'POST' || method === 'PUT' || method === 'PATCH') return ok({ ok: true });
+    if (url.includes('/api/auth/me'))              return ok(PLAYER_USER);
+    if (url.includes('/api/downtime_cycles'))      return ok([CYCLE_464]);
+    if (url.includes('/api/downtime_submissions')) return ok(submissions);
+    if (url.includes('/api/archive_documents'))    return ok([]);
+    if (url.includes('/api/characters/names'))     return ok([{ _id: CHAR_464._id, name: CHAR_464.name, moniker: null, honorific: null }]);
+    if (url.includes('/api/characters'))           return ok([CHAR_464]);
+    if (url.includes('/api/territories'))          return ok([]);
+    if (url.includes('/api/game_sessions'))        return ok([]);
+    if (url.includes('/api/session_logs'))         return ok([]);
+    if (url.includes('/api/st_mods'))              return ok([]);
+    if (url.includes('/api/ordeal-responses'))     return ok([]);
+    return ok([]);
+  });
+
+  await page.goto('/');
+  await page.waitForSelector('#app', { state: 'visible', timeout: 15000 });
+  await page.waitForFunction(() => typeof window.goTab === 'function', { timeout: 8000 });
+  await page.evaluate(() => window.goTab('archive'));
+  await page.waitForTimeout(800);
+}
+
+async function openFirstDtItem(page) {
+  // Wait for archive list to populate with a downtime entry.
+  await page.waitForSelector('.arc-doc-item[data-sub-id]', { timeout: 8000 });
+  await page.click('.arc-doc-item[data-sub-id]');
+  // Wait for the detail view to render with story-narrative.
+  await page.waitForSelector('.story-narrative', { timeout: 5000 });
+  await page.waitForTimeout(300);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────────
+
+test.describe('fix-464: Archive tab Story Moment deduplication', () => {
+
+  test('AC1: structured story_moment + published_outcome heading → exactly one Story Moment block', async ({ page }) => {
+    await setup(page, [SUB_AC1]);
+    await openFirstDtItem(page);
+
+    const heads = page.locator('.story-section-head');
+    const storyMomentHeads = heads.filter({ hasText: 'Story Moment' });
+    await expect(storyMomentHeads).toHaveCount(1);
+  });
+
+  test('AC2: no structured fields, published_outcome heading only → exactly one Story Moment block', async ({ page }) => {
+    await setup(page, [SUB_AC2]);
+    await openFirstDtItem(page);
+
+    const heads = page.locator('.story-section-head');
+    const storyMomentHeads = heads.filter({ hasText: 'Story Moment' });
+    await expect(storyMomentHeads).toHaveCount(1);
+  });
+
+  test('AC3: structured home_report + published_outcome heading → exactly one Home Report block', async ({ page }) => {
+    await setup(page, [SUB_AC3]);
+    await openFirstDtItem(page);
+
+    const heads = page.locator('.story-section-head');
+    const homeReportHeads = heads.filter({ hasText: 'Home Report' });
+    await expect(homeReportHeads).toHaveCount(1);
+  });
+
+  test('AC4: legacy letter_from_home only → exactly one Story Moment block (no regression)', async ({ page }) => {
+    await setup(page, [SUB_AC4]);
+    await openFirstDtItem(page);
+
+    const heads = page.locator('.story-section-head');
+    const storyMomentHeads = heads.filter({ hasText: 'Story Moment' });
+    await expect(storyMomentHeads).toHaveCount(1);
+  });
+
+  test('AC1 content integrity: structured story_moment text is what renders', async ({ page }) => {
+    await setup(page, [SUB_AC1]);
+    await openFirstDtItem(page);
+
+    // The structured field should be preferred over the published_outcome text.
+    const narrative = page.locator('.story-narrative');
+    await expect(narrative).toContainText('The structured story moment text from admin tool.');
+  });
+
+});

--- a/tests/fix-464-archive-story-moment-dedup.spec.js
+++ b/tests/fix-464-archive-story-moment-dedup.spec.js
@@ -92,7 +92,7 @@ const SUB_AC3 = {
   section_flags: [],
 };
 
-// AC4: legacy letter_from_home only — published_outcome has NO Story Moment heading.
+// AC4a: legacy letter_from_home only — published_outcome has NO Story Moment heading.
 // The archive tab requires a truthy published_outcome to list the submission.
 // renderStoryMoment's legacy path handles this; must produce exactly 1 block.
 const SUB_AC4 = {
@@ -102,6 +102,40 @@ const SUB_AC4 = {
   published_outcome: 'Some general narrative text with no section headings.',
   st_narrative: {
     letter_from_home: { response: 'Dear Alice,\n\nLegacy letter content here.', status: 'complete' },
+  },
+  responses: {},
+  projects_resolved: [],
+  merit_actions_resolved: [],
+  section_flags: [],
+};
+
+// AC4b: legacy touchstone only + ## Story Moment in published_outcome.
+// renderStoryMoment returns non-empty (touchstone path), so the loop must skip
+// the published_outcome heading — same guard, different legacy trigger.
+const SUB_AC4B = {
+  _id: 'sub-464-ac4b',
+  character_id: 'char-464',
+  cycle_id: 'cycle-464',
+  published_outcome: '## Story Moment\n\nThe push text story moment.',
+  st_narrative: {
+    touchstone: { response: 'Touchstone vignette content.', status: 'complete' },
+  },
+  responses: {},
+  projects_resolved: [],
+  merit_actions_resolved: [],
+  section_flags: [],
+};
+
+// Combined: both story_moment AND home_report set; published_outcome has both headings.
+// Guard must fire independently for each — no cross-contamination.
+const SUB_COMBINED = {
+  _id: 'sub-464-combined',
+  character_id: 'char-464',
+  cycle_id: 'cycle-464',
+  published_outcome: '## Story Moment\n\nStory push text.\n\n## Home Report\n\nHome report push text.',
+  st_narrative: {
+    story_moment: { response: 'Structured story moment.', status: 'complete' },
+    home_report:  { response: 'Structured home report.', status: 'complete' },
   },
   responses: {},
   projects_resolved: [],
@@ -201,6 +235,24 @@ test.describe('fix-464: Archive tab Story Moment deduplication', () => {
     // The structured field should be preferred over the published_outcome text.
     const narrative = page.locator('.story-narrative');
     await expect(narrative).toContainText('The structured story moment text from admin tool.');
+  });
+
+  test('AC4b: legacy touchstone only + published_outcome heading → exactly one Story Moment block', async ({ page }) => {
+    await setup(page, [SUB_AC4B]);
+    await openFirstDtItem(page);
+
+    const heads = page.locator('.story-section-head');
+    const storyMomentHeads = heads.filter({ hasText: 'Story Moment' });
+    await expect(storyMomentHeads).toHaveCount(1);
+  });
+
+  test('Combined: story_moment + home_report + both headings in published_outcome → one of each', async ({ page }) => {
+    await setup(page, [SUB_COMBINED]);
+    await openFirstDtItem(page);
+
+    const heads = page.locator('.story-section-head');
+    await expect(heads.filter({ hasText: 'Story Moment' })).toHaveCount(1);
+    await expect(heads.filter({ hasText: 'Home Report' })).toHaveCount(1);
   });
 
 });

--- a/tests/fix-466-dt-report-rendering-bugs.spec.js
+++ b/tests/fix-466-dt-report-rendering-bugs.spec.js
@@ -1,0 +1,226 @@
+/**
+ * fix-466: DT player report rendering bugs —
+ *   Bug 1: ST notes missing heading (proj-card-feedback-label invisible / not heading)
+ *   Bug 2: Line breaks not rendering (split /\n{2,}/ ignored single \n)
+ *   Bug 3: Player feedback text not italicised
+ *
+ * All three bugs were in public/js/tabs/story-tab.js (renderOutcomeWithCards,
+ * _storyNarrSection) and public/css/{components,suite}.css.
+ *
+ * Tests use the Archive tab on the player portal (player.html at /),
+ * stubbing API responses — same pattern as fix-464.
+ *
+ * AC1: h4.proj-card-feedback-label renders and contains "ST Note"
+ * AC2: Single \n line breaks produce distinct <p> elements in story section body
+ * AC3: player_facing_note text is wrapped in <em>
+ * AC4: Double \n\n paragraph breaks still produce distinct <p> elements (regression)
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Shared identity ─────────────────────────────────────────────────────────
+
+const PLAYER_USER = {
+  id: '466000001', username: 'test_player_466', global_name: 'Test Player 466',
+  avatar: null, role: 'player', player_id: 'p-466',
+  character_ids: ['char-466'], is_dual_role: false,
+};
+
+const CHAR_466 = {
+  _id: 'char-466', name: 'Anichka Test', moniker: null, honorific: null,
+  clan: 'Mekhet', covenant: 'Circle of the Crone', player: 'Test Player 466',
+  blood_potency: 2, humanity: 6, humanity_base: 7, court_title: null,
+  regent_territory: null, retired: false,
+  status: {
+    city: 1, clan: 0,
+    covenant: { 'Carthian Movement': 0, 'Circle of the Crone': 1, 'Invictus': 0, 'Lancea et Sanctum': 0, 'Ordo Dracul': 0 },
+  },
+  attributes: {
+    Strength: { dots: 1, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+    Intelligence: { dots: 3, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 3, bonus: 0 },
+    Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: {}, disciplines: { Auspex: { dots: 2 }, Cruac: { dots: 3 } },
+  merits: [], powers: [], ordeals: [],
+};
+
+const CYCLE_466 = {
+  _id: 'cycle-466', label: 'Downtime 3', cycle_number: 3, status: 'closed',
+  game_number: 3, confirmed_ambience: {}, narrative_notes: '',
+};
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+// AC1 + AC3: project card with player_facing_note.
+// Needs:
+//   - published_outcome with ## heading matching project_1_title so card is injected
+//   - st_narrative.project_responses[0].response truthy (or card is "withheld" and note skipped)
+//   - projects_resolved[0].player_facing_note = feedback text
+const SUB_PROJCARD = {
+  _id: 'sub-466-projcard',
+  character_id: 'char-466',
+  cycle_id: 'cycle-466',
+  published_outcome: '## Research the Barrens\n\nShe searched the edges of the Barrens night after night.',
+  st_narrative: {
+    project_responses: [
+      { response: 'You found what you were looking for in the shadows.', status: 'complete' },
+    ],
+  },
+  responses: {
+    project_1_title: 'Research the Barrens',
+    project_1_action: 'investigate',
+  },
+  projects_resolved: [
+    {
+      action_type: 'investigate',
+      player_facing_note: 'Switched your Disc pool to Cruac as it felt more appropriate with the magical glyphs.',
+      pool: { expression: 'Intelligence + Occult', total: 5 },
+      roll: { successes: 2, exceptional: false, dice_string: '2, 5, 6, 7, 9' },
+      no_roll: false,
+    },
+  ],
+  merit_actions_resolved: [],
+  section_flags: [],
+};
+
+// AC2: story moment with single \n between paragraphs.
+// Bug: split(/\n{2,}/) collapses all into one <p>. Fix: split(/\n/) produces 3 <p>.
+const SUB_SINGLE_NEWLINES = {
+  _id: 'sub-466-single-nl',
+  character_id: 'char-466',
+  cycle_id: 'cycle-466',
+  published_outcome: 'Some general outcome text.',
+  st_narrative: {
+    story_moment: {
+      response: 'A dream\nYou are walking a road that is not a road.\nThe country opens around you.',
+      status: 'complete',
+    },
+  },
+  responses: {},
+  projects_resolved: [],
+  merit_actions_resolved: [],
+  section_flags: [],
+};
+
+// AC4 regression: story moment with double \n\n paragraph breaks.
+// Must still produce distinct <p> elements after the split(/\n/) change.
+const SUB_DOUBLE_NEWLINES = {
+  _id: 'sub-466-double-nl',
+  character_id: 'char-466',
+  cycle_id: 'cycle-466',
+  published_outcome: 'Some general outcome text.',
+  st_narrative: {
+    story_moment: {
+      response: 'First paragraph of the dream sequence.\n\nSecond paragraph continues here.',
+      status: 'complete',
+    },
+  },
+  responses: {},
+  projects_resolved: [],
+  merit_actions_resolved: [],
+  section_flags: [],
+};
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+async function setup(page, submissions) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: PLAYER_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url = route.request().url();
+    const method = route.request().method();
+    const ok = body => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+
+    if (method === 'POST' || method === 'PUT' || method === 'PATCH') return ok({ ok: true });
+    if (url.includes('/api/auth/me'))              return ok(PLAYER_USER);
+    if (url.includes('/api/downtime_cycles'))      return ok([CYCLE_466]);
+    if (url.includes('/api/downtime_submissions')) return ok(submissions);
+    if (url.includes('/api/archive_documents'))    return ok([]);
+    if (url.includes('/api/characters/names'))     return ok([{ _id: CHAR_466._id, name: CHAR_466.name, moniker: null, honorific: null }]);
+    if (url.includes('/api/characters'))           return ok([CHAR_466]);
+    if (url.includes('/api/territories'))          return ok([]);
+    if (url.includes('/api/game_sessions'))        return ok([]);
+    if (url.includes('/api/session_logs'))         return ok([]);
+    if (url.includes('/api/st_mods'))              return ok([]);
+    if (url.includes('/api/ordeal-responses'))     return ok([]);
+    return ok([]);
+  });
+
+  await page.goto('/');
+  await page.waitForSelector('#app', { state: 'visible', timeout: 15000 });
+  await page.waitForFunction(() => typeof window.goTab === 'function', { timeout: 8000 });
+  await page.evaluate(() => window.goTab('archive'));
+  await page.waitForTimeout(800);
+}
+
+async function openFirstDtItem(page) {
+  await page.waitForSelector('.arc-doc-item[data-sub-id]', { timeout: 8000 });
+  await page.click('.arc-doc-item[data-sub-id]');
+  await page.waitForSelector('.story-narrative', { timeout: 5000 });
+  await page.waitForTimeout(300);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('fix-466: DT player report rendering bugs', () => {
+
+  test('AC1: proj-card-feedback-label is rendered as h4 with text "ST Note"', async ({ page }) => {
+    await setup(page, [SUB_PROJCARD]);
+    await openFirstDtItem(page);
+
+    const label = page.locator('h4.proj-card-feedback-label');
+    await expect(label).toBeVisible();
+    await expect(label).toContainText('ST Note');
+  });
+
+  test('AC2: single \\n line breaks produce distinct <p> elements in story moment', async ({ page }) => {
+    await setup(page, [SUB_SINGLE_NEWLINES]);
+    await openFirstDtItem(page);
+
+    // Story Moment section body should have one <p> per line (3 lines → 3 <p>)
+    const storySection = page.locator('.story-section', {
+      has: page.locator('.story-section-head', { hasText: 'Story Moment' }),
+    });
+    const paragraphs = storySection.locator('.story-section-body p');
+    await expect(paragraphs).toHaveCount(3);
+    await expect(paragraphs.nth(0)).toContainText('A dream');
+    await expect(paragraphs.nth(1)).toContainText('You are walking a road');
+    await expect(paragraphs.nth(2)).toContainText('The country opens');
+  });
+
+  test('AC3: player_facing_note is wrapped in <em> (italic)', async ({ page }) => {
+    await setup(page, [SUB_PROJCARD]);
+    await openFirstDtItem(page);
+
+    const noteEm = page.locator('.proj-card-feedback em');
+    await expect(noteEm).toBeVisible();
+    await expect(noteEm).toContainText('Switched your Disc pool to Cruac');
+  });
+
+  test('AC4 regression: double \\n\\n paragraph breaks still produce distinct <p> elements', async ({ page }) => {
+    await setup(page, [SUB_DOUBLE_NEWLINES]);
+    await openFirstDtItem(page);
+
+    const storySection = page.locator('.story-section', {
+      has: page.locator('.story-section-head', { hasText: 'Story Moment' }),
+    });
+    const paragraphs = storySection.locator('.story-section-body p');
+    await expect(paragraphs).toHaveCount(2);
+    await expect(paragraphs.nth(0)).toContainText('First paragraph');
+    await expect(paragraphs.nth(1)).toContainText('Second paragraph');
+  });
+
+  test('AC1+AC3 combined: label heading and italic text both present in same proj-card', async ({ page }) => {
+    await setup(page, [SUB_PROJCARD]);
+    await openFirstDtItem(page);
+
+    const card = page.locator('.proj-card-feedback');
+    await expect(card.locator('h4.proj-card-feedback-label')).toContainText('ST Note');
+    await expect(card.locator('em')).toContainText('Switched your Disc pool to Cruac');
+  });
+
+});


### PR DESCRIPTION
## Summary

- Fix single-newline paragraph breaks in DT narrative text — `split(/\n{2,}/)` was
  ignoring single `\n`, collapsing all lines into one wall of text; changed to
  `split(/\n/)` across all five DT render sites in `story-tab.js`
- Promote `proj-card-feedback-label` from `<span>` to `<h4>` and wrap
  `player_facing_note` in `<em>` so the ST note is visually distinct from project
  narrative above it
- Fix Archive tab Story Moment duplication (#464) — guard in `renderOutcomeWithCards`
  skips `published_outcome` headings already rendered by dedicated section renderers

## Closes

- Closes #466
- Closes #464

## Story

- specs/stories/fix.466.dt-report-rendering-bugs.story.md
- specs/stories/fix.464.archive-story-moment-dedup.story.md

## Test plan

- [ ] `npx playwright test tests/fix-466-dt-report-rendering-bugs.spec.js` — 5 tests
- [ ] `npx playwright test tests/fix-464-archive-story-moment-dedup.spec.js` — 7 tests
- [ ] CI green
- [ ] Manual: open Anichka's DT 3 report in Archive tab — Story Moment should show
  paragraph breaks; last project card should show "ST NOTE" label above italic feedback

## Branch flow

- From: `ms/issue-466-dt-report-rendering`
- Into: `dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)