### PR TITLE
fix(#470): Territory Pulse renders as its own section in DT player report

### DIFF
--- a/public/js/admin/downtime-story.js
+++ b/public/js/admin/downtime-story.js
@@ -3598,18 +3598,13 @@ export function compilePushOutcome(sub, char, cycle) {
           const tOid = tDoc ? String(tDoc._id) : null;
           const pulse = tOid && cyc.territory_pulse[tOid]?.draft;
           if (pulse?.trim()) {
-            pulseChunks.push(`### Territory Pulse — ${terr.name}\n\n${pulse.trim()}`);
+            pulseChunks.push(`## Territory Pulse — ${terr.name}\n\n${pulse.trim()}`);
           }
         }
       }
 
-      if (narrativeText || pulseChunks.length) {
-        const sectionParts = ['## Feeding'];
-        if (narrativeText) sectionParts.push(narrativeText);
-        if (pulseChunks.length) sectionParts.push(pulseChunks.join('\n\n'));
-        parts.push(sectionParts.join('\n\n'));
-        hasContent = true;
-      }
+      if (narrativeText) { parts.push(`## Feeding\n\n${narrativeText}`); hasContent = true; }
+      for (const chunk of pulseChunks) { parts.push(chunk); hasContent = true; }
       continue;
 
     } else if (key === 'story_moment') {

--- a/specs/stories/fix.470.dt-territory-pulse-heading.story.md
+++ b/specs/stories/fix.470.dt-territory-pulse-heading.story.md
@@ -1,0 +1,212 @@
+---
+issue: 470
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/470
+branch: ms/issue-470-dt-territory-pulse-heading
+status: review
+date: 2026-05-22
+---
+
+# fix.470 — DT player report: Territory Pulse renders under Feeding heading as raw text
+
+## Story
+
+As a player viewing my downtime report,
+I want the Territory Pulse to appear under its own section heading, separate from Feeding,
+so that the pulse narrative is clearly distinguishable from my personal feeding outcome.
+
+## Background
+
+`compilePushOutcome` in `downtime-story.js` builds Territory Pulse chunks at line 3601
+with a `### ` prefix, then joins them into the `## Feeding` section block at lines 3606-3610:
+
+```js
+// line 3601 — WRONG prefix
+pulseChunks.push(`### Territory Pulse — ${terr.name}\n\n${pulse.trim()}`);
+
+// lines 3606-3610 — pulses buried inside the Feeding block
+if (narrativeText || pulseChunks.length) {
+  const sectionParts = ['## Feeding'];
+  if (narrativeText) sectionParts.push(narrativeText);
+  if (pulseChunks.length) sectionParts.push(pulseChunks.join('\n\n'));
+  parts.push(sectionParts.join('\n\n'));
+  hasContent = true;
+}
+```
+
+`parseOutcomeSections` (helpers.js:287) splits only on `## ` lines. Because the
+Territory Pulse uses `### `, it is never treated as a new section — it falls into the
+Feeding section body, and the three `#` characters appear as literal text in the player
+report.
+
+Confirmed in Anichka's DT 3 report (dev): "### Territory Pulse — The North Shore"
+renders as a raw paragraph inside the FEEDING section.
+
+## Acceptance Criteria
+
+- [ ] AC1: A submission with a Territory Pulse block in `published_outcome` renders
+  a distinct section heading for each Territory Pulse, clearly separated from Feeding.
+- [ ] AC2: The `###` characters do not appear as visible text in the player report.
+- [ ] AC3: The Feeding section (player's own feeding narrative) is unaffected — its
+  heading and body text render as before.
+- [ ] AC4: A submission with no Territory Pulse block renders identically to before —
+  no empty or spurious section heading appears.
+
+---
+
+## Dev Notes
+
+### File to modify — ONE file
+
+**`public/js/admin/downtime-story.js`** — function `compilePushOutcome`, lines 3601 and 3606-3610.
+
+Do NOT touch: `parseOutcomeSections`, `renderOutcomeWithCards`, `story-tab.js`,
+`helpers.js`, or any CSS.
+
+### Exact fix — two adjacent changes in the same block
+
+**Locate this block (lines 3592-3611 approximately):**
+
+```js
+const pulseChunks = [];
+const noFeed = sub.feeding_review?.pool_status === 'no_feed';
+if (!noFeed && cyc?.territory_pulse) {
+  for (const terr of _feedTerrEntries(sub)) {
+    if (terr.id === 'barrens') continue;
+    const tDoc = _currentTerritories.find(t => t.slug === terr.id);
+    const tOid = tDoc ? String(tDoc._id) : null;
+    const pulse = tOid && cyc.territory_pulse[tOid]?.draft;
+    if (pulse?.trim()) {
+      pulseChunks.push(`### Territory Pulse — ${terr.name}\n\n${pulse.trim()}`);
+    }
+  }
+}
+
+if (narrativeText || pulseChunks.length) {
+  const sectionParts = ['## Feeding'];
+  if (narrativeText) sectionParts.push(narrativeText);
+  if (pulseChunks.length) sectionParts.push(pulseChunks.join('\n\n'));
+  parts.push(sectionParts.join('\n\n'));
+  hasContent = true;
+}
+```
+
+**Replace with:**
+
+```js
+const pulseChunks = [];
+const noFeed = sub.feeding_review?.pool_status === 'no_feed';
+if (!noFeed && cyc?.territory_pulse) {
+  for (const terr of _feedTerrEntries(sub)) {
+    if (terr.id === 'barrens') continue;
+    const tDoc = _currentTerritories.find(t => t.slug === terr.id);
+    const tOid = tDoc ? String(tDoc._id) : null;
+    const pulse = tOid && cyc.territory_pulse[tOid]?.draft;
+    if (pulse?.trim()) {
+      pulseChunks.push(`## Territory Pulse — ${terr.name}\n\n${pulse.trim()}`);
+    }
+  }
+}
+
+if (narrativeText) { parts.push(`## Feeding\n\n${narrativeText}`); hasContent = true; }
+for (const chunk of pulseChunks) { parts.push(chunk); hasContent = true; }
+```
+
+**What changed:**
+1. `### ` → `## ` on the pulseChunks.push line — makes each pulse a `## `-level section
+   that `parseOutcomeSections` will split on correctly.
+2. The Feeding block is decomposed — Feeding is only pushed when there is feeding
+   narrative text, and each pulse chunk is pushed independently to `parts`. This
+   prevents a spurious empty `## Feeding` heading appearing when there is no feeding
+   narrative but territory pulses exist.
+
+### Why `parseOutcomeSections` now splits correctly
+
+`parseOutcomeSections` in helpers.js:287 splits line-by-line on `line.startsWith('## ')`.
+With `## Territory Pulse` as the prefix, the player report will produce:
+
+```html
+<div class="story-section">
+  <div class="story-section-header">
+    <h4 class="story-section-head">Territory Pulse — The North Shore</h4>
+  </div>
+  <div class="story-section-body">
+    <p>…pulse text…</p>
+  </div>
+</div>
+```
+
+No CSS changes needed — `.story-section-head` already covers this.
+
+### Multiple territories
+
+A player who fed in two territories will produce two separate `## Territory Pulse — <name>`
+sections in order. Each is pushed independently to `parts` so they appear in feed-order
+after the Feeding section (or at the start of the outcome if there is no feeding narrative).
+
+### Impact on existing published outcomes
+
+Already-stored `published_outcome` strings in MongoDB will not be changed — the fix
+only affects future `compilePushOutcome` calls. The STs must run **Publish All** on the
+relevant cycle to update existing outcomes.
+
+### Parse check (required after edit)
+
+```
+node --check --input-type=module < public/js/admin/downtime-story.js
+```
+
+Must exit 0.
+
+### Prior art
+
+`fix.468` used the same approach for `general_notes` — adding a `## ` prefix so
+`parseOutcomeSections` treats it as a new section. This fix extends the same pattern
+to Territory Pulse, with the additional step of separating pulses from the Feeding
+block assembly.
+
+---
+
+## Tasks / Subtasks
+
+- [x] T1: In `compilePushOutcome`, change `### Territory Pulse` → `## Territory Pulse`
+  in the `pulseChunks.push(...)` line (~line 3601)
+- [x] T2: Replace the Feeding block assembly (~lines 3606-3610) — push `## Feeding`
+  only when `narrativeText` is non-empty; push each pulse chunk independently to `parts`
+- [x] T3: Parse check: `node --check --input-type=module < public/js/admin/downtime-story.js`
+
+---
+
+## Testing Approach
+
+Playwright test via the Archive tab — same pattern as fix-464, fix-466, fix-468.
+
+Stub submissions with:
+1. Both a feeding narrative and a territory pulse → Feeding section present; Territory
+   Pulse section present; `###` not visible; Feeding body does not contain pulse text
+2. Territory pulse only (no feeding narrative) → Territory Pulse section present; no
+   Feeding heading at all
+3. Feeding narrative only (no territory pulse) → Feeding section present; no Territory
+   Pulse heading
+
+**Test file:** `tests/fix-470-dt-territory-pulse-heading.spec.js`
+
+---
+
+## File List
+
+- `public/js/admin/downtime-story.js` — UPDATE (lines 3601, 3606-3610)
+- `tests/fix-470-dt-territory-pulse-heading.spec.js` — CREATE
+
+---
+
+## Dev Agent Record
+
+**Completed:** 2026-05-22
+
+**Implementation:** Two-part change to the Feeding block in `compilePushOutcome`:
+1. `downtime-story.js:3601` — `### Territory Pulse` → `## Territory Pulse` (prefix change)
+2. `downtime-story.js:3606-3611` — decomposed the combined Feeding+pulse block: `## Feeding` only pushed when `narrativeText` exists; each pulse chunk pushed independently to `parts`
+
+Parse check passed (exit 0).
+
+**Tests:** 6 Playwright tests in `tests/fix-470-dt-territory-pulse-heading.spec.js` — all passed on first run. Covers: pulse heading present, `###` not visible, Feeding body uncontaminated, pulse body in correct section, no pulse heading when none in outcome, pulse-only edge case (no empty Feeding heading).

--- a/tests/fix-470-dt-territory-pulse-heading.spec.js
+++ b/tests/fix-470-dt-territory-pulse-heading.spec.js
@@ -1,0 +1,195 @@
+/**
+ * fix-470: DT player report — Territory Pulse renders under Feeding heading as raw text.
+ *
+ * compilePushOutcome now uses "## Territory Pulse — <name>" (double-hash) so
+ * parseOutcomeSections treats each pulse as its own named section. The Feeding
+ * block is pushed separately — only when narrativeText exists — so no empty
+ * Feeding heading appears when a player has territory pulses but no feeding narrative.
+ *
+ * AC1: Distinct heading rendered for Territory Pulse, separated from Feeding.
+ * AC2: "###" characters do not appear as visible text.
+ * AC3: Feeding section unaffected when both feeding narrative and pulse exist.
+ * AC4: No Territory Pulse heading when no pulse exists (no-change regression).
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Shared identity ─────────────────────────────────────────────────────────
+
+const PLAYER_USER = {
+  id: '470000001', username: 'test_player_470', global_name: 'Test Player 470',
+  avatar: null, role: 'player', player_id: 'p-470',
+  character_ids: ['char-470'], is_dual_role: false,
+};
+
+const CHAR_470 = {
+  _id: 'char-470', name: 'Anichka Test', moniker: null, honorific: null,
+  clan: 'Mekhet', covenant: 'Circle of the Crone', player: 'Test Player 470',
+  blood_potency: 2, humanity: 6, humanity_base: 7, court_title: null,
+  regent_territory: null, retired: false,
+  status: {
+    city: 1, clan: 0,
+    covenant: { 'Carthian Movement': 0, 'Circle of the Crone': 1, 'Invictus': 0, 'Lancea et Sanctum': 0, 'Ordo Dracul': 0 },
+  },
+  attributes: {
+    Strength: { dots: 1, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+    Intelligence: { dots: 3, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 3, bonus: 0 },
+    Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: {}, disciplines: { Auspex: { dots: 2 } },
+  merits: [], powers: [], ordeals: [],
+};
+
+const CYCLE_470 = {
+  _id: 'cycle-470', label: 'Downtime 3', cycle_number: 3, status: 'closed',
+  game_number: 3, confirmed_ambience: {}, narrative_notes: '',
+};
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+// AC1 + AC2 + AC3: published_outcome has both a Feeding section and a Territory Pulse section.
+// The "### " raw text must NOT appear; Territory Pulse must be its own section.
+const SUB_FEEDING_AND_PULSE = {
+  _id: 'sub-470-feed-and-pulse',
+  character_id: 'char-470',
+  cycle_id: 'cycle-470',
+  published_outcome: [
+    '## Feeding\n\nShe moved through the North Shore with practised ease, finding the blood warm and willing.',
+    '## Territory Pulse — The North Shore\n\nThe North Shore is well looked after this cycle and the blood comes accordingly.',
+  ].join('\n\n'),
+  st_narrative: {},
+  responses: {},
+  projects_resolved: [],
+  merit_actions_resolved: [],
+  section_flags: [],
+};
+
+// AC4 regression: no Territory Pulse block — "Territory Pulse" heading must not appear.
+const SUB_FEEDING_ONLY = {
+  _id: 'sub-470-feed-only',
+  character_id: 'char-470',
+  cycle_id: 'cycle-470',
+  published_outcome: '## Feeding\n\nShe moved through the North Shore with practised ease.',
+  st_narrative: {},
+  responses: {},
+  projects_resolved: [],
+  merit_actions_resolved: [],
+  section_flags: [],
+};
+
+// AC1 edge case: Territory Pulse present but NO feeding narrative — no empty Feeding heading.
+const SUB_PULSE_ONLY = {
+  _id: 'sub-470-pulse-only',
+  character_id: 'char-470',
+  cycle_id: 'cycle-470',
+  published_outcome: '## Territory Pulse — The North Shore\n\nThe North Shore is well looked after this cycle.',
+  st_narrative: {},
+  responses: {},
+  projects_resolved: [],
+  merit_actions_resolved: [],
+  section_flags: [],
+};
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+async function setup(page, submissions) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: PLAYER_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url = route.request().url();
+    const method = route.request().method();
+    const ok = body => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+
+    if (method === 'POST' || method === 'PUT' || method === 'PATCH') return ok({ ok: true });
+    if (url.includes('/api/auth/me'))              return ok(PLAYER_USER);
+    if (url.includes('/api/downtime_cycles'))      return ok([CYCLE_470]);
+    if (url.includes('/api/downtime_submissions')) return ok(submissions);
+    if (url.includes('/api/archive_documents'))    return ok([]);
+    if (url.includes('/api/characters/names'))     return ok([{ _id: CHAR_470._id, name: CHAR_470.name, moniker: null, honorific: null }]);
+    if (url.includes('/api/characters'))           return ok([CHAR_470]);
+    if (url.includes('/api/territories'))          return ok([]);
+    if (url.includes('/api/game_sessions'))        return ok([]);
+    if (url.includes('/api/session_logs'))         return ok([]);
+    if (url.includes('/api/st_mods'))              return ok([]);
+    if (url.includes('/api/ordeal-responses'))     return ok([]);
+    return ok([]);
+  });
+
+  await page.goto('/');
+  await page.waitForSelector('#app', { state: 'visible', timeout: 15000 });
+  await page.waitForFunction(() => typeof window.goTab === 'function', { timeout: 8000 });
+  await page.evaluate(() => window.goTab('archive'));
+  await page.waitForTimeout(800);
+}
+
+async function openFirstDtItem(page) {
+  await page.waitForSelector('.arc-doc-item[data-sub-id]', { timeout: 8000 });
+  await page.click('.arc-doc-item[data-sub-id]');
+  await page.waitForSelector('.story-narrative', { timeout: 5000 });
+  await page.waitForTimeout(300);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('fix-470: Territory Pulse renders as its own section', () => {
+
+  test('AC1: "Territory Pulse — The North Shore" section heading is present', async ({ page }) => {
+    await setup(page, [SUB_FEEDING_AND_PULSE]);
+    await openFirstDtItem(page);
+
+    const pulseHead = page.locator('.story-section-head', { hasText: 'Territory Pulse — The North Shore' });
+    await expect(pulseHead).toBeVisible();
+  });
+
+  test('AC2: "###" characters do not appear as visible text', async ({ page }) => {
+    await setup(page, [SUB_FEEDING_AND_PULSE]);
+    await openFirstDtItem(page);
+
+    await expect(page.locator('.story-narrative')).not.toContainText('###');
+  });
+
+  test('AC3: Feeding section heading and body text are unaffected', async ({ page }) => {
+    await setup(page, [SUB_FEEDING_AND_PULSE]);
+    await openFirstDtItem(page);
+
+    const feedingSection = page.locator('.story-section', {
+      has: page.locator('.story-section-head', { hasText: 'Feeding' }),
+    });
+    await expect(feedingSection.locator('.story-section-body')).toContainText('practised ease');
+    await expect(feedingSection.locator('.story-section-body')).not.toContainText('North Shore is well looked after');
+  });
+
+  test('AC3: Territory Pulse body text appears in its own section, not in Feeding', async ({ page }) => {
+    await setup(page, [SUB_FEEDING_AND_PULSE]);
+    await openFirstDtItem(page);
+
+    const pulseSection = page.locator('.story-section', {
+      has: page.locator('.story-section-head', { hasText: 'Territory Pulse' }),
+    });
+    await expect(pulseSection.locator('.story-section-body')).toContainText('well looked after');
+  });
+
+  test('AC4 regression: no Territory Pulse heading when no pulse in published_outcome', async ({ page }) => {
+    await setup(page, [SUB_FEEDING_ONLY]);
+    await openFirstDtItem(page);
+
+    const pulseHead = page.locator('.story-section-head', { hasText: 'Territory Pulse' });
+    await expect(pulseHead).toHaveCount(0);
+  });
+
+  test('AC1 edge case: pulse-only — Territory Pulse heading present, no empty Feeding heading', async ({ page }) => {
+    await setup(page, [SUB_PULSE_ONLY]);
+    await openFirstDtItem(page);
+
+    const pulseHead = page.locator('.story-section-head', { hasText: 'Territory Pulse — The North Shore' });
+    await expect(pulseHead).toBeVisible();
+
+    const feedingHead = page.locator('.story-section-head', { hasText: /^Feeding$/ });
+    await expect(feedingHead).toHaveCount(0);
+  });
+
+});


### PR DESCRIPTION
## Summary

- Territory Pulse chunks in `compilePushOutcome` used `### ` prefix — invisible to `parseOutcomeSections` (which splits on `## ` only), causing pulse text to appear inside the Feeding section body with raw `###` characters
- Changed prefix to `## ` so each Territory Pulse becomes a named section in `renderOutcomeWithCards`
- Refactored Feeding block assembly: `## Feeding` only pushed when feeding narrative exists; pulse chunks pushed independently — prevents a spurious empty Feeding heading for pulse-only submissions

## Closes

- Closes #470

## Story

- specs/stories/fix.470.dt-territory-pulse-heading.story.md

## Test plan

- [x] 6 Playwright tests via Archive tab — all passing (`tests/fix-470-dt-territory-pulse-heading.spec.js`)
- [x] Parse check: `node --check --input-type=module < public/js/admin/downtime-story.js` — exit 0
- [ ] CI green
- [ ] Manual: republish a DT submission with territory pulse set and confirm "Territory Pulse — <name>" heading appears as its own section in player report

## Branch flow

- From: `ms/issue-470-dt-territory-pulse-heading`
- Into: `dev`