### PR TITLE
fix(#477): computeVitateTally status filter — replace blocklist with explicit whitelist

### DIFF
--- a/public/js/tabs/feeding-tab.js
+++ b/public/js/tabs/feeding-tab.js
@@ -496,8 +496,9 @@ function computeVitateTally(char, sub, liveTerrDocs = []) {
   if (sub?.responses?.feeding_territories) {
     try {
       const grid = JSON.parse(sub.responses.feeding_territories);
+      const ACTIVE_FEED_STATUSES = new Set(['feeding_rights', 'poaching', 'resident', 'poacher', 'poach']);
       for (const [tid, status] of Object.entries(grid)) {
-        if (!status || status === 'none' || status === 'barrens') continue;
+        if (!ACTIVE_FEED_STATUSES.has(status)) continue;
         const td = effectiveTerrs.find(t =>
           t.slug === tid ||
           tid.startsWith(t.slug) ||

--- a/specs/stories/fix.477.vitae-tally-status-filter.story.md
+++ b/specs/stories/fix.477.vitae-tally-status-filter.story.md
@@ -1,0 +1,168 @@
+---
+issue: 477
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/477
+branch: ms/issue-477-vitae-tally-status-filter
+---
+
+# fix.477 — computeVitateTally status filter: feeding_rights replaces resident
+
+**Status:** review
+
+## Story
+
+As a player with Regency, Lieutenant role, or merit-granted feeding rights,
+I want the vitae tally in my feeding tab to reflect my actual territory's ambience,
+so that I see the correct vitae sources rather than an incorrect Barrens −4.
+
+## Acceptance Criteria
+
+- **AC1** — Submission with `the_second_city: "feeding_rights"` → vitae tally shows Second City ambience, not Barrens
+- **AC2** — Submission with `the_harbour: "poaching"` → vitae tally shows Harbour ambience, not Barrens
+- **AC3** — Submission with legacy `the_academy: "resident"` → vitae tally still resolves correctly (backward compat)
+- **AC4** — Submission with legacy `the_harbour: "poacher"` → vitae tally still resolves correctly (backward compat)
+- **AC5** — Submission with all territories `"none"` → vitae tally defaults to Barrens −4
+- **AC6** — Blocklist hotfix on main (commit `49c628e`) is replaced by the correct explicit whitelist
+- **AC7** — Playwright test covers AC1 (`feeding_rights`) and AC2 (`poaching`) cases
+
+## Tasks / Subtasks
+
+- [x] T1 — Replace blocklist with explicit whitelist in `computeVitateTally`
+  - [x] T1.1 — Change the status filter at `feeding-tab.js:500` from blocklist to whitelist
+  - [x] T1.2 — Include all current and legacy status values (see Dev Notes)
+  - [x] T1.3 — Parse-check via pre-commit hook: `git add` file, run `bash .githooks/pre-commit`
+- [x] T2 — Add Playwright tests for AC1, AC2, AC3, AC4, AC5
+  - [x] T2.1 — Create `tests/fix-477-vitae-tally-status-filter.spec.js`
+  - [x] T2.2 — Run tests and verify all pass
+
+## Dev Notes
+
+### The bug
+
+`computeVitateTally` in `public/js/tabs/feeding-tab.js` originally filtered territory grid entries with:
+
+```js
+if (status !== 'resident' && status !== 'poach') continue;
+```
+
+The DT form (downtime-form.js) writes `"feeding_rights"` for any territory where the character has feeding rights (Regent, Lieutenant, or merit), and `"poaching"` for poaching entries. Neither matches `"resident"` or `"poach"`, so ALL feeding-rights characters fell through to the Barrens −4 default whenever `feeding_vitae_tally` was not yet saved by the ST.
+
+A hotfix (commit `49c628e`) replaced this with a blocklist:
+```js
+if (!status || status === 'none' || status === 'barrens') continue;
+```
+
+This is functional but does not express intent. The desired fix is an explicit whitelist.
+
+### Canonical status values (from downtime-form.js)
+
+From the DT form source (lines 5381–5389, 6164):
+
+| Status value | Meaning | Written by |
+|---|---|---|
+| `"feeding_rights"` | Current term — character has feeding rights | DT form (current) |
+| `"poaching"` | Current term — character is poaching | DT form (current) |
+| `"none"` | Territory not selected | DT form |
+| `"barrens"` | Player chose Barrens explicitly | DT form |
+| `"resident"` | **Retired** — DT form migrates this to `"feeding_rights"` on load | Old submissions |
+| `"poacher"` | **Retired** — DT form migrates this to `"poaching"` on load | Old submissions |
+| `"poach"` | **Never used in real data** — was in original filter but the legacy term was always `"poacher"` | Original code artefact |
+
+`"none"` and `"barrens"` must be skipped. All other values must be accepted (whitelist).
+
+### The correct fix
+
+```js
+// Accept current terms and all legacy variants; skip unselected and the
+// special Barrens entry (handled by the Barrens default above).
+const ACTIVE_FEED_STATUSES = new Set([
+  'feeding_rights', 'poaching',          // current
+  'resident', 'poacher', 'poach',        // legacy / retired
+]);
+if (!ACTIVE_FEED_STATUSES.has(status)) continue;
+```
+
+Or inline as a single condition — either form is acceptable. The Set approach is preferred because it documents all values explicitly.
+
+### File to modify
+
+`public/js/tabs/feeding-tab.js` — **one line change** at the filter inside `computeVitateTally` (currently line 500 on the dev branch, which has the blocklist hotfix).
+
+Do NOT change:
+- The rest of `computeVitateTally` — slug lookup, ambience merging, tally shape
+- `renderVitaeTallyCard` — purely display
+- `buildPool` — pool computation, not tally
+- Anything in `downtime-form.js` or `downtime-views.js`
+
+### Pre-existing state on branch
+
+The branch (`ms/issue-477-vitae-tally-status-filter`) was cut from `dev` after the hotfix was merged. The file currently has:
+```js
+if (!status || status === 'none' || status === 'barrens') continue;
+```
+This must be replaced with the whitelist.
+
+### Test approach
+
+Create a new Playwright spec: `tests/fix-477-vitae-tally-status-filter.spec.js`
+
+Reuse the same sandbox pattern from `tests/fix-475-feeding-vitae-pipeline.spec.js`:
+- `openFeedingTabSandbox(page, char, sub)` — same approach, cycle status `"game"`, inject submission, render feeding tab, wait for `.fvt-card`
+- Route `**/api/downtime_cycles*` → `[{ _id: 'cycle-fix477', status: 'game', ... }]`
+- Route `**/api/downtime_submissions*` → `[sub]`
+- Route `**/api/territories*` → `[]`
+- Route `**/api/**` → `[]` (catch-all)
+
+The test helper should be self-contained in the new file (copy the minimal setup helpers rather than importing from the fix-475 file).
+
+Test character: Presence 3, no merits (pool irrelevant — we're testing the vitae card, not dice).
+
+Test submissions differ only in `feeding_territories` JSON:
+- AC1: `{ the_second_city: 'feeding_rights' }` → `.fvt-card` contains "Second City", not "Barrens"
+- AC2: `{ the_harbour: 'poaching' }` → `.fvt-card` contains "Harbour", not "Barrens"
+- AC3: `{ the_academy: 'resident' }` → `.fvt-card` contains "Academy", not "Barrens"
+- AC4: `{ the_harbour: 'poacher' }` → `.fvt-card` contains "Harbour", not "Barrens"
+- AC5: `{ the_second_city: 'none', the_barrens_no_territory_: 'none' }` → `.fvt-card` contains "Barrens", value "-4"
+
+Note: The vitae card only shows ambience when `tally.ambience !== 0`. Second City `ambienceMod` in TERRITORY_DATA should be non-zero (check the hardcoded data). For AC1, use Second City. For AC2, use Harbour (ambienceMod varies). For AC3, use Academy (Curated +3 in TERRITORY_DATA). Actually — for reliable tests, pick territories with non-zero ambienceMod so the card renders an ambience row. See `TERRITORY_DATA` in `public/js/tabs/downtime-data.js` for slug/ambienceMod values.
+
+**Important from fix-475 experience:** The vitae card renders Barrens ambience row only when `tally.ambience !== 0`. Barrens is `−4` so it always renders. Named territories: check their `ambienceMod` — if `0`, the ambience row won't appear. Use territories with non-zero ambienceMod for named territory tests (Academy +3, Harbour 0 but can check `ambience_territory` text instead via `.fvt-card` containing text).
+
+### Territory ambienceMod values (from TERRITORY_DATA)
+
+Check `public/js/tabs/downtime-data.js` for exact values. From context:
+- The Academy: `ambienceMod: 3` (Curated +3) — good for named territory test
+- The Harbour: `ambienceMod: 0` (Untended −2? or Settled 0?) — varies per live DB; use `.not.toContainText('Barrens')` assertion for Harbour test
+- The Second City: variable (Settled +0 in screenshots) — use text assertion not value assertion
+
+Safest assertion pattern for named territory tests:
+```js
+await expect(sandbox.locator('.fvt-card')).not.toContainText('Barrens');
+// OR for Academy specifically:
+await expect(sandbox.locator('.fvt-card')).toContainText('Academy');
+```
+
+### Relation to fix-475
+
+fix-475 (issue #475) fixed three bugs in the feeding pipeline. This story (fix-477) is a follow-up that was not in scope for fix-475 — it corrects the status filter terminology. The fix-475 test `AC5` tested the slug lookup fix using `{ the_academy: 'resident' }` as the submission — that test still passes because `'resident'` is now in the whitelist. No changes to fix-475 tests are needed.
+
+## Dev Agent Record
+
+### Debug Log
+
+- AC1/AC3/AC4 value assertions initially failed with "strict mode violation" — `.fvt-card .fvt-val` resolves to 2 elements with the same positive value. Fixed by scoping to the `.fvt-row` containing the territory name, matching the pattern used in AC5's Barrens row assertion.
+
+### Completion Notes
+
+- T1: Replaced blocklist `if (!status || status === 'none' || status === 'barrens') continue;` with explicit `ACTIVE_FEED_STATUSES` Set in `computeVitateTally` at `feeding-tab.js`. Set includes all current (`feeding_rights`, `poaching`) and legacy (`resident`, `poacher`, `poach`) status values.
+- T2: 5 Playwright tests created and all pass (5/5). Assertions for value rows scoped to `.fvt-row` by territory name to avoid strict-mode multiple-match failures.
+
+## File List
+
+- `public/js/tabs/feeding-tab.js` — whitelist filter applied in `computeVitateTally`
+- `tests/fix-477-vitae-tally-status-filter.spec.js` — new Playwright spec (5 tests, AC1–AC5)
+- `specs/stories/fix.477.vitae-tally-status-filter.story.md` — this story
+
+## Change Log
+
+- 2026-05-22: Story created from issue #477
+- 2026-05-22: Implementation complete — T1 and T2 done, all 5 tests pass

--- a/tests/fix-477-vitae-tally-status-filter.spec.js
+++ b/tests/fix-477-vitae-tally-status-filter.spec.js
@@ -1,0 +1,186 @@
+/**
+ * Tests for fix.477 — computeVitateTally status filter whitelist
+ *
+ * Bug: the territory grid filter in computeVitateTally used retired status
+ * terms ('resident', 'poach') and missed the current terms ('feeding_rights',
+ * 'poaching') and legacy variant 'poacher'. Characters with feeding rights
+ * (Regents, Lieutenants, merit holders) fell back to Barrens −4.
+ *
+ * A blocklist hotfix (commit 49c628e) was shipped as an emergency measure.
+ * This story replaces it with an explicit whitelist of known status values.
+ *
+ * AC1: feeding_rights → named territory ambience, not Barrens
+ * AC2: poaching → named territory ambience, not Barrens
+ * AC3: resident (legacy) → still resolves correctly
+ * AC4: poacher (legacy) → still resolves correctly
+ * AC5: all 'none' → Barrens −4 default preserved
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Mock data ─────────────────────────────────────────────────────────────────
+
+const PLAYER_USER = {
+  id: '777000477', username: 'test_player477', global_name: 'Test Player 477',
+  avatar: null, role: 'player', player_id: 'p-fix477',
+  character_ids: ['char-fix477'], is_dual_role: false,
+};
+
+const GAME_CYCLE = {
+  _id: 'cycle-fix477', status: 'game', label: 'Downtime Test',
+  feeding_rights_confirmed: true, is_chapter_finale: false,
+  created_at: '2026-05-22T00:00:00.000Z',
+};
+
+function buildChar() {
+  return {
+    _id: 'char-fix477', name: 'Test Character', moniker: null, honorific: null,
+    clan: 'Daeva', covenant: 'Invictus', player: 'Test Player',
+    blood_potency: 2, humanity: 7, humanity_base: 7, court_title: null, retired: false,
+    status: {
+      city: 1, clan: 1,
+      covenant: { 'Carthian Movement': 0, 'Circle of the Crone': 0, 'Invictus': 1, 'Lancea et Sanctum': 0, 'Ordo Dracul': 0 },
+    },
+    attributes: {
+      Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+      Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+      Presence: { dots: 3, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+    },
+    skills: {}, disciplines: {}, merits: [], powers: [], ordeals: [],
+  };
+}
+
+function buildSub(feedingTerritories) {
+  return {
+    _id: 'sub-fix477',
+    cycle_id: GAME_CYCLE._id,
+    character_id: 'char-fix477',
+    status: 'submitted',
+    responses: {
+      _feed_method: 'seduction',
+      _feed_disc: '',
+      _feed_spec: '',
+      feeding_territories: JSON.stringify(feedingTerritories),
+    },
+  };
+}
+
+// ── Setup helpers ─────────────────────────────────────────────────────────────
+
+async function setupRoutes(page, submission) {
+  await page.route('**/api/**', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.route('**/api/auth/me', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(PLAYER_USER) })
+  );
+  await page.route(/\/api\/characters(\?.*)?$/, r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([buildChar()]) })
+  );
+  await page.route('**/api/characters/names', r =>
+    r.fulfill({ status: 200, contentType: 'application/json',
+      body: JSON.stringify([{ _id: 'char-fix477', name: 'Test Character', moniker: null, honorific: null }]) })
+  );
+  await page.route('**/api/downtime_cycles*', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([GAME_CYCLE]) })
+  );
+  await page.route('**/api/downtime_submissions*', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([submission]) })
+  );
+  await page.route('**/api/territories*', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.addInitScript((u) => {
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 36000000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(u));
+  }, PLAYER_USER);
+}
+
+async function openFeedingTabSandbox(page, submission) {
+  const char = buildChar();
+  await setupRoutes(page, submission);
+  await page.goto('/');
+  await page.waitForSelector('#app', { state: 'visible', timeout: 15000 });
+  await page.waitForTimeout(300);
+  await page.evaluate(async (c) => {
+    const sandbox = document.createElement('div');
+    sandbox.id = 'feed-sandbox-477';
+    sandbox.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;background:#1a1208;z-index:99999;overflow:auto;';
+    document.body.appendChild(sandbox);
+    const { renderFeedingTab } = await import('/js/tabs/feeding-tab.js');
+    await renderFeedingTab(sandbox, c);
+  }, char);
+  await page.waitForTimeout(500);
+  return page.locator('#feed-sandbox-477');
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('fix.477 — computeVitateTally status filter whitelist', () => {
+
+  // AC1: current term "feeding_rights" — Regent / Lieutenant / merit holder
+  test('AC1: feeding_rights status → Academy ambience (+3), not Barrens', async ({ page }) => {
+    const sub = buildSub({ the_academy: 'feeding_rights' });
+    const sandbox = await openFeedingTabSandbox(page, sub);
+
+    await expect(sandbox.locator('.fvt-card')).toBeVisible({ timeout: 8000 });
+    await expect(sandbox.locator('.fvt-card')).toContainText('Academy');
+    await expect(sandbox.locator('.fvt-card')).not.toContainText('Barrens');
+    const ambRow1 = sandbox.locator('.fvt-card .fvt-row', { hasText: 'Academy' });
+    await expect(ambRow1).toBeVisible();
+    await expect(ambRow1.locator('.fvt-val')).toHaveText('+3');
+  });
+
+  // AC2: current term "poaching"
+  test('AC2: poaching status → Harbour ambience (−2), not Barrens', async ({ page }) => {
+    const sub = buildSub({ the_harbour: 'poaching' });
+    const sandbox = await openFeedingTabSandbox(page, sub);
+
+    await expect(sandbox.locator('.fvt-card')).toBeVisible({ timeout: 8000 });
+    await expect(sandbox.locator('.fvt-card')).toContainText('Harbour');
+    await expect(sandbox.locator('.fvt-card')).not.toContainText('Barrens');
+    await expect(sandbox.locator('.fvt-card .fvt-val', { hasText: '-2' })).toBeVisible();
+  });
+
+  // AC3: legacy term "resident" — old submissions before the term was retired
+  test('AC3: resident (legacy) → North Shore ambience (+2), not Barrens', async ({ page }) => {
+    const sub = buildSub({ the_north_shore: 'resident' });
+    const sandbox = await openFeedingTabSandbox(page, sub);
+
+    await expect(sandbox.locator('.fvt-card')).toBeVisible({ timeout: 8000 });
+    await expect(sandbox.locator('.fvt-card')).toContainText('North Shore');
+    await expect(sandbox.locator('.fvt-card')).not.toContainText('Barrens');
+    const ambRow3 = sandbox.locator('.fvt-card .fvt-row', { hasText: 'North Shore' });
+    await expect(ambRow3).toBeVisible();
+    await expect(ambRow3.locator('.fvt-val')).toHaveText('+2');
+  });
+
+  // AC4: legacy term "poacher" — old submissions before the term was retired
+  test('AC4: poacher (legacy) → Second City ambience (+2), not Barrens', async ({ page }) => {
+    const sub = buildSub({ the_second_city: 'poacher' });
+    const sandbox = await openFeedingTabSandbox(page, sub);
+
+    await expect(sandbox.locator('.fvt-card')).toBeVisible({ timeout: 8000 });
+    await expect(sandbox.locator('.fvt-card')).toContainText('Second City');
+    await expect(sandbox.locator('.fvt-card')).not.toContainText('Barrens');
+    const ambRow4 = sandbox.locator('.fvt-card .fvt-row', { hasText: 'Second City' });
+    await expect(ambRow4).toBeVisible();
+    await expect(ambRow4.locator('.fvt-val')).toHaveText('+2');
+  });
+
+  // AC5: all territories "none" → Barrens default preserved
+  test('AC5: all territories "none" → Barrens −4 default', async ({ page }) => {
+    const sub = buildSub({
+      the_academy: 'none', the_harbour: 'none', the_dockyards: 'none',
+      the_second_city: 'none', the_north_shore: 'none', the_barrens_no_territory_: 'none',
+    });
+    const sandbox = await openFeedingTabSandbox(page, sub);
+
+    await expect(sandbox.locator('.fvt-card')).toBeVisible({ timeout: 8000 });
+    const ambRow = sandbox.locator('.fvt-card .fvt-row', { hasText: 'Barrens' });
+    await expect(ambRow).toBeVisible();
+    await expect(ambRow.locator('.fvt-val')).toHaveText('-4');
+  });
+
+});


### PR DESCRIPTION
## Summary

- `computeVitateTally` in `feeding-tab.js` used retired status terms (`'resident'`, `'poach'`), causing characters with `feeding_rights` status (Regents, Lieutenants, merit holders) to silently fall back to Barrens −4 ambience instead of their named territory
- An emergency blocklist hotfix (commit `49c628e`) was shipped to main as a stopgap; this PR replaces it with an explicit `ACTIVE_FEED_STATUSES` whitelist that documents all valid status values — current (`feeding_rights`, `poaching`) and legacy (`resident`, `poacher`, `poach`)
- 5 Playwright tests added covering every status term and the all-`none` Barrens default

## Closes

- Closes #477

## Story

- specs/stories/fix.477.vitae-tally-status-filter.story.md

## Test plan

- [x] `npx playwright test tests/fix-477-vitae-tally-status-filter.spec.js` — 5/5 pass
- [ ] CI green
- [ ] Manual: open feeding tab for a character with feeding rights in a named territory — vitae tally must show named territory ambience, not Barrens −4

## Branch flow

- From: `ms/issue-477-vitae-tally-status-filter`
- Into: `dev`