### PR TITLE
fix(#479): influence steppers enforce budget cap visually

### DIFF
--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -3245,6 +3245,17 @@ function renderForm(container) {
       }
     }
 
+    // Refresh disabled states so buttons reflect the new remaining value.
+    for (const t of INFLUENCE_TERRITORIES) {
+      const otherTk = t.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+      const otherEl = document.getElementById(`inf-val-${otherTk}`);
+      const v = otherEl ? parseInt(otherEl.textContent, 10) || 0 : 0;
+      const mBtn = document.querySelector(`[data-inf-terr="${otherTk}"][data-inf-dir="-1"]`);
+      const pBtn = document.querySelector(`[data-inf-terr="${otherTk}"][data-inf-dir="1"]`);
+      if (mBtn) mBtn.disabled = v <= 0 && remaining <= 0;
+      if (pBtn) pBtn.disabled = v >= 0 && remaining <= 0;
+    }
+
     scheduleSave();
   });
 
@@ -6754,13 +6765,15 @@ function renderQuestion(q, value) {
         // vertically aligned across rows; text content is value-driven.
         const leftText  = val < 0 ? 'decreasing ambience' : '';
         const rightText = val > 0 ? 'increasing ambience' : '';
+        const minusDis  = val <= 0 && remaining <= 0 ? ' disabled' : '';
+        const plusDis   = val >= 0 && remaining <= 0 ? ' disabled' : '';
         h += '<div class="dt-influence-row">';
         h += `<span class="dt-influence-terr">${esc(terr)}</span>`;
         h += '<span class="dt-influence-control">';
         h += `<span class="dt-influence-label dt-influence-label-left">${leftText}</span>`;
-        h += `<button type="button" class="dt-inf-btn" data-inf-terr="${tk}" data-inf-dir="-1">−</button>`;
+        h += `<button type="button" class="dt-inf-btn"${minusDis} data-inf-terr="${tk}" data-inf-dir="-1">−</button>`;
         h += `<span class="dt-inf-val" id="inf-val-${tk}">${val}</span>`;
-        h += `<button type="button" class="dt-inf-btn" data-inf-terr="${tk}" data-inf-dir="1">+</button>`;
+        h += `<button type="button" class="dt-inf-btn"${plusDis} data-inf-terr="${tk}" data-inf-dir="1">+</button>`;
         h += `<span class="dt-influence-label dt-influence-label-right">${rightText}</span>`;
         h += '</span>';
         h += '</div>';

--- a/specs/stories/fix.479.dt-influence-budget-cap.story.md
+++ b/specs/stories/fix.479.dt-influence-budget-cap.story.md
@@ -1,0 +1,171 @@
+---
+issue: 479
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/479
+branch: ms/issue-479-dt-influence-budget-cap
+---
+
+# fix.479 — DT form: influence spend does not enforce budget cap
+
+**Status:** ready-for-dev
+
+## Story
+
+As a player filling in my downtime form,
+I want the influence spend steppers to prevent me from going over my budget,
+so that I cannot accidentally submit an over-budget allocation.
+
+## Acceptance Criteria
+
+- **AC1** — When `remaining = 0`, the `+` button on any territory with a non-negative value is disabled
+- **AC2** — When `remaining = 0`, the `−` button on any territory with a non-positive value is disabled
+- **AC3** — A character cannot reach a state where `Σ|influence_spend values| > budget` via the steppers
+- **AC4** — Buttons that would FREE budget (reduce absolute value toward zero) remain enabled when remaining = 0
+- **AC5** — The remaining counter display is consistent with actual spend at all times
+- **AC6** — Existing valid submissions (within budget) render and function normally
+
+## Tasks / Subtasks
+
+- [x] T1 — Disable over-budget stepper buttons at render time
+  - [x] T1.1 — In the `influence_grid` render block (`downtime-form.js` ~line 6761–6763), add `disabled` attribute to `+`/`−` buttons that would cause overspend
+  - [x] T1.2 — In the click handler (`downtime-form.js` ~line 3221–3235), update button disabled states after each stepper click (or trigger a re-render of just the budget+buttons)
+  - [x] T1.3 — Parse-check via pre-commit hook
+- [x] T2 — Playwright tests for AC1–AC6
+  - [x] T2.1 — Create `tests/fix-479-dt-influence-budget-cap.spec.js`
+  - [x] T2.2 — Run tests and verify all pass
+
+## Dev Notes
+
+### What the code does today
+
+**Render path** (`influence_grid` case, ~line 6727–6769):
+- Reads saved `influence_spend` JSON from `responseDoc.responses`
+- Computes `remaining = budget − Σ|values|` for the counter display
+- Renders `+` and `−` buttons with `data-inf-terr` and `data-inf-dir` attributes — but **no `disabled` attribute**, ever
+
+**Click path** (~line 3198–3248, inside the delegated `click` listener):
+- Reads the current DOM value from `#inf-val-${tk}`
+- Computes `newVal = currentVal + dir`
+- Recomputes `totalSpent` as `Σ Math.abs` across all territories (including the prospective newVal)
+- **Has an early-return guard**: `if (totalSpent > budget) return;` (line 3219)
+- If allowed: updates DOM value and the budget counter in-place, calls `scheduleSave()`
+
+**The gap:** The early-return guard silently blocks the click but gives no visual feedback — the button appears enabled and clickable. There is also no submit-time validation, so over-budget data already in the DB (like Wan Yelong's DT3 submission) can be loaded and re-submitted as-is.
+
+### Disable rule
+
+A button should be `disabled` when pressing it would INCREASE the absolute value of any territory and `remaining <= 0`:
+
+```
++ button disabled when: currentVal >= 0 AND remaining <= 0
+  (pressing + on a non-negative value increases absolute spend)
+
+− button disabled when: currentVal <= 0 AND remaining <= 0
+  (pressing − on a non-positive value increases absolute spend)
+```
+
+Buttons that move a value toward zero (reducing absolute spend) must always remain enabled — a character who overspent historically must be able to reduce their allocation.
+
+### The correct render-time fix
+
+In the `influence_grid` render loop (around line 6750), compute per-territory disabled state before building the button HTML:
+
+```js
+for (const terr of INFLUENCE_TERRITORIES) {
+  const tk = terr.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+  const val = infVals[tk] || 0;
+  // ...existing label logic...
+
+  const minusDisabled = val <= 0 && remaining <= 0 ? ' disabled' : '';
+  const plusDisabled  = val >= 0 && remaining <= 0 ? ' disabled' : '';
+
+  h += `<button type="button" class="dt-inf-btn"${minusDisabled} data-inf-terr="${tk}" data-inf-dir="-1">−</button>`;
+  h += `<span class="dt-inf-val" id="inf-val-${tk}">${val}</span>`;
+  h += `<button type="button" class="dt-inf-btn"${plusDisabled} data-inf-terr="${tk}" data-inf-dir="1">+</button>`;
+}
+```
+
+### The correct click-time update
+
+After a successful stepper click updates the DOM counter, also update the disabled state of all 10 buttons (5 territories × 2 directions) to match the new remaining value. The cleanest approach is to call a helper that re-evaluates all buttons:
+
+```js
+// After updating the budget display (line ~3238):
+function refreshInfluenceButtonStates(budget, newTotalSpent) {
+  const newRemaining = budget - newTotalSpent;
+  for (const terr of INFLUENCE_TERRITORIES) {
+    const otherTk = terr.toLowerCase().replace(/[^a-z0-9]+/g, '_');
+    const otherEl = document.getElementById(`inf-val-${otherTk}`);
+    const v = otherEl ? parseInt(otherEl.textContent, 10) || 0 : 0;
+    const minusBtn = document.querySelector(`[data-inf-terr="${otherTk}"][data-inf-dir="-1"]`);
+    const plusBtn  = document.querySelector(`[data-inf-terr="${otherTk}"][data-inf-dir="1"]`);
+    if (minusBtn) minusBtn.disabled = v <= 0 && newRemaining <= 0;
+    if (plusBtn)  plusBtn.disabled  = v >= 0 && newRemaining <= 0;
+  }
+}
+```
+
+Call this at the end of the click handler (after `scheduleSave()`).
+
+### File to modify
+
+`public/js/tabs/downtime-form.js` — two locations:
+
+1. **Render** (~line 6761–6763): add conditional `disabled` attributes (T1.1)
+2. **Click handler** (~line 3238–3248): add `refreshInfluenceButtonStates` call after updating budget display (T1.2)
+
+Do NOT change:
+- `getInfluenceBudget()` — correct as-is
+- The existing `if (totalSpent > budget) return;` guard — keep it as a safety net
+- The `collectResponses()` / save path — no submit-time validation needed (the stepper guard is sufficient)
+- Any other section of the form
+
+### CSS
+
+The `dt-inf-btn` class is already styled. Disabled state should be handled by the browser's native `:disabled` styling. No new CSS needed unless the disabled appearance is invisible — check visually after implementation.
+
+### Test approach
+
+Reuse the sandbox pattern from `tests/fix-475-feeding-vitae-pipeline.spec.js` and `tests/fix-477-vitae-tally-status-filter.spec.js`:
+- Open `renderDowntimeTab` in a sandbox div
+- Expand the "Territory and Influence" section
+- Use a character with known influence budget (e.g., 2 influence total)
+
+Test scenarios:
+- **AC1/AC2**: Character with budget 2, spend 2 on one territory → both `+` (on non-negative) and `−` (on non-positive) buttons across all territories disabled
+- **AC3**: Attempt stepper click that would go over budget → value unchanged, button visually disabled
+- **AC4**: Character at budget cap with a positive value → `−` button still enabled (reduces toward zero)
+- **AC5**: Counter always matches Σ|values| correctly
+- **AC6**: Character with 0 influence spend → all steppers enabled, normal operation
+
+Character: use `calcTotalInfluence` result — simplest is a character with exactly 1 Resources dot (= 1 influence). Or hardcode a character with a known influence merit.
+
+### Relationship to existing enforcement
+
+The click-time `if (totalSpent > budget) return;` guard (line 3219) is correct and must be preserved. This story adds the **visual layer** on top: buttons reflect their state rather than silently blocking. The guard remains as a defence-in-depth backstop.
+
+### Known over-budget data
+
+Wan Yelong's DT3 submission is already in the DB at -4 Academy / +6 Harbour = 10 absolute against budget 8. This is an ST data-correction task, out of scope for this story. The form will correctly load and display the -2 remaining state; the steppers will correctly disable further overspend.
+
+## Dev Agent Record
+
+### Debug Log
+
+- T2.2: Tests initially failed with `waitFor` timeout because the territory section only renders in `advanced` mode (`_formMode` returns `'minimal'` by default). Fixed by adding `_mode: 'advanced'` to `buildSub` responses and replacing `waitForTimeout(400)` with `waitForSelector('#dt-btn-submit')` as the render-complete signal.
+
+### Completion Notes
+
+- T1.1: Added `minusDis`/`plusDis` computed attributes to the `influence_grid` render loop in `downtime-form.js`. `+` disabled when `val >= 0 && remaining <= 0`; `−` disabled when `val <= 0 && remaining <= 0`.
+- T1.2: Added a post-click refresh loop after the budget counter update that re-evaluates all 10 stepper buttons (5 territories × 2 directions) against the new remaining value.
+- T2: 5 Playwright tests cover AC1–AC6. All 5 pass (5/5, 11s).
+
+## File List
+
+- `public/js/tabs/downtime-form.js` — T1.1 render-time disabled attributes; T1.2 click-handler button refresh loop
+- `tests/fix-479-dt-influence-budget-cap.spec.js` — T2 Playwright tests (AC1–AC6)
+- `specs/stories/fix.479.dt-influence-budget-cap.story.md` — this file
+
+## Change Log
+
+- 2026-05-22: Story created from issue #479
+- 2026-05-22: Implementation complete — T1 + T2 done, all tests pass

--- a/tests/fix-479-dt-influence-budget-cap.spec.js
+++ b/tests/fix-479-dt-influence-budget-cap.spec.js
@@ -1,0 +1,250 @@
+/**
+ * Tests for fix.479 — DT form influence spend budget cap enforcement
+ *
+ * Bug: influence steppers had no visual disabled state when remaining = 0.
+ *      Buttons silently did nothing on click but appeared enabled, giving
+ *      no feedback and historically allowing over-budget submissions.
+ *
+ * Fix: + disabled when val >= 0 && remaining <= 0
+ *      − disabled when val <= 0 && remaining <= 0
+ *      Buttons that reduce absolute value (free budget) always stay enabled.
+ *
+ * AC1: + button disabled on all territories when remaining = 0
+ * AC2: − button disabled on zero-value territories when remaining = 0
+ * AC3: values cannot be increased past budget via steppers
+ * AC4: − button on a spent territory remains enabled (frees budget)
+ * AC5: remaining counter is accurate throughout interactions
+ * AC6: with zero spend, all buttons are enabled and remaining shows correctly
+ *
+ * Character budget: clan 1 + covenant Invictus 1 = 2 influence
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Mock data ─────────────────────────────────────────────────────────────────
+
+const PLAYER_USER = {
+  id: '777000479', username: 'test_player479', global_name: 'Test Player 479',
+  avatar: null, role: 'player', player_id: 'p-fix479',
+  character_ids: ['char-fix479'], is_dual_role: false,
+};
+
+const GAME_CYCLE = {
+  _id: 'cycle-fix479', status: 'game', label: 'Downtime Test',
+  feeding_rights_confirmed: true, is_chapter_finale: false,
+  created_at: '2026-05-22T00:00:00.000Z',
+};
+
+function buildChar() {
+  return {
+    _id: 'char-fix479', name: 'Test Character', moniker: null, honorific: null,
+    clan: 'Daeva', covenant: 'Invictus', player: 'Test Player',
+    blood_potency: 2, humanity: 7, humanity_base: 7, court_title: null, retired: false,
+    // clan: 1, covenant Invictus: 1 → calcTotalInfluence = 2
+    status: {
+      city: 1, clan: 1,
+      covenant: { 'Carthian Movement': 0, 'Circle of the Crone': 0, 'Invictus': 1, 'Lancea et Sanctum': 0, 'Ordo Dracul': 0 },
+    },
+    attributes: {
+      Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+      Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+      Presence: { dots: 3, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+    },
+    skills: {}, disciplines: {}, merits: [], powers: [], ordeals: [],
+  };
+}
+
+function buildSub(influenceSpend = {}) {
+  return {
+    _id: 'sub-fix479',
+    cycle_id: GAME_CYCLE._id,
+    character_id: 'char-fix479',
+    status: 'submitted',
+    responses: {
+      _mode: 'advanced',
+      _feed_method: 'seduction',
+      _feed_disc: '',
+      _feed_spec: '',
+      feeding_territories: JSON.stringify({}),
+      influence_spend: JSON.stringify(influenceSpend),
+    },
+  };
+}
+
+// ── Setup helpers ─────────────────────────────────────────────────────────────
+
+async function setupRoutes(page, submission) {
+  await page.route('**/api/**', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.route('**/api/auth/me', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(PLAYER_USER) })
+  );
+  await page.route(/\/api\/characters(\?.*)?$/, r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([buildChar()]) })
+  );
+  await page.route('**/api/characters/names', r =>
+    r.fulfill({ status: 200, contentType: 'application/json',
+      body: JSON.stringify([{ _id: 'char-fix479', name: 'Test Character', moniker: null, honorific: null }]) })
+  );
+  await page.route('**/api/downtime_cycles*', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([GAME_CYCLE]) })
+  );
+  await page.route('**/api/downtime_submissions*', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([submission]) })
+  );
+  await page.route('**/api/territories*', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.addInitScript((u) => {
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 36000000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(u));
+  }, PLAYER_USER);
+}
+
+async function openInfluenceSection(page, submission) {
+  const char = buildChar();
+  await setupRoutes(page, submission);
+  await page.goto('/');
+  await page.waitForSelector('#app', { state: 'visible', timeout: 15000 });
+  await page.waitForTimeout(300);
+  await page.evaluate(async ({ c, terrs }) => {
+    const sandbox = document.createElement('div');
+    sandbox.id = 'dt-sandbox-479';
+    sandbox.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;background:#1a1208;z-index:99999;overflow:auto;';
+    document.body.appendChild(sandbox);
+    const mod = await import('/js/tabs/downtime-form.js');
+    await mod.renderDowntimeTab(sandbox, c, [], { skipFreshFetch: true });
+  }, { c: char, terrs: [] });
+  // Wait for form submit button as a render-complete signal
+  await page.waitForSelector('#dt-sandbox-479 #dt-btn-submit', { timeout: 10000 });
+  const sandbox = page.locator('#dt-sandbox-479');
+
+  // Expand the territory section (advanced mode = rendered; starts collapsed)
+  const terrSection = sandbox.locator('.qf-section[data-section-key="territory"]');
+  await terrSection.waitFor({ state: 'attached', timeout: 5000 });
+  await terrSection.locator('.qf-section-title').click();
+  await page.waitForTimeout(300);
+
+  // Wait for influence grid
+  await sandbox.locator('.dt-influence-grid').waitFor({ timeout: 5000 });
+  return sandbox;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('fix.479 — influence spend budget cap enforcement', () => {
+
+  // AC6: zero spend state — all buttons enabled, counter correct
+  test('AC6: zero spend → all stepper buttons enabled, remaining shows budget', async ({ page }) => {
+    const sandbox = await openInfluenceSection(page, buildSub({}));
+
+    // Remaining counter should show 2 (budget)
+    const remSpan = sandbox.locator('.dt-influence-budget .dt-influence-remaining');
+    await expect(remSpan).toHaveText('2');
+
+    // All + and − buttons should be enabled
+    const plusAcademy  = sandbox.locator('[data-inf-terr="the_academy"][data-inf-dir="1"]');
+    const minusAcademy = sandbox.locator('[data-inf-terr="the_academy"][data-inf-dir="-1"]');
+    const plusHarbour  = sandbox.locator('[data-inf-terr="the_harbour"][data-inf-dir="1"]');
+    const minusHarbour = sandbox.locator('[data-inf-terr="the_harbour"][data-inf-dir="-1"]');
+
+    await expect(plusAcademy).toBeEnabled();
+    await expect(minusAcademy).toBeEnabled();
+    await expect(plusHarbour).toBeEnabled();
+    await expect(minusHarbour).toBeEnabled();
+  });
+
+  // AC1 + AC2 + AC5: spend full budget via steppers — buttons disable, counter = 0
+  test('AC1/AC2/AC5: after spending full budget, + and − on zero territories disabled, counter = 0', async ({ page }) => {
+    const sandbox = await openInfluenceSection(page, buildSub({}));
+
+    const plusAcademy  = sandbox.locator('[data-inf-terr="the_academy"][data-inf-dir="1"]');
+    const minusAcademy = sandbox.locator('[data-inf-terr="the_academy"][data-inf-dir="-1"]');
+    const plusHarbour  = sandbox.locator('[data-inf-terr="the_harbour"][data-inf-dir="1"]');
+    const minusHarbour = sandbox.locator('[data-inf-terr="the_harbour"][data-inf-dir="-1"]');
+    const remSpan      = sandbox.locator('.dt-influence-budget .dt-influence-remaining');
+
+    // Spend budget: click + on Academy twice
+    await plusAcademy.click();
+    await plusAcademy.click();
+    await expect(remSpan).toHaveText('0');
+
+    // AC1: + buttons disabled on all territories (remaining = 0)
+    await expect(plusAcademy).toBeDisabled();
+    await expect(plusHarbour).toBeDisabled();
+
+    // AC2: − disabled on zero-value territory (Harbour val = 0, remaining = 0)
+    await expect(minusHarbour).toBeDisabled();
+
+    // AC4 (partial): − on Academy is NOT disabled (val = 2 > 0, would free budget)
+    await expect(minusAcademy).toBeEnabled();
+  });
+
+  // AC3: stepper value cannot exceed budget — val stays at budget ceiling
+  test('AC3: value cannot increase past budget', async ({ page }) => {
+    const sandbox = await openInfluenceSection(page, buildSub({}));
+
+    const plusAcademy = sandbox.locator('[data-inf-terr="the_academy"][data-inf-dir="1"]');
+    const valAcademy  = sandbox.locator('#inf-val-the_academy');
+
+    // Spend full budget
+    await plusAcademy.click();
+    await plusAcademy.click();
+    await expect(valAcademy).toHaveText('2');
+
+    // Button is now disabled — clicking should not change the value
+    await expect(plusAcademy).toBeDisabled();
+    await expect(valAcademy).toHaveText('2');
+  });
+
+  // AC4: − button on a spent territory remains enabled and re-enables others on click
+  test('AC4: − on spent territory frees budget and re-enables + buttons', async ({ page }) => {
+    const sandbox = await openInfluenceSection(page, buildSub({}));
+
+    const plusAcademy  = sandbox.locator('[data-inf-terr="the_academy"][data-inf-dir="1"]');
+    const minusAcademy = sandbox.locator('[data-inf-terr="the_academy"][data-inf-dir="-1"]');
+    const plusHarbour  = sandbox.locator('[data-inf-terr="the_harbour"][data-inf-dir="1"]');
+    const remSpan      = sandbox.locator('.dt-influence-budget .dt-influence-remaining');
+
+    // Spend full budget
+    await plusAcademy.click();
+    await plusAcademy.click();
+    await expect(remSpan).toHaveText('0');
+    await expect(plusHarbour).toBeDisabled();
+
+    // AC4: − Academy is enabled despite remaining = 0
+    await expect(minusAcademy).toBeEnabled();
+    await minusAcademy.click();
+
+    // Remaining recovers to 1 → + Harbour re-enabled
+    await expect(remSpan).toHaveText('1');
+    await expect(plusHarbour).toBeEnabled();
+  });
+
+  // AC1/AC2: pre-loaded over-budget submission — buttons reflect over-spent state
+  test('AC1/AC2: pre-loaded at budget → buttons correctly disabled on render', async ({ page }) => {
+    // Load with Academy already at full budget (2)
+    const sandbox = await openInfluenceSection(page, buildSub({ the_academy: 2 }));
+
+    const remSpan      = sandbox.locator('.dt-influence-budget .dt-influence-remaining');
+    const plusAcademy  = sandbox.locator('[data-inf-terr="the_academy"][data-inf-dir="1"]');
+    const minusAcademy = sandbox.locator('[data-inf-terr="the_academy"][data-inf-dir="-1"]');
+    const plusHarbour  = sandbox.locator('[data-inf-terr="the_harbour"][data-inf-dir="1"]');
+    const minusHarbour = sandbox.locator('[data-inf-terr="the_harbour"][data-inf-dir="-1"]');
+
+    await expect(remSpan).toHaveText('0');
+
+    // + disabled on all (remaining = 0)
+    await expect(plusAcademy).toBeDisabled();
+    await expect(plusHarbour).toBeDisabled();
+
+    // − disabled on zero territories (Harbour = 0)
+    await expect(minusHarbour).toBeDisabled();
+
+    // − enabled on spent territory (Academy val = 2 > 0)
+    await expect(minusAcademy).toBeEnabled();
+  });
+
+});


### PR DESCRIPTION
## Summary

- Influence spend steppers now visually disable when the budget is exhausted, matching the silent early-return guard that was already in place
- `+` disabled on any territory where `val >= 0 && remaining <= 0`; `−` disabled where `val <= 0 && remaining <= 0`
- Buttons that move a value toward zero (freeing budget) stay enabled regardless — handles existing over-budget DB data (e.g. Wan Yelong DT3) without locking the player out
- Both render-time (initial state on load) and click-time (refresh loop after every stepper interaction) are covered

## Closes

- Closes #479

## Story

- specs/stories/fix.479.dt-influence-budget-cap.story.md

## Test plan

- [ ] `npx playwright test tests/fix-479-dt-influence-budget-cap.spec.js` — 5/5 pass (AC1–AC6)
- [ ] CI green
- [ ] Manual: open DT form as a player in advanced mode, expand Territory and Influence, spend to budget — stepper buttons should visually disable; clicking a spent territory's − should re-enable + buttons elsewhere

## Branch flow

- From: `ms/issue-479-dt-influence-budget-cap`
- Into: `dev`