### PR TITLE
feat(#483): Check-In roster-first rendering + New Session button

### DIFF
--- a/public/js/game/signin-tab.js
+++ b/public/js/game/signin-tab.js
@@ -2,17 +2,17 @@
  * signin-tab.js — Live game check-in tab (ST + coordinator).
  *
  * Repurposed by fin.3 as the coordinator check-in tool.
- * Shows attendance entries for the most recent game session.
- * Each row: player name, character name, attended tick, payment method,
- * amount, and starting Vitae / WP / Influence derived from character data.
- * Payment is written to the structured attendance[n].payment object
- * (fin.2 schema). Changes auto-save to /api/game_sessions/:id.
+ * Renders the full non-retired character roster against the most recent
+ * game session. Ticking a character creates their attendance entry on demand
+ * (upsert-on-tick). When no session exists a "+ New Session" button lets the
+ * coordinator create one without leaving this tab.
+ * Changes auto-save to /api/game_sessions/:id.
  */
 
-import { apiGet, apiPut } from '../data/api.js';
+import { apiGet, apiPut, apiPost } from '../data/api.js';
 import { calcVitaeMax, calcWillpowerMax } from '../data/accessors.js';
 import { calcTotalInfluence } from '../editor/domain.js';
-import { displayName, sortName, esc } from '../data/helpers.js';
+import { displayName, esc } from '../data/helpers.js';
 import { readPayment } from './payment-helpers.js';
 
 // fin.2 schema enum. Display labels paired with stored values.
@@ -56,27 +56,7 @@ let _playerByCharId = new Map();
 // Placeholder strings seeded by an early redacted import. Treat as missing.
 const PLACEHOLDER_RE = /^Player [A-Z]{1,2}$/;
 
-export async function initSignIn(el, chars) {
-  _el = el;
-  _chars = chars || [];
-  el.innerHTML = '<div class="si-loading">Loading session\u2026</div>';
-
-  try {
-    const sessions = await apiGet('/api/game_sessions');
-    _session = sessions.sort((a, b) => b.session_date.localeCompare(a.session_date))[0] || null;
-  } catch {
-    el.innerHTML = '<div class="si-empty">Could not load sessions. Check your connection.</div>';
-    return;
-  }
-
-  if (!_session) {
-    el.innerHTML = '<div class="si-empty">No game sessions found. Create one in ST Admin \u2192 Attendance.</div>';
-    return;
-  }
-
-  // Build character_id \u2192 display_name lookup once. Coordinator-accessible
-  // narrow endpoint; if it fails (network or auth), fall back to whatever
-  // string is on the row so the tab still renders.
+async function loadPlayerNames() {
   _playerByCharId = new Map();
   try {
     const pairs = await apiGet('/api/players/display-names');
@@ -89,20 +69,66 @@ export async function initSignIn(el, chars) {
   } catch (err) {
     console.warn('[signin] player name lookup failed; falling back to row.player strings', err);
   }
+}
 
+export async function initSignIn(el, chars) {
+  _el = el;
+  _chars = chars || [];
+  el.innerHTML = '<div class="si-loading">Loading session…</div>';
+
+  try {
+    const sessions = await apiGet('/api/game_sessions');
+    _session = sessions.sort((a, b) => b.session_date.localeCompare(a.session_date))[0] || null;
+  } catch {
+    el.innerHTML = '<div class="si-empty">Could not load sessions. Check your connection.</div>';
+    return;
+  }
+
+  if (!_session) {
+    renderNoSession();
+    return;
+  }
+
+  await loadPlayerNames();
   render();
 }
 
-function resolvePlayerName(att) {
-  const raw = (att.player || '').trim();
+function renderNoSession() {
+  _el.innerHTML = `<div class="si-empty">
+    No upcoming session.
+    <button class="si-new-session-btn">+ New Session</button>
+  </div>`;
+  _el.querySelector('.si-new-session-btn').addEventListener('click', handleNewSession);
+}
+
+async function handleNewSession() {
+  let sessions = [];
+  try { sessions = await apiGet('/api/game_sessions'); } catch { sessions = []; }
+  const maxNum = sessions.reduce((m, s) => Math.max(m, s.game_number || 0), 0);
+  const gameNum = maxNum + 1;
+  if (!confirm(`Create session for Game ${gameNum}?`)) return;
+  const today = new Date().toISOString().slice(0, 10);
+  const created = await apiPost('/api/game_sessions', {
+    session_date: today,
+    game_number:  gameNum,
+    attendance:   [],
+  });
+  _session = created;
+  await loadPlayerNames();
+  render();
+}
+
+function resolveRosterPlayerName(c) {
+  const fromMap = _playerByCharId.get(String(c._id));
+  if (fromMap) return fromMap;
+  const raw = (c.player || '').trim();
   if (raw && !PLACEHOLDER_RE.test(raw)) return raw;
-  const fromMap = _playerByCharId.get(String(att.character_id));
-  return fromMap || raw || '\u2014';
+  return displayName(c);
 }
 
 function scheduleAutosave() {
   const statusEl = _el?.querySelector('.si-status');
-  if (statusEl) statusEl.textContent = 'Saving\u2026';
+  if (statusEl) statusEl.textContent = 'Saving…';
   clearTimeout(_saveTimer);
   _saveTimer = setTimeout(doAutosave, 800);
 }
@@ -116,29 +142,29 @@ async function doAutosave() {
     Object.assign(_session, updated);
     if (statusEl) statusEl.textContent = '';
   } catch {
-    if (statusEl) statusEl.textContent = 'Save failed \u2014 retrying\u2026';
+    if (statusEl) statusEl.textContent = 'Save failed — retrying…';
     _saveTimer = setTimeout(doAutosave, 3000);
   }
-}
-
-function charForEntry(a) {
-  return _chars.find(c =>
-    String(c._id) === String(a.character_id) ||
-    c.name === (a.character_name || a.name)
-  ) || null;
 }
 
 function render() {
   if (!_el || !_session) return;
 
-  const att = (_session.attendance || []).slice().sort((a, b) => {
-    const pa = resolvePlayerName(a).toLowerCase();
-    const pb = resolvePlayerName(b).toLowerCase();
-    return pa.localeCompare(pb);
-  });
+  const entryByCharId = new Map(
+    (_session.attendance || []).map(a => [String(a.character_id), a])
+  );
 
-  const label = _session.session_date + (_session.title ? ' \u2014 ' + _session.title : '');
-  const attended = att.filter(a => a.attended).length;
+  const roster = _chars
+    .filter(c => !c.retired)
+    .sort((a, b) => resolveRosterPlayerName(a).localeCompare(resolveRosterPlayerName(b)));
+
+  const attendedCount = roster.filter(c => entryByCharId.get(String(c._id))?.attended).length;
+
+  const parts = [];
+  if (_session.game_number != null) parts.push(`Game ${_session.game_number}`);
+  if (_session.session_date) parts.push(_session.session_date);
+  if (_session.title) parts.push(_session.title);
+  const label = parts.join(' — ');
 
   const { eminence, ascendancy } = calcEminence(_session, _chars);
   const fmtTop = (arr) => arr.length
@@ -149,7 +175,7 @@ function render() {
 
   let h = `<div class="si-header">
     <span class="si-session-label">${esc(label)}</span>
-    <span class="si-stat">${attended} / ${att.length} attended</span>
+    <span class="si-stat">${attendedCount} / ${roster.length} attended</span>
     <span class="si-status"></span>
   </div>
   <div class="si-eminence-block">
@@ -163,38 +189,37 @@ function render() {
   </div>`;
 
   h += '<div class="si-list">';
-  att.forEach((a, idx) => {
-    const c = charForEntry(a);
-    const charName = c ? displayName(c) : (a.character_display || a.character_name || a.name || '\u2014');
+  roster.forEach(c => {
+    const a = entryByCharId.get(String(c._id)) || null;
+    const attended = a?.attended || false;
+    const charName = displayName(c);
+    const playerName = resolveRosterPlayerName(c);
 
-    let resourceRow = '';
-    if (c) {
-      const vMax  = calcVitaeMax(c);
-      const wpMax = calcWillpowerMax(c);
-      const infMax = calcTotalInfluence(c);
-      resourceRow = `<div class="si-resources">
-        <span class="si-res-item"><span class="si-res-lbl">V</span> ${vMax}/${vMax}</span>
-        <span class="si-res-item"><span class="si-res-lbl">WP</span> ${wpMax}/${wpMax}</span>
-        ${infMax > 0 ? `<span class="si-res-item"><span class="si-res-lbl">Inf</span> ${infMax}/${infMax}</span>` : ''}
-      </div>`;
-    }
+    const vMax  = calcVitaeMax(c);
+    const wpMax = calcWillpowerMax(c);
+    const infMax = calcTotalInfluence(c);
+    const resourceRow = `<div class="si-resources">
+      <span class="si-res-item"><span class="si-res-lbl">V</span> ${vMax}/${vMax}</span>
+      <span class="si-res-item"><span class="si-res-lbl">WP</span> ${wpMax}/${wpMax}</span>
+      ${infMax > 0 ? `<span class="si-res-item"><span class="si-res-lbl">Inf</span> ${infMax}/${infMax}</span>` : ''}
+    </div>`;
 
-    const { method: currentMethod } = readPayment(a);
+    const { method: currentMethod } = a ? readPayment(a) : { method: '' };
     const rowAmount = PAID_METHODS.has(currentMethod) ? rate : 0;
     const payOpts = PAYMENT_METHODS.map(m =>
       `<option value="${esc(m.value)}"${currentMethod === m.value ? ' selected' : ''}>${esc(m.label)}</option>`
     ).join('');
 
-    h += `<div class="si-row${a.attended ? ' si-attended' : ''}" data-idx="${idx}">
+    h += `<div class="si-row${attended ? ' si-attended' : ''}" data-char-id="${esc(String(c._id))}">
       <label class="si-attended-wrap">
-        <input type="checkbox" class="si-att-chk" data-idx="${idx}"${a.attended ? ' checked' : ''}>
+        <input type="checkbox" class="si-att-chk" data-char-id="${esc(String(c._id))}"${attended ? ' checked' : ''}>
       </label>
       <div class="si-info">
-        <div class="si-player">${esc(resolvePlayerName(a))}</div>
+        <div class="si-player">${esc(playerName)}</div>
         <div class="si-char">${esc(charName)}</div>
         ${resourceRow}
       </div>
-      <select class="si-pay-sel" data-idx="${idx}">
+      <select class="si-pay-sel" data-char-id="${esc(String(c._id))}">
         ${payOpts}
       </select>
       <span class="si-pay-amt-display">$${rowAmount}</span>
@@ -202,17 +227,15 @@ function render() {
   });
   h += '</div>';
 
-  // Footer: attended count + collected total. Post-FIN-7, every paid row
-  // collects the session rate, so total = rate × paid count. (Reading from
-  // stored payment.amount would understate the total for any historical
-  // row whose mirror hasn't been refreshed since the rate was lifted to
-  // session level.)
-  const paidCount = att.reduce((n, a) => {
+  // Footer: attended count + collected total.
+  const paidCount = roster.reduce((n, c) => {
+    const a = entryByCharId.get(String(c._id));
+    if (!a) return n;
     const { method } = readPayment(a);
     return PAID_METHODS.has(method) ? n + 1 : n;
   }, 0);
   const collected = paidCount * rate;
-  h += `<div class="si-footer"><strong>${attended}</strong> attended · <strong>$${collected}</strong> collected</div>`;
+  h += `<div class="si-footer"><strong>${attendedCount}</strong> attended · <strong>$${collected}</strong> collected</div>`;
 
   _el.innerHTML = h;
   wireEvents();
@@ -221,25 +244,60 @@ function render() {
 function wireEvents() {
   _el.querySelectorAll('.si-att-chk').forEach(chk => {
     chk.addEventListener('change', () => {
-      const idx = parseInt(chk.dataset.idx);
-      if (_session.attendance[idx]) {
-        _session.attendance[idx].attended = chk.checked;
-        scheduleAutosave();
-        render();
+      const charId = String(chk.dataset.charId);
+      let entry = (_session.attendance || []).find(a => String(a.character_id) === charId);
+      if (!entry) {
+        const c = _chars.find(ch => String(ch._id) === charId);
+        if (!c) return;
+        entry = {
+          character_id:      c._id,
+          character_name:    c.name,
+          character_display: displayName(c),
+          player:            c.player || '',
+          attended:          false,
+          costuming:         false,
+          downtime:          false,
+          extra:             0,
+          paid:              false,
+          payment:           {},
+          payment_method:    '',
+        };
+        if (!_session.attendance) _session.attendance = [];
+        _session.attendance.push(entry);
       }
+      entry.attended = chk.checked;
+      scheduleAutosave();
+      render();
     });
   });
 
   _el.querySelectorAll('.si-pay-sel').forEach(sel => {
     sel.addEventListener('change', () => {
-      const idx = parseInt(sel.dataset.idx);
-      const entry = _session.attendance[idx];
-      if (!entry) return;
+      const charId = String(sel.dataset.charId);
+      let entry = (_session.attendance || []).find(a => String(a.character_id) === charId);
+      if (!entry) {
+        const c = _chars.find(ch => String(ch._id) === charId);
+        if (!c) return;
+        entry = {
+          character_id:      c._id,
+          character_name:    c.name,
+          character_display: displayName(c),
+          player:            c.player || '',
+          attended:          false,
+          costuming:         false,
+          downtime:          false,
+          extra:             0,
+          paid:              false,
+          payment:           {},
+          payment_method:    '',
+        };
+        if (!_session.attendance) _session.attendance = [];
+        _session.attendance.push(entry);
+      }
       const method = sel.value;
       const rate = Number.isFinite(_session.session_rate) ? _session.session_rate : DEFAULT_RATE;
       const amount = PAID_METHODS.has(method) ? rate : 0;
       entry.payment = { ...(entry.payment || {}), method, amount };
-      // Legacy mirror for any old readers
       entry.payment_method = method;
       scheduleAutosave();
       render();
@@ -255,7 +313,6 @@ function wireEvents() {
         return;
       }
       _session.session_rate = v;
-      // Sweep paid rows so their stored amount mirrors the new rate.
       for (const a of (_session.attendance || [])) {
         const m = a.payment?.method;
         if (PAID_METHODS.has(m)) {

--- a/specs/stories/feature.483.checkin-roster-new-session.story.md
+++ b/specs/stories/feature.483.checkin-roster-new-session.story.md
@@ -1,0 +1,231 @@
+---
+issue: 483
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/483
+branch: ms/issue-483-checkin-roster-new-session
+---
+
+# feature.483 — Check-In: roster-first rendering + New Session in Check-In
+
+**Status:** review
+
+## Story
+
+As a coordinator or ST running game-night check-in,
+I want Check-In to show the full non-retired character roster automatically,
+so that I can tick who arrived without needing to pre-populate the session in a separate admin tab.
+
+## Acceptance Criteria
+
+- **AC1** — Check-In shows all non-retired characters regardless of whether they have an existing `session.attendance[]` entry
+- **AC2** — Ticking a character attended creates their entry in `session.attendance[]` and saves it to the API
+- **AC3** — Characters already in `session.attendance[]` retain their existing data (payment method, costuming, downtime flags) across renders
+- **AC4** — When no session exists, Check-In shows a "+ New Session" button; confirming creates the session and re-renders the roster
+- **AC5** — The new session confirm dialog shows the derived game number (max existing game_number + 1)
+- **AC6** — Session header shows game date, game number, and attended/total count
+- **AC7** — Eminence/Ascendancy summary continues to work correctly (reads from `session.attendance` which now gets populated on tick)
+
+## Tasks / Subtasks
+
+- [x] T1 — Roster-first rendering in `signin-tab.js`
+  - [x] T1.1 — Change `render()` to iterate `_chars.filter(c => !c.retired)` sorted by player name, merging with existing `session.attendance[]` entries by `character_id`
+  - [x] T1.2 — For a char with an existing entry: render their existing row (attended, payment, etc.) as before
+  - [x] T1.3 — For a char with no existing entry: render a row with all fields unchecked/empty
+  - [x] T1.4 — Update header stat to show `attendedCount / totalRosterCount` (not attendance array length)
+- [x] T2 — Upsert-on-tick write path
+  - [x] T2.1 — Change `wireEvents()` to key by `character_id` (data attribute `data-char-id`) instead of array `idx`
+  - [x] T2.2 — When a char has no existing attendance entry and their checkbox is ticked, push a new entry to `_session.attendance[]` and schedule autosave
+  - [x] T2.3 — New entry shape: `{ character_id, character_name, character_display, player, attended: true, costuming: false, downtime: false, extra: 0, paid: false, payment: {}, payment_method: '' }` — matches the shape that `confirmAddCharacter()` uses in `attendance.js`
+- [x] T3 — "+ New Session" button when no session exists
+  - [x] T3.1 — Add `apiPost` to the imports from `../data/api.js`
+  - [x] T3.2 — When `!_session` after load, render a prompt with a "+ New Session" button instead of the old "Create one in ST Admin → Attendance" message
+  - [x] T3.3 — On click: fetch all sessions to derive next game number (max `session.game_number` + 1, default to 1), confirm with user ("Create session for Game N?"), POST to `/api/game_sessions` with `{ session_date: today, game_number: N, attendance: [] }`, then re-render
+  - [x] T3.4 — After creation, set `_session` and call `render()` normally
+- [x] T4 — Preserve session rate and eminence
+  - [x] T4.1 — Confirm `calcEminence()` still works — it reads from `_session.attendance` filtered by `attended`, which is correctly populated by T2
+
+## Dev Notes
+
+### Architecture overview
+
+**Entry point:** `app.js:361`
+```js
+if (t === 'signin') initSignIn(document.getElementById('t-signin'), suiteState.chars);
+```
+`suiteState.chars` is the full loaded character array (already has ST mods overlay applied). Retired characters must be filtered out — use `_chars.filter(c => !c.retired)`.
+
+The tab is `coordinatorOnly: true` — visible to coordinators and STs, not plain players.
+
+### File to modify: `public/js/game/signin-tab.js`
+
+**Current state — what it does today:**
+- Fetches all sessions, picks the most recent by `session_date`
+- Renders only rows in `session.attendance[]` — empty session = empty table
+- `wireEvents()` keys by array index (`data-idx`), directly mutates `_session.attendance[idx]`
+- `charForEntry(a)` looks up the char for an attendance row
+- `doAutosave()` does `PUT /api/game_sessions/:id` with full session body (no change needed)
+
+**What this story changes:**
+- `render()` now drives from `_chars` (roster), not `session.attendance`
+- `wireEvents()` keys by `character_id` (roster-safe, stable across renders)
+- New: upsert logic when ticking a char with no prior entry
+- New: no-session state with "+ New Session" button
+
+**What must be preserved:**
+- `doAutosave()` and its retry logic — no change
+- `calcEminence()` — reads from `_session.attendance`; stays correct as long as entries are in `session.attendance` when marked attended (which T2 ensures)
+- Session rate input and payment handling — these work on existing entries; same pattern applies to new entries
+- `resolvePlayerName()` — unchanged
+- `_playerByCharId` lookup via `/api/players/display-names` — unchanged
+
+### Key implementation pattern
+
+Replace the render loop. Current:
+```js
+const att = (_session.attendance || []).slice().sort(...);
+att.forEach((a, idx) => {
+  const c = charForEntry(a);
+  ...
+  h += `<div class="si-row..." data-idx="${idx}">`;
+});
+```
+
+New approach — iterate roster, merge entries:
+```js
+const entryByCharId = new Map(
+  (_session.attendance || []).map(a => [String(a.character_id), a])
+);
+const roster = _chars
+  .filter(c => !c.retired)
+  .sort((a, b) => resolveRosterPlayerName(a).localeCompare(resolveRosterPlayerName(b)));
+
+roster.forEach(c => {
+  const a = entryByCharId.get(String(c._id)) || null; // null = no entry yet
+  const attended = a?.attended || false;
+  ...
+  h += `<div class="si-row..." data-char-id="${c._id}">`;
+});
+```
+
+For `resolveRosterPlayerName(c)` — just use `c.player || displayName(c)` to sort by player name.
+
+### Key implementation pattern — upsert on tick
+
+In `wireEvents()`, change from index-based to char-id-based:
+```js
+_el.querySelectorAll('.si-att-chk').forEach(chk => {
+  chk.addEventListener('change', () => {
+    const charId = String(chk.dataset.charId);
+    let entry = _session.attendance.find(a => String(a.character_id) === charId);
+    if (!entry) {
+      // First tick: create the attendance entry
+      const c = _chars.find(ch => String(ch._id) === charId);
+      if (!c) return;
+      entry = {
+        character_id:      c._id,
+        character_name:    c.name,
+        character_display: displayName(c),
+        player:            c.player || '',
+        attended:          false,
+        costuming:         false,
+        downtime:          false,
+        extra:             0,
+        paid:              false,
+        payment:           {},
+        payment_method:    '',
+      };
+      _session.attendance.push(entry);
+    }
+    entry.attended = chk.checked;
+    scheduleAutosave();
+    render();
+  });
+});
+```
+
+Apply the same pattern to payment select and other per-row controls: find entry by `charId`, create if missing.
+
+### "+ New Session" implementation
+
+When `!_session`, render:
+```html
+<div class="si-empty">
+  No upcoming session.
+  <button class="si-new-session-btn">+ New Session</button>
+</div>
+```
+
+Handler:
+```js
+async function handleNewSession() {
+  let sessions = [];
+  try { sessions = await apiGet('/api/game_sessions'); } catch { sessions = []; }
+  const maxNum = sessions.reduce((m, s) => Math.max(m, s.game_number || 0), 0);
+  const gameNum = maxNum + 1;
+  if (!confirm(`Create session for Game ${gameNum}?`)) return;
+  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  const created = await apiPost('/api/game_sessions', {
+    session_date: today,
+    game_number:  gameNum,
+    attendance:   [],
+  });
+  _session = created;
+  await loadPlayerNames();  // populate _playerByCharId
+  render();
+}
+```
+
+Extract player-name loading into a helper (`loadPlayerNames()`) so it can be called both in `initSignIn` and after session creation.
+
+### Import change needed
+
+`signin-tab.js` currently imports:
+```js
+import { apiGet, apiPut } from '../data/api.js';
+```
+
+Add `apiPost`:
+```js
+import { apiGet, apiPut, apiPost } from '../data/api.js';
+```
+
+### What NOT to change
+
+- `public/js/admin/attendance.js` — out of scope; remains the historical management view
+- `public/js/admin/next-session.js` — out of scope; leave as secondary path for editing session metadata
+- `public/js/app.js` — call signature of `initSignIn(el, chars)` does not change
+- `doAutosave()` — no change; `PUT /api/game_sessions/:id` with full body already handles partial attendance arrays correctly
+- The payment amount display (`$${rowAmount}`) — render it as `$0` for chars with no entry (rowAmount defaults to 0 when no payment method set)
+
+### Session header
+
+Keep showing: session date, attended count, status span. Update `attended / total` to `attendedCount / roster.length` (not `att.length`).
+
+### Retired characters
+
+Show only non-retired characters (`.filter(c => !c.retired)`). Do not show retired as dimmed — out of scope per issue.
+
+## Dev Agent Record
+
+### Debug Log
+- `fin-checkin-finance.spec.js` had a stale assertion for `'Did Not Attend'` option (retired in FIN-6 per `payment-helpers.js`). Test was failing before this story; removed the assertion.
+- `attendance.spec.js` has 3 pre-existing failures in "Save flow" tests (around `window.attUpdate`). These cover `attendance.js` which was not modified; not a regression.
+
+### Completion Notes
+- T1: `render()` rewritten to iterate `_chars.filter(c => !c.retired)` sorted by `resolveRosterPlayerName(c)`. Builds `entryByCharId` map from `session.attendance`; merges per char. `data-idx` replaced with `data-char-id` on row div, checkbox, and select. Header stat updated to `attendedCount / roster.length`.
+- T2: `wireEvents()` keyed by `dataset.charId` throughout. On first tick of a char with no entry: creates a full entry object (matching `confirmAddCharacter()` shape from `attendance.js`) and pushes to `_session.attendance` before setting `attended`. Same upsert pattern applied to payment select.
+- T3: `apiPost` added to imports. `initSignIn` now calls `renderNoSession()` when `!_session`, which renders the `+ New Session` button and wires its click handler. `handleNewSession()` fetches all sessions, derives game number, confirms, POSTs, sets `_session`, calls `loadPlayerNames()` then `render()`. Player name loading extracted into `loadPlayerNames()` helper so it can be called from both `initSignIn` and `handleNewSession`.
+- T4: `calcEminence()` unchanged — reads from `_session.attendance`; correctly populated by T2 upsert.
+- Session header now shows "Game N — date" format (AC6). `charForEntry` removed (no longer needed). `resolvePlayerName(att)` replaced by `resolveRosterPlayerName(c)`. `sortName` import removed.
+- 9 new E2E tests in `tests/feature-483-checkin-roster-new-session.spec.js` — all pass (9/9).
+- 15/15 tests pass across both Check-In test files.
+
+## File List
+
+- `public/js/game/signin-tab.js` — full rewrite per story spec
+- `tests/feature-483-checkin-roster-new-session.spec.js` — 9 new E2E tests (AC1–AC6)
+- `tests/fin-checkin-finance.spec.js` — removed stale 'Did Not Attend' assertion (pre-existing failure)
+
+## Change Log
+
+- 2026-05-22: Story created — Check-In roster-first rendering + New Session button
+- 2026-05-22: Implementation complete — all tasks done, 9/9 new tests pass, 15/15 total Check-In tests pass

--- a/tests/feature-483-checkin-roster-new-session.spec.js
+++ b/tests/feature-483-checkin-roster-new-session.spec.js
@@ -199,6 +199,101 @@ test('feature.483/AC5: new session confirm dialog shows game number', async ({ p
   expect(dialogMessage).toContain('Game 1');
 });
 
+// ── AC3 continued: existing payment method retained ─────────────────────────
+
+test('feature.483/AC3: existing payment method renders as selected option', async ({ page }) => {
+  await setup(page);
+  await goToCheckin(page);
+  // c-001 (Alice) has payment.method = 'cash' stored in session
+  const paySelect = page.locator('.si-pay-sel[data-char-id="c-001"]');
+  await expect(paySelect).toHaveValue('cash');
+});
+
+// ── AC6 continued: footer collected total ────────────────────────────────────
+
+test('feature.483/AC6: footer shows correct attended count and collected total', async ({ page }) => {
+  await setup(page);
+  await goToCheckin(page);
+  // 1 attended (Alice, cash at default $15 rate) → $15 collected
+  const footer = page.locator('.si-footer');
+  await expect(footer).toContainText('1');
+  await expect(footer).toContainText('$15');
+});
+
+// ── AC7: eminence/ascendancy still works ────────────────────────────────────
+
+test('feature.483/AC7: eminence block shows attended chars clan and covenant', async ({ page }) => {
+  await setup(page);
+  await goToCheckin(page);
+  // c-001 (Alice, Mekhet, Carthian Movement, city status 2) is attended=true
+  // Eminence should show Mekhet; Ascendancy should show Carthian Movement
+  const emBlock = page.locator('.si-eminence-block');
+  await expect(emBlock).toContainText('Mekhet');
+  await expect(emBlock).toContainText('Carthian Movement');
+});
+
+test('feature.483/AC7: eminence updates after ticking a new char', async ({ page }) => {
+  await setup(page);
+
+  await page.route('**/api/game_sessions/sess-483-001', async route => {
+    if (route.request().method() === 'PUT') {
+      const body = route.request().postDataJSON();
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ...TEST_SESSION, ...body }) });
+    } else { await route.continue(); }
+  });
+
+  await goToCheckin(page);
+
+  // Dave (c-004, Ventrue, Invictus, city=1) is not yet attended
+  // Eminence block should NOT show Ventrue before tick
+  await expect(page.locator('.si-eminence-block')).not.toContainText('Ventrue');
+
+  const putDone = page.waitForResponse(
+    res => res.url().includes('/api/game_sessions/sess-483-001') && res.request().method() === 'PUT',
+    { timeout: 4000 }
+  );
+  await page.locator('.si-att-chk[data-char-id="c-004"]').check();
+  await putDone;
+
+  // After tick + re-render, Ventrue should appear in eminence
+  await expect(page.locator('.si-eminence-block')).toContainText('Ventrue');
+});
+
+// ── AC4 continued: new session POST + roster render ──────────────────────────
+
+test('feature.483/AC4: confirming new session POSTs and renders roster', async ({ page }) => {
+  await setup(page, []);
+
+  const CREATED_SESSION = {
+    _id: 'sess-483-new', session_date: '2026-05-22', game_number: 1, attendance: [],
+  };
+
+  // Mock the POST that handleNewSession fires
+  await page.route(/\/api\/game_sessions$/, async route => {
+    if (route.request().method() === 'POST') {
+      await route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify(CREATED_SESSION) });
+    } else {
+      await route.fulfill({ status: 200, contentType: 'application/json', body: '[]' });
+    }
+  });
+
+  await page.locator('#n-signin').click();
+  await page.waitForSelector('.si-new-session-btn', { timeout: 5000 });
+
+  page.on('dialog', async dialog => { await dialog.accept(); });
+
+  const postDone = page.waitForResponse(
+    res => res.url().includes('/api/game_sessions') && res.request().method() === 'POST',
+    { timeout: 5000 }
+  );
+  await page.locator('.si-new-session-btn').click();
+  await postDone;
+
+  // After creation the tab should render the full roster (3 non-retired chars)
+  await page.waitForSelector('.si-list', { timeout: 5000 });
+  await expect(page.locator('.si-row')).toHaveCount(3);
+});
+
 // ── AC2: upsert-on-tick ──────────────────────────────────────────────────────
 
 test('feature.483/AC2: ticking unattended char triggers PUT with new entry', async ({ page }) => {

--- a/tests/feature-483-checkin-roster-new-session.spec.js
+++ b/tests/feature-483-checkin-roster-new-session.spec.js
@@ -1,0 +1,239 @@
+/**
+ * E2E — feature.483: Check-In roster-first rendering + New Session
+ *
+ * Covers:
+ *   AC1 — Roster drives rows (all non-retired chars visible, with or without attendance entry)
+ *   AC2 — Ticking an unattended char creates their entry and triggers autosave
+ *   AC3 — Chars already in attendance retain their data (attended state)
+ *   AC4 — No-session state shows "+ New Session" button
+ *   AC5 — New session confirm dialog shows derived game number
+ *   AC6 — Session header shows game number, date, attended/total from roster
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const ST_USER = {
+  id: 'test-st-483', username: 'test_st_483', global_name: 'Test ST 483',
+  avatar: null, role: 'st', player_id: 'p-st-483', character_ids: [], is_dual_role: false,
+};
+
+// 4 chars: 3 non-retired, 1 retired.  Session attendance has only c-001.
+const TEST_CHARS = [
+  {
+    _id: 'c-001', name: 'Alice Active', player: 'AliceP', retired: false,
+    blood_potency: 1, humanity: 7, humanity_base: 7, moniker: null, honorific: null,
+    clan: 'Mekhet', covenant: 'Carthian Movement',
+    status: { city: 2, clan: 1, covenant: { 'Carthian Movement': 1 } },
+    attributes: { Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 }, Strength: { dots: 1, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 }, Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 } },
+    skills: {}, disciplines: {}, merits: [], powers: [], ordeals: [],
+  },
+  {
+    _id: 'c-002', name: 'Bob Active', player: 'BobP', retired: false,
+    blood_potency: 1, humanity: 7, humanity_base: 7, moniker: null, honorific: null,
+    clan: 'Daeva', covenant: 'Invictus',
+    status: { city: 1, clan: 0, covenant: {} },
+    attributes: { Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 }, Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 }, Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 } },
+    skills: {}, disciplines: {}, merits: [], powers: [], ordeals: [],
+  },
+  {
+    _id: 'c-003', name: 'Carol Retired', player: 'CarolP', retired: true,
+    blood_potency: 1, humanity: 7, humanity_base: 7, moniker: null, honorific: null,
+    clan: 'Gangrel', covenant: 'Ordo Dracul',
+    status: { city: 0, clan: 0, covenant: {} },
+    attributes: { Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 }, Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 }, Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 } },
+    skills: {}, disciplines: {}, merits: [], powers: [], ordeals: [],
+  },
+  {
+    _id: 'c-004', name: 'Dave Active', player: 'DaveP', retired: false,
+    blood_potency: 1, humanity: 7, humanity_base: 7, moniker: null, honorific: null,
+    clan: 'Ventrue', covenant: 'Invictus',
+    status: { city: 1, clan: 1, covenant: {} },
+    attributes: { Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 }, Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 }, Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 } },
+    skills: {}, disciplines: {}, merits: [], powers: [], ordeals: [],
+  },
+];
+
+// c-001 is already in attendance (attended=true); c-002, c-004 have no entry
+const TEST_SESSION = {
+  _id: 'sess-483-001',
+  session_date: '2026-05-23',
+  game_number: 4,
+  attendance: [
+    {
+      character_id: 'c-001', character_name: 'Alice Active', character_display: 'Alice Active',
+      player: 'AliceP', attended: true, costuming: false, downtime: false, extra: 0,
+      paid: false, payment: { method: 'cash', amount: 15 }, payment_method: 'cash',
+    },
+  ],
+};
+
+async function setup(page, sessions = [TEST_SESSION]) {
+  // Register catch-all last so specific routes (registered later in test body) take precedence.
+  await page.route('**/api/**', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.route('**/api/st_mods*', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.route('**/api/players/display-names', route =>
+    route.fulfill({
+      status: 200, contentType: 'application/json',
+      body: JSON.stringify(
+        TEST_CHARS.filter(c => c.player).map(c => ({ character_id: String(c._id), display_name: c.player }))
+      ),
+    })
+  );
+  await page.route(/\/api\/game_sessions$/, route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(sessions) })
+  );
+  await page.route(/\/api\/characters$/, route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(TEST_CHARS) })
+  );
+  await page.route('**/api/auth/me', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(ST_USER) })
+  );
+
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER });
+
+  await page.setViewportSize({ width: 800, height: 900 });
+  await page.goto('/');
+  await page.waitForSelector('#bnav', { timeout: 10000 });
+}
+
+async function goToCheckin(page) {
+  await page.locator('#n-signin').click();
+  await page.waitForSelector('.si-list', { timeout: 5000 });
+}
+
+// ── AC1: roster-first rendering ─────────────────────────────────────────────
+
+test('feature.483/AC1: shows all non-retired chars (roster drives row count)', async ({ page }) => {
+  await setup(page);
+  await goToCheckin(page);
+  // 3 non-retired chars (c-001, c-002, c-004); c-003 is retired — 3 rows expected
+  await expect(page.locator('.si-row')).toHaveCount(3);
+});
+
+test('feature.483/AC1: char without attendance entry renders as unchecked row', async ({ page }) => {
+  await setup(page);
+  await goToCheckin(page);
+  // c-002 (Bob) has no attendance entry; use .si-row prefix to avoid strict-mode clash with checkbox/select
+  const row = page.locator('.si-row[data-char-id="c-002"]');
+  await expect(row).toBeVisible();
+  await expect(row.locator('.si-att-chk')).not.toBeChecked();
+});
+
+test('feature.483/AC1: rows use data-char-id (not data-idx)', async ({ page }) => {
+  await setup(page);
+  await goToCheckin(page);
+  // Roster-first keying: attribute is data-char-id, not data-idx
+  const rows = page.locator('.si-row[data-char-id]');
+  await expect(rows).toHaveCount(3);
+  // Old data-idx attribute must not exist
+  const oldRows = page.locator('.si-row[data-idx]');
+  await expect(oldRows).toHaveCount(0);
+});
+
+// ── AC3: existing entries retain state ──────────────────────────────────────
+
+test('feature.483/AC3: char with attended=true renders checked with si-attended class', async ({ page }) => {
+  await setup(page);
+  await goToCheckin(page);
+  // c-001 (Alice) is in attendance with attended=true
+  const row = page.locator('.si-row[data-char-id="c-001"]');
+  await expect(row).toHaveClass(/si-attended/);
+  await expect(row.locator('.si-att-chk')).toBeChecked();
+});
+
+// ── AC6: session header ──────────────────────────────────────────────────────
+
+test('feature.483/AC6: session header shows game number', async ({ page }) => {
+  await setup(page);
+  await goToCheckin(page);
+  await expect(page.locator('.si-session-label')).toContainText('Game 4');
+});
+
+test('feature.483/AC6: attended/total count uses roster length', async ({ page }) => {
+  await setup(page);
+  await goToCheckin(page);
+  // 1 attended (Alice), 3 non-retired in roster
+  await expect(page.locator('.si-stat')).toContainText('1 / 3');
+});
+
+// ── AC4/AC5: new session ─────────────────────────────────────────────────────
+
+test('feature.483/AC4: no-session state shows + New Session button', async ({ page }) => {
+  await setup(page, []);
+  await page.locator('#n-signin').click();
+  await page.waitForSelector('.si-new-session-btn', { timeout: 5000 });
+  await expect(page.locator('.si-new-session-btn')).toContainText('+ New Session');
+});
+
+test('feature.483/AC5: new session confirm dialog shows game number', async ({ page }) => {
+  await setup(page, [TEST_SESSION]); // one existing session with game_number 4
+  // Override: re-add the sessions route (last registered wins) to simulate game 4 existing
+  // so new session = game 5
+  await page.route(/\/api\/game_sessions$/, route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([TEST_SESSION]) })
+  );
+
+  // Temporarily switch to no-session state for the no-session render
+  // but game_sessions GET still returns one session when queried by handleNewSession
+  // => easier to test via an empty sessions setup
+  await setup(page, []);
+  await page.locator('#n-signin').click();
+  await page.waitForSelector('.si-new-session-btn', { timeout: 5000 });
+
+  let dialogMessage = '';
+  page.on('dialog', async dialog => {
+    dialogMessage = dialog.message();
+    await dialog.dismiss();
+  });
+
+  await page.locator('.si-new-session-btn').click();
+  await page.waitForTimeout(300);
+  expect(dialogMessage).toContain('Game 1');
+});
+
+// ── AC2: upsert-on-tick ──────────────────────────────────────────────────────
+
+test('feature.483/AC2: ticking unattended char triggers PUT with new entry', async ({ page }) => {
+  await setup(page);
+
+  let savedBody = null;
+  await page.route('**/api/game_sessions/sess-483-001', async route => {
+    if (route.request().method() === 'PUT') {
+      savedBody = route.request().postDataJSON();
+      await route.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify({ ...TEST_SESSION, ...savedBody }),
+      });
+    } else {
+      await route.continue();
+    }
+  });
+
+  await goToCheckin(page);
+
+  // Watch for the PUT before clicking (waitForResponse must be set up first)
+  const putDone = page.waitForResponse(
+    res => res.url().includes('/api/game_sessions/sess-483-001') && res.request().method() === 'PUT',
+    { timeout: 4000 }
+  );
+
+  // Tick Bob (c-002) who has no existing attendance entry
+  await page.locator('.si-att-chk[data-char-id="c-002"]').check();
+
+  // Wait for the 800ms autosave debounce to fire and the PUT to complete
+  await putDone;
+
+  expect(savedBody).not.toBeNull();
+  const newEntry = (savedBody.attendance || []).find(a => String(a.character_id) === 'c-002');
+  expect(newEntry).toBeTruthy();
+  expect(newEntry.attended).toBe(true);
+  expect(newEntry.character_name).toBe('Bob Active');
+});

--- a/tests/fin-checkin-finance.spec.js
+++ b/tests/fin-checkin-finance.spec.js
@@ -76,7 +76,7 @@ test('fin.3: payment method dropdown uses fin.2 enum values', async ({ page }) =
   expect(options.some(o => /PayPal/i.test(o))).toBe(true);
   expect(options.some(o => /Exiles/i.test(o))).toBe(true);
   expect(options.some(o => /Waived/i.test(o))).toBe(true);
-  expect(options.some(o => /Did Not Attend/i.test(o))).toBe(true);
+  // 'Did Not Attend' was retired in FIN-6; canonical signal is the attended checkbox.
 });
 
 // ── fin.4 — Finance tab ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Rewrites `signin-tab.js` so Check-In renders the full non-retired character roster regardless of `session.attendance` contents — coordinators see everyone, not just pre-populated entries
- Ticking a character for the first time upserts their attendance entry keyed by `character_id` (replacing fragile array-index keying); payment select uses the same upsert pattern
- Adds a `+ New Session` button when no session exists, deriving game number as `max(game_number) + 1` automatically and POSTing to `/api/game_sessions`
- Session header now shows `attendedCount / roster.length` (not attendance array length); stale `'Did Not Attend'` assertion removed from `fin-checkin-finance.spec.js`

## Closes

- Closes #483

## Story

- specs/stories/feature.483.checkin-roster-new-session.story.md

## Test plan

- [ ] `npx playwright test tests/feature-483-checkin-roster-new-session.spec.js` — 14 tests, all AC1–AC7
- [ ] `npx playwright test tests/fin-checkin-finance.spec.js` — 5 tests (regression check)
- [ ] CI green
- [ ] Manual: open Check-In tab as coordinator with a live session; confirm roster shows all non-retired chars; tick an unattended char; confirm attended count updates and autosave fires; if no session exists, confirm `+ New Session` button appears and creates one

## Branch flow

- From: `ms/issue-483-checkin-roster-new-session`
- Into: `dev`