### PR TITLE
feat(#485): Check-In shows remaining INF (total minus last-cycle spend)

### DIFF
--- a/public/js/game/signin-tab.js
+++ b/public/js/game/signin-tab.js
@@ -52,6 +52,7 @@ let _chars = [];
 let _saveTimer = null;
 let _el = null;
 let _playerByCharId = new Map();
+let _infSpentByCharId = new Map();
 
 // Placeholder strings seeded by an early redacted import. Treat as missing.
 const PLACEHOLDER_RE = /^Player [A-Z]{1,2}$/;
@@ -68,6 +69,27 @@ async function loadPlayerNames() {
     console.info('[signin] player name lookup: %d mappings loaded', _playerByCharId.size);
   } catch (err) {
     console.warn('[signin] player name lookup failed; falling back to row.player strings', err);
+  }
+}
+
+async function loadInfluenceSpend() {
+  _infSpentByCharId = new Map();
+  try {
+    const allCycles = await apiGet('/api/downtime_cycles');
+    const lastClosed = (allCycles || []).find(c => c.status === 'closed');
+    if (!lastClosed) return;
+    const subs = await apiGet('/api/downtime_submissions?cycle_id=' + lastClosed._id);
+    for (const sub of (subs || [])) {
+      const raw = sub.responses?.influence_spend;
+      if (!raw) continue;
+      let spendObj;
+      try { spendObj = JSON.parse(raw); } catch { continue; }
+      const total = Object.values(spendObj).reduce((s, v) => s + (Number(v) || 0), 0);
+      if (total > 0) _infSpentByCharId.set(String(sub.character_id), total);
+    }
+    console.info('[signin] inf spend loaded: %d entries', _infSpentByCharId.size);
+  } catch (err) {
+    console.warn('[signin] influence spend load failed; defaulting to 0', err);
   }
 }
 
@@ -89,7 +111,7 @@ export async function initSignIn(el, chars) {
     return;
   }
 
-  await loadPlayerNames();
+  await Promise.all([loadPlayerNames(), loadInfluenceSpend()]);
   render();
 }
 
@@ -114,7 +136,7 @@ async function handleNewSession() {
     attendance:   [],
   });
   _session = created;
-  await loadPlayerNames();
+  await Promise.all([loadPlayerNames(), loadInfluenceSpend()]);
   render();
 }
 
@@ -198,10 +220,12 @@ function render() {
     const vMax  = calcVitaeMax(c);
     const wpMax = calcWillpowerMax(c);
     const infMax = calcTotalInfluence(c);
+    const infSpent = _infSpentByCharId.get(String(c._id)) || 0;
+    const infRemaining = infMax - infSpent;
     const resourceRow = `<div class="si-resources">
       <span class="si-res-item"><span class="si-res-lbl">V</span> ${vMax}/${vMax}</span>
       <span class="si-res-item"><span class="si-res-lbl">WP</span> ${wpMax}/${wpMax}</span>
-      ${infMax > 0 ? `<span class="si-res-item"><span class="si-res-lbl">Inf</span> ${infMax}/${infMax}</span>` : ''}
+      ${infMax > 0 ? `<span class="si-res-item"><span class="si-res-lbl">Inf</span> ${infRemaining}/${infMax}</span>` : ''}
     </div>`;
 
     const { method: currentMethod } = a ? readPayment(a) : { method: '' };

--- a/specs/stories/feature.485.checkin-inf-remaining-spend.story.md
+++ b/specs/stories/feature.485.checkin-inf-remaining-spend.story.md
@@ -1,0 +1,274 @@
+---
+issue: 485
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/485
+branch: ms/issue-485-checkin-inf-remaining-spend
+---
+
+# feature.485 — Check-In: show remaining INF (total minus last-cycle spend)
+
+**Status:** review
+
+## Story
+
+As a coordinator running game-night check-in,
+I want the INF figure for each character to show remaining / max (not max / max),
+so that I can see at a glance how much influence each character has available after last cycle's spend.
+
+## Acceptance Criteria
+
+- **AC1** — Given a character with INF 7 who spent 3 dots in the last closed cycle, Check-In shows `4/7`
+- **AC2** — Given a character with no submission for the last closed cycle, Check-In shows `7/7`
+- **AC3** — Given a character whose submission predates the `influence_spend` field (DT1 era), Check-In shows `7/7`
+- **AC4** — Given no closed cycle exists, Check-In shows `max/max` for all characters
+- **AC5** — The new data-fetch calls are parallelised with `loadPlayerNames()` so load time does not increase perceptibly
+
+## Tasks / Subtasks
+
+- [x] T1 — Add `loadInfluenceSpend()` helper to `signin-tab.js`
+  - [x] T1.1 — Add module-level `let _infSpentByCharId = new Map();`
+  - [x] T1.2 — Implement `loadInfluenceSpend()`: fetch `/api/downtime_cycles`, find first doc with `status === 'closed'`, fetch `/api/downtime_submissions?cycle_id=<id>`, build `_infSpentByCharId` map of `character_id → totalSpent`
+  - [x] T1.3 — Parse `submission.responses.influence_spend` as a JSON string (it is stored as a string, not an object); sum all numeric values; store in map
+  - [x] T1.4 — Wrap in try/catch; on failure log warning and leave map empty (defaults to 0 spend for all)
+- [x] T2 — Wire `loadInfluenceSpend()` into the init flow
+  - [x] T2.1 — In `initSignIn()`: change `await loadPlayerNames()` to `await Promise.all([loadPlayerNames(), loadInfluenceSpend()])`
+  - [x] T2.2 — In `handleNewSession()`: change `await loadPlayerNames()` to `await Promise.all([loadPlayerNames(), loadInfluenceSpend()])` (new session creation still needs spend data for the roster)
+- [x] T3 — Update `render()` resource row
+  - [x] T3.1 — After `const infMax = calcTotalInfluence(c);`, add `const infSpent = _infSpentByCharId.get(String(c._id)) || 0;` and `const infRemaining = infMax - infSpent;`
+  - [x] T3.2 — Change the Inf span from `${infMax}/${infMax}` to `${infRemaining}/${infMax}`
+- [x] T4 — E2E tests in `tests/feature-485-checkin-inf-remaining-spend.spec.js`
+  - [x] T4.1 — AC1: char with `influence_spend` JSON string → shows `remaining/max`
+  - [x] T4.2 — AC2: char with no submission → shows `max/max`
+  - [x] T4.3 — AC3: char with submission but no `influence_spend` field → shows `max/max`
+  - [x] T4.4 — AC4: no closed cycle → shows `max/max`
+
+## Dev Notes
+
+### Only file to modify
+
+**`public/js/game/signin-tab.js`** — full current content in place as of feature.483 / PR #484.
+
+Do NOT touch:
+- `public/js/admin/attendance.js` — out of scope
+- `server/` — no backend changes needed; existing endpoints are sufficient
+- Any other file
+
+### Critical data shape discovery
+
+**`influence_spend` is a JSON-encoded string, not a plain object.**
+
+From live submission data (backup_downtime_3_2026-05-16.json):
+```json
+"responses": {
+  "influence_spend": "{\"the_academy\":5,\"the_harbour\":0,\"the_dockyards\":0,\"the_second_city\":0,\"the_north_shore\":5}"
+}
+```
+
+The dev-fixtures (`data/dev-fixtures/downtime_submissions.json`) are DT1-era CSV imports and do NOT have `influence_spend` — they are the AC3 test case. App-form submissions (DT2+) have it as a JSON string under `responses.influence_spend`.
+
+Correct parsing:
+```js
+const raw = sub.responses?.influence_spend;
+if (!raw) continue; // no field = 0 spend (AC2/AC3)
+let spendObj;
+try { spendObj = JSON.parse(raw); } catch { continue; }
+const total = Object.values(spendObj).reduce((s, v) => s + (Number(v) || 0), 0);
+```
+
+Note: territory values include 0s (unspent territories) — summing all values is correct because 0 + N = N.
+
+### API endpoints used
+
+**`GET /api/downtime_cycles`**
+- Returns all cycles sorted by `_id` desc (most recently created first)
+- Both ST and player roles can call this
+- Cycle status field: `'open'` or `'closed'`
+- "Most recently closed cycle" = first doc where `status === 'closed'` (since already sorted desc)
+
+**`GET /api/downtime_submissions?cycle_id=<id>`**
+- ST role: returns all submissions for the cycle
+- Player role: returns only their own characters' submissions
+- Check-In tab is `coordinatorOnly: true` (visible to ST + coordinator roles) — coordinator uses ST auth, so gets all submissions
+
+### Current `initSignIn` flow (as of feature.483)
+
+```js
+export async function initSignIn(el, chars) {
+  _el = el;
+  _chars = chars || [];
+  el.innerHTML = '<div class="si-loading">Loading session…</div>';
+  try {
+    const sessions = await apiGet('/api/game_sessions');
+    _session = sessions.sort(...)[0] || null;
+  } catch { /* render error, return */ }
+
+  if (!_session) {
+    renderNoSession();
+    return;
+  }
+
+  await loadPlayerNames();   // ← change to Promise.all
+  render();
+}
+```
+
+And `handleNewSession`:
+```js
+async function handleNewSession() {
+  // ... fetch, confirm, POST ...
+  _session = created;
+  await loadPlayerNames();   // ← change to Promise.all
+  render();
+}
+```
+
+### New module-level state
+
+Add alongside existing `let _playerByCharId = new Map();`:
+```js
+let _infSpentByCharId = new Map();
+```
+
+### `loadInfluenceSpend()` implementation
+
+```js
+async function loadInfluenceSpend() {
+  _infSpentByCharId = new Map();
+  try {
+    const allCycles = await apiGet('/api/downtime_cycles');
+    const lastClosed = (allCycles || []).find(c => c.status === 'closed');
+    if (!lastClosed) return; // AC4: no closed cycle → map stays empty → all default to 0
+    const subs = await apiGet('/api/downtime_submissions?cycle_id=' + lastClosed._id);
+    for (const sub of (subs || [])) {
+      const raw = sub.responses?.influence_spend;
+      if (!raw) continue;
+      let spendObj;
+      try { spendObj = JSON.parse(raw); } catch { continue; }
+      const total = Object.values(spendObj).reduce((s, v) => s + (Number(v) || 0), 0);
+      if (total > 0) _infSpentByCharId.set(String(sub.character_id), total);
+    }
+    console.info('[signin] inf spend loaded: %d entries', _infSpentByCharId.size);
+  } catch (err) {
+    console.warn('[signin] influence spend load failed; defaulting to 0', err);
+  }
+}
+```
+
+### `render()` change (resource row — line ~200–204)
+
+Current:
+```js
+const infMax = calcTotalInfluence(c);
+const resourceRow = `<div class="si-resources">
+  ...
+  ${infMax > 0 ? `<span class="si-res-item"><span class="si-res-lbl">Inf</span> ${infMax}/${infMax}</span>` : ''}
+</div>`;
+```
+
+New:
+```js
+const infMax = calcTotalInfluence(c);
+const infSpent = _infSpentByCharId.get(String(c._id)) || 0;
+const infRemaining = infMax - infSpent;
+const resourceRow = `<div class="si-resources">
+  ...
+  ${infMax > 0 ? `<span class="si-res-item"><span class="si-res-lbl">Inf</span> ${infRemaining}/${infMax}</span>` : ''}
+</div>`;
+```
+
+### Playwright test setup pattern
+
+This story uses the same test patterns established in feature.483:
+- Use `fake-test-token` (NOT `local-test-token`) to bypass `dev-fixtures.js` interceptor
+- Register catch-all route first (lowest priority), specific routes after
+- ST_USER with `role: 'st'`
+
+New routes to mock:
+```js
+await page.route('**/api/downtime_cycles', route =>
+  route.fulfill({ body: JSON.stringify([CLOSED_CYCLE, OPEN_CYCLE]) })
+);
+await page.route('**/api/downtime_submissions**', route =>
+  route.fulfill({ body: JSON.stringify(SUBMISSIONS) })
+);
+```
+
+For AC4 (no closed cycle):
+```js
+await page.route('**/api/downtime_cycles', route =>
+  route.fulfill({ body: JSON.stringify([OPEN_CYCLE]) }) // no closed cycle
+);
+```
+
+Test data shape:
+```js
+const CLOSED_CYCLE = { _id: 'cycle-closed-001', status: 'closed', cycle_number: 3 };
+const OPEN_CYCLE   = { _id: 'cycle-open-001',   status: 'open',   cycle_number: 4 };
+
+// Character c-001 spent 3 dots total (2 + 1)
+const SUBMISSIONS = [{
+  _id: 'sub-001',
+  character_id: 'c-001',
+  cycle_id: 'cycle-closed-001',
+  status: 'submitted',
+  responses: {
+    influence_spend: JSON.stringify({ the_harbour: 2, the_academy: 1, the_north_shore: 0 })
+  }
+}];
+```
+
+TEST_CHARS should include characters with known `calcTotalInfluence` values. Since `calcTotalInfluence` reads merit dots, give the test char a simple influence merit:
+```js
+const TEST_CHARS = [
+  {
+    _id: 'c-001', name: 'Alice Char', player: 'Alice Player', retired: false,
+    clan: 'Daeva', covenant: 'Invictus',
+    status: { city: 0, clan: 0, covenant: {} },
+    merits: [{ name: 'Allies', category: 'influence', dots: 7, bonus: 0 }],
+    // calcTotalInfluence(c-001) = 7
+  },
+  {
+    _id: 'c-002', name: 'Bob Char', player: 'Bob Player', retired: false,
+    clan: 'Gangrel', covenant: 'Circle of the Crone',
+    status: { city: 0, clan: 0, covenant: {} },
+    merits: [{ name: 'Allies', category: 'influence', dots: 4, bonus: 0 }],
+    // calcTotalInfluence(c-002) = 4, no submission → 4/4
+  },
+];
+```
+
+Wait — `calcTotalInfluence` uses `calcMeritInfluence` which checks the effective rating and various merit-specific rules. For a simple Allies merit, the rating is the dot count. To avoid coupling tests to `domain.js` internals, assert on the pattern `N/M` where `N < M` rather than hardcoded numbers, or use a character known to have a predictable total (e.g., Status 0, no other influence sources, a single Allies 7 = 7 total).
+
+### What NOT to change
+
+- `loadPlayerNames()` — no change, already parallel-ready
+- `doAutosave()` — no change
+- `calcEminence()` — no change
+- `wireEvents()` — no change
+- `PAYMENT_METHODS`, `PAID_METHODS`, `DEFAULT_RATE` — no change
+- The `V` and `WP` resource displays remain `max/max` (unchanged)
+- `handleNewSession()` logic — only the `await loadPlayerNames()` line changes to `Promise.all`
+
+### Predecessor story
+
+feature.483 (PR #484) rewrote this file. The current state on `dev` is the post-483 version — read it carefully before editing.
+
+## Dev Agent Record
+
+### Debug Log
+- Test chars initially used `dots` field for Allies merits — `meritEffectiveRating` reads `m.cp + m.xp`, not `m.dots`, so `calcTotalInfluence` returned 0 and the Inf span was suppressed. Fixed by using `status.clan` dots instead (direct 1:1 mapping to influence, no merit calc path).
+
+### Completion Notes
+- T1: `loadInfluenceSpend()` added after `loadPlayerNames()`. Fetches cycles, finds first `status === 'closed'`, fetches all submissions for that cycle, parses `responses.influence_spend` as JSON string, sums territory values, stores in `_infSpentByCharId` map keyed by `String(character_id)`. Entries with total=0 are skipped (default to 0 via `|| 0` lookup).
+- T2: Both `initSignIn()` and `handleNewSession()` now use `Promise.all([loadPlayerNames(), loadInfluenceSpend()])`.
+- T3: Resource row now computes `infSpent` and `infRemaining`; Inf display changed from `${infMax}/${infMax}` to `${infRemaining}/${infMax}`.
+- T4: 6 E2E tests — 2 for AC1, 1 each for AC2/AC3/AC4(no-closed)/AC4(no-cycles). All 6 pass. 20/20 total Check-In tests pass (0 regressions).
+
+## File List
+
+- `public/js/game/signin-tab.js` — add `_infSpentByCharId` map, `loadInfluenceSpend()`, wire into `initSignIn` and `handleNewSession`, update resource row in `render()`
+- `tests/feature-485-checkin-inf-remaining-spend.spec.js` — new E2E tests (AC1–AC4)
+
+## Change Log
+
+- 2026-05-22: Story created — Check-In INF remaining display
+- 2026-05-22: Implementation complete — all tasks done, 6/6 new tests pass, 20/20 total Check-In tests pass

--- a/tests/feature-485-checkin-inf-remaining-spend.spec.js
+++ b/tests/feature-485-checkin-inf-remaining-spend.spec.js
@@ -1,0 +1,181 @@
+/**
+ * E2E — feature.485: Check-In INF remaining = total minus last-cycle spend
+ *
+ * AC1 — char with influence_spend in last closed cycle → shows (max - spent) / max
+ * AC2 — char with no submission for last cycle → shows max / max
+ * AC3 — char with submission but no influence_spend field (DT1 era) → shows max / max
+ * AC4 — no closed cycle exists → shows max / max for all
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const ST_USER = {
+  id: 'test-st-001', username: 'test_st', global_name: 'Test ST',
+  avatar: null, role: 'st', player_id: 'p-st-001', character_ids: [], is_dual_role: false,
+};
+
+const SESSION = {
+  _id: 'sess-485-001',
+  session_date: '2099-06-01',
+  game_number: 5,
+  attendance: [],
+};
+
+// calcTotalInfluence adds status.clan + status.covenant[covenant] directly (no merit calc needed).
+// c-001: clan status 4 → infMax=4; spent 3 in last cycle → remaining=1
+// c-002: clan status 5 → infMax=5; no submission → remaining=5
+// c-003: clan status 3 → infMax=3; DT1 submission (no influence_spend) → 3
+const TEST_CHARS = [
+  {
+    _id: 'c-001', name: 'Alice Char', player: 'Alice Player', retired: false,
+    clan: 'Daeva', covenant: 'Invictus',
+    status: { city: 0, clan: 4, covenant: {} },
+    merits: [],
+  },
+  {
+    _id: 'c-002', name: 'Bob Char', player: 'Bob Player', retired: false,
+    clan: 'Gangrel', covenant: 'Circle of the Crone',
+    status: { city: 0, clan: 5, covenant: {} },
+    merits: [],
+  },
+  {
+    _id: 'c-003', name: 'Carol Char', player: 'Carol Player', retired: false,
+    clan: 'Mekhet', covenant: 'Carthian Movement',
+    status: { city: 0, clan: 3, covenant: {} },
+    merits: [],
+  },
+];
+
+const CLOSED_CYCLE = { _id: 'cycle-closed-001', status: 'closed', cycle_number: 3 };
+const OPEN_CYCLE   = { _id: 'cycle-open-001',   status: 'open',   cycle_number: 4 };
+
+// c-001 spent 3 total (2 + 1 + 0)
+const SUBMISSIONS_WITH_SPEND = [
+  {
+    _id: 'sub-001',
+    character_id: 'c-001',
+    cycle_id: 'cycle-closed-001',
+    status: 'submitted',
+    responses: {
+      influence_spend: JSON.stringify({ the_harbour: 2, the_academy: 1, the_north_shore: 0 }),
+    },
+  },
+];
+
+// c-003 has a DT1-era submission with no influence_spend field
+const SUBMISSIONS_DT1 = [
+  {
+    _id: 'sub-003',
+    character_id: 'c-003',
+    cycle_id: 'cycle-closed-001',
+    status: 'submitted',
+    responses: {}, // no influence_spend
+  },
+];
+
+async function setup(page, {
+  sessions = [SESSION],
+  cycles = [CLOSED_CYCLE, OPEN_CYCLE],
+  submissions = SUBMISSIONS_WITH_SPEND,
+} = {}) {
+  await page.addInitScript(({ user, chars }) => {
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+    window.__TEST_CHARS__ = chars;
+  }, { user: ST_USER, chars: TEST_CHARS });
+
+  // Catch-all first (lowest priority)
+  await page.route('**/api/**', route => route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }));
+
+  await page.route('**/api/auth/me', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(ST_USER) })
+  );
+  await page.route('**/api/game_sessions', route => {
+    if (route.request().method() === 'GET')
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(sessions) });
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(sessions[0] || {}) });
+  });
+  await page.route('**/api/characters**', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(TEST_CHARS) })
+  );
+  await page.route('**/api/players/display-names', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.route('**/api/downtime_cycles', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(cycles) })
+  );
+  await page.route('**/api/downtime_submissions**', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(submissions) })
+  );
+  await page.route('**/api/st_mods**', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+
+  await page.setViewportSize({ width: 800, height: 900 });
+  await page.goto('/');
+  await page.waitForSelector('#bnav', { timeout: 10000 });
+  await page.locator('#n-signin').click();
+  await page.waitForSelector('.si-row', { timeout: 8000 });
+}
+
+// ── AC1: char with influence_spend shows remaining/max ────────────────────────
+
+test('AC1: char with 3 spent of 4 total shows 1/4 in INF display', async ({ page }) => {
+  await setup(page);
+  // c-001 has Allies 4 → infMax=4, spent=3 → remaining=1
+  const aliceRow = page.locator('.si-row[data-char-id="c-001"]');
+  await expect(aliceRow).toBeVisible();
+  const infSpan = aliceRow.locator('.si-res-lbl:text("Inf")').locator('..');
+  await expect(infSpan).toContainText('1/4');
+});
+
+test('AC1: INF display format is remaining/max (not max/max) when spend exists', async ({ page }) => {
+  await setup(page);
+  const aliceRow = page.locator('.si-row[data-char-id="c-001"]');
+  const infSpan = aliceRow.locator('.si-res-lbl:text("Inf")').locator('..');
+  const text = await infSpan.textContent();
+  // Should be "Inf 1/4" not "Inf 4/4"
+  expect(text).not.toContain('4/4');
+  expect(text).toContain('1/4');
+});
+
+// ── AC2: char with no submission shows max/max ────────────────────────────────
+
+test('AC2: char with no submission shows max/max for INF', async ({ page }) => {
+  await setup(page);
+  // c-002 has Allies 5 → infMax=5, no submission → remaining=5
+  const bobRow = page.locator('.si-row[data-char-id="c-002"]');
+  await expect(bobRow).toBeVisible();
+  const infSpan = bobRow.locator('.si-res-lbl:text("Inf")').locator('..');
+  await expect(infSpan).toContainText('5/5');
+});
+
+// ── AC3: DT1-era submission (no influence_spend) shows max/max ────────────────
+
+test('AC3: DT1 submission with no influence_spend shows max/max', async ({ page }) => {
+  await setup(page, { submissions: SUBMISSIONS_DT1 });
+  // c-003 has Allies 3 → infMax=3, DT1 sub has no influence_spend → remaining=3
+  const carolRow = page.locator('.si-row[data-char-id="c-003"]');
+  await expect(carolRow).toBeVisible();
+  const infSpan = carolRow.locator('.si-res-lbl:text("Inf")').locator('..');
+  await expect(infSpan).toContainText('3/3');
+});
+
+// ── AC4: no closed cycle → all chars show max/max ────────────────────────────
+
+test('AC4: no closed cycle → all INF displays show max/max', async ({ page }) => {
+  await setup(page, { cycles: [OPEN_CYCLE] }); // only open cycle, no closed
+  // c-001 has Allies 4 → infMax=4, no closed cycle to derive spend → remaining=4
+  const aliceRow = page.locator('.si-row[data-char-id="c-001"]');
+  await expect(aliceRow).toBeVisible();
+  const infSpan = aliceRow.locator('.si-res-lbl:text("Inf")').locator('..');
+  await expect(infSpan).toContainText('4/4');
+});
+
+test('AC4: no cycles at all → all INF displays show max/max', async ({ page }) => {
+  await setup(page, { cycles: [] });
+  const aliceRow = page.locator('.si-row[data-char-id="c-001"]');
+  const infSpan = aliceRow.locator('.si-res-lbl:text("Inf")').locator('..');
+  await expect(infSpan).toContainText('4/4');
+});

--- a/tests/feature-485-checkin-inf-remaining-spend.spec.js
+++ b/tests/feature-485-checkin-inf-remaining-spend.spec.js
@@ -179,3 +179,82 @@ test('AC4: no cycles at all → all INF displays show max/max', async ({ page })
   const infSpan = aliceRow.locator('.si-res-lbl:text("Inf")').locator('..');
   await expect(infSpan).toContainText('4/4');
 });
+
+// ── Regression: V and WP still show max/max ──────────────────────────────────
+
+test('regression: V and WP resource displays still show max/max after INF change', async ({ page }) => {
+  await setup(page);
+  const aliceRow = page.locator('.si-row[data-char-id="c-001"]');
+  await expect(aliceRow).toBeVisible();
+  // V and WP are unchanged — they always show max/max
+  const vSpan = aliceRow.locator('.si-res-lbl:text("V")').locator('..');
+  const wpSpan = aliceRow.locator('.si-res-lbl:text("WP")').locator('..');
+  await expect(vSpan).toBeVisible();
+  await expect(wpSpan).toBeVisible();
+  const vText = await vSpan.textContent();
+  const wpText = await wpSpan.textContent();
+  // Both should be N/N (same numerator and denominator)
+  expect(vText).toMatch(/\d+\/\d+/);
+  expect(wpText).toMatch(/\d+\/\d+/);
+  const [vL, vR] = vText.replace(/[^0-9/]/g, '').split('/');
+  const [wpL, wpR] = wpText.replace(/[^0-9/]/g, '').split('/');
+  expect(vL).toBe(vR);
+  expect(wpL).toBe(wpR);
+});
+
+// ── Graceful degradation: API failure → max/max ───────────────────────────────
+
+test('graceful degradation: downtime_cycles API error → INF shows max/max', async ({ page }) => {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER });
+
+  await page.route('**/api/**', route => route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }));
+  await page.route('**/api/auth/me', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(ST_USER) })
+  );
+  await page.route('**/api/game_sessions', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([SESSION]) })
+  );
+  await page.route('**/api/characters**', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(TEST_CHARS) })
+  );
+  await page.route('**/api/players/display-names', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  // downtime_cycles returns 500 error
+  await page.route('**/api/downtime_cycles', route =>
+    route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ error: 'SERVER_ERROR' }) })
+  );
+  await page.route('**/api/st_mods**', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+
+  await page.setViewportSize({ width: 800, height: 900 });
+  await page.goto('/');
+  await page.waitForSelector('#bnav', { timeout: 10000 });
+  await page.locator('#n-signin').click();
+  await page.waitForSelector('.si-row', { timeout: 8000 });
+
+  // c-001 has clan status 4 → infMax=4; API error → spent defaults to 0 → shows 4/4
+  const aliceRow = page.locator('.si-row[data-char-id="c-001"]');
+  const infSpan = aliceRow.locator('.si-res-lbl:text("Inf")').locator('..');
+  await expect(infSpan).toContainText('4/4');
+});
+
+// ── AC5: both new API calls are fired on load ─────────────────────────────────
+
+test('AC5: downtime_cycles and downtime_submissions are both requested on init', async ({ page }) => {
+  const requested = new Set();
+  page.on('request', req => {
+    if (req.url().includes('/api/downtime_cycles')) requested.add('cycles');
+    if (req.url().includes('/api/downtime_submissions')) requested.add('submissions');
+  });
+
+  await setup(page);
+
+  expect(requested.has('cycles')).toBe(true);
+  expect(requested.has('submissions')).toBe(true);
+});


### PR DESCRIPTION
## Summary

- Adds `loadInfluenceSpend()` to Check-In, fetching the most recently closed downtime cycle's submissions and building a `character_id → spent-dots` map from the `responses.influence_spend` JSON string field
- INF resource display changes from `max/max` to `(max − spent)/max`, giving coordinators a real-time read on each character's available influence at game night
- Defaults gracefully to `max/max` when no closed cycle exists, no submission is found for a character, or the submission predates the `influence_spend` field (DT1-era CSV imports)
- Both new API calls (`/api/downtime_cycles`, `/api/downtime_submissions`) are parallelised with `loadPlayerNames()` via `Promise.all` so init latency is unchanged

## Closes

- Closes #485

## Story

- specs/stories/feature.485.checkin-inf-remaining-spend.story.md

## Test plan

- [ ] `npx playwright test tests/feature-485-checkin-inf-remaining-spend.spec.js` — 9 tests (AC1–AC5 + regression + degradation)
- [ ] `npx playwright test tests/feature-483-checkin-roster-new-session.spec.js tests/fin-checkin-finance.spec.js` — 20 tests (regression)
- [ ] CI green
- [ ] Manual: open Check-In on dev, confirm INF column shows `remaining/max`; characters who submitted last downtime should show reduced INF; characters without submissions show `max/max`

## Branch flow

- From: `ms/issue-485-checkin-inf-remaining-spend`
- Into: `dev`