### PR TITLE
fix(#485): Check-In INF — absolute spend + clamp remaining at 0

### DIFF
--- a/public/js/game/signin-tab.js
+++ b/public/js/game/signin-tab.js
@@ -89,7 +89,9 @@ async function loadInfluenceSpend() {
       if (!raw) continue;
       let spendObj;
       try { spendObj = JSON.parse(raw); } catch { continue; }
-      const total = Object.values(spendObj).reduce((s, v) => s + (Number(v) || 0), 0);
+      // Absolute amounts: a negative per-territory value is influence
+      // moved, not refunded — it still counts against the spend total.
+      const total = Object.values(spendObj).reduce((s, v) => s + Math.abs(Number(v) || 0), 0);
       if (total > 0) _infSpentByCharId.set(String(sub.character_id), total);
     }
     console.info('[signin] inf spend loaded: %d entries', _infSpentByCharId.size);
@@ -226,7 +228,7 @@ function render() {
     const wpMax = calcWillpowerMax(c);
     const infMax = calcTotalInfluence(c);
     const infSpent = _infSpentByCharId.get(String(c._id)) || 0;
-    const infRemaining = infMax - infSpent;
+    const infRemaining = Math.max(0, infMax - infSpent);
     const resourceRow = `<div class="si-resources">
       <span class="si-res-item"><span class="si-res-lbl">V</span> ${vMax}/${vMax}</span>
       <span class="si-res-item"><span class="si-res-lbl">WP</span> ${wpMax}/${wpMax}</span>

--- a/tests/feature-485-checkin-inf-remaining-spend.spec.js
+++ b/tests/feature-485-checkin-inf-remaining-spend.spec.js
@@ -7,6 +7,8 @@
  * AC4 — no closed cycle exists → shows max / max for all
  * Regression — most-recent cycle is chosen by game_number, not array order
  *   (live DT1 was re-imported with a newer _id than DT3, breaking .find()).
+ * Regression — per-territory spend is summed as absolute amounts, and
+ *   remaining never renders below 0 (live: Wan Yelong's -4/+6 DT3 entries).
  */
 
 const { test, expect } = require('@playwright/test');
@@ -206,6 +208,37 @@ test('regression: spend resolves from highest game_number cycle, not array order
   const aliceRow = page.locator('.si-row[data-char-id="c-001"]');
   const infSpan = aliceRow.locator('.si-res-lbl:text("Inf")').locator('..');
   await expect(infSpan).toContainText('1/4');
+});
+
+// ── Regression: per-territory spend is absolute, remaining clamps at 0 ───────
+// Live bug — Wan Yelong's DT3 submission held the_academy: -4 alongside
+// the_harbour: 6. Net summing (-4 + 6 = 2) under-counted his spend; influence
+// moved is still influence spent, so totals sum absolute values.
+
+test('absolute spend: negative per-territory value counts toward spend, not refund', async ({ page }) => {
+  await setup(page, {
+    submissions: [
+      { _id: 'sub-abs', character_id: 'c-001', cycle_id: 'cycle-closed-001', status: 'submitted',
+        responses: { influence_spend: JSON.stringify({ the_academy: -2, the_harbour: 1 }) } },
+    ],
+  });
+  // c-001 infMax=4; |-2| + |1| = 3 spent → 1/4 (net summing would wrongly give 5/4).
+  const aliceRow = page.locator('.si-row[data-char-id="c-001"]');
+  const infSpan = aliceRow.locator('.si-res-lbl:text("Inf")').locator('..');
+  await expect(infSpan).toContainText('1/4');
+});
+
+test('clamp: absolute spend exceeding max shows 0, not negative remaining', async ({ page }) => {
+  await setup(page, {
+    submissions: [
+      { _id: 'sub-over', character_id: 'c-001', cycle_id: 'cycle-closed-001', status: 'submitted',
+        responses: { influence_spend: JSON.stringify({ the_academy: -4, the_harbour: 6 }) } },
+    ],
+  });
+  // c-001 infMax=4; |-4| + |6| = 10 spent → remaining clamps to 0/4.
+  const aliceRow = page.locator('.si-row[data-char-id="c-001"]');
+  const infSpan = aliceRow.locator('.si-res-lbl:text("Inf")').locator('..');
+  await expect(infSpan).toContainText('0/4');
 });
 
 // ── AC4: no closed cycle → all chars show max/max ────────────────────────────


### PR DESCRIPTION
## Summary
Follow-up to #485. Per-territory `influence_spend` values can be negative
when influence is *moved* rather than freshly spent (live: Wan Yelong's
DT3 entry had `the_academy: -4` with `the_harbour: +6`). Net summing
under-counted the spend. Now sums absolute values, and clamps the
displayed remaining at 0 so a character who overspends shows `0/N`
rather than a negative.

## Test plan
- [x] `tests/feature-485-checkin-inf-remaining-spend.spec.js` — 13/13 pass, incl. new absolute-summing and zero-clamp regression tests
- [ ] Verify on terramortis-dev: Wan Yelong shows `0/8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)