### PR TITLE
Check-In: vitae shows last cycle's logged feed roll, else 0

### DIFF
--- a/public/js/game/signin-tab.js
+++ b/public/js/game/signin-tab.js
@@ -53,6 +53,7 @@ let _saveTimer = null;
 let _el = null;
 let _playerByCharId = new Map();
 let _infSpentByCharId = new Map();
+let _feedVitaeByCharId = new Map();
 
 // Placeholder strings seeded by an early redacted import. Treat as missing.
 const PLACEHOLDER_RE = /^Player [A-Z]{1,2}$/;
@@ -72,8 +73,9 @@ async function loadPlayerNames() {
   }
 }
 
-async function loadInfluenceSpend() {
+async function loadLastCycleData() {
   _infSpentByCharId = new Map();
+  _feedVitaeByCharId = new Map();
   try {
     const allCycles = await apiGet('/api/downtime_cycles');
     // The cycles API sorts by _id desc, but DT1 was re-imported with a newer
@@ -85,18 +87,35 @@ async function loadInfluenceSpend() {
     if (!lastClosed) return;
     const subs = await apiGet('/api/downtime_submissions?cycle_id=' + lastClosed._id);
     for (const sub of (subs || [])) {
+      const charId = String(sub.character_id);
+
+      // Influence spend (#485) — guarded block, not an early continue, so the
+      // feeding extraction below still runs for influence-less submissions.
       const raw = sub.responses?.influence_spend;
-      if (!raw) continue;
-      let spendObj;
-      try { spendObj = JSON.parse(raw); } catch { continue; }
-      // Absolute amounts: a negative per-territory value is influence
-      // moved, not refunded — it still counts against the spend total.
-      const total = Object.values(spendObj).reduce((s, v) => s + Math.abs(Number(v) || 0), 0);
-      if (total > 0) _infSpentByCharId.set(String(sub.character_id), total);
+      if (raw) {
+        let spendObj = null;
+        try { spendObj = JSON.parse(raw); } catch { spendObj = null; }
+        if (spendObj) {
+          // Absolute amounts: a negative per-territory value is influence
+          // moved, not refunded — it still counts against the spend total.
+          const total = Object.values(spendObj).reduce((s, v) => s + Math.abs(Number(v) || 0), 0);
+          if (total > 0) _infSpentByCharId.set(charId, total);
+        }
+      }
+
+      // Feeding vitae from the logged feed roll (#489): vessel allocation
+      // plus the saved bonus tally. No allocation means no logged feed.
+      const alloc = sub.feeding_vitae_allocation;
+      if (Array.isArray(alloc) && alloc.length > 0) {
+        const vesselTotal = alloc.reduce((s, v) => s + (Number(v) || 0), 0);
+        const bonus = Number(sub.feeding_vitae_tally?.total_bonus) || 0;
+        _feedVitaeByCharId.set(charId, vesselTotal + bonus);
+      }
     }
-    console.info('[signin] inf spend loaded: %d entries', _infSpentByCharId.size);
+    console.info('[signin] last-cycle data loaded: %d inf, %d feed',
+      _infSpentByCharId.size, _feedVitaeByCharId.size);
   } catch (err) {
-    console.warn('[signin] influence spend load failed; defaulting to 0', err);
+    console.warn('[signin] last-cycle data load failed; defaulting to 0', err);
   }
 }
 
@@ -118,7 +137,7 @@ export async function initSignIn(el, chars) {
     return;
   }
 
-  await Promise.all([loadPlayerNames(), loadInfluenceSpend()]);
+  await Promise.all([loadPlayerNames(), loadLastCycleData()]);
   render();
 }
 
@@ -143,7 +162,7 @@ async function handleNewSession() {
     attendance:   [],
   });
   _session = created;
-  await Promise.all([loadPlayerNames(), loadInfluenceSpend()]);
+  await Promise.all([loadPlayerNames(), loadLastCycleData()]);
   render();
 }
 
@@ -229,8 +248,10 @@ function render() {
     const infMax = calcTotalInfluence(c);
     const infSpent = _infSpentByCharId.get(String(c._id)) || 0;
     const infRemaining = Math.max(0, infMax - infSpent);
+    const feedVitae = _feedVitaeByCharId.get(String(c._id)) ?? 0;
+    const vitaeShown = Math.min(feedVitae, vMax);
     const resourceRow = `<div class="si-resources">
-      <span class="si-res-item"><span class="si-res-lbl">V</span> ${vMax}/${vMax}</span>
+      <span class="si-res-item"><span class="si-res-lbl">V</span> ${vitaeShown}/${vMax}</span>
       <span class="si-res-item"><span class="si-res-lbl">WP</span> ${wpMax}/${wpMax}</span>
       ${infMax > 0 ? `<span class="si-res-item"><span class="si-res-lbl">Inf</span> ${infRemaining}/${infMax}</span>` : ''}
     </div>`;

--- a/specs/stories/feature.489.checkin-vitae-feed-roll.story.md
+++ b/specs/stories/feature.489.checkin-vitae-feed-roll.story.md
@@ -1,0 +1,281 @@
+---
+issue: 489
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/489
+branch: ms/issue-489-checkin-vitae-feed-roll
+---
+
+# feature.489 — Check-In: vitae shows last cycle's logged feed roll, else 0
+
+**Status:** review
+
+## Story
+
+As a coordinator running game-night check-in,
+I want each character's V (vitae) figure to show the vitae from their logged feed roll in the last downtime cycle (or 0 if none was logged),
+so that I can see at a glance how much blood each character is walking into the session with.
+
+## Acceptance Criteria
+
+- **AC1** — Given a character whose last-cycle submission has a logged feed roll (vessels allocated `[3,3]`, feeding bonus `+2`) and a vitae max of 10, Check-In shows `V 8/10`
+- **AC2** — Given a character with no submission for the last cycle, Check-In shows `V 0/10`
+- **AC3** — Given a character whose last-cycle submission has no logged feed roll (feed deferred, or `feeding_vitae_allocation` absent/empty), Check-In shows `V 0/10`
+- **AC4** — Given no last cycle exists (no non-open downtime cycle at all), Check-In shows `V 0/<vMax>` for every character
+- **AC5** — Given a logged feed roll whose total exceeds the character's vitae max, Check-In shows `V <vMax>/<vMax>` (display clamped to vMax)
+- **AC6** — The feeding-data load is parallelised with `loadPlayerNames()` and the influence load, so Check-In load time does not increase perceptibly
+- **AC7** — The WP and INF displays are unchanged, and the existing 13 `feature-485` E2E tests still pass (zero regression)
+
+## Tasks / Subtasks
+
+- [x] T1 — Extend last-cycle loading to also collect feeding vitae
+  - [x] T1.1 — Add module-level `let _feedVitaeByCharId = new Map();` alongside `_infSpentByCharId`
+  - [x] T1.2 — Rename `loadInfluenceSpend()` to `loadLastCycleData()`; reset BOTH maps at the top
+  - [x] T1.3 — **Restructure the `subs` loop to remove the two `continue` statements** so feeding extraction runs even for submissions with no `influence_spend` (see "The `continue` trap" below — this is the #1 mistake to avoid)
+  - [x] T1.4 — Feeding extraction: if `sub.feeding_vitae_allocation` is a non-empty array, `feedTotal = sum(allocation) + (sub.feeding_vitae_tally?.total_bonus || 0)`; store in `_feedVitaeByCharId` keyed by `String(sub.character_id)`
+- [x] T2 — Wire the rename through both call sites
+  - [x] T2.1 — `initSignIn()`: `Promise.all([loadPlayerNames(), loadLastCycleData()])`
+  - [x] T2.2 — `handleNewSession()`: `Promise.all([loadPlayerNames(), loadLastCycleData()])`
+- [x] T3 — Update `render()` V span
+  - [x] T3.1 — Add `const feedVitae = _feedVitaeByCharId.get(String(c._id)) ?? 0;`
+  - [x] T3.2 — Add `const vitaeShown = Math.min(feedVitae, vMax);`
+  - [x] T3.3 — Change the V span from `${vMax}/${vMax}` to `${vitaeShown}/${vMax}`
+- [x] T4 — E2E tests in `tests/feature-489-checkin-vitae-feed-roll.spec.js`
+  - [x] T4.1 — AC1: logged feed (allocation + bonus) → `V <total>/<vMax>`
+  - [x] T4.2 — AC2: no submission → `V 0/<vMax>`
+  - [x] T4.3 — AC3: submission with feed deferred / no allocation → `V 0/<vMax>`
+  - [x] T4.4 — AC4: no last cycle → `V 0/<vMax>` for all
+  - [x] T4.5 — AC5: feed total exceeds vMax → clamped to `V <vMax>/<vMax>`
+  - [x] T4.6 — Regression: run the existing `feature-485` spec, expect 13/13 still passing
+
+## Dev Notes
+
+### Files to modify
+
+- **`public/js/game/signin-tab.js`** — all changes (recommended approach needs NO server changes)
+- **`tests/feature-489-checkin-vitae-feed-roll.spec.js`** — new E2E spec
+
+Do NOT touch `server/`, `feeding-tab.js`, `accessors.js`, or any other file.
+
+### Current state of `signin-tab.js` (post #487 / #488 — read it before editing)
+
+This file was last changed by feature.485 and its two follow-up fixes (#487
+cycle-selection, #488 absolute-spend). The **current** `loadInfluenceSpend()` on
+`dev` is:
+
+```js
+async function loadInfluenceSpend() {
+  _infSpentByCharId = new Map();
+  try {
+    const allCycles = await apiGet('/api/downtime_cycles');
+    // The cycles API sorts by _id desc, but DT1 was re-imported with a newer
+    // _id than DT3 — so array order no longer tracks recency. Order on
+    // game_number explicitly to pick the genuine most-recent cycle.
+    const lastClosed = (allCycles || [])
+      .filter(c => c.status && c.status !== 'open')
+      .sort((a, b) => (b.game_number || 0) - (a.game_number || 0))[0] || null;
+    if (!lastClosed) return;
+    const subs = await apiGet('/api/downtime_submissions?cycle_id=' + lastClosed._id);
+    for (const sub of (subs || [])) {
+      const raw = sub.responses?.influence_spend;
+      if (!raw) continue;                                    // ← TRAP
+      let spendObj;
+      try { spendObj = JSON.parse(raw); } catch { continue; } // ← TRAP
+      const total = Object.values(spendObj).reduce((s, v) => s + Math.abs(Number(v) || 0), 0);
+      if (total > 0) _infSpentByCharId.set(String(sub.character_id), total);
+    }
+    console.info('[signin] inf spend loaded: %d entries', _infSpentByCharId.size);
+  } catch (err) {
+    console.warn('[signin] influence spend load failed; defaulting to 0', err);
+  }
+}
+```
+
+The current `render()` resource row:
+
+```js
+const vMax  = calcVitaeMax(c);
+const wpMax = calcWillpowerMax(c);
+const infMax = calcTotalInfluence(c);
+const infSpent = _infSpentByCharId.get(String(c._id)) || 0;
+const infRemaining = Math.max(0, infMax - infSpent);
+const resourceRow = `<div class="si-resources">
+  <span class="si-res-item"><span class="si-res-lbl">V</span> ${vMax}/${vMax}</span>
+  <span class="si-res-item"><span class="si-res-lbl">WP</span> ${wpMax}/${wpMax}</span>
+  ${infMax > 0 ? `<span class="si-res-item"><span class="si-res-lbl">Inf</span> ${infRemaining}/${infMax}</span>` : ''}
+</div>`;
+```
+
+### The `continue` trap (most important note)
+
+`loadInfluenceSpend()`'s loop has two `continue` statements that skip a
+submission entirely when it has no `influence_spend`. If you append feeding code
+after them in the same loop, **a character who fed but spent no influence will
+never have their feeding extracted.** You MUST restructure the loop so the
+influence branch is a guarded `if (raw) { ... }` block rather than an early
+`continue`, leaving feeding extraction to run unconditionally.
+
+### Feeding data shapes (live, from DT3 — cycle `69e955c784bbfc821bed2810`)
+
+Feeding fields live at the **top level** of a `downtime_submissions` document
+(NOT under `responses`, unlike `influence_spend`):
+
+- `feeding_vitae_allocation` — array of integers, one per drained vessel. e.g. `[2,2]`, `[3,3]`, `[2,2,2,2,2,2,2,2]`
+- `feeding_vitae_tally` — object; the only field needed here is `total_bonus` (integer, already clamped at 0 server-side). e.g. `{ herd: 0, ambience: 3, ..., total_bonus: 3 }`
+- `feeding_deferred` — boolean; `true` means the player deferred ("see STs at game") and there is no allocation
+
+The DT3 data is **uneven** — some submissions have `feeding_vitae_allocation`
+only, some have `feeding_vitae_tally` only, some have both, some neither. The
+"else 0" rule (OQ2) makes this safe: a submission with no `feeding_vitae_allocation`
+is simply treated as no logged feed.
+
+Final feeding vitae = `sum(feeding_vitae_allocation) + (feeding_vitae_tally.total_bonus || 0)`.
+This mirrors `grandTotal` in `feeding-tab.js` (`vesselTotal + total_bonus`).
+
+### Recommended implementation
+
+Add module-level state next to `_infSpentByCharId`:
+
+```js
+let _feedVitaeByCharId = new Map();
+```
+
+Rename `loadInfluenceSpend` to `loadLastCycleData` and restructure the loop:
+
+```js
+async function loadLastCycleData() {
+  _infSpentByCharId = new Map();
+  _feedVitaeByCharId = new Map();
+  try {
+    const allCycles = await apiGet('/api/downtime_cycles');
+    const lastClosed = (allCycles || [])
+      .filter(c => c.status && c.status !== 'open')
+      .sort((a, b) => (b.game_number || 0) - (a.game_number || 0))[0] || null;
+    if (!lastClosed) return;
+    const subs = await apiGet('/api/downtime_submissions?cycle_id=' + lastClosed._id);
+    for (const sub of (subs || [])) {
+      const charId = String(sub.character_id);
+
+      // Influence spend (#485) — guarded block, no early continue.
+      const raw = sub.responses?.influence_spend;
+      if (raw) {
+        let spendObj = null;
+        try { spendObj = JSON.parse(raw); } catch { spendObj = null; }
+        if (spendObj) {
+          const total = Object.values(spendObj)
+            .reduce((s, v) => s + Math.abs(Number(v) || 0), 0);
+          if (total > 0) _infSpentByCharId.set(charId, total);
+        }
+      }
+
+      // Feeding vitae from the logged feed roll (#489).
+      const alloc = sub.feeding_vitae_allocation;
+      if (Array.isArray(alloc) && alloc.length > 0) {
+        const vesselTotal = alloc.reduce((s, v) => s + (Number(v) || 0), 0);
+        const bonus = Number(sub.feeding_vitae_tally?.total_bonus) || 0;
+        _feedVitaeByCharId.set(charId, vesselTotal + bonus);
+      }
+    }
+    console.info('[signin] last-cycle data loaded: %d inf, %d feed',
+      _infSpentByCharId.size, _feedVitaeByCharId.size);
+  } catch (err) {
+    console.warn('[signin] last-cycle data load failed; defaulting to 0', err);
+  }
+}
+```
+
+`render()` V span — change from `${vMax}/${vMax}` to:
+
+```js
+const feedVitae  = _feedVitaeByCharId.get(String(c._id)) ?? 0;
+const vitaeShown = Math.min(feedVitae, vMax);
+// ...
+<span class="si-res-item"><span class="si-res-lbl">V</span> ${vitaeShown}/${vMax}</span>
+```
+
+### Resolved decisions
+
+These were open questions on the issue; resolved by Angelus 2026-05-22 and now
+fixed requirements:
+
+- **Data source — the logged feed roll in the downtime submission is authoritative.**
+  The vitae number is `sum(feeding_vitae_allocation) + (feeding_vitae_tally.total_bonus || 0)`.
+  `tracker_state.vitae` is NOT consulted: the logged feed roll is trusted directly,
+  with no ST-confirmation cross-check and no new endpoint. (This means the figure
+  reflects gross intake and may not net out a heavy Cruac rite cost — accepted.)
+- **"Logged" = `feeding_vitae_allocation` is a non-empty array.** A submission with
+  only a `feeding_vitae_tally` (bonuses computed but no vessels allocated), a
+  deferred feed, or no submission at all all count as NOT logged and show `0`.
+- **Display is clamped: `Math.min(feedTotal, vMax)`.** A raw feed total above the
+  character's vitae max renders as `vMax/vMax`.
+
+### What NOT to change
+
+- `loadPlayerNames()`, `doAutosave()`, `calcEminence()`, `wireEvents()` — no change
+- `PAYMENT_METHODS`, `PAID_METHODS`, `DEFAULT_RATE` — no change
+- The WP display stays `${wpMax}/${wpMax}`; the INF display stays `${infRemaining}/${infMax}`
+- The influence-spend logic itself — only the loop *structure* changes (drop the `continue`s); the influence result must be byte-identical, which the 13 `feature-485` tests verify
+
+### Related stories
+
+- **feature.485** (`feature.485.checkin-inf-remaining-spend.story.md`) — the INF feature this mirrors; same fetch, same map-keyed-by-character pattern
+- **feature.483** (`feature.483.checkin-roster-new-session.story.md`) — established the roster render and the Playwright test patterns
+- Follow-up fixes #487 (cycle selection by `game_number`) and #488 (absolute spend + clamp) are already merged to `dev` and reflected in the current-state snapshot above
+
+### Playwright test patterns (from feature.485)
+
+- Use `fake-test-token` (NOT `local-test-token`) to bypass the `dev-fixtures.js` interceptor
+- Register the catch-all `**/api/**` route first (lowest priority), specific routes after
+- `ST_USER` with `role: 'st'`
+- The `feature-485` spec's `setup()` already routes `downtime_cycles` and a cycle-aware `downtime_submissions`; copy that scaffold. Cycle fixtures must carry `game_number` (the cycle picker sorts on it).
+- Feeding fields go at the **top level** of the submission fixture, not under `responses`:
+  ```js
+  const SUBMISSION_FED = {
+    _id: 'sub-f1', character_id: 'c-001', cycle_id: 'cycle-closed-001',
+    status: 'submitted',
+    feeding_vitae_allocation: [3, 3],
+    feeding_vitae_tally: { total_bonus: 2 },
+  };
+  ```
+- `calcVitaeMax` depends on blood potency, not merits — give test chars a known/derivable vMax, or assert on the `N/M` pattern rather than hardcoding, as the feature.485 story advised for influence.
+
+## Dev Agent Record
+
+### Debug Log
+
+- The feature-485 regression test `V and WP resource displays still show max/max`
+  failed on the first run (`expect(vL).toBe(vR)` — got `0` vs `5`). This was
+  expected, not a code regression: feature.489 intentionally changes V away from
+  `max/max`. The test was rewritten to assert WP only; V is now covered by the
+  feature-489 spec.
+
+### Completion Notes
+
+- T1 — `loadInfluenceSpend()` renamed to `loadLastCycleData()`; it resets both
+  `_infSpentByCharId` and the new `_feedVitaeByCharId`. The submissions loop was
+  restructured so the influence branch is a guarded `if (raw) { ... }` block
+  instead of two early `continue`s, so feeding extraction runs for every
+  submission. Feeding total = `sum(feeding_vitae_allocation) + (feeding_vitae_tally.total_bonus || 0)`,
+  stored only when `feeding_vitae_allocation` is a non-empty array.
+- T2 — both `Promise.all` call sites (`initSignIn`, `handleNewSession`) now call
+  `loadLastCycleData()`.
+- T3 — `render()` resource row computes `feedVitae` (default 0) and
+  `vitaeShown = Math.min(feedVitae, vMax)`; the V span shows `${vitaeShown}/${vMax}`.
+- T4 — 10 E2E tests in `tests/feature-489-checkin-vitae-feed-roll.spec.js`
+  (AC1 x2, AC2, AC3 x2, AC4 x2, AC5, WP regression). All pass.
+- Regression — 36/36 across the three Check-In specs (483 / 485 / 489), zero
+  code regressions. The one feature-485 test change is a spec update, not a fix
+  (see Debug Log).
+- `feeding-tab.js` has its own unrelated module-private `loadInfluenceSpend(charId)`
+  — confirmed no collision with the renamed function (both are non-exported).
+
+## File List
+
+- `public/js/game/signin-tab.js` — added `_feedVitaeByCharId`, renamed `loadInfluenceSpend` to `loadLastCycleData` and extended its loop, updated both call sites, updated `render()` V span
+- `tests/feature-489-checkin-vitae-feed-roll.spec.js` — new E2E spec (13 tests; 10 from dev-story + 3 from QA review)
+- `tests/feature-485-checkin-inf-remaining-spend.spec.js` — updated the V/WP regression test to WP-only (feature.489 intentionally changes V from max/max)
+
+## Change Log
+
+- 2026-05-22: Story created from issue #489 — Check-In vitae shows last cycle's logged feed roll, else 0.
+- 2026-05-22: Open questions resolved by Angelus (submission feed roll authoritative; "logged" = vessel allocation present; display clamped to vMax). Status → ready-for-dev.
+- 2026-05-22: Implementation complete — T1-T4 done; 10 new feature-489 E2E tests pass; 36/36 across Check-In specs (483 / 485 / 489), zero regressions. Status → review.
+- 2026-05-22: QA review (Quinn) — 3 coverage tests added (both-fields submission, empty allocation array, allocation-without-tally); 39/39 Check-In tests pass. QA-clear, ready for PR.

--- a/specs/stories/tests/test-summary.md
+++ b/specs/stories/tests/test-summary.md
@@ -1,3 +1,56 @@
+# Test Automation Summary — feature.489 Check-In vitae from last feed roll
+
+**Date:** 2026-05-22
+**Author:** Quinn (QA)
+**Scope:** E2E coverage review for feature.489 — the Check-In V column shows the
+last cycle's logged feed roll (`feeding_vitae_allocation` + tally bonus), else 0.
+
+## Generated Tests
+
+### E2E Tests (Playwright)
+- [x] `tests/feature-489-checkin-vitae-feed-roll.spec.js` — 13 tests (10 from dev-story, 3 added in QA)
+
+## Coverage
+
+| AC | Behaviour | Status |
+|---|---|---|
+| AC1 | logged feed roll → `feedTotal / vMax` | 2 tests |
+| AC2 | no submission → `0 / vMax` | 1 test |
+| AC3 | no logged feed (deferred, tally-only) → `0 / vMax` | 2 tests |
+| AC4 | no last cycle → `0 / vMax` for all | 2 tests |
+| AC5 | feed total > vMax → clamped to `vMax / vMax` | 1 test |
+| AC6 | parallelised load | Structural — feeding rides the existing `loadLastCycleData` fetch; code-review check, not an E2E counter |
+| AC7 | WP / INF unchanged | WP regression test + full feature-485 (13) + feature-483 (13) |
+
+## Gaps Closed in QA
+
+1. No test exercised a single submission carrying both `influence_spend` and a feed roll — the real DT3 shape, and what the loop restructure was for. Added.
+2. `feeding_vitae_allocation: []` (empty array) was untested versus an absent field. Added — pins the `length > 0` guard.
+3. A logged feed with an allocation but no `feeding_vitae_tally` (a real DT3 shape) was untested. Added — pins the bonus `|| 0` fallback.
+
+## Run
+
+```bash
+npx playwright test tests/feature-489-checkin-vitae-feed-roll.spec.js tests/feature-485-checkin-inf-remaining-spend.spec.js tests/feature-483-checkin-roster-new-session.spec.js --reporter=list
+```
+
+39/39 passed — 13 #489 + 13 #485 + 13 #483, zero regressions.
+
+## Notes
+
+- AC6 has no dedicated E2E test: an absolute `/api/downtime_submissions` request
+  count is not a clean signal — other app code hits that endpoint on boot
+  (observed 3 requests). The "no added fetch" guarantee is structural: feeding is
+  extracted inside the existing `loadLastCycleData` call.
+- The feature-485 `V and WP max/max` regression test was updated during dev-story
+  to WP-only, since feature.489 intentionally changes V. Correct and expected.
+
+## Next Steps
+
+- feature.489 is QA-clear — ready for PR into `dev`.
+
+---
+
 # Test Automation Summary — Issue #327 Feeding matrix rote+normal double-feed
 
 **Date:** 2026-05-17

--- a/tests/feature-485-checkin-inf-remaining-spend.spec.js
+++ b/tests/feature-485-checkin-inf-remaining-spend.spec.js
@@ -259,25 +259,19 @@ test('AC4: no cycles at all → all INF displays show max/max', async ({ page })
   await expect(infSpan).toContainText('4/4');
 });
 
-// ── Regression: V and WP still show max/max ──────────────────────────────────
+// ── Regression: WP still shows max/max ───────────────────────────────────────
 
-test('regression: V and WP resource displays still show max/max after INF change', async ({ page }) => {
+test('regression: WP resource display still shows max/max after INF change', async ({ page }) => {
   await setup(page);
   const aliceRow = page.locator('.si-row[data-char-id="c-001"]');
   await expect(aliceRow).toBeVisible();
-  // V and WP are unchanged — they always show max/max
-  const vSpan = aliceRow.locator('.si-res-lbl:text("V")').locator('..');
+  // WP is unaffected by the INF change — still max/max.
+  // (V is no longer max/max as of feature.489 — covered by feature-489 spec.)
   const wpSpan = aliceRow.locator('.si-res-lbl:text("WP")').locator('..');
-  await expect(vSpan).toBeVisible();
   await expect(wpSpan).toBeVisible();
-  const vText = await vSpan.textContent();
   const wpText = await wpSpan.textContent();
-  // Both should be N/N (same numerator and denominator)
-  expect(vText).toMatch(/\d+\/\d+/);
   expect(wpText).toMatch(/\d+\/\d+/);
-  const [vL, vR] = vText.replace(/[^0-9/]/g, '').split('/');
   const [wpL, wpR] = wpText.replace(/[^0-9/]/g, '').split('/');
-  expect(vL).toBe(vR);
   expect(wpL).toBe(wpR);
 });
 

--- a/tests/feature-489-checkin-vitae-feed-roll.spec.js
+++ b/tests/feature-489-checkin-vitae-feed-roll.spec.js
@@ -1,0 +1,255 @@
+/**
+ * E2E — feature.489: Check-In V shows last cycle's logged feed roll, else 0
+ *
+ * AC1 — char with a logged feed roll (vessel allocation + bonus) → shows feedTotal / vMax
+ * AC2 — char with no submission for the last cycle → shows 0 / vMax
+ * AC3 — char whose submission has no logged feed (deferred, or tally only) → shows 0 / vMax
+ * AC4 — no last cycle exists → shows 0 / vMax for every character
+ * AC5 — feed total exceeding vMax → clamped to vMax / vMax
+ *
+ * "Logged" = feeding_vitae_allocation is a non-empty array.
+ * feedTotal = sum(feeding_vitae_allocation) + (feeding_vitae_tally.total_bonus || 0).
+ * Feeding fields sit at the TOP LEVEL of a submission, not under responses.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const ST_USER = {
+  id: 'test-st-001', username: 'test_st', global_name: 'Test ST',
+  avatar: null, role: 'st', player_id: 'p-st-001', character_ids: [], is_dual_role: false,
+};
+
+const SESSION = {
+  _id: 'sess-489-001',
+  session_date: '2099-06-01',
+  game_number: 5,
+  attendance: [],
+};
+
+// blood_potency 1 → calcVitaeMax = 10 for every test char (BP_TABLE, accessors.js).
+const TEST_CHARS = [
+  {
+    _id: 'c-001', name: 'Alice Char', player: 'Alice Player', retired: false,
+    blood_potency: 1, clan: 'Daeva', covenant: 'Invictus',
+    status: { city: 0, clan: 0, covenant: {} }, merits: [],
+  },
+  {
+    _id: 'c-002', name: 'Bob Char', player: 'Bob Player', retired: false,
+    blood_potency: 1, clan: 'Gangrel', covenant: 'Circle of the Crone',
+    status: { city: 0, clan: 0, covenant: {} }, merits: [],
+  },
+  {
+    _id: 'c-003', name: 'Carol Char', player: 'Carol Player', retired: false,
+    blood_potency: 1, clan: 'Mekhet', covenant: 'Carthian Movement',
+    status: { city: 0, clan: 0, covenant: {} }, merits: [],
+  },
+  {
+    _id: 'c-004', name: 'Dave Char', player: 'Dave Player', retired: false,
+    blood_potency: 1, clan: 'Ventrue', covenant: 'Lancea et Sanctum',
+    // status.clan 5 → calcTotalInfluence = 5; used by the both-fields coverage test.
+    status: { city: 0, clan: 5, covenant: {} }, merits: [],
+  },
+];
+
+const CLOSED_CYCLE = { _id: 'cycle-closed-001', status: 'closed', game_number: 3 };
+const OPEN_CYCLE   = { _id: 'cycle-open-001',   status: 'open',   game_number: 4 };
+
+// c-001: vessels [3,3] = 6, bonus +2 → feedTotal 8
+const SUB_LOGGED_FEED = {
+  _id: 'sub-489-001', character_id: 'c-001', cycle_id: 'cycle-closed-001', status: 'submitted',
+  feeding_vitae_allocation: [3, 3],
+  feeding_vitae_tally: { total_bonus: 2 },
+};
+
+function vSpan(page, charId) {
+  return page.locator(`.si-row[data-char-id="${charId}"]`)
+    .locator('.si-res-lbl:text("V")').locator('..');
+}
+
+async function setup(page, {
+  sessions = [SESSION],
+  cycles = [CLOSED_CYCLE, OPEN_CYCLE],
+  submissions = [SUB_LOGGED_FEED],
+} = {}) {
+  await page.addInitScript(({ user, chars }) => {
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+    window.__TEST_CHARS__ = chars;
+  }, { user: ST_USER, chars: TEST_CHARS });
+
+  // Catch-all first (lowest priority)
+  await page.route('**/api/**', route => route.fulfill({ status: 200, contentType: 'application/json', body: '[]' }));
+
+  await page.route('**/api/auth/me', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(ST_USER) })
+  );
+  await page.route('**/api/game_sessions', route => {
+    if (route.request().method() === 'GET')
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(sessions) });
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(sessions[0] || {}) });
+  });
+  await page.route('**/api/characters**', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(TEST_CHARS) })
+  );
+  await page.route('**/api/players/display-names', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.route('**/api/downtime_cycles', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(cycles) })
+  );
+  await page.route('**/api/downtime_submissions**', route => {
+    // Mirror the real endpoint: scope returned submissions to ?cycle_id=.
+    const cid = new URL(route.request().url()).searchParams.get('cycle_id');
+    const body = cid
+      ? submissions.filter(s => String(s.cycle_id) === cid)
+      : submissions;
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+  });
+  await page.route('**/api/st_mods**', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+
+  await page.setViewportSize({ width: 800, height: 900 });
+  await page.goto('/');
+  await page.waitForSelector('#bnav', { timeout: 10000 });
+  await page.locator('#n-signin').click();
+  await page.waitForSelector('.si-row', { timeout: 8000 });
+}
+
+// ── AC1: logged feed roll → feedTotal / vMax ─────────────────────────────────
+
+test('AC1: char with logged feed (vessels 3+3, bonus +2) shows V 8/10', async ({ page }) => {
+  await setup(page);
+  const v = vSpan(page, 'c-001');
+  await expect(v).toBeVisible();
+  await expect(v).toContainText('8/10');
+});
+
+test('AC1: V is feedTotal/vMax, not vMax/vMax, when a feed is logged', async ({ page }) => {
+  await setup(page);
+  const text = await vSpan(page, 'c-001').textContent();
+  expect(text).toContain('8/10');
+  expect(text).not.toContain('10/10');
+});
+
+// ── AC2: no submission → 0 / vMax ────────────────────────────────────────────
+
+test('AC2: char with no submission for the last cycle shows V 0/10', async ({ page }) => {
+  await setup(page);
+  // c-002 has no submission in SUB_LOGGED_FEED set.
+  const v = vSpan(page, 'c-002');
+  await expect(v).toBeVisible();
+  await expect(v).toContainText('0/10');
+});
+
+// ── AC3: submission with no logged feed → 0 / vMax ───────────────────────────
+
+test('AC3: deferred feed (no allocation) shows V 0/10', async ({ page }) => {
+  await setup(page, {
+    submissions: [
+      { _id: 'sub-def', character_id: 'c-003', cycle_id: 'cycle-closed-001', status: 'submitted',
+        feeding_deferred: true },
+    ],
+  });
+  const v = vSpan(page, 'c-003');
+  await expect(v).toBeVisible();
+  await expect(v).toContainText('0/10');
+});
+
+test('AC3: submission with a tally but no vessel allocation shows V 0/10', async ({ page }) => {
+  await setup(page, {
+    submissions: [
+      { _id: 'sub-tally', character_id: 'c-003', cycle_id: 'cycle-closed-001', status: 'submitted',
+        feeding_vitae_tally: { total_bonus: 5 } },
+    ],
+  });
+  // A bonus tally alone is not a logged feed — allocation is required.
+  await expect(vSpan(page, 'c-003')).toContainText('0/10');
+});
+
+// ── AC4: no last cycle → 0 / vMax for all ────────────────────────────────────
+
+test('AC4: no last cycle → every character shows V 0/10', async ({ page }) => {
+  await setup(page, { cycles: [OPEN_CYCLE] }); // only an open cycle, none past it
+  await expect(vSpan(page, 'c-001')).toContainText('0/10');
+  await expect(vSpan(page, 'c-002')).toContainText('0/10');
+});
+
+test('AC4: no cycles at all → V 0/10', async ({ page }) => {
+  await setup(page, { cycles: [] });
+  await expect(vSpan(page, 'c-001')).toContainText('0/10');
+});
+
+// ── AC5: feed total exceeding vMax clamps to vMax/vMax ───────────────────────
+
+test('AC5: feed total above vMax is clamped to V 10/10', async ({ page }) => {
+  await setup(page, {
+    submissions: [
+      { _id: 'sub-over', character_id: 'c-001', cycle_id: 'cycle-closed-001', status: 'submitted',
+        feeding_vitae_allocation: [5, 5, 5], feeding_vitae_tally: { total_bonus: 3 } },
+    ],
+  });
+  // 15 + 3 = 18 spent, vMax 10 → clamped to 10/10.
+  const text = await vSpan(page, 'c-001').textContent();
+  expect(text).toContain('10/10');
+  expect(text).not.toContain('18');
+});
+
+// ── Regression: WP display unchanged by the V change ─────────────────────────
+
+test('regression: WP display still renders max/max after the V change', async ({ page }) => {
+  await setup(page);
+  const wp = page.locator('.si-row[data-char-id="c-001"]')
+    .locator('.si-res-lbl:text("WP")').locator('..');
+  await expect(wp).toBeVisible();
+  const wpText = await wp.textContent();
+  expect(wpText).toMatch(/\d+\/\d+/);
+  const [l, r] = wpText.replace(/[^0-9/]/g, '').split('/');
+  expect(l).toBe(r);
+});
+
+// ── QA coverage (feature.489 review) ─────────────────────────────────────────
+
+test('coverage: a submission with both influence_spend and a feed roll resolves both INF and V', async ({ page }) => {
+  // Real DT3 shape — many submissions carry both. Guards the loadLastCycleData
+  // loop restructure: dropping the influence `continue`s must leave both
+  // extractions running from a single document.
+  await setup(page, {
+    submissions: [
+      {
+        _id: 'sub-both', character_id: 'c-004', cycle_id: 'cycle-closed-001', status: 'submitted',
+        responses: { influence_spend: JSON.stringify({ the_harbour: 2, the_academy: 1 }) },
+        feeding_vitae_allocation: [4, 4],
+        feeding_vitae_tally: { total_bonus: 1 },
+      },
+    ],
+  });
+  const row = page.locator('.si-row[data-char-id="c-004"]');
+  // INF: max 5, spent 3 → 2/5
+  await expect(row.locator('.si-res-lbl:text("Inf")').locator('..')).toContainText('2/5');
+  // V: vessels 4+4 + bonus 1 = 9, max 10 → 9/10
+  await expect(row.locator('.si-res-lbl:text("V")').locator('..')).toContainText('9/10');
+});
+
+test('coverage: empty feeding_vitae_allocation array counts as no logged feed', async ({ page }) => {
+  await setup(page, {
+    submissions: [
+      { _id: 'sub-empty', character_id: 'c-001', cycle_id: 'cycle-closed-001', status: 'submitted',
+        feeding_vitae_allocation: [] },
+    ],
+  });
+  // A length-0 array fails the `length > 0` guard → treated as not logged → 0/10.
+  await expect(vSpan(page, 'c-001')).toContainText('0/10');
+});
+
+test('coverage: logged feed with allocation but no tally → V is allocation sum / vMax', async ({ page }) => {
+  await setup(page, {
+    submissions: [
+      { _id: 'sub-notally', character_id: 'c-001', cycle_id: 'cycle-closed-001', status: 'submitted',
+        feeding_vitae_allocation: [2, 2] },
+    ],
+  });
+  // No feeding_vitae_tally → bonus defaults to 0 → 2 + 2 = 4 → 4/10. (Real DT3 shape.)
+  await expect(vSpan(page, 'c-001')).toContainText('4/10');
+});


### PR DESCRIPTION
## Summary

- The Check-In roster's V column was a `vMax/vMax` placeholder; it now shows each character's vitae from their logged feed roll in the last downtime cycle.
- Feed total = `sum(feeding_vitae_allocation) + (feeding_vitae_tally.total_bonus || 0)`, clamped to `vMax`. No logged feed (no submission, deferred, or no vessel allocation) shows `0/vMax`.
- `loadInfluenceSpend()` renamed to `loadLastCycleData()`; its loop restructured so feeding extraction runs for every submission, not only those carrying influence spend.

## Closes

- Closes #489

## Story

- specs/stories/feature.489.checkin-vitae-feed-roll.story.md

## Test plan

- [ ] `npx playwright test tests/feature-489-checkin-vitae-feed-roll.spec.js tests/feature-485-checkin-inf-remaining-spend.spec.js tests/feature-483-checkin-roster-new-session.spec.js` — 39/39 pass
- [ ] CI green
- [ ] Manual: on terramortis-dev, open Check-In and confirm V shows fed vitae for characters with DT3 feed rolls, 0 for those without

## Branch flow

- From: \`ms/issue-489-checkin-vitae-feed-roll\`
- Into: \`dev\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)