### PR TITLE
fix(491): skill acquisitions render Outcome card, not Validation Status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,9 @@ data copy/
 
 # Scratch working directory — ad-hoc inputs/outputs, never tracked
 scratch/
+
+# DT prototype — static data snapshot, never merges to dev/main
+public/dt-proto-data/
 server/scripts/build-rubric-digests.js
 
 # One-off DB cleanup script backups — local-only audit trail

--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -5968,6 +5968,20 @@ body {
 .proc-recat-row-spaced { margin-top: 8px; padding-top: 8px; }
 .proc-recat-row-top    { margin-top: 0; padding-top: 0; border-top: none; margin-bottom: 10px; padding-bottom: 10px; border-bottom: 1px solid var(--bdr); }
 
+/* ── Action progress ribbon (Pending › Valid › Complete) ── */
+.proc-action-ribbon { display: flex; align-items: center; gap: 4px; margin-left: auto; font-size: 0.72rem; }
+.proc-ar-step {
+  padding: 2px 8px; border-radius: 10px;
+  border: 1px solid transparent; color: var(--txt3); white-space: nowrap;
+}
+.proc-ar-step.ar-past    { color: var(--txt2); border-color: var(--surf3); }
+.proc-ar-step.ar-active  { font-weight: 600; }
+.proc-ar-step.ar-active.ar-pending  { border-color: var(--txt3);        color: var(--txt3); }
+.proc-ar-step.ar-active.ar-valid    { border-color: var(--gold2);       color: var(--gold2); }
+.proc-ar-step.ar-active.ar-complete { border-color: var(--result-succ); color: var(--result-succ); }
+.proc-ar-step.ar-future  { opacity: 0.35; }
+.proc-ar-arrow { color: var(--txt3); font-size: 0.7rem; }
+
 /* Pool committed state — locks pool builder and modifier panels */
 .proc-pool-committed { opacity: 0.65; pointer-events: none; user-select: none; }
 .proc-pool-committed-badge {

--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -5966,6 +5966,7 @@ body {
 }
 .proc-recat-row-tight  { margin-top: 4px; padding-top: 4px; border-top: none; }
 .proc-recat-row-spaced { margin-top: 8px; padding-top: 8px; }
+.proc-recat-row-top    { margin-top: 0; padding-top: 0; border-top: none; margin-bottom: 10px; padding-bottom: 10px; border-bottom: 1px solid var(--bdr); }
 
 /* Pool committed state — locks pool builder and modifier panels */
 .proc-pool-committed { opacity: 0.65; pointer-events: none; user-select: none; }
@@ -5979,12 +5980,20 @@ body {
   vertical-align: middle;
 }
 
-/* Territory pills rendered inline alongside the Action Type selector (ambience actions) */
+/* Territory pills rendered inline (action type row for merit/non-normalised; territory rail for normalised card) */
 .proc-terr-inline-pills {
   display: inline-flex;
   align-items: center;
   gap: 4px;
   margin-left: 12px;
+}
+/* Territory rail in normalised card — flex so pills align with the label */
+.proc-proj-terr-rail {
+  display: flex;
+  align-items: center;
+}
+.proc-proj-terr-rail .proc-terr-inline-pills {
+  margin-left: 8px;
 }
 
 .proc-recat-select {

--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -5969,18 +5969,26 @@ body {
 .proc-recat-row-top    { margin-top: 0; padding-top: 0; border-top: none; margin-bottom: 10px; padding-bottom: 10px; border-bottom: 1px solid var(--bdr); }
 
 /* ── Action progress ribbon (Pending › Valid › Complete) ── */
+/* Shared colour tokens — used by both ribbon steps and the row chip */
+.ar-pending  { --ar-c: var(--result-pend);  --ar-bdr: var(--result-pend-bdr);  --ar-bg: var(--result-pend-bg); }
+.ar-valid    { --ar-c: #e07a30;             --ar-bdr: rgba(224,122,48,.45);    --ar-bg: rgba(224,122,48,.12); }
+.ar-complete { --ar-c: var(--result-succ);  --ar-bdr: var(--result-succ-bdr);  --ar-bg: var(--result-succ-bg); }
+html:not([data-theme="dark"]) .ar-valid { --ar-c: #8b3d00; --ar-bdr: rgba(139,61,0,.40); --ar-bg: rgba(139,61,0,.10); }
+
 .proc-action-ribbon { display: flex; align-items: center; gap: 4px; margin-left: auto; font-size: 0.72rem; }
 .proc-ar-step {
   padding: 2px 8px; border-radius: 10px;
   border: 1px solid transparent; color: var(--txt3); white-space: nowrap;
 }
 .proc-ar-step.ar-past    { color: var(--txt2); border-color: var(--surf3); }
-.proc-ar-step.ar-active  { font-weight: 600; }
-.proc-ar-step.ar-active.ar-pending  { border-color: var(--txt3);        color: var(--txt3); }
-.proc-ar-step.ar-active.ar-valid    { border-color: var(--gold2);       color: var(--gold2); }
-.proc-ar-step.ar-active.ar-complete { border-color: var(--result-succ); color: var(--result-succ); }
+.proc-ar-step.ar-active  { font-weight: 600; border-color: var(--ar-bdr); color: var(--ar-c); }
 .proc-ar-step.ar-future  { opacity: 0.35; }
 .proc-ar-arrow { color: var(--txt3); font-size: 0.7rem; }
+
+/* Row chip — shows ribbon state instead of raw pool_status */
+.proc-row-status.ar-pending, .proc-row-status.ar-valid, .proc-row-status.ar-complete {
+  background: var(--ar-bg); color: var(--ar-c);
+}
 
 /* Pool committed state — locks pool builder and modifier panels */
 .proc-pool-committed { opacity: 0.65; pointer-events: none; user-select: none; }

--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -6329,12 +6329,46 @@ html:not([data-theme="dark"]) .cc-audit-err {
 /* Ambience pending chip — dark background/neon text don't suit parchment */
 html:not([data-theme="dark"]) .proc-amb-pending-chip { background: var(--crim-a12); color: var(--crim2); border-color: var(--crim-a30); }
 
-/* ── Connected Characters ────────────────────────────────────────────────── */
+/* ── Connected Characters — typeahead ────────────────────────────────────── */
 .proc-connected-section {
   margin-top: 10px;
   padding: 8px 12px 10px;
   border-top: 1px solid var(--bdr);
 }
+.proc-conn-typeahead { position: relative; margin-top: 6px; }
+.proc-conn-chips { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 6px; }
+.proc-conn-chip {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 6px 2px 9px; border-radius: 12px;
+  background: var(--gold-a12); border: 1px solid var(--gold2-a25);
+  color: var(--gold2); font-size: 12px; white-space: nowrap;
+}
+.proc-conn-chip-x {
+  background: none; border: none; cursor: pointer;
+  color: var(--txt3); font-size: 15px; line-height: 1;
+  padding: 0; margin: 0;
+}
+.proc-conn-chip-x:hover { color: var(--result-pend); }
+.proc-conn-input {
+  width: 100%; box-sizing: border-box;
+  padding: 5px 8px; background: var(--surf2);
+  border: 1px solid var(--bdr); border-radius: 4px;
+  color: var(--text); font-size: 13px; font-family: var(--fl);
+}
+.proc-conn-input:focus { outline: none; border-color: var(--gold2); }
+.proc-conn-dropdown {
+  position: absolute; top: 100%; left: 0; right: 0; z-index: 200;
+  background: var(--surf2); border: 1px solid var(--bdr);
+  border-top: none; border-radius: 0 0 4px 4px;
+  max-height: 180px; overflow-y: auto;
+  box-shadow: 0 4px 12px rgba(0,0,0,.35);
+}
+.proc-conn-dd-item {
+  padding: 6px 10px; cursor: pointer;
+  font-size: 13px; color: var(--text);
+}
+.proc-conn-dd-item:hover { background: var(--gold-a10); color: var(--gold2); }
+
 .proc-connected-list {
   display: flex;
   flex-wrap: wrap;

--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -6335,8 +6335,9 @@ html:not([data-theme="dark"]) .proc-amb-pending-chip { background: var(--crim-a1
   padding: 8px 12px 10px;
   border-top: 1px solid var(--bdr);
 }
-.proc-conn-typeahead { position: relative; margin-top: 6px; }
-.proc-conn-chips { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 6px; }
+.proc-conn-typeahead { margin-top: 6px; }
+.proc-conn-input-row { position: relative; }
+.proc-conn-chips { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
 .proc-conn-chip {
   display: inline-flex; align-items: center; gap: 4px;
   padding: 2px 6px 2px 9px; border-radius: 12px;

--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -4914,6 +4914,64 @@ body {
   border-top: 1px solid var(--bdr);
 }
 
+/* ── Dice Pool Builder chip row ── */
+.proc-pool-chips {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-top: 6px;
+  margin-bottom: 8px;
+}
+/* Dice Pool Modifiers panel when inlined inside the Dice Pool Builder card */
+.proc-pool-builder .proc-feed-mod-panel.proc-pool-mod-inline,
+.proc-pool-mod-inline {
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0 0 8px 0;
+}
+/* Spec-chip wrapper is layout-transparent so spec chips align with sibling chips */
+.proc-pool-chips .dt-feed-builder-meta.dt-skill-meta {
+  display: contents;
+  margin: 0;
+}
+/* Shared chip token — pool-builder chips match proc-val-status button style */
+.proc-spec-chip,
+.proc-rote-chip,
+.proc-again-opt {
+  background: var(--surf2);
+  border: 1px solid var(--bdr);
+  color: var(--txt3);
+  padding: 5px 12px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-family: var(--fl);
+  margin: 0;
+  cursor: pointer;
+  transition: border-color 0.12s, color 0.12s, background 0.12s;
+  appearance: none;
+  -webkit-appearance: none;
+  box-sizing: border-box;
+  white-space: nowrap;
+}
+
+/* Hover */
+.proc-spec-chip:hover:not(:disabled),
+.proc-rote-chip:hover:not(:disabled),
+.proc-again-opt:hover:not(:disabled) { border-color: var(--accent); color: var(--txt1); }
+
+/* Active states — semantic colour treatments */
+.proc-spec-chip.is-active { border-color: var(--gold2); color: var(--gold2); background: var(--gold2-a12); }
+.proc-rote-chip.is-active { border-color: var(--crim); color: var(--crim); background: var(--crim-a15); }
+.proc-again-opt.is-active { border-color: var(--gold2); color: var(--gold2); background: var(--gold2-a12); }
+.proc-again-opt.is-active.is-auto { border-color: var(--green); color: var(--green); background: var(--green-a15); }
+
+/* Disabled */
+.proc-spec-chip:disabled,
+.proc-rote-chip:disabled,
+.proc-again-opt:disabled { opacity: 0.45; cursor: not-allowed; }
+
 .proc-pool-parse-ref {
   font-size: 12px;
   color: var(--txt3);
@@ -5970,20 +6028,19 @@ body {
 
 /* ── Action progress ribbon (Pending › Valid › Complete) ── */
 /* Shared colour tokens — used by both ribbon steps and the row chip */
-.ar-pending  { --ar-c: var(--result-pend);  --ar-bdr: var(--result-pend-bdr);  --ar-bg: var(--result-pend-bg); }
-.ar-valid    { --ar-c: #e07a30;             --ar-bdr: rgba(224,122,48,.45);    --ar-bg: rgba(224,122,48,.12); }
-.ar-complete { --ar-c: var(--result-succ);  --ar-bdr: var(--result-succ-bdr);  --ar-bg: var(--result-succ-bg); }
-html:not([data-theme="dark"]) .ar-valid { --ar-c: #8b3d00; --ar-bdr: rgba(139,61,0,.40); --ar-bg: rgba(139,61,0,.10); }
+.ar-pending  { --ar-c: var(--result-pend);    --ar-bdr: var(--result-pend-bdr);    --ar-bg: var(--result-pend-bg); }
+.ar-valid    { --ar-c: var(--warn-orange);    --ar-bdr: var(--warn-orange-bdr);    --ar-bg: var(--warn-orange-bg); }
+.ar-complete { --ar-c: var(--result-succ);    --ar-bdr: var(--result-succ-bdr);    --ar-bg: var(--result-succ-bg); }
 
-.proc-action-ribbon { display: flex; align-items: center; gap: 4px; margin-left: auto; font-size: 0.72rem; }
+.proc-action-ribbon { display: flex; align-items: center; gap: 5px; margin-left: auto; font-size: 0.8rem; font-family: var(--fl); }
 .proc-ar-step {
-  padding: 2px 8px; border-radius: 10px;
+  padding: 3px 11px; border-radius: 12px;
   border: 1px solid transparent; color: var(--txt3); white-space: nowrap;
 }
 .proc-ar-step.ar-past    { color: var(--txt2); border-color: var(--surf3); }
-.proc-ar-step.ar-active  { font-weight: 600; border-color: var(--ar-bdr); color: var(--ar-c); }
+.proc-ar-step.ar-active  { font-weight: 700; border-color: var(--ar-bdr); color: var(--ar-c); background: var(--ar-bg); }
 .proc-ar-step.ar-future  { opacity: 0.35; }
-.proc-ar-arrow { color: var(--txt3); font-size: 0.7rem; }
+.proc-ar-arrow { color: var(--txt3); font-size: 0.75rem; }
 
 /* Row chip — shows ribbon state instead of raw pool_status */
 .proc-row-status.ar-pending, .proc-row-status.ar-valid, .proc-row-status.ar-complete {

--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -5602,6 +5602,28 @@ body {
   font-style: italic;
   font-size: 12px;
 }
+/* ── Ambience direction badge (▲/▼) in action-type row ── */
+.proc-ambience-dir-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: .04em;
+  padding: 1px 7px;
+  border-radius: 3px;
+  margin-left: 6px;
+}
+.proc-ambience-dir-increase {
+  background: color-mix(in srgb, var(--green, #3a7d44) 18%, transparent);
+  color: var(--green, #5cb85c);
+  border: 1px solid color-mix(in srgb, var(--green, #3a7d44) 35%, transparent);
+}
+.proc-ambience-dir-decrease {
+  background: color-mix(in srgb, var(--crim) 18%, transparent);
+  color: #c06060;
+  border: 1px solid color-mix(in srgb, var(--crim) 35%, transparent);
+}
 /* ── Detail card shared input styles (feeding / project / sorcery / merit) ── */
 .proc-detail-input,
 .proc-detail-ta {

--- a/public/css/theme.css
+++ b/public/css/theme.css
@@ -96,6 +96,7 @@
   --result-pend:#c04040;--result-pend-bg:rgba(192,64,64,.10);--result-pend-bdr:rgba(192,64,64,.35);
   --green-dk:#1b5e20;--green-dk-bg:rgba(27,94,32,.12);--green-dk-bdr:rgba(27,94,32,.35);
   --warn-dk:#7a5c00;--warn-dk-bg:rgba(122,92,0,.12);
+  --warn-orange:#8b3d00;--warn-orange-bg:rgba(139,61,0,.10);--warn-orange-bdr:rgba(139,61,0,.40);
 
   /* Reading pane — warm parchment surfaces (questionnaires, player portal, dossiers).
      Used in both light (parchment tokens below) and dark (overrides at bottom of file). */
@@ -249,6 +250,7 @@
   --result-pend:#ff9090;--result-pend-bg:rgba(255,144,144,.12);--result-pend-bdr:rgba(255,144,144,.35);
   --green-dk:#6abf6a;--green-dk-bg:rgba(106,191,106,.15);--green-dk-bdr:rgba(106,191,106,.40);
   --warn-dk:#d4a832;--warn-dk-bg:rgba(212,168,50,.15);
+  --warn-orange:#e07a30;--warn-orange-bg:rgba(224,122,48,.12);--warn-orange-bdr:rgba(224,122,48,.45);
 
   /* Lethal damage (dark amber) */
   --dmg-lethal:#D4830A;

--- a/public/dt-proto.html
+++ b/public/dt-proto.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>DT Proto — Terra Mortis</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Lato:wght@400;600;700;900&family=Libre+Baskerville:wght@400;700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="css/theme.css">
+<link rel="stylesheet" href="css/components.css">
+<link rel="stylesheet" href="css/admin-layout.css">
+<script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+<script>
+  // Prevent theme flash
+  (function(){
+    var t = localStorage.getItem('tm-theme');
+    if (t === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
+  })();
+  // Fake ST auth — no Discord needed in proto
+  localStorage.setItem('tm_auth_token', 'local-test-token');
+  localStorage.setItem('tm_auth_user', JSON.stringify({
+    role: 'st', username: 'Proto ST', global_name: 'Proto ST', _localTest: true
+  }));
+  localStorage.setItem('tm_auth_player', JSON.stringify({ role: 'st' }));
+</script>
+<style>
+  body { margin: 0; background: var(--bg); color: var(--text); }
+  #proto-app { display: flex; flex-direction: column; min-height: 100vh; padding: 16px; box-sizing: border-box; }
+  #proto-banner {
+    font-family: 'Cinzel', serif;
+    font-size: 11px;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+    color: var(--gold2);
+    opacity: .6;
+    margin-bottom: 8px;
+  }
+  #proto-loading { padding: 32px; text-align: center; opacity: .6; }
+</style>
+</head>
+<body>
+<div id="proto-app">
+  <div id="proto-banner">DT Prototype — local only — data is static</div>
+
+  <!-- DT domain — mirrors admin.html #d-downtime exactly -->
+  <section id="d-downtime" class="domain active" style="display:flex;flex-direction:column;flex:1">
+    <div class="domain-header">
+      <h2>Downtime</h2>
+    </div>
+    <div id="dt-ctrl-bar">
+      <div class="dt-toolbar">
+        <button class="dt-btn dt-btn-new" id="dt-new-cycle">+ New Cycle</button>
+        <button class="dt-btn" id="dt-close-cycle" style="display:none">Close Cycle</button>
+        <button class="dt-btn dt-btn-export" id="dt-export-all" style="display:none">Export MD</button>
+        <button class="dt-btn dt-btn-export" id="dt-export-json" style="display:none">Export JSON</button>
+        <button class="dt-btn dt-btn-export" id="dt-import-csv">Import CSV</button>
+        <input type="file" id="dt-import-csv-input" accept=".csv" style="display:none">
+      </div>
+      <div id="dt-cycle-bar" class="dt-cycle-bar">
+        <select id="dt-cycle-sel" class="dt-cycle-sel"></select>
+        <span id="dt-cycle-status" class="dt-cycle-status"></span>
+      </div>
+    </div>
+    <div id="dt-phase-ribbon" style="display:none"></div>
+    <div id="dt-sub-ribbon" style="display:none"></div>
+    <div id="dt-prep-panel" class="dt-prep-panel" style="display:none"></div>
+    <div id="dt-processing-panel" class="dt-panel" style="display:none">
+      <div id="downtime-content"></div>
+    </div>
+    <div id="dt-city-panel" class="dt-panel" style="display:none"></div>
+    <div id="dt-story-panel" class="dt-panel" style="display:none"></div>
+    <div id="dt-ready-panel" class="dt-panel" style="display:none"></div>
+  </section>
+
+  <div id="proto-loading">Loading prototype data…</div>
+</div>
+<script type="module" src="js/dt-proto-boot.js"></script>
+</body>
+</html>

--- a/public/dt-proto.html
+++ b/public/dt-proto.html
@@ -44,7 +44,7 @@
   <div id="proto-banner">DT Prototype — local only — data is static</div>
 
   <!-- DT domain — mirrors admin.html #d-downtime exactly -->
-  <section id="d-downtime" class="domain active" style="display:flex;flex-direction:column;flex:1">
+  <section id="d-downtime" class="domain active" style="display:flex;flex-direction:column;flex:1;overflow-y:auto">
     <div class="domain-header">
       <h2>Downtime</h2>
     </div>
@@ -54,6 +54,7 @@
         <button class="dt-btn" id="dt-close-cycle" style="display:none">Close Cycle</button>
         <button class="dt-btn dt-btn-export" id="dt-export-all" style="display:none">Export MD</button>
         <button class="dt-btn dt-btn-export" id="dt-export-json" style="display:none">Export JSON</button>
+        <button class="dt-btn dt-btn-export" id="dt-city-export-btn" style="display:none">Export City JSON</button>
         <button class="dt-btn dt-btn-export" id="dt-import-csv">Import CSV</button>
         <input type="file" id="dt-import-csv-input" accept=".csv" style="display:none">
       </div>

--- a/public/js/admin/downtime-constants.js
+++ b/public/js/admin/downtime-constants.js
@@ -153,6 +153,9 @@ export const TERRITORY_SLUG_MAP = {
   dockyards:  'dockyards',
   secondcity: 'secondcity',
   northshore: 'northshore',
+  // Explicit Barrens and N/A pill IDs → resolve to null (no territory)
+  barrens:    null,
+  na:         null,
 };
 
 // Human-readable labels for pool_status values (shared with downtime-views.js and downtime-story.js)

--- a/public/js/admin/downtime-constants.js
+++ b/public/js/admin/downtime-constants.js
@@ -16,6 +16,7 @@
 export const ACTION_TYPE_LABELS = {
   ambience_increase: 'Ambience Increase',
   ambience_decrease: 'Ambience Decrease',
+  ambience_change:   'Ambience Change',
   feed:              'Feed',
   attack:            'Attack',
   hide_protect:      'Hide / Protect',

--- a/public/js/admin/downtime-story.js
+++ b/public/js/admin/downtime-story.js
@@ -50,8 +50,7 @@ const CS_ACTION_PRIORITY = [
   'attack',
   'patrol_scout',
   'investigate',
-  'ambience_increase',
-  'ambience_decrease',
+  'ambience_change',
   'support',
   'misc',
   'rumour',
@@ -664,7 +663,7 @@ function buildProjectContext(char, sub, idx, cycleData, territories) {
 
   // Ambience actions use a dedicated territory field; patrol uses another.
   // Read the action-type-appropriate field so territory is never 'Unknown'.
-  const isAmbience      = actionType === 'ambience_increase' || actionType === 'ambience_decrease';
+  const isAmbience      = actionType === 'ambience_change' || actionType === 'ambience_increase' || actionType === 'ambience_decrease';
   const isInvestigation = actionType === 'investigate';
   const isFeed          = actionType === 'feed';
   const terrRaw    = isAmbience
@@ -789,7 +788,7 @@ function buildProjectContext(char, sub, idx, cycleData, territories) {
         if (!r || r.pool_status === 'skipped') return;
         const sl = i + 1;
         const otherType = r.action_type_override || r.action_type || '';
-        const otherIsAmb = otherType === 'ambience_increase' || otherType === 'ambience_decrease';
+        const otherIsAmb = otherType === 'ambience_change' || otherType === 'ambience_increase' || otherType === 'ambience_decrease';
         const otherTerrRaw = otherIsAmb
           ? (s.responses?.[`project_${sl}_ambience_target`] || s.responses?.[`project_${sl}_territory`] || '')
           : otherType === 'patrol_scout'
@@ -1012,7 +1011,7 @@ function buildPatrolContext(char, sub, idx, cycleData, territories) {
       if (!r || r.pool_status === 'skipped') return;
       const sl = i + 1;
       const aType = r.action_type_override || r.action_type || '';
-      const otherIsAmb = aType === 'ambience_increase' || aType === 'ambience_decrease';
+      const otherIsAmb = aType === 'ambience_change' || aType === 'ambience_increase' || aType === 'ambience_decrease';
       const otherIsPatrol = aType === 'patrol_scout' || aType === 'support';
       const otherTerrRaw = otherIsAmb
         ? (s.responses?.[`project_${sl}_ambience_target`] || s.responses?.[`project_${sl}_territory`] || '')

--- a/public/js/admin/downtime-story.js
+++ b/public/js/admin/downtime-story.js
@@ -2320,10 +2320,13 @@ function renderMeritSummary(char, sub) {
     const displayLabel = qualifier ? `${meritLabel} (${qualifier})` : meritLabel;
     let outcome = rev.outcome_summary?.trim() || '';
     if (cat === 'resources') {
-      const thread = (Array.isArray(rev.notes_thread) && rev.notes_thread.length ? rev.notes_thread : null)
-        || (Array.isArray(sub?.acquisitions_resolved?.[0]?.notes_thread) && sub.acquisitions_resolved[0].notes_thread.length
-          ? sub.acquisitions_resolved[0].notes_thread : null);
-      if (thread) outcome = thread[thread.length - 1]?.text?.trim() || '';
+      if (!outcome) outcome = sub?.acquisitions_resolved?.[0]?.outcome_summary?.trim() || '';
+      if (!outcome) {
+        const thread = (Array.isArray(rev.notes_thread) && rev.notes_thread.length ? rev.notes_thread : null)
+          || (Array.isArray(sub?.acquisitions_resolved?.[0]?.notes_thread) && sub.acquisitions_resolved[0].notes_thread.length
+            ? sub.acquisitions_resolved[0].notes_thread : null);
+        if (thread) outcome = thread[thread.length - 1]?.text?.trim() || '';
+      }
     }
     groups[cat].push({
       meritLabel: displayLabel || a.merit_type || 'Merit',

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -6500,17 +6500,17 @@ function _poolTotalDisplay(attr, attrDots, skill, skillDots, disc, discDots, mod
  * Render a territory pill row. Wires up via the existing proc-terr-pill click handler.
  * feedingSet: pass a Set of active territory IDs for feeding multi-select; null for single-select.
  */
-function _renderInlineTerrPills(subId, terrContext, currentTerrId, feedingSet = null) {
+function _renderInlineTerrPills(subId, terrContext, currentTerrId, feedingSet = null, noLabel = false) {
   const TERR_PILLS = [
-    { id: '',           label: '\u2014' },
     { id: 'academy',   label: 'Academy' },
     { id: 'harbour',   label: 'Harbour' },
     { id: 'dockyards', label: 'Dockyards' },
     { id: 'northshore', label: 'N. Shore' },
-    { id: 'secondcity', label: '2nd City' },
+    { id: 'barrens',   label: 'Barrens' },
+    { id: '',          label: 'N/A' },
   ];
   let h = `<span class="proc-terr-pill-row proc-terr-inline-pills" data-sub-id="${esc(subId)}" data-terr-context="${esc(terrContext)}">`;
-  h += `<span class="proc-feed-lbl">Terr.</span>`;
+  if (!noLabel) h += `<span class="proc-feed-lbl">Terr.</span>`;
   for (const t of TERR_PILLS) {
     const active = feedingSet
       ? ((t.id === '' ? feedingSet.size === 0 : feedingSet.has(t.id)) ? ' active' : '')
@@ -7669,13 +7669,14 @@ function _renderXpSpendBreakdown(rows, budget) {
     `</div>`;
 }
 
-function _renderActionTypeRow(entry, rev, char) {
+function _renderActionTypeRow(entry, rev, char, opts = {}) {
+  const { suppressTerrPills = false } = opts;
   const key        = entry.key;
   const actionType = entry.actionType;
   const isMerit    = entry.source === 'merit';
   let h = '';
 
-  h += `<div class="proc-recat-row">`;
+  h += `<div class="proc-recat-row${suppressTerrPills ? ' proc-recat-row-top' : ''}">`;
   h += `<span class="proc-feed-lbl">Action Type</span>`;
   h += `<select class="proc-recat-select" data-proc-key="${esc(key)}">`;
   for (const [val, lbl] of Object.entries(ACTION_TYPE_LABELS)) {
@@ -7702,7 +7703,7 @@ function _renderActionTypeRow(entry, rev, char) {
     }
     h += `</div>`;
     // Add territory pills for project-based investigate (not merit)
-    if (!isMerit) {
+    if (!isMerit && !suppressTerrPills) {
       const _invSub = submissions.find(s => s._id === entry.subId);
       const _invCtx = String(entry.actionIdx);
       const _invTid = _invSub?.st_review?.territory_overrides?.[_invCtx] || '';
@@ -7741,20 +7742,22 @@ function _renderActionTypeRow(entry, rev, char) {
         const _dirLabel = entry.ambienceDir === 'increase' ? '▲ Increase' : '▼ Decrease';
         h += `<span class="proc-ambience-dir-badge proc-ambience-dir-${esc(entry.ambienceDir)}">${_dirLabel}</span>`;
       }
-      const _ambiSub = submissions.find(s => s._id === entry.subId);
-      const _ambiCtx = String(entry.actionIdx);
-      const _stOvrTid = _ambiSub?.st_review?.territory_overrides?.[_ambiCtx];
-      let _ambiTid;
-      if (_stOvrTid) {
-        _ambiTid = _stOvrTid;
-      } else {
-        // No ST override — pre-select from player's submitted territory (visual only)
-        const _slot = entry.projSlot;
-        const _resp = _ambiSub?.responses || {};
-        const _raw = _resp[`project_${_slot}_ambience_target`] || _resp[`project_${_slot}_territory`] || '';
-        _ambiTid = resolveTerrId(_raw) || '';
+      if (!suppressTerrPills) {
+        const _ambiSub = submissions.find(s => s._id === entry.subId);
+        const _ambiCtx = String(entry.actionIdx);
+        const _stOvrTid = _ambiSub?.st_review?.territory_overrides?.[_ambiCtx];
+        let _ambiTid;
+        if (_stOvrTid) {
+          _ambiTid = _stOvrTid;
+        } else {
+          // No ST override — pre-select from player's submitted territory (visual only)
+          const _slot = entry.projSlot;
+          const _resp = _ambiSub?.responses || {};
+          const _raw = _resp[`project_${_slot}_ambience_target`] || _resp[`project_${_slot}_territory`] || '';
+          _ambiTid = resolveTerrId(_raw) || '';
+        }
+        h += _renderInlineTerrPills(entry.subId, _ambiCtx, _ambiTid);
       }
-      h += _renderInlineTerrPills(entry.subId, _ambiCtx, _ambiTid);
     }
     // merit ambience: territory handled via isAlliesAction pills below
   } else if (!isMerit) {
@@ -7878,6 +7881,9 @@ function renderNormalisedCard(entry, review) {
     }
   }
 
+  // ── Action Type row (at top — territory pills appear in the territory rail below) ──
+  h += _renderActionTypeRow(entry, rev, projChar, { suppressTerrPills: true });
+
   // ── Two-column layout ──
   h += `<div class="proc-feed-layout"><div class="proc-feed-left">`;
 
@@ -7926,16 +7932,35 @@ function renderNormalisedCard(entry, review) {
       h += `<div class="proc-proj-field proc-proj-xp"><span class="proc-feed-lbl">${xpLabel}</span> ${esc(xpTrait)}</div>`;
     }
 
-    // Territory (read-only)
-    if (entry.projTerritory) h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Territory</span> ${esc(entry.projTerritory)}</div>`;
+    // Territory rail (interactive pills for ambience/investigate; plain text for others)
+    if (_isAmbienceAction(entry.actionType)) {
+      const _ambiCtx  = String(entry.actionIdx);
+      const _stOvrTid = projSub?.st_review?.territory_overrides?.[_ambiCtx];
+      let _ambiTid;
+      if (_stOvrTid) {
+        _ambiTid = _stOvrTid;
+      } else {
+        const _resp = projSub?.responses || {};
+        const _raw  = _resp[`project_${entry.projSlot}_ambience_target`] || _resp[`project_${entry.projSlot}_territory`] || '';
+        _ambiTid = resolveTerrId(_raw) || '';
+      }
+      h += `<div class="proc-proj-field proc-proj-terr-rail"><span class="proc-feed-lbl">Territory</span>`;
+      h += _renderInlineTerrPills(entry.subId, _ambiCtx, _ambiTid, null, true);
+      h += `</div>`;
+    } else if (entry.actionType === 'investigate') {
+      const _invCtx = String(entry.actionIdx);
+      const _invTid = projSub?.st_review?.territory_overrides?.[_invCtx] || '';
+      h += `<div class="proc-proj-field proc-proj-terr-rail"><span class="proc-feed-lbl">Territory</span>`;
+      h += _renderInlineTerrPills(entry.subId, _invCtx, _invTid, null, true);
+      h += `</div>`;
+    } else if (entry.projTerritory) {
+      h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Territory</span> ${esc(entry.projTerritory)}</div>`;
+    }
     if (entry.actionType === 'feed') {
       const _nomText = _playerFeedTerrsText(projSub);
       if (_nomText) h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Territories</span> ${esc(_nomText)}</div>`;
     }
   }
-
-  // ── Action Type row (includes interactive target for investigate/attack + territory pills) ──
-  h += _renderActionTypeRow(entry, rev, projChar);
 
   // ── Connected Characters ──
   {

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -904,9 +904,11 @@ function renderJointGroup(joint, entries) {
       (status === 'validated' && review?.pool_validated_by) ? review.pool_validated_by :
       (status === 'confirmed' && review?.pool_confirmed_by) ? review.pool_confirmed_by :
       (status === 'resolved'  && review?.pool_resolved_by)  ? review.pool_resolved_by  : '';
+    const _chipState = _deriveActionRibbonState(review);
+    const _chipLabels = { pending: 'Pending', valid: 'Valid', complete: 'Complete' };
     h += `<span class="proc-row-status-cell">`;
     if (_attributedName) h += `<span class="proc-row-validator">${esc(_attributedName)}</span>`;
-    h += `<span class="proc-row-status ${status}">${POOL_STATUS_LABELS[status] || status}</span>`;
+    h += `<span class="proc-row-status ar-${_chipState}">${_chipLabels[_chipState]}</span>`;
     h += `</span>`;
     if (review?.second_opinion) h += `<span class="proc-row-second-opinion-dot" title="Flagged for second opinion">●</span>`;
     // No Dup / Del on joint participant rows — lifecycle handled via JDT-6.
@@ -4520,9 +4522,11 @@ function renderProcessingMode(container) {
           (status === 'validated' && review?.pool_validated_by) ? review.pool_validated_by :
           (status === 'confirmed' && review?.pool_confirmed_by) ? review.pool_confirmed_by :
           (status === 'resolved'  && review?.pool_resolved_by)  ? review.pool_resolved_by  : '';
+        const _chipState = _deriveActionRibbonState(review);
+        const _chipLabels = { pending: 'Pending', valid: 'Valid', complete: 'Complete' };
         h += `<span class="proc-row-status-cell">`;
         if (_attributedName) h += `<span class="proc-row-validator">${esc(_attributedName)}</span>`;
-        h += `<span class="proc-row-status ${status}">${POOL_STATUS_LABELS[status] || status}</span>`;
+        h += `<span class="proc-row-status ar-${_chipState}">${_chipLabels[_chipState]}</span>`;
         h += `</span>`;
         if (review?.second_opinion) h += `<span class="proc-row-second-opinion-dot" title="Flagged for second opinion">\u25CF</span>`;
         h += `<span class="proc-row-actions">`;
@@ -7011,7 +7015,6 @@ function _renderMeritRightPanel(entry, rev) {
   h += `<div class="proc-feed-right-section proc-feed-right-validation">`;
   h += `<div class="proc-mod-panel-title">Validation Status</div>`;
   const meritBtns = [['resolved', 'Validated'], ['no_roll', 'No Roll Needed'], ['skipped', 'Skip']];
-  if (!isAuto && ['pending', 'confirmed', 'rolled'].includes(poolStatus)) h += _renderStatusRibbon(key, poolStatus);
   h += _renderValStatusButtons(key, poolStatus, meritBtns);
   // Committed pool display
   const poolValidatedMerit = rev.pool_validated || '';
@@ -7076,7 +7079,6 @@ function _renderSorceryRightPanel(entry, char, sub, rev) {
   // ── Validation Status ──
   h += `<div class="proc-feed-right-section proc-feed-right-validation">`;
   h += `<div class="proc-mod-panel-title">Validation Status</div>`;
-  if (['pending', 'confirmed', 'rolled'].includes(poolStatus)) h += _renderStatusRibbon(key, poolStatus);
   h += _renderValStatusButtons(key, poolStatus, [['resolved', 'Resolved'], ['no_effect', 'No Effect'], ['skipped', 'Skip']]);
   // Committed pool display — shows computed total when rite is selected
   if (canRoll) {
@@ -7217,7 +7219,6 @@ function _renderProjRightPanel(entry, char, rev) {
   // ── Validation Status ──
   h += `<div class="proc-feed-right-section proc-feed-right-validation">`;
   h += `<div class="proc-mod-panel-title">Validation Status</div>`;
-  if (['pending', 'confirmed', 'rolled'].includes(poolStatus)) h += _renderStatusRibbon(key, poolStatus);
   h += _renderValStatusButtons(key, poolStatus, [['validated', 'Validated'], ['no_roll', 'No Roll Needed'], ['skipped', 'Skip']]);
   // Committed pool expression with active specs
   const displayPool = _augmentPoolWithSpecs(poolValidated, rev.active_feed_specs || [], char);
@@ -7467,7 +7468,6 @@ function _renderFeedRightPanel(entry, char, rev) {
   const poolStatus = rev.pool_status || 'pending';
   h += `<div class="proc-feed-right-section proc-feed-right-validation">`;
   h += `<div class="proc-mod-panel-title">Validation Status</div>`;
-  if (['pending', 'confirmed', 'rolled'].includes(poolStatus)) h += _renderStatusRibbon(key, poolStatus);
   h += _renderValStatusButtons(key, poolStatus, [['validated', 'Validated'], ['no_feed', 'No Valid Feeding']]);
   // Committed pool expression display — augmented with active spec names if any
   const displayPool = _augmentPoolWithSpecs(poolValidated, rev.active_feed_specs || [], char);

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -371,6 +371,10 @@ function showDtuxPhase(phase) {
   document.querySelectorAll('#dt-phase-ribbon .pr-tab').forEach(btn => {
     btn.classList.toggle('pr-tab-active', btn.dataset.phase === phase);
   });
+  // Show city export button only on the city tab
+  const cityExportBtn = document.getElementById('dt-city-export-btn');
+  if (cityExportBtn) cityExportBtn.style.display = phase === 'city' ? '' : 'none';
+
   // Lazy-init city/story tabs the first time they're shown.
   if (phase === 'city' && !_dtuxCityInited) { _dtuxCityInited = true; renderCityOverview(); }
   if (phase === 'story' && !_dtuxStoryInited) { _dtuxStoryInited = true; _initDtStoryFromRibbon(); }
@@ -378,6 +382,7 @@ function showDtuxPhase(phase) {
 
 let _dtuxCityInited = false;
 let _dtuxStoryInited = false;
+let _cityMatrix = null;
 
 async function _initDtStoryFromRibbon() {
   // Lazily import to avoid a circular dep \u2014 DT Story reads characters via API
@@ -504,6 +509,9 @@ export async function initDowntimeView(passedChars) {
     document.getElementById('dt-close-cycle').addEventListener('click', handleCloseCycle);
     document.getElementById('dt-export-all').addEventListener('click', handleExportAll);
     document.getElementById('dt-export-json').addEventListener('click', handleExportJson);
+    document.getElementById('dt-city-export-btn')?.addEventListener('click', () => {
+      if (_cityMatrix) _exportCityOverview(_cityMatrix);
+    });
     document.getElementById('dt-import-csv').addEventListener('click', () => {
       document.getElementById('dt-import-csv-input').click();
     });
@@ -10538,7 +10546,6 @@ export function renderCityOverview() {
     return;
   }
 
-  const isOpen  = el.dataset.open !== 'false';
   const profile = currentCycle?.discipline_profile || {};
   const notes   = currentCycle?.ambience_notes    || '';
 
@@ -10578,19 +10585,12 @@ export function renderCityOverview() {
   const activePhases = TAAG_PHASES.filter(p =>
     TERRITORY_DATA.some(t => (matrix[p.key][t.slug] || []).length > 0)
   );
+  _cityMatrix = matrix;
 
   // ── HTML ──
   let h = `<div class="dt-conflict-panel">`;
 
-  // Header row: title toggle + export button
-  h += `<div class="dt-city-panel-head">`;
-  h += `<div class="dt-matrix-toggle dt-city-title" id="dt-city-toggle">${isOpen ? '\u25BC' : '\u25BA'} City Overview</div>`;
-  h += `<button class="dt-city-export-btn" id="dt-city-export-btn">\u2193 Export JSON</button>`;
-  h += `</div>`;
-
-  if (isOpen) {
-
-    // ── 1. Feeding Matrix ─────────────────────────────────────────
+  // ── 1. Feeding Matrix ─────────────────────────────────────────
     h += `<div class="proc-disc-header" data-toggle="city-feed-matrix">`;
     h += `<span class="proc-amb-title">Feeding Matrix</span>`;
     h += `<span class="proc-amb-toggle">${matrixCollapsed ? '&#9660; Show' : '&#9650; Hide'}</span>`;
@@ -10698,22 +10698,11 @@ export function renderCityOverview() {
 
     // ── 6. Territory Pulse (DTIL-4) ───────────────────────────────
     h += renderTerritoryPulsePanel(currentCycle, submissions, characters);
-  }
-
   h += `</div>`; // dt-conflict-panel
   el.innerHTML = h;
 
   // ── Event wiring ──
 
-  document.getElementById('dt-city-toggle')?.addEventListener('click', () => {
-    el.dataset.open = isOpen ? 'false' : 'true';
-    renderCityOverview();
-  });
-
-  document.getElementById('dt-city-export-btn')?.addEventListener('click', e => {
-    e.stopPropagation();
-    _exportCityOverview(matrix);
-  });
 
   el.querySelector('[data-toggle="city-feed-matrix"]')?.addEventListener('click', () => {
     matrixCollapsed = !matrixCollapsed;

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -5494,17 +5494,82 @@ function renderProcessingMode(container) {
     });
   });
 
-  // Wire connected character checkboxes
-  container.querySelectorAll('.proc-conn-char-chk').forEach(cb => {
-    cb.addEventListener('click', e => e.stopPropagation());
-    cb.addEventListener('change', async e => {
-      e.stopPropagation();
-      const key   = cb.dataset.procKey;
+  // Wire connected character typeahead widgets
+  container.querySelectorAll('.proc-conn-typeahead').forEach(wrap => {
+    const key      = wrap.dataset.procKey;
+    const allChars = JSON.parse(wrap.dataset.allChars || '[]');
+    const input    = wrap.querySelector('.proc-conn-input');
+    const dropdown = wrap.querySelector('.proc-conn-dropdown');
+    const chipsEl  = wrap.querySelector('.proc-conn-chips');
+
+    function getSelectedKeys() {
+      return new Set([...chipsEl.querySelectorAll('.proc-conn-chip')].map(c => c.dataset.charName));
+    }
+
+    function showDropdown(query) {
+      const selected = getSelectedKeys();
+      const q = query.trim().toLowerCase();
+      const matches = allChars.filter(c =>
+        !selected.has(c.key) && (!q || c.label.toLowerCase().includes(q))
+      );
+      if (!matches.length) { dropdown.style.display = 'none'; return; }
+      dropdown.innerHTML = '';
+      for (const { key: cKey, label } of matches.slice(0, 10)) {
+        const item = document.createElement('div');
+        item.className = 'proc-conn-dd-item';
+        item.dataset.charName = cKey;
+        item.textContent = label;
+        dropdown.appendChild(item);
+      }
+      dropdown.style.display = '';
+    }
+
+    function addChip(charKey, label) {
+      const chip = document.createElement('span');
+      chip.className = 'proc-conn-chip';
+      chip.dataset.charName = charKey;
+      chip.appendChild(document.createTextNode(label));
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'proc-conn-chip-x';
+      btn.title = 'Remove';
+      btn.textContent = '×';
+      chip.appendChild(btn);
+      chipsEl.appendChild(chip);
+    }
+
+    async function saveConnected() {
       const entry = _getQueueEntry(key);
       if (!entry) return;
-      const allChks   = container.querySelectorAll(`.proc-conn-char-chk[data-proc-key="${key}"]`);
-      const connected = [...allChks].filter(c => c.checked).map(c => c.dataset.charName);
+      const connected = [...chipsEl.querySelectorAll('.proc-conn-chip')].map(c => c.dataset.charName);
       await saveEntryReview(entry, { connected_chars: connected });
+    }
+
+    input.addEventListener('focus', () => showDropdown(input.value));
+    input.addEventListener('input', () => showDropdown(input.value));
+    input.addEventListener('keydown', e => {
+      if (e.key === 'Escape') { dropdown.style.display = 'none'; input.value = ''; }
+    });
+    input.addEventListener('blur', () => setTimeout(() => { dropdown.style.display = 'none'; }, 150));
+
+    wrap.addEventListener('click', async e => {
+      const ddItem = e.target.closest('.proc-conn-dd-item');
+      if (ddItem) {
+        const charKey = ddItem.dataset.charName;
+        const charObj = allChars.find(c => c.key === charKey);
+        if (charObj && !getSelectedKeys().has(charKey)) {
+          addChip(charKey, charObj.label);
+          input.value = '';
+          dropdown.style.display = 'none';
+          await saveConnected();
+        }
+        return;
+      }
+      const chipX = e.target.closest('.proc-conn-chip-x');
+      if (chipX) {
+        chipX.closest('.proc-conn-chip')?.remove();
+        await saveConnected();
+      }
     });
   });
 
@@ -7995,19 +8060,24 @@ function renderNormalisedCard(entry, review) {
   // ── Connected Characters ──
   {
     const connectedChars = rev.connected_chars || [];
+    const connectedSet   = new Set(connectedChars);
     const otherChars = characters
       .filter(c => !c.retired)
       .map(c => ({ key: sortName(c), label: c.moniker || c.name }))
       .filter(({ key }) => key !== entry.charName.toLowerCase())
       .sort((a, b) => a.key.localeCompare(b.key));
     if (otherChars.length > 0) {
+      const allCharsJson = esc(JSON.stringify(otherChars));
       h += `<div class="proc-connected-section">`;
       h += `<div class="proc-detail-label">Connected Characters</div>`;
-      h += `<div class="proc-connected-list">`;
-      for (const { key, label } of otherChars) {
-        const chk = connectedChars.includes(key) ? ' checked' : '';
-        h += `<label class="proc-conn-char-lbl"><input type="checkbox" class="proc-conn-char-chk" data-proc-key="${esc(entry.key)}" data-char-name="${esc(key)}"${chk}> ${esc(label)}</label>`;
+      h += `<div class="proc-conn-typeahead" data-proc-key="${esc(entry.key)}" data-all-chars="${allCharsJson}">`;
+      h += `<div class="proc-conn-chips">`;
+      for (const { key: cKey, label } of otherChars.filter(c => connectedSet.has(c.key))) {
+        h += `<span class="proc-conn-chip" data-char-name="${esc(cKey)}">${esc(label)}<button type="button" class="proc-conn-chip-x" title="Remove">×</button></span>`;
       }
+      h += `</div>`;
+      h += `<input type="text" class="proc-conn-input" data-proc-key="${esc(entry.key)}" placeholder="Add character…" autocomplete="off">`;
+      h += `<div class="proc-conn-dropdown" style="display:none"></div>`;
       h += `</div></div>`;
     }
   }

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -111,7 +111,7 @@ const PHASE_ORDER = {
   resolve_first: 0,
   feeding: 1,
   feed: 1,
-  ambience_increase: 2, ambience_decrease: 2,
+  ambience_increase: 2, ambience_decrease: 2, ambience_change: 2,
   hide_protect: 3,
   investigate: 4,
   attack: 5,
@@ -125,6 +125,7 @@ const PHASE_LABELS = {
   feeding: 'Step 3 — Feeding',
   joint: 'Step 4 — Joint Projects',
   ambience: 'Step 5 — Ambience',
+  ambience_change: 'Step 5 — Ambience',
   hide_protect: 'Step 6 — Defensive',
   investigate: 'Step 7 — Investigative',
   attack: 'Step 8 — Hostile',
@@ -170,7 +171,7 @@ const ST_ACTION_PHASE_MAP = {
 const ACTION_TYPE_LABELS = { ..._ACTION_TYPE_LABELS_BASE, feed: 'Rote Feed' };
 
 const ALL_ACTION_TYPES = [
-  'ambience_increase', 'ambience_decrease', 'feed', 'attack', 'hide_protect',
+  'ambience_change', 'feed', 'attack', 'hide_protect',
   'investigate', 'patrol_scout', 'support', 'misc', 'maintenance', 'xp_spend',
   'block', 'rumour', 'grow', 'acquisition',
 ];
@@ -3044,16 +3045,17 @@ function buildProcessingQueue(subs) {
       const projReview = (sub.projects_resolved || [])[idx] || {};
       let effectiveActionType = projReview.action_type_override || actionType;
 
-      // Issue #196 — dt-form.25's project ambience redesign keeps action
-      // = 'ambience_change' and persists direction in `_ambience_direction`
-      // ('up' | 'down'). Normalise to the canonical enum so phase routing,
-      // ACTION_TYPE_LABELS, and downstream tally + render code match. The
-      // ST override (if set) was already applied above, so this only
-      // touches the player-submitted shape.
-      if (effectiveActionType === 'ambience_change') {
+      // Canonical ambience normalisation: all ambience project entries use
+      // actionType='ambience_change'; direction is stamped as ambienceDir.
+      // Legacy DB entries stored the split types directly — normalise those too.
+      let ambienceDir = null;
+      if (_AMBIENCE_ACTION_TYPES.has(effectiveActionType)) {
         const projDir = resp[`project_${slot}_ambience_direction`] || resp[`project_${slot}_ambience_dir`] || '';
-        if (projDir === 'up' || projDir === 'improve') effectiveActionType = 'ambience_increase';
-        else if (projDir === 'down' || projDir === 'degrade') effectiveActionType = 'ambience_decrease';
+        if (effectiveActionType === 'ambience_increase')      ambienceDir = 'increase';
+        else if (effectiveActionType === 'ambience_decrease') ambienceDir = 'decrease';
+        else if (projDir === 'up'   || projDir === 'improve') ambienceDir = 'increase';
+        else if (projDir === 'down' || projDir === 'degrade') ambienceDir = 'decrease';
+        effectiveActionType = 'ambience_change';
       }
 
       let phaseNum = PHASE_ORDER[effectiveActionType] ?? 7;
@@ -3067,11 +3069,9 @@ function buildProcessingQueue(subs) {
         phaseKey = PHASE_NUM_TO_LABEL[PHASE_JOINT];
       }
 
-      // Issue #196 — for ambience-change projects, dt-form.25 writes the
-      // territory to `_ambience_target` instead of `_territory`. Prefer
-      // the new key, fall back to legacy for pre-redesign drafts.
-      const _isProjAmb = effectiveActionType === 'ambience_increase'
-                      || effectiveActionType === 'ambience_decrease';
+      // For ambience-change projects, dt-form.25 writes the territory to
+      // `_ambience_target` instead of `_territory`. Prefer new key, fall back.
+      const _isProjAmb = effectiveActionType === 'ambience_change';
       const _projTerritory = _isProjAmb
         ? (resp[`project_${slot}_ambience_target`] || resp[`project_${slot}_territory`] || '')
         : (resp[`project_${slot}_territory`] || '');
@@ -3148,6 +3148,7 @@ function buildProcessingQueue(subs) {
         projXpBreakdown:      _projXpBreakdown,
         projXpRows:           _projXpRows,
         projXpBudgetSnapshot: _projXpBudgetSnapshot,
+        ambienceDir,
         // JDT-5: joint membership — populated when the slot belongs to a joint.
         joint_id:        _jointInfo?.joint?._id || null,
         joint_role:      _jointInfo?.role || null,
@@ -3858,18 +3859,10 @@ function _gatherProjectAmbience(subs) {
       const resolved = (sub.projects_resolved || [])[idx] || {};
       // Effective action type: ST override takes priority over player submission
       let effectiveType = resolved.action_type_override || proj.action_type || resp[`project_${n}_action`] || '';
-      // Issue #196 — dt-form.25's project ambience redesign keeps the raw
-      // action `'ambience_change'` and persists direction in
-      // `_ambience_direction` ('up' | 'down'). Sphere-side normalises to
-      // ambience_increase / _decrease at form-write time; project-side does
-      // not. Map at admin read so the existing tally branches still match.
-      if (effectiveType === 'ambience_change') {
-        const dir = resp[`project_${n}_ambience_direction`] || resp[`project_${n}_ambience_dir`] || '';
-        if (dir === 'up' || dir === 'improve') effectiveType = 'ambience_increase';
-        else if (dir === 'down' || dir === 'degrade') effectiveType = 'ambience_decrease';
-      }
-      const isIncrease = effectiveType === 'ambience_increase';
-      const isDecrease = effectiveType === 'ambience_decrease';
+      if (!_AMBIENCE_ACTION_TYPES.has(effectiveType)) continue;
+      const _ambiDir = _ambienceDirection(effectiveType, n, resp);
+      const isIncrease = _ambiDir === 'increase';
+      const isDecrease = _ambiDir === 'decrease';
       if (!isIncrease && !isDecrease) continue;
       // Pending: not yet rolled (pool_status is never updated on project roll, so use roll presence)
       if (!resolved.roll) { pendingCount++; continue; }
@@ -6941,7 +6934,7 @@ function _renderMeritRightPanel(entry, rev) {
   h += `<div class="proc-merit-mode-row">`;
   h += `<span class="proc-mod-label">Action Mode</span>`;
   h += `<span class="proc-merit-mode-chip proc-merit-mode-${mode}">${MODE_LABELS[mode] || mode}</span>`;
-  if (actionType === 'ambience_increase' || actionType === 'ambience_decrease') {
+  if (_isAmbienceAction(actionType)) {
     const mLbl = entry.meritLabel || '';
     const mQual = entry.meritQualifier || '';
     h += `<span class="proc-merit-cat-chip proc-merit-cat-${esc(category)}">${esc(mLbl.toUpperCase())}</span>`;
@@ -7741,8 +7734,13 @@ function _renderActionTypeRow(entry, rev, char) {
       h += `<option value="${esc((m.name || '') + '|' + mQual)}"${isSelected ? ' selected' : ''}>${mLabel} ${mDots}</option>`;
     }
     h += `</select>`;
-  } else if (actionType === 'ambience_increase' || actionType === 'ambience_decrease') {
+  } else if (_isAmbienceAction(actionType)) {
     if (!isMerit) {
+      // Direction badge (increase ↑ / decrease ↓)
+      if (entry.ambienceDir) {
+        const _dirLabel = entry.ambienceDir === 'increase' ? '▲ Increase' : '▼ Decrease';
+        h += `<span class="proc-ambience-dir-badge proc-ambience-dir-${esc(entry.ambienceDir)}">${_dirLabel}</span>`;
+      }
       const _ambiSub = submissions.find(s => s._id === entry.subId);
       const _ambiCtx = String(entry.actionIdx);
       const _stOvrTid = _ambiSub?.st_review?.territory_overrides?.[_ambiCtx];
@@ -7798,7 +7796,7 @@ function _renderActionTypeRow(entry, rev, char) {
           return mName === _meritNameKey || _meritNameKey.includes(mName) || mName.includes(_meritNameKey);
         })
         .sort((a, b) => (a.qualifier || a.area || '').localeCompare(b.qualifier || b.area || ''));
-      const _isAmb = actionType === 'ambience_increase' || actionType === 'ambience_decrease';
+      const _isAmb = _isAmbienceAction(actionType);
       const _hasHWV = _isAmb && (char?.merits || []).some(m => /honey with vinegar/i.test(m.name || ''));
       h += `<span class="proc-feed-lbl">Merit</span>`;
       h += `<select class="proc-recat-select proc-merit-link-sel" data-proc-key="${esc(key)}">`;
@@ -7847,6 +7845,251 @@ function _renderActionTypeRow(entry, rev, char) {
   return h;
 }
 
+/**
+ * Normalised project card — Step 0 template.
+ * Details card: title + outcome + description + player pool (always) + merits/bonuses + XP spend.
+ * Target/lead/cast are removed from Details; target is handled interactively by _renderActionTypeRow.
+ */
+function renderNormalisedCard(entry, review) {
+  const rev               = review || {};
+  const poolStatus        = rev.pool_status       || 'pending';
+  const poolPlayer        = rev.pool_player       || entry.poolPlayer || '';
+  const poolValidated     = rev.pool_validated    || '';
+  const thread            = rev.notes_thread      || [];
+  const feedback          = rev.story_context     || '';
+  const playerFacingNote  = rev.player_facing_note || '';
+
+  const projSub  = submissions.find(s => s._id === entry.subId) || null;
+  const projChar = _findCharForSub(projSub);
+
+  const xpTrait  = projSub?.responses?.[`project_${entry.projSlot}_xp_trait`] || '';
+  const xpAmount = projSub?.responses?.[`project_${entry.projSlot}_xp`]       || '';
+
+  let h = `<div class="proc-action-detail" data-proc-key="${esc(entry.key)}">`;
+
+  // ── Reminder badges ──
+  const actionKey = entryActionKey(entry);
+  if (actionKey) {
+    const badges = cycleReminders.filter(r =>
+      r.targets && r.targets.some(t => t.sub_id === entry.subId && t.action_key === actionKey)
+    );
+    for (const r of badges) {
+      h += `<div class="proc-reminder-badge">⚑ ${esc(r.source_rite)} (${esc(r.source_tradition)}) — ${esc(r.text)}</div>`;
+    }
+  }
+
+  // ── Two-column layout ──
+  h += `<div class="proc-feed-layout"><div class="proc-feed-left">`;
+
+  // ── Details card ──
+  {
+    const titleVal      = rev.title           ?? entry.projTitle   ?? '';
+    const outcomeVal    = rev.desired_outcome ?? entry.projOutcome ?? '';
+    const descVal       = rev.description     ?? entry.description ?? '';
+    const _meritsRaw    = rev.merits_bonuses  ?? entry.projMerits  ?? '';
+    const meritsVal     = Array.isArray(_meritsRaw) ? (_meritsRaw.length ? _meritsRaw.join(', ') : '') : String(_meritsRaw || '');
+    const playerPoolVal = poolPlayer || '';
+    const showOutcome   = entry.actionType === 'misc';
+
+    h += `<div class="proc-feed-desc-card">`;
+    h += `<div class="proc-feed-desc-card-hd"><span class="proc-detail-label">Details</span><button class="dt-btn proc-feed-desc-edit-btn" data-proc-key="${esc(entry.key)}">Edit</button></div>`;
+
+    // View mode
+    h += `<div class="proc-feed-desc-view">`;
+    if (titleVal)                  h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Title</span> ${esc(titleVal)}</div>`;
+    if (showOutcome && outcomeVal) h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Desired Outcome</span> ${esc(outcomeVal)}</div>`;
+    if (descVal)                   h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Description</span> ${esc(descVal)}</div>`;
+    if (entry.projXpRows && entry.projXpRows.length) {
+      h += _renderXpSpendBreakdown(entry.projXpRows, entry.projXpBudgetSnapshot);
+    } else if (entry.projXpBreakdown) {
+      h += `<div class="proc-proj-field"><span class="proc-feed-lbl">XP Spend</span> ${esc(entry.projXpBreakdown)}</div>`;
+    }
+    h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Player’s Pool</span> ${playerPoolVal ? esc(playerPoolVal) : '<span class="proc-feed-desc-empty">—</span>'}</div>`;
+    if (meritsVal)     h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Merits &amp; Bonuses</span> ${esc(meritsVal)}</div>`;
+    if (!titleVal && !(showOutcome && outcomeVal) && !descVal) h += `<div class="proc-proj-field proc-feed-desc-empty">— No details recorded</div>`;
+    h += `</div>`;
+
+    // Edit mode
+    h += `<div class="proc-feed-desc-edit" style="display:none">`;
+    h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Title</span><input type="text" class="proc-detail-input proc-proj-title-input" data-proc-key="${esc(entry.key)}" value="${esc(titleVal)}"></div>`;
+    if (showOutcome) h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Desired Outcome</span><input type="text" class="proc-detail-input proc-proj-outcome-input" data-proc-key="${esc(entry.key)}" value="${esc(outcomeVal)}"></div>`;
+    h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Description</span><textarea class="proc-detail-ta proc-feed-desc-ta" data-proc-key="${esc(entry.key)}" rows="4">${esc(descVal)}</textarea><span class="dt-autosave-status" data-proc-key="${esc(entry.key)}" data-field="description"></span></div>`;
+    h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Player’s Pool</span><input type="text" class="proc-detail-input proc-feed-pool-input" data-proc-key="${esc(entry.key)}" value="${esc(playerPoolVal)}"></div>`;
+    h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Merits &amp; Bonuses</span><input type="text" class="proc-detail-input proc-proj-merits-input" data-proc-key="${esc(entry.key)}" value="${esc(meritsVal)}"></div>`;
+    h += `<div class="proc-feed-desc-actions"><button class="dt-btn proc-proj-desc-save-btn" data-proc-key="${esc(entry.key)}">Save</button><button class="dt-btn proc-feed-desc-cancel-btn" data-proc-key="${esc(entry.key)}">Cancel</button></div>`;
+    h += `</div>`;
+    h += `</div>`; // proc-feed-desc-card
+
+    // XP spend approval row (outside card)
+    if (xpTrait) {
+      const xpLabel = xpAmount ? `XP Spend (${esc(String(xpAmount))} XP)` : 'XP Spend';
+      h += `<div class="proc-proj-field proc-proj-xp"><span class="proc-feed-lbl">${xpLabel}</span> ${esc(xpTrait)}</div>`;
+    }
+
+    // Territory (read-only)
+    if (entry.projTerritory) h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Territory</span> ${esc(entry.projTerritory)}</div>`;
+    if (entry.actionType === 'feed') {
+      const _nomText = _playerFeedTerrsText(projSub);
+      if (_nomText) h += `<div class="proc-proj-field"><span class="proc-feed-lbl">Territories</span> ${esc(_nomText)}</div>`;
+    }
+  }
+
+  // ── Action Type row (includes interactive target for investigate/attack + territory pills) ──
+  h += _renderActionTypeRow(entry, rev, projChar);
+
+  // ── Connected Characters ──
+  {
+    const connectedChars = rev.connected_chars || [];
+    const otherChars = characters
+      .filter(c => !c.retired)
+      .map(c => ({ key: sortName(c), label: c.moniker || c.name }))
+      .filter(({ key }) => key !== entry.charName.toLowerCase())
+      .sort((a, b) => a.key.localeCompare(b.key));
+    if (otherChars.length > 0) {
+      h += `<div class="proc-connected-section">`;
+      h += `<div class="proc-detail-label">Connected Characters</div>`;
+      h += `<div class="proc-connected-list">`;
+      for (const { key, label } of otherChars) {
+        const chk = connectedChars.includes(key) ? ' checked' : '';
+        h += `<label class="proc-conn-char-lbl"><input type="checkbox" class="proc-conn-char-chk" data-proc-key="${esc(entry.key)}" data-char-name="${esc(key)}"${chk}> ${esc(label)}</label>`;
+      }
+      h += `</div></div>`;
+    }
+  }
+
+  // ── ST Pool Builder ──
+  {
+    const char = projChar;
+    const charDiscs    = _charDiscsArray(char).filter(d => d.dots > 0);
+    const allDiscNames = char ? charDiscs.map(d => d.name) : KNOWN_DISCIPLINES;
+
+    let preAttr = '', preSkill = '', preDisc = 'none', showParseRef = false;
+    if (poolValidated) {
+      const parsed = _parsePoolExpr(poolValidated, ALL_ATTRS, ALL_SKILLS, allDiscNames);
+      if (parsed) { preAttr = parsed.attr || ''; preSkill = parsed.skill || ''; preDisc = parsed.disc || 'none'; }
+      else { showParseRef = true; }
+    } else if (projSub) {
+      const resp2 = projSub.responses || {};
+      preAttr  = resp2[`project_${entry.projSlot}_pool_attr`]  || '';
+      preSkill = resp2[`project_${entry.projSlot}_pool_skill`] || '';
+      preDisc  = resp2[`project_${entry.projSlot}_pool_disc`]  || 'none';
+    }
+
+    const attrOptHtml = ['<option value="" data-dots="0">-- Attribute --</option>',
+      ...ALL_ATTRS.map(a => {
+        const dots = char ? (getAttrVal(char, a) || 0) : null;
+        return `<option value="${esc(a)}" data-dots="${dots ?? 0}"${a === preAttr ? ' selected' : ''}>${dots !== null ? `${esc(a)} (${dots})` : esc(a)}</option>`;
+      })
+    ].join('');
+
+    const skillOptHtml = ['<option value="" data-dots="0">-- Skill --</option>',
+      ...ALL_SKILLS.map(s => {
+        const dots = char ? (skTotal(char, s) || 0) : null;
+        return `<option value="${esc(s)}" data-dots="${dots ?? 0}"${s === preSkill ? ' selected' : ''}>${dots !== null ? `${esc(s)} (${dots})` : esc(s)}</option>`;
+      })
+    ].join('');
+
+    const discOptHtml = ['<option value="none" data-dots="0">None</option>',
+      ...allDiscNames.map(name => {
+        const d = charDiscs.find(cd => cd.name === name);
+        const dots = d ? d.dots : null;
+        return `<option value="${esc(name)}" data-dots="${dots ?? 0}"${name === preDisc ? ' selected' : ''}>${dots !== null ? `${esc(name)} (${dots})` : esc(name)}</option>`;
+      })
+    ].join('');
+
+    const eqMod0        = rev.pool_mod_equipment !== undefined ? rev.pool_mod_equipment : 0;
+    const initAttrDots  = preAttr  ? (char ? (getAttrVal(char, preAttr)  || 0) : 0) : 0;
+    const initSkillDots = preSkill ? (char ? (skTotal(char, preSkill)     || 0) : 0) : 0;
+    const initDiscDots  = (preDisc && preDisc !== 'none') ? (charDiscs.find(d => d.name === preDisc)?.dots || 0) : 0;
+    const _pnA          = char && preSkill ? skNineAgain(char, preSkill) : false;
+    const initTotalStr  = _poolTotalDisplay(preAttr, initAttrDots, preSkill, initSkillDots, preDisc, initDiscDots, eqMod0, preSkill, _pnA);
+
+    const _committed = poolStatus === 'confirmed';
+    const _dis = _committed ? ' disabled' : '';
+    h += `<div class="proc-pool-builder${_committed ? ' proc-pool-committed' : ''}" data-proc-key="${esc(entry.key)}">`;
+    h += `<div class="proc-detail-label">ST Pool Builder${!char ? ' <span class="dt-hint">(dot values unavailable — character not loaded)</span>' : ''}${_committed ? ' <span class="proc-pool-committed-badge">[Confirmed]</span>' : ''}</div>`;
+    if (showParseRef) h += `<div class="proc-pool-parse-ref">Could not restore selection — previous: "${esc(poolValidated)}"</div>`;
+    h += '<div class="proc-pool-builder-selects">';
+    h += `<select class="proc-pool-attr" data-proc-key="${esc(entry.key)}"${_dis}>${attrOptHtml}</select>`;
+    h += `<span class="proc-pool-plus">+</span>`;
+    h += `<select class="proc-pool-skill" data-proc-key="${esc(entry.key)}"${_dis}>${skillOptHtml}</select>`;
+    h += `<span class="proc-pool-plus">+</span>`;
+    h += `<select class="proc-pool-disc" data-proc-key="${esc(entry.key)}"${_dis}>${discOptHtml}</select>`;
+    h += '</div>';
+    h += `<input type="hidden" class="proc-pool-mod-val" data-proc-key="${esc(entry.key)}" value="${eqMod0}">`;
+    h += `<div class="proc-pool-total" data-proc-key="${esc(entry.key)}" data-nine-again="${_pnA ? '1' : '0'}">${esc(initTotalStr)}</div>`;
+    h += `<div class="dt-feed-builder-meta dt-skill-meta" data-proc-key="${esc(entry.key)}" data-sub-id="${esc(entry.subId)}">`;
+    h += _buildSpecTogglesHtml(char, preSkill, entry.key, rev.active_feed_specs || [], _dis);
+    h += '</div>';
+    h += '</div>'; // proc-pool-builder
+  }
+
+  // ── ST Notes thread ──
+  h += '<div class="proc-section proc-notes-panel proc-notes-primary">';
+  h += '<div class="proc-detail-label">ST Notes <span class="proc-label-sub">— visible to Claude</span></div>';
+  if (thread.length) {
+    h += '<div class="proc-notes-thread">';
+    for (let noteIdx = 0; noteIdx < thread.length; noteIdx++) {
+      const note = thread[noteIdx];
+      const time = note.created_at
+        ? new Date(note.created_at).toLocaleString('en-GB', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' })
+        : '';
+      h += '<div class="proc-note-entry">';
+      h += `<div class="proc-note-meta">${esc(note.author_name)}${time ? '  ·  ' + esc(time) : ''}<button class="proc-note-delete-btn" data-proc-key="${esc(entry.key)}" data-note-idx="${noteIdx}" title="Delete note">×</button></div>`;
+      h += `<div class="proc-note-text">${esc(note.text)}</div>`;
+      h += '</div>';
+    }
+    h += '</div>';
+  }
+  h += '<div class="proc-note-add">';
+  h += `<textarea class="proc-note-textarea" data-proc-key="${esc(entry.key)}" placeholder="Add ST note..." rows="3"></textarea>`;
+  h += `<button class="dt-btn proc-add-note-btn" data-proc-key="${esc(entry.key)}">Add Note</button>`;
+  h += '</div>';
+  h += '</div>'; // proc-notes-panel
+
+  // ── Narrative Constraint ──
+  h += '<div class="proc-section proc-feedback-section">';
+  h += '<div class="proc-detail-label">Narrative Constraint <span class="proc-label-sub">— Claude must not contradict this</span></div>';
+  h += `<input class="proc-feedback-input" type="text" data-proc-key="${esc(entry.key)}" value="${esc(feedback)}" placeholder="Hard constraint injected into AI prompt (not sent to player)...">`;
+  h += '</div>';
+
+  // ── Player Feedback ──
+  h += '<div class="proc-section proc-player-note-section">';
+  h += '<div class="proc-detail-label">Player Feedback <span class="proc-label-sub">— sent to player</span></div>';
+  h += `<textarea class="proc-player-note-input" data-proc-key="${esc(entry.key)}" rows="2" placeholder="Plain-language note included verbatim in player outcome...">${esc(playerFacingNote)}</textarea>`;
+  h += '</div>';
+
+  // ── XRef callout ──
+  {
+    const xrefLines = [];
+    if (entry.projTerritory) {
+      const others = (_xrefIndex.get(`terr:${entry.projTerritory}`) || []).filter(r => r.charName !== entry.charName);
+      if (others.length) xrefLines.push(`Also in ${entry.projTerritory}: ${others.map(r => `${r.charName} (${r.label})`).join(', ')}`);
+    }
+    if (entry.actionType === 'investigate' && rev.investigate_target_char) {
+      const target = rev.investigate_target_char;
+      const others = (_xrefIndex.get(`inv-target:${target}`) || []).filter(r => r.charName !== entry.charName);
+      if (others.length) xrefLines.push(`Also investigating ${target}: ${others.map(r => r.charName).join(', ')}`);
+      if ([..._procQueueMap.values()].some(e => e.actionType === 'hide_protect' && e.charName.toLowerCase() === target)) {
+        xrefLines.push(`${target} has an active hide/protect action this cycle`);
+      }
+    }
+    if (xrefLines.length) {
+      h += `<div class="proc-xref-callout">`;
+      for (const line of xrefLines) h += `<div class="proc-xref-line">${esc(line)}</div>`;
+      h += `</div>`;
+    }
+  }
+
+  // ── Close left + right panel ──
+  h += '</div>'; // proc-feed-left
+  h += _renderProjRightPanel(entry, projChar, rev);
+  h += '</div>'; // proc-feed-layout
+
+  h += '</div>'; // proc-action-detail
+  return h;
+}
+
 /** Render the expanded detail panel for a single action row. */
 function renderActionPanel(entry, review) {
   const rev = review || {};
@@ -7865,6 +8108,9 @@ function renderActionPanel(entry, review) {
     h += `</div>`;
     return h;
   }
+
+  // Project entries use the normalised card template (Step 0)
+  if (entry.source === 'project') return renderNormalisedCard(entry, review);
 
   const poolPlayer    = rev.pool_player    || entry.poolPlayer || '';
   const poolValidated = rev.pool_validated || '';

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -9089,6 +9089,7 @@ function renderActionPanel(entry, review) {
       h += `<input class="proc-pool-input" type="text" data-proc-key="${esc(entry.key)}" value="${esc(poolValidated)}" placeholder="Enter validated pool...">`;
       h += '</div>';
       h += '</div>';
+      h += _renderMeritOutcomeZone(entry, rev);
     }
   } else if (entry.source !== 'merit') {
     // Non-feeding, non-project, non-sorcery, non-merit: standard 2-column layout
@@ -9104,8 +9105,9 @@ function renderActionPanel(entry, review) {
     h += '</div>'; // proc-detail-grid
   }
 
-  // Validation status — feeding, project, sorcery, merit move to right panel; others rendered here
-  if (entry.source !== 'feeding' && entry.source !== 'project' && !isSorcery && entry.source !== 'merit') {
+  // Validation status — feeding, project, sorcery, merit, skill acquisitions move to right panel; others rendered here
+  const isSkillAcq = entry.source === 'acquisition' && entry.actionType === 'skill_acquisitions';
+  if (entry.source !== 'feeding' && entry.source !== 'project' && !isSorcery && entry.source !== 'merit' && !isSkillAcq) {
     const statusOptions = isSorcery
       ? [['pending', 'Pending'], ['resolved', 'Resolved'], ['no_effect', 'No Effect'], ['skipped', 'Skip']]
       : [['pending', 'Pending'], ['validated', 'Validated'], ['no_roll', 'No Roll Needed'], ['skipped', 'Skip']];

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -5083,6 +5083,48 @@ function renderProcessingMode(container) {
     });
   });
 
+  // Wire Rote chip button → sync hidden checkbox + save
+  container.querySelectorAll('.proc-rote-chip').forEach(btn => {
+    btn.addEventListener('click', async e => {
+      e.stopPropagation();
+      const key = btn.dataset.procKey;
+      const entry = _getQueueEntry(key);
+      if (!entry) return;
+      const isActive = btn.classList.toggle('is-active');
+      const hiddenCb = container.querySelector(`.proc-pool-rote[data-proc-key="${key}"]`);
+      if (hiddenCb) hiddenCb.checked = isActive;
+      if (entry.source === 'project') {
+        await saveEntryReview(entry, { rote: isActive });
+        renderProcessingMode(container);
+      } else {
+        const sub = submissions.find(s => s._id === entry.subId);
+        if (sub) {
+          const stReview = { ...(sub.st_review || {}), feeding_rote: isActive };
+          await updateSubmission(entry.subId, { st_review: stReview });
+          sub.st_review = stReview;
+        }
+      }
+    });
+  });
+
+  // Wire Again option buttons (10/9/8) — mutually exclusive radio group
+  container.querySelectorAll('.proc-again-opt').forEach(btn => {
+    btn.addEventListener('click', async e => {
+      e.stopPropagation();
+      const key = btn.dataset.procKey;
+      const entry = _getQueueEntry(key);
+      if (!entry) return;
+      const again = btn.dataset.again;
+      container.querySelectorAll(`.proc-again-opt[data-proc-key="${key}"]`).forEach(b => b.classList.remove('is-active'));
+      btn.classList.add('is-active');
+      const na = container.querySelector(`.proc-proj-9a[data-proc-key="${key}"]`);
+      const ea = container.querySelector(`.proc-proj-8a[data-proc-key="${key}"]`);
+      if (na) na.checked = (again === '9');
+      if (ea) ea.checked = (again === '8');
+      await saveEntryReview(entry, { nine_again: again === '9', eight_again: again === '8' });
+    });
+  });
+
   // ── feature.51: Equipment modifier ticker (pool mod panel) ──
   _wireTickerHandler(container, {
     decCls: 'proc-equip-mod-dec', incCls: 'proc-equip-mod-inc',
@@ -5207,15 +5249,16 @@ function renderProcessingMode(container) {
   });
 
   // Wire feeding roll buttons
-  // Wire feeding spec toggles
-  container.querySelectorAll('.dt-feed-spec-toggle').forEach(cb => {
-    cb.addEventListener('change', async e => {
+  // Wire spec chip buttons (proc-spec-chip = button elements, no hidden checkbox)
+  container.querySelectorAll('.proc-spec-chip').forEach(btn => {
+    btn.addEventListener('click', async e => {
       e.stopPropagation();
-      const key  = cb.dataset.procKey;
-      const spec = cb.dataset.spec;
+      const key  = btn.dataset.procKey;
+      const spec = btn.dataset.spec;
       const entry = _getQueueEntry(key);
       if (!entry || !spec) return;
       const review = getEntryReview(entry) || {};
+      const isNowActive = btn.classList.toggle('is-active');
 
       // Snapshot current builder expression so it survives future re-renders
       const builder = container.querySelector(`.proc-pool-builder[data-proc-key="${key}"]`);
@@ -5225,7 +5268,7 @@ function renderProcessingMode(container) {
       }
 
       const activeFeedSpecs = [...(review.active_feed_specs || [])];
-      if (cb.checked) {
+      if (isNowActive) {
         if (!activeFeedSpecs.includes(spec)) activeFeedSpecs.push(spec);
       } else {
         const i = activeFeedSpecs.indexOf(spec);
@@ -5235,10 +5278,9 @@ function renderProcessingMode(container) {
       const char = sub
         ? (characters.find(c => String(c._id) === String(sub.character_id)) || charMap.get((sub.character_name || '').toLowerCase().trim()))
         : null;
-      const skillSel = container.querySelector(`.proc-pool-builder[data-proc-key="${key}"] .proc-pool-skill`);
       const specBonus = activeFeedSpecs.reduce((sum, sp) => sum + (char && hasAoE(char, sp) ? 2 : 1), 0);
-      // pool_mod_spec is applied at roll time only — no re-render needed; checkbox state already reflects the change
       await saveEntryReview(entry, { active_feed_specs: activeFeedSpecs, pool_mod_spec: specBonus });
+      _updatePoolTotal(container, key);
     });
   });
 
@@ -6481,17 +6523,22 @@ function _buildSpecTogglesHtml(char, preSkill, procKey, activeSpecs, disabled) {
   if (!char || !preSkill) return '';
   let h = '';
   for (const sp of skSpecs(char, preSkill)) {
-    const checked = activeSpecs.includes(sp) ? ' checked' : '';
     const aoe = hasAoE(char, sp);
-    h += `<label class="dt-spec-toggle-lbl"><input type="checkbox" class="dt-feed-spec-toggle" data-proc-key="${esc(procKey)}" data-spec="${esc(sp)}"${checked}${disabled}>${esc(sp)} ${aoe ? '+2' : '+1'}</label>`;
+    h += `<button type="button" class="proc-spec-chip${activeSpecs.includes(sp) ? ' is-active' : ''}" data-proc-key="${esc(procKey)}" data-spec="${esc(sp)}"${disabled}>${esc(sp)} ${aoe ? '+2' : '+1'}</button>`;
   }
   for (const { spec: isSp, fromSkill } of isSpecs(char)) {
     if (fromSkill === preSkill) continue; // already present as a native spec on this skill
-    const checked = activeSpecs.includes(isSp) ? ' checked' : '';
     const aoe = hasAoE(char, isSp);
-    h += `<label class="dt-spec-toggle-lbl"><input type="checkbox" class="dt-feed-spec-toggle" data-proc-key="${esc(procKey)}" data-spec="${esc(isSp)}"${checked}${disabled}>${esc(isSp)} (${esc(fromSkill)}) ${aoe ? '+2' : '+1'}</label>`;
+    h += `<button type="button" class="proc-spec-chip${activeSpecs.includes(isSp) ? ' is-active' : ''}" data-proc-key="${esc(procKey)}" data-spec="${esc(isSp)}"${disabled}>${esc(isSp)} (${esc(fromSkill)}) ${aoe ? '+2' : '+1'}</button>`;
   }
   return h;
+}
+
+/** Return display label for the Again ticker (state = '10' | '9' | '8'). */
+function _againerLabel(state) {
+  if (state === '8') return '8-Again';
+  if (state === '9') return '9-Again';
+  return '10-Again';
 }
 
 /**
@@ -6556,16 +6603,18 @@ function _formatDiceString(diceString) {
  * nineAgain is optional; when true, appends (9-Again).
  */
 function _poolTotalDisplay(attr, attrDots, skill, skillDots, disc, discDots, modifier, skillName, nineAgain = false) {
-  if (!attr || !skill) return '\u2014 + \u2014 = 0';
-  const base = _buildPoolExpr(attr, attrDots, skill, skillDots, disc, discDots, modifier);
+  if (!attr || !skill) return '\u2014 + \u2014 \u00b10 = 0';
+  let expr = `${attr} ${attrDots} + ${skill} ${skillDots}`;
+  if (disc && disc !== 'none') expr += ` + ${disc} ${discDots}`;
+  expr += ` ${_fmtMod(modifier)}`;
+  const rawTotal = attrDots + skillDots + (disc && disc !== 'none' ? discDots : 0) + modifier;
   const penalty = _unskilledPenalty(skillName, skillDots);
   let result;
   if (!penalty) {
-    result = base;
+    result = `${expr} = ${rawTotal}`;
   } else {
-    const rawTotal = attrDots + skillDots + (disc && disc !== 'none' ? discDots : 0) + modifier;
     const corrected = rawTotal + penalty;
-    result = base.replace(`= ${rawTotal}`, `= ${corrected} (\u2212${Math.abs(penalty)} unskilled)`);
+    result = `${expr} = ${corrected} (\u2212${Math.abs(penalty)} unskilled)`;
   }
   if (nineAgain) result += ' (9-Again)';
   return result;
@@ -6664,8 +6713,6 @@ function _updateVitaeTotal(container, key) {
  * Update the unskilled row in the right panel when the skill dropdown changes.
  */
 function _updateUnskilledRow(container, key) {
-  const right = container.querySelector(`.proc-feed-right[data-proc-key="${key}"]`);
-  if (!right) return;
   const builder = container.querySelector(`.proc-pool-builder[data-proc-key="${key}"]`);
   if (!builder) return;
   const skillSel  = builder.querySelector('.proc-pool-skill');
@@ -6674,7 +6721,7 @@ function _updateUnskilledRow(container, key) {
   const skillDots = parseInt(skillSel.selectedOptions[0]?.dataset.dots || '0', 10);
   const penalty   = _unskilledPenalty(skillName, skillDots);
 
-  const row = right.querySelector('.proc-feed-unskilled-row');
+  const row = container.querySelector(`.proc-feed-unskilled-row[data-proc-key="${key}"]`);
   if (row) {
     if (penalty === 0) {
       row.style.display = 'none';
@@ -6712,30 +6759,38 @@ function _updateFeedBuilderMeta(container, key) {
     if (sidebarNineA) sidebarNineA.checked = nineA;
     const poolTotalEl = container.querySelector(`.proc-pool-total[data-proc-key="${key}"]`);
     if (poolTotalEl) poolTotalEl.dataset.nineAgain = nineA ? '1' : '0';
+    const cur8aProj = container.querySelector(`.proc-proj-8a[data-proc-key="${key}"]`)?.checked || false;
+    const newStateProj = cur8aProj ? '8' : nineA ? '9' : '10';
+    container.querySelectorAll(`.proc-again-opt[data-proc-key="${key}"]`).forEach(b => {
+      b.classList.toggle('is-active', b.dataset.again === newStateProj);
+      if (b.dataset.again === '9') b.classList.toggle('is-auto', nineA && !cur8aProj);
+    });
     let h = '';
     for (const sp of specs) {
       const checked = activeSpecs.includes(sp);
       const bon = (nineA || hasAoE(char, sp)) ? 2 : 1;
-      h += `<label class="dt-spec-toggle-lbl"><input type="checkbox" class="dt-feed-spec-toggle" data-proc-key="${key}" data-spec="${esc(sp)}"${checked ? ' checked' : ''}>${esc(sp)} +${bon}</label>`;
+      h += `<button type="button" class="proc-spec-chip${checked ? ' is-active' : ''}" data-proc-key="${key}" data-spec="${esc(sp)}">${esc(sp)} +${bon}</button>`;
     }
     for (const { spec: isSp, fromSkill } of isSpecs(char)) {
       if (fromSkill === skillName) continue; // already present as a native spec on this skill
       const checked = activeSpecs.includes(isSp);
       const bon = (nineA || hasAoE(char, isSp)) ? 2 : 1;
-      h += `<label class="dt-spec-toggle-lbl"><input type="checkbox" class="dt-feed-spec-toggle" data-proc-key="${key}" data-spec="${esc(isSp)}"${checked ? ' checked' : ''}>${esc(isSp)} (${esc(fromSkill)}) +${bon}</label>`;
+      h += `<button type="button" class="proc-spec-chip${checked ? ' is-active' : ''}" data-proc-key="${key}" data-spec="${esc(isSp)}">${esc(isSp)} (${esc(fromSkill)}) +${bon}</button>`;
     }
     metaEl.innerHTML = h;
-    metaEl.querySelectorAll('.dt-feed-spec-toggle').forEach(cb => {
-      cb.addEventListener('change', async e => {
+    metaEl.querySelectorAll('.proc-spec-chip').forEach(btn => {
+      btn.addEventListener('click', async e => {
         e.stopPropagation();
-        const entry2 = _getQueueEntry(cb.dataset.procKey);
-        if (!entry2 || !cb.dataset.spec) return;
+        const entry2 = _getQueueEntry(btn.dataset.procKey);
+        if (!entry2 || !btn.dataset.spec) return;
         const rev2 = getEntryReview(entry2) || {};
         const activeSpecs2 = [...(rev2.active_feed_specs || [])];
-        if (cb.checked) { if (!activeSpecs2.includes(cb.dataset.spec)) activeSpecs2.push(cb.dataset.spec); }
-        else { const i = activeSpecs2.indexOf(cb.dataset.spec); if (i !== -1) activeSpecs2.splice(i, 1); }
+        const isNowActive = btn.classList.toggle('is-active');
+        if (isNowActive) { if (!activeSpecs2.includes(btn.dataset.spec)) activeSpecs2.push(btn.dataset.spec); }
+        else { const i = activeSpecs2.indexOf(btn.dataset.spec); if (i !== -1) activeSpecs2.splice(i, 1); }
         const specBonus2 = activeSpecs2.reduce((sum, sp) => sum + ((nineA || hasAoE(char, sp)) ? 2 : 1), 0);
         await saveEntryReview(entry2, { active_feed_specs: activeSpecs2, pool_mod_spec: specBonus2 });
+        _updatePoolTotal(container, btn.dataset.procKey);
       });
     });
     return;
@@ -6748,31 +6803,38 @@ function _updateFeedBuilderMeta(container, key) {
   if (sidebarNineAFeed && (nineA || review.nine_again == null)) {
     sidebarNineAFeed.checked = nineA;
   }
+  const cur8aFeed = container.querySelector(`.proc-proj-8a[data-proc-key="${key}"]`)?.checked || false;
+  const newStateFeed = cur8aFeed ? '8' : (nineA && (nineA || review.nine_again == null)) ? '9' : '10';
+  container.querySelectorAll(`.proc-again-opt[data-proc-key="${key}"]`).forEach(b => {
+    b.classList.toggle('is-active', b.dataset.again === newStateFeed);
+    if (b.dataset.again === '9') b.classList.toggle('is-auto', nineA && !cur8aFeed);
+  });
   let h = '';
   for (const sp of specs) {
     const checked = activeSpecs.includes(sp);
     const bon = (nineA || hasAoE(char, sp)) ? 2 : 1;
-    h += `<label class="dt-spec-toggle-lbl"><input type="checkbox" class="dt-feed-spec-toggle" data-proc-key="${key}" data-spec="${esc(sp)}"${checked ? ' checked' : ''}>${esc(sp)} +${bon}</label>`;
+    h += `<button type="button" class="proc-spec-chip${checked ? ' is-active' : ''}" data-proc-key="${key}" data-spec="${esc(sp)}">${esc(sp)} +${bon}</button>`;
   }
   for (const { spec: isSp, fromSkill } of isSpecs(char)) {
     if (fromSkill === skillName) continue; // already present as a native spec on this skill
     const checked = activeSpecs.includes(isSp);
     const bon = (nineA || hasAoE(char, isSp)) ? 2 : 1;
-    h += `<label class="dt-spec-toggle-lbl"><input type="checkbox" class="dt-feed-spec-toggle" data-proc-key="${key}" data-spec="${esc(isSp)}"${checked ? ' checked' : ''}>${esc(isSp)} (${esc(fromSkill)}) +${bon}</label>`;
+    h += `<button type="button" class="proc-spec-chip${checked ? ' is-active' : ''}" data-proc-key="${key}" data-spec="${esc(isSp)}">${esc(isSp)} (${esc(fromSkill)}) +${bon}</button>`;
   }
   metaEl.innerHTML = h;
-  // Wire spec toggles injected by _updateFeedBuilderMeta — no re-render; pool_mod_spec applied at roll time
-  metaEl.querySelectorAll('.dt-feed-spec-toggle').forEach(cb => {
-    cb.addEventListener('change', async e => {
+  metaEl.querySelectorAll('.proc-spec-chip').forEach(btn => {
+    btn.addEventListener('click', async e => {
       e.stopPropagation();
-      const entry2 = _getQueueEntry(cb.dataset.procKey);
-      if (!entry2 || !cb.dataset.spec) return;
+      const entry2 = _getQueueEntry(btn.dataset.procKey);
+      if (!entry2 || !btn.dataset.spec) return;
       const rev2 = getEntryReview(entry2) || {};
       const activeSpecs2 = [...(rev2.active_feed_specs || [])];
-      if (cb.checked) { if (!activeSpecs2.includes(cb.dataset.spec)) activeSpecs2.push(cb.dataset.spec); }
-      else { const i = activeSpecs2.indexOf(cb.dataset.spec); if (i !== -1) activeSpecs2.splice(i, 1); }
+      const isNowActive = btn.classList.toggle('is-active');
+      if (isNowActive) { if (!activeSpecs2.includes(btn.dataset.spec)) activeSpecs2.push(btn.dataset.spec); }
+      else { const i = activeSpecs2.indexOf(btn.dataset.spec); if (i !== -1) activeSpecs2.splice(i, 1); }
       const specBonus2 = activeSpecs2.reduce((sum, sp) => sum + ((nineA || hasAoE(char, sp)) ? 2 : 1), 0);
       await saveEntryReview(entry2, { active_feed_specs: activeSpecs2, pool_mod_spec: specBonus2 });
+      _updatePoolTotal(container, btn.dataset.procKey);
     });
   });
 }
@@ -6808,7 +6870,15 @@ function _updatePoolTotal(container, key) {
   const skillDots = parseInt(skillSel.selectedOptions[0]?.dataset.dots || '0', 10);
   const discDots  = (discSel && disc !== 'none') ? parseInt(discSel.selectedOptions[0]?.dataset.dots || '0', 10) : 0;
   const nineAgain = totalEl.dataset.nineAgain === '1';
-  totalEl.textContent = _poolTotalDisplay(attr, attrDots, skill, skillDots, disc, discDots, modifier, skill, nineAgain);
+  const baseDisplay = _poolTotalDisplay(attr, attrDots, skill, skillDots, disc, discDots, modifier, skill, nineAgain);
+  const entry = _getQueueEntry(key);
+  const review = entry ? (getEntryReview(entry) || {}) : {};
+  const activeSpecs = review.active_feed_specs || [];
+  const sub = entry ? submissions.find(s => s._id === entry.subId) : null;
+  const char = sub
+    ? (characters.find(c => String(c._id) === String(sub.character_id)) || charMap.get((sub.character_name || '').toLowerCase().trim()))
+    : null;
+  totalEl.textContent = _augmentPoolWithSpecs(baseDisplay, activeSpecs, char) || baseDisplay;
 }
 
 /**
@@ -6856,6 +6926,76 @@ function _renderTickerRow(key, label, cssPrefix, displayStr, storedVal) {
   h += `<button class="${cssPrefix}-inc" type="button" data-proc-key="${esc(key)}">+</button>`;
   h += `</span></div>`;
   return h;
+}
+
+/**
+ * Render the Dice Pool Modifiers panel inline inside a Dice Pool Builder card.
+ * kind = 'feeding' | 'project' | 'sorcery'
+ */
+function _renderPoolModPanel(entry, char, rev, kind) {
+  const key = entry.key;
+  const eqMod = rev.pool_mod_equipment !== undefined ? rev.pool_mod_equipment : 0;
+  const eqStr = _fmtMod(eqMod);
+
+  if (kind === 'feeding') {
+    const fg = (char?.merits || []).find(m => m.name === 'Feeding Grounds');
+    const fgDice = fg ? Math.min(fg.rating || 0, 5) : null;
+    const poolValidated = _refreshPoolExpr(rev.pool_validated || '', char);
+    let initSkillName = '', initSkillDots = 0;
+    if (poolValidated && char) {
+      const charDiscs0 = _charDiscsArray(char).filter(d => d.dots > 0).map(d => d.name);
+      const parsed0 = _parsePoolExpr(poolValidated, ALL_ATTRS, ALL_SKILLS, charDiscs0);
+      if (parsed0?.skill) {
+        initSkillName = parsed0.skill;
+        initSkillDots = skTotal(char, initSkillName) || 0;
+      }
+    }
+    const initUnskilled = _unskilledPenalty(initSkillName, initSkillDots);
+    const poolModTotal = (fgDice ?? 0) + initUnskilled + eqMod;
+    const poolModTotalStr = _fmtMod(poolModTotal);
+    const fgDataAttr = fgDice !== null ? String(fgDice) : '';
+    const fgDisplay  = fgDice !== null ? (fgDice > 0 ? `+${fgDice}` : String(fgDice)) : '\u2014';
+
+    let h = `<div class="proc-feed-mod-panel proc-pool-mod-inline" data-proc-key="${esc(key)}" data-fg="${esc(fgDataAttr)}">`;
+    h += `<div class="proc-mod-panel-title">Dice Pool Modifiers</div>`;
+    h += `<div class="proc-mod-row"><span class="proc-mod-label">Feeding Grounds</span><span class="proc-mod-val${fgDice !== null && fgDice > 0 ? ' proc-mod-pos' : ''}">${fgDisplay}</span></div>`;
+    const unskilledDisplay = initUnskilled !== 0 ? String(initUnskilled) : '0';
+    h += `<div class="proc-feed-unskilled-row proc-mod-row" data-proc-key="${esc(key)}" style="${initUnskilled === 0 ? 'display:none' : ''}">`;
+    h += `<span class="proc-mod-label">Unskilled penalty</span>`;
+    h += `<span class="proc-mod-val proc-mod-neg proc-mod-unskilled-val">${unskilledDisplay}</span>`;
+    h += `</div>`;
+    h += _renderTickerRow(key, 'Equipment / other', 'proc-equip-mod', eqStr, eqMod);
+    h += `<span class="proc-mod-total-val" data-proc-key="${esc(key)}" style="display:none">${poolModTotalStr}</span>`;
+    h += `</div>`;
+    return h;
+  }
+
+  if (kind === 'project') {
+    const poolModTotalStr = eqStr;
+    let h = `<div class="proc-feed-mod-panel proc-pool-mod-inline" data-proc-key="${esc(key)}" data-fg="">`;
+    h += `<div class="proc-mod-panel-title">Dice Pool Modifiers</div>`;
+    h += _renderTickerRow(key, 'Equipment / other', 'proc-equip-mod', eqStr, eqMod);
+    h += `<span class="proc-mod-total-val" data-proc-key="${esc(key)}" style="display:none">${poolModTotalStr}</span>`;
+    h += `</div>`;
+    return h;
+  }
+
+  if (kind === 'sorcery') {
+    const isCruac = entry.tradition === 'Cruac';
+    const hasMandragora = isCruac && (char?.merits || []).some(m => m.name === 'Mandragora Garden');
+    const _sorcCommitted = (rev.pool_status || 'pending') === 'confirmed';
+    let h = `<div class="proc-feed-mod-panel proc-pool-mod-inline${_sorcCommitted ? ' proc-pool-committed' : ''}" data-proc-key="${esc(key)}">`;
+    h += `<div class="proc-mod-panel-title">Dice Pool Modifiers${_sorcCommitted ? ' <span class="proc-pool-committed-badge">[Confirmed]</span>' : ''}</div>`;
+    h += `<div class="proc-mod-row"><span class="proc-mod-label">Downtime bonus</span><span class="proc-mod-static">+3</span></div>`;
+    if (hasMandragora) {
+      h += `<div class="proc-mod-row"><span class="proc-mod-label">Mandragora Garden</span><span class="proc-mod-static">+3</span></div>`;
+    }
+    h += _renderTickerRow(key, 'Equipment / other', 'proc-equip-mod', eqStr, eqMod);
+    h += `</div>`;
+    return h;
+  }
+
+  return '';
 }
 
 /**
@@ -7109,33 +7249,10 @@ function _renderSorceryRightPanel(entry, char, sub, rev) {
   const hasMandragora = isCruac && (char?.merits || []).some(m => m.name === 'Mandragora Garden');
   const mgDots       = hasMandragora ? 3 : 0;
   const eqMod        = rev.pool_mod_equipment || 0;
-  const eqStr        = _fmtMod(eqMod);
   const base         = ritInfo ? _computeRitePool(char, ritInfo.attr, ritInfo.skill, ritInfo.disc) : 0;
   const total        = base + 3 + mgDots + eqMod;
 
-  const _sorcCommitted = poolStatus === 'confirmed';
-  const _sorcDis = _sorcCommitted ? ' disabled' : '';
-
   let h = `<div class="proc-feed-right" data-proc-key="${esc(key)}">`;
-
-  // ── Dice Pool Modifiers ──
-  h += `<div class="proc-feed-mod-panel${_sorcCommitted ? ' proc-pool-committed' : ''}" data-proc-key="${esc(key)}">`;
-  h += `<div class="proc-mod-panel-title">Dice Pool Modifiers${_sorcCommitted ? ' <span class="proc-pool-committed-badge">[Confirmed]</span>' : ''}</div>`;
-
-  // +3 Downtime bonus (always on)
-  h += `<div class="proc-mod-row"><span class="proc-mod-label">Downtime bonus</span><span class="proc-mod-static">+3</span></div>`;
-
-  // Mandragora Garden — flat +3 for Cruac users with the merit, always-on.
-  // No toggle: the player-side parked-rite flag is for sustained-cost storage,
-  // not for gating the dice bonus.
-  if (hasMandragora) {
-    h += `<div class="proc-mod-row"><span class="proc-mod-label">Mandragora Garden</span><span class="proc-mod-static">+3</span></div>`;
-  }
-
-  // Equipment / other ticker
-  h += _renderTickerRow(key, 'Equipment / other', 'proc-equip-mod', eqStr, eqMod);
-
-  h += `</div>`; // proc-feed-mod-panel
 
   // ── Roll card ──
   const ritRoll = rev.ritual_roll || null;
@@ -7176,23 +7293,10 @@ function _renderProjRightPanel(entry, char, rev) {
   const poolValidated = _refreshPoolExpr(rev.pool_validated || '', char);
   const poolStatus    = rev.pool_status    || 'pending';
 
-  const eqMod = rev.pool_mod_equipment !== undefined ? rev.pool_mod_equipment : 0;
-  const eqStr = _fmtMod(eqMod);
-  const poolModTotalStr = eqStr;
-
   const succMod = rev.succ_mod_manual !== undefined ? rev.succ_mod_manual : 0;
   const succStr = _fmtMod(succMod);
 
   let h = `<div class="proc-feed-right" data-proc-key="${esc(key)}">`;
-
-  // ── Dice Pool Modifiers (equipment only) ──
-  h += `<div class="proc-feed-mod-panel" data-proc-key="${esc(key)}" data-fg="">`;
-  h += `<div class="proc-mod-panel-title">Dice Pool Modifiers</div>`;
-  h += _renderTickerRow(key, 'Equipment / other', 'proc-equip-mod', eqStr, eqMod);
-  h += `<div class="proc-mod-total-row"><span class="proc-mod-label">Total</span>`;
-  h += `<span class="proc-mod-total-val" data-proc-key="${esc(key)}">${poolModTotalStr}</span>`;
-  h += `</div>`;
-  h += `</div>`; // proc-feed-mod-panel
 
   // ── Investigation: Target Secrecy + Lead toggle (project investigate only) ──
   if (entry.actionType === 'investigate') {
@@ -7281,7 +7385,7 @@ function _renderProjRightPanel(entry, char, rev) {
   const eightAgainState = rev.eight_again || false;
   // Auto-detect nine_again from the character's validated skill — only when not explicitly saved
   const nineAgainState = _resolveNineAgainState(rev, poolValidated, char);
-  h += `<div class="proc-feed-right-section proc-feed-toggles-row">`;
+  h += `<div class="proc-feed-right-section proc-feed-toggles-row" style="display:none">`;
   h += `<label class="proc-pool-rote-label proc-feed-rote-right"><input type="checkbox" class="proc-pool-rote" data-proc-key="${esc(key)}"${isRote ? ' checked' : ''}> Rote Action</label>`;
   h += `<label class="proc-pool-rote-label proc-feed-rote-right"><input type="checkbox" class="proc-proj-9a" data-proc-key="${esc(key)}"${nineAgainState ? ' checked' : ''}> 9-Again</label>`;
   h += `<label class="proc-pool-rote-label proc-feed-rote-right"><input type="checkbox" class="proc-proj-8a" data-proc-key="${esc(key)}"${eightAgainState ? ' checked' : ''}> 8-Again</label>`;
@@ -7338,52 +7442,7 @@ function _renderProjRightPanel(entry, char, rev) {
 function _renderFeedRightPanel(entry, char, rev) {
   const key = entry.key;
 
-  // ── Pool modifier panel data ──
-  const fg = (char?.merits || []).find(m => m.name === 'Feeding Grounds');
-  const fgDice = fg ? Math.min(fg.rating || 0, 5) : null; // null = char not loaded; cap at merit max
-
-  // Always derive pool expression from current effective character stats (dots + bonus)
-  const poolValidated = _refreshPoolExpr(rev.pool_validated || '', char);
-  let initSkillName = '', initSkillDots = 0;
-  if (poolValidated && char) {
-    const charDiscs0 = _charDiscsArray(char).filter(d => d.dots > 0).map(d => d.name);
-    const parsed0 = _parsePoolExpr(poolValidated, ALL_ATTRS, ALL_SKILLS, charDiscs0);
-    if (parsed0?.skill) {
-      initSkillName = parsed0.skill;
-      initSkillDots = skTotal(char, initSkillName) || 0;
-    }
-  }
-  const initUnskilled = _unskilledPenalty(initSkillName, initSkillDots);
-
-  const eqMod = rev.pool_mod_equipment !== undefined ? rev.pool_mod_equipment : 0;
-  const eqStr = _fmtMod(eqMod);
-  const poolModTotal = (fgDice ?? 0) + initUnskilled + eqMod;
-  const poolModTotalStr = _fmtMod(poolModTotal);
-
-  // fgDice data attr: '' when char null (so live update can detect "unknown")
-  const fgDataAttr = fgDice !== null ? String(fgDice) : '';
-  const fgDisplay  = fgDice !== null ? (fgDice > 0 ? `+${fgDice}` : String(fgDice)) : '\u2014';
-
   let h = `<div class="proc-feed-right" data-proc-key="${esc(key)}">`;
-
-  // ── Dice Pool Modifiers ──
-  h += `<div class="proc-feed-right-section proc-feed-mod-panel" data-proc-key="${esc(key)}" data-fg="${esc(fgDataAttr)}">`;
-  h += `<div class="proc-mod-panel-title">Dice Pool Modifiers</div>`;
-  // Feeding Grounds row
-  h += `<div class="proc-mod-row"><span class="proc-mod-label">Feeding Grounds</span><span class="proc-mod-val${fgDice !== null && fgDice > 0 ? ' proc-mod-pos' : ''}">${fgDisplay}</span></div>`;
-  // Unskilled penalty row (hidden when 0)
-  const unskilledDisplay = initUnskilled !== 0 ? String(initUnskilled) : '0';
-  h += `<div class="proc-feed-unskilled-row proc-mod-row" data-proc-key="${esc(key)}" style="${initUnskilled === 0 ? 'display:none' : ''}">`;
-  h += `<span class="proc-mod-label">Unskilled penalty</span>`;
-  h += `<span class="proc-mod-val proc-mod-neg proc-mod-unskilled-val">${unskilledDisplay}</span>`;
-  h += `</div>`;
-  // Equipment ticker
-  h += _renderTickerRow(key, 'Equipment / other', 'proc-equip-mod', eqStr, eqMod);
-  // Total
-  h += `<div class="proc-mod-total-row"><span class="proc-mod-label">Total</span>`;
-  h += `<span class="proc-mod-total-val" data-proc-key="${esc(key)}">${poolModTotalStr}</span>`;
-  h += `</div>`;
-  h += `</div>`; // proc-feed-mod-panel
 
   // ── Vitae Tally ──
   const herd = (char?.merits || []).find(m => m.name === 'Herd');
@@ -7529,7 +7588,7 @@ function _renderFeedRightPanel(entry, char, rev) {
   const isRote = entry.feedRote || feedSubR?.st_review?.feeding_rote || false;
   const eightAgainStateFeed = rev.eight_again || false;
   const nineAgainStateFeed = _resolveNineAgainState(rev, poolValidated, char);
-  h += `<div class="proc-feed-right-section proc-feed-toggles-row">`;
+  h += `<div class="proc-feed-right-section proc-feed-toggles-row" style="display:none">`;
   h += `<label class="proc-pool-rote-label proc-feed-rote-right"><input type="checkbox" class="proc-pool-rote" data-proc-key="${esc(key)}"${isRote ? ' checked' : ''}> Rote Action</label>`;
   h += `<label class="proc-pool-rote-label proc-feed-rote-right"><input type="checkbox" class="proc-proj-9a" data-proc-key="${esc(key)}"${nineAgainStateFeed ? ' checked' : ''}> 9-Again</label>`;
   h += `<label class="proc-pool-rote-label proc-feed-rote-right"><input type="checkbox" class="proc-proj-8a" data-proc-key="${esc(key)}"${eightAgainStateFeed ? ' checked' : ''}> 8-Again</label>`;
@@ -8063,7 +8122,7 @@ function renderNormalisedCard(entry, review) {
     }
   }
 
-  // ── ST Pool Builder ──
+  // ── Dice Pool Builder ──
   {
     const char = projChar;
     const charDiscs    = _charDiscsArray(char).filter(d => d.dots > 0);
@@ -8112,8 +8171,11 @@ function renderNormalisedCard(entry, review) {
 
     const _committed = poolStatus === 'confirmed';
     const _dis = _committed ? ' disabled' : '';
+    const _isRote0  = rev.rote || false;
+    const _is8a0    = rev.eight_again || false;
+    const _again0   = _is8a0 ? '8' : (_pnA ? '9' : (rev.nine_again ? '9' : '10'));
     h += `<div class="proc-pool-builder${_committed ? ' proc-pool-committed' : ''}" data-proc-key="${esc(entry.key)}">`;
-    h += `<div class="proc-detail-label">ST Pool Builder${!char ? ' <span class="dt-hint">(dot values unavailable — character not loaded)</span>' : ''}${_committed ? ' <span class="proc-pool-committed-badge">[Confirmed]</span>' : ''}</div>`;
+    h += `<div class="proc-detail-label">Dice Pool Builder${!char ? ' <span class="dt-hint">(dot values unavailable — character not loaded)</span>' : ''}${_committed ? ' <span class="proc-pool-committed-badge">[Confirmed]</span>' : ''}</div>`;
     if (showParseRef) h += `<div class="proc-pool-parse-ref">Could not restore selection — previous: "${esc(poolValidated)}"</div>`;
     h += '<div class="proc-pool-builder-selects">';
     h += `<select class="proc-pool-attr" data-proc-key="${esc(entry.key)}"${_dis}>${attrOptHtml}</select>`;
@@ -8123,10 +8185,17 @@ function renderNormalisedCard(entry, review) {
     h += `<select class="proc-pool-disc" data-proc-key="${esc(entry.key)}"${_dis}>${discOptHtml}</select>`;
     h += '</div>';
     h += `<input type="hidden" class="proc-pool-mod-val" data-proc-key="${esc(entry.key)}" value="${eqMod0}">`;
-    h += `<div class="proc-pool-total" data-proc-key="${esc(entry.key)}" data-nine-again="${_pnA ? '1' : '0'}">${esc(initTotalStr)}</div>`;
+    h += `<div class="proc-pool-chips">`;
     h += `<div class="dt-feed-builder-meta dt-skill-meta" data-proc-key="${esc(entry.key)}" data-sub-id="${esc(entry.subId)}">`;
     h += _buildSpecTogglesHtml(char, preSkill, entry.key, rev.active_feed_specs || [], _dis);
     h += '</div>';
+    h += `<button class="proc-rote-chip${_isRote0 ? ' is-active' : ''}" type="button" data-proc-key="${esc(entry.key)}"${_dis ? ' disabled' : ''}>Rote</button>`;
+    h += `<button class="proc-again-opt${_again0 === '10' ? ' is-active' : ''}" type="button" data-proc-key="${esc(entry.key)}" data-again="10"${_dis ? ' disabled' : ''}>10-Again</button>`;
+    h += `<button class="proc-again-opt${_again0 === '9' ? ' is-active' : ''}${_pnA && !_is8a0 && _again0 === '9' ? ' is-auto' : ''}" type="button" data-proc-key="${esc(entry.key)}" data-again="9"${_dis ? ' disabled' : ''}>9-Again</button>`;
+    h += `<button class="proc-again-opt${_again0 === '8' ? ' is-active' : ''}" type="button" data-proc-key="${esc(entry.key)}" data-again="8"${_dis ? ' disabled' : ''}>8-Again</button>`;
+    h += '</div>';
+    h += _renderPoolModPanel(entry, char, rev, 'project');
+    h += `<div class="proc-pool-total" data-proc-key="${esc(entry.key)}" data-nine-again="${_pnA ? '1' : '0'}">${esc(initTotalStr)}</div>`;
     h += '</div>'; // proc-pool-builder
   }
 
@@ -8700,7 +8769,7 @@ function renderActionPanel(entry, review) {
     const resp = feedSub?.responses || {};
     const char = feedChar;
 
-    // ST Pool Builder — always rendered; dot values filled from char data when available
+    // Dice Pool Builder — always rendered; dot values filled from char data when available
     {
       const charDiscs = _charDiscsArray(char).filter(d => d.dots > 0);
       const discNames = charDiscs.map(d => d.name);
@@ -8788,8 +8857,13 @@ function renderActionPanel(entry, review) {
 
       const _feedCommitted = poolStatus === 'confirmed';
       const _feedDis = _feedCommitted ? ' disabled' : '';
+      const _feedSubR0  = submissions.find(s => s._id === entry.subId);
+      const _isRoteFeed = entry.feedRote || _feedSubR0?.st_review?.feeding_rote || false;
+      const _pnAFeed    = char && preSkill ? skNineAgain(char, preSkill) : false;
+      const _is8aFeed   = rev.eight_again || false;
+      const _againFeed  = _is8aFeed ? '8' : (_pnAFeed ? '9' : (rev.nine_again ? '9' : '10'));
       h += `<div class="proc-pool-builder${_feedCommitted ? ' proc-pool-committed' : ''}" data-proc-key="${esc(entry.key)}">`;
-      h += `<div class="proc-detail-label">ST Pool Builder${!char ? ' <span class="dt-hint">(dot values unavailable \u2014 character not loaded)</span>' : ''}${_feedCommitted ? ' <span class="proc-pool-committed-badge">[Confirmed]</span>' : ''}</div>`;
+      h += `<div class="proc-detail-label">Dice Pool Builder${!char ? ' <span class="dt-hint">(dot values unavailable \u2014 character not loaded)</span>' : ''}${_feedCommitted ? ' <span class="proc-pool-committed-badge">[Confirmed]</span>' : ''}</div>`;
       if (showParseRef) {
         h += `<div class="proc-pool-parse-ref">Could not restore selection \u2014 previous: "${esc(poolValidated)}"</div>`;
       }
@@ -8800,13 +8874,18 @@ function renderActionPanel(entry, review) {
       h += `<span class="proc-pool-plus">+</span>`;
       h += `<select class="proc-pool-disc" data-proc-key="${esc(entry.key)}"${_feedDis}>${discOptHtml}</select>`;
       h += '</div>'; // proc-pool-builder-selects
-      // Hidden modifier input — receives right-panel pool mod total so _readBuilderExpr includes it
       h += `<input type="hidden" class="proc-pool-mod-val" data-proc-key="${esc(entry.key)}" value="${initModForDisplay}">`;
-      h += `<div class="proc-pool-total" data-proc-key="${esc(entry.key)}">${esc(initTotalStr)}</div>`;
-      // Skill metadata: spec checkboxes only (9-again lives in the right panel)
+      h += `<div class="proc-pool-chips">`;
       h += `<div class="dt-feed-builder-meta dt-skill-meta" data-proc-key="${esc(entry.key)}" data-sub-id="${esc(entry.subId)}">`;
       h += _buildSpecTogglesHtml(char, preSkill, entry.key, rev.active_feed_specs || [], _feedDis);
       h += '</div>';
+      h += `<button class="proc-rote-chip${_isRoteFeed ? ' is-active' : ''}" type="button" data-proc-key="${esc(entry.key)}"${_feedDis ? ' disabled' : ''}>Rote</button>`;
+      h += `<button class="proc-again-opt${_againFeed === '10' ? ' is-active' : ''}" type="button" data-proc-key="${esc(entry.key)}" data-again="10"${_feedDis ? ' disabled' : ''}>10-Again</button>`;
+      h += `<button class="proc-again-opt${_againFeed === '9' ? ' is-active' : ''}${_pnAFeed && !_is8aFeed && _againFeed === '9' ? ' is-auto' : ''}" type="button" data-proc-key="${esc(entry.key)}" data-again="9"${_feedDis ? ' disabled' : ''}>9-Again</button>`;
+      h += `<button class="proc-again-opt${_againFeed === '8' ? ' is-active' : ''}" type="button" data-proc-key="${esc(entry.key)}" data-again="8"${_feedDis ? ' disabled' : ''}>8-Again</button>`;
+      h += '</div>'; // proc-pool-chips
+      h += _renderPoolModPanel(entry, char, rev, 'feeding');
+      h += `<div class="proc-pool-total" data-proc-key="${esc(entry.key)}">${esc(initTotalStr)}</div>`;
       h += '</div>'; // proc-pool-builder
     }
   } else if (entry.source === 'project') {
@@ -8873,8 +8952,11 @@ function renderActionPanel(entry, review) {
 
     const _projCommitted = poolStatus === 'confirmed';
     const _projDis = _projCommitted ? ' disabled' : '';
+    const _isRoteProj = rev.rote || false;
+    const _is8aProj   = rev.eight_again || false;
+    const _againProj  = _is8aProj ? '8' : (_pnA ? '9' : (rev.nine_again ? '9' : '10'));
     h += `<div class="proc-pool-builder${_projCommitted ? ' proc-pool-committed' : ''}" data-proc-key="${esc(entry.key)}">`;
-    h += `<div class="proc-detail-label">ST Pool Builder${!char ? ' <span class="dt-hint">(dot values unavailable \u2014 character not loaded)</span>' : ''}${_projCommitted ? ' <span class="proc-pool-committed-badge">[Confirmed]</span>' : ''}</div>`;
+    h += `<div class="proc-detail-label">Dice Pool Builder${!char ? ' <span class="dt-hint">(dot values unavailable \u2014 character not loaded)</span>' : ''}${_projCommitted ? ' <span class="proc-pool-committed-badge">[Confirmed]</span>' : ''}</div>`;
     if (showParseRef) {
       h += `<div class="proc-pool-parse-ref">Could not restore selection \u2014 previous: "${esc(poolValidated)}"</div>`;
     }
@@ -8886,11 +8968,17 @@ function renderActionPanel(entry, review) {
     h += `<select class="proc-pool-disc" data-proc-key="${esc(entry.key)}"${_projDis}>${discOptHtml}</select>`;
     h += '</div>';
     h += `<input type="hidden" class="proc-pool-mod-val" data-proc-key="${esc(entry.key)}" value="${initModForDisplay}">`;
-    h += `<div class="proc-pool-total" data-proc-key="${esc(entry.key)}" data-nine-again="${_pnA ? '1' : '0'}">${esc(initTotalStr)}</div>`;
-    // Spec toggles only — 9-again moved to right sidebar for project entries
+    h += `<div class="proc-pool-chips">`;
     h += `<div class="dt-feed-builder-meta dt-skill-meta" data-proc-key="${esc(entry.key)}" data-sub-id="${esc(entry.subId)}">`;
     h += _buildSpecTogglesHtml(char, preSkill, entry.key, rev.active_feed_specs || [], _projDis);
     h += '</div>';
+    h += `<button class="proc-rote-chip${_isRoteProj ? ' is-active' : ''}" type="button" data-proc-key="${esc(entry.key)}"${_projDis ? ' disabled' : ''}>Rote</button>`;
+    h += `<button class="proc-again-opt${_againProj === '10' ? ' is-active' : ''}" type="button" data-proc-key="${esc(entry.key)}" data-again="10"${_projDis ? ' disabled' : ''}>10-Again</button>`;
+    h += `<button class="proc-again-opt${_againProj === '9' ? ' is-active' : ''}${_pnA && !_is8aProj && _againProj === '9' ? ' is-auto' : ''}" type="button" data-proc-key="${esc(entry.key)}" data-again="9"${_projDis ? ' disabled' : ''}>9-Again</button>`;
+    h += `<button class="proc-again-opt${_againProj === '8' ? ' is-active' : ''}" type="button" data-proc-key="${esc(entry.key)}" data-again="8"${_projDis ? ' disabled' : ''}>8-Again</button>`;
+    h += '</div>'; // proc-pool-chips
+    h += _renderPoolModPanel(entry, char, rev, 'project');
+    h += `<div class="proc-pool-total" data-proc-key="${esc(entry.key)}" data-nine-again="${_pnA ? '1' : '0'}">${esc(initTotalStr)}</div>`;
     h += '</div>'; // proc-pool-builder
   } else if (isSorcery) {
     // ── Sorcery: player details card + rite dropdown + computed pool display + result note ──
@@ -8933,6 +9021,8 @@ function renderActionPanel(entry, review) {
     const shortRiteName = entry.riteName && entry.riteName.length <= 60;
     if (overridden && shortRiteName) h += `<span class="proc-recat-original">Player: ${esc(entry.riteName)}</span>`;
     h += '</div>';
+
+    h += _renderPoolModPanel(entry, sorcChar, rev, 'sorcery');
 
     // Pool + target display (auto-computed from selected rite + char)
     // For Custom, build a fake ritInfo from tradition pool + entered level

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -7669,6 +7669,35 @@ function _renderXpSpendBreakdown(rows, budget) {
     `</div>`;
 }
 
+// ── Action progress ribbon ────────────────────────────────────────────────────
+// Pending → Valid → Complete, derived from review state at render time.
+// Valid:    any non-pending pool_status (mechanical decisions made).
+// Complete: terminal pool_status AND narrative written (player_facing_note or story_context).
+function _deriveActionRibbonState(rev) {
+  const ps = rev?.pool_status || 'pending';
+  if (ps === 'pending') return 'pending';
+  const hasNarrative = !!(rev?.player_facing_note?.trim() || rev?.story_context?.trim());
+  if (DONE_STATUSES.has(ps) && hasNarrative) return 'complete';
+  return 'valid';
+}
+
+function _renderActionRibbon(rev) {
+  const state = _deriveActionRibbonState(rev);
+  const steps = [['pending', 'Pending'], ['valid', 'Valid'], ['complete', 'Complete']];
+  const activeIdx = steps.findIndex(([s]) => s === state);
+  let h = '<div class="proc-action-ribbon">';
+  steps.forEach(([val, label], i) => {
+    let cls = 'proc-ar-step';
+    if (i < activeIdx)        cls += ' ar-past';
+    else if (i === activeIdx) cls += ` ar-active ar-${val}`;
+    else                      cls += ' ar-future';
+    h += `<span class="${cls}">${label}</span>`;
+    if (i < steps.length - 1) h += '<span class="proc-ar-arrow">›</span>';
+  });
+  h += '</div>';
+  return h;
+}
+
 function _renderActionTypeRow(entry, rev, char, opts = {}) {
   const { suppressTerrPills = false } = opts;
   const key        = entry.key;
@@ -7824,6 +7853,7 @@ function _renderActionTypeRow(entry, rev, char, opts = {}) {
     }
   }
 
+  h += _renderActionRibbon(rev);
   h += `</div>`;
 
   // Attack merit dropdown (second row, shown for both project and merit)

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -5497,7 +5497,13 @@ function renderProcessingMode(container) {
   // Wire connected character typeahead widgets
   container.querySelectorAll('.proc-conn-typeahead').forEach(wrap => {
     const key      = wrap.dataset.procKey;
-    const allChars = JSON.parse(wrap.dataset.allChars || '[]');
+    const entry    = _getQueueEntry(key);
+    const selfKey  = (entry?.charName || '').toLowerCase();
+    const allChars = characters
+      .filter(c => !c.retired)
+      .map(c => ({ key: sortName(c), label: c.moniker || c.name || c.character_name || '?' }))
+      .filter(c => c.key !== selfKey)
+      .sort((a, b) => a.key.localeCompare(b.key));
     const input    = wrap.querySelector('.proc-conn-input');
     const dropdown = wrap.querySelector('.proc-conn-dropdown');
     const chipsEl  = wrap.querySelector('.proc-conn-chips');
@@ -8057,31 +8063,6 @@ function renderNormalisedCard(entry, review) {
     }
   }
 
-  // ── Connected Characters ──
-  {
-    const connectedChars = rev.connected_chars || [];
-    const connectedSet   = new Set(connectedChars);
-    const otherChars = characters
-      .filter(c => !c.retired)
-      .map(c => ({ key: sortName(c), label: c.moniker || c.name }))
-      .filter(({ key }) => key !== entry.charName.toLowerCase())
-      .sort((a, b) => a.key.localeCompare(b.key));
-    if (otherChars.length > 0) {
-      const allCharsJson = esc(JSON.stringify(otherChars));
-      h += `<div class="proc-connected-section">`;
-      h += `<div class="proc-detail-label">Connected Characters</div>`;
-      h += `<div class="proc-conn-typeahead" data-proc-key="${esc(entry.key)}" data-all-chars="${allCharsJson}">`;
-      h += `<div class="proc-conn-chips">`;
-      for (const { key: cKey, label } of otherChars.filter(c => connectedSet.has(c.key))) {
-        h += `<span class="proc-conn-chip" data-char-name="${esc(cKey)}">${esc(label)}<button type="button" class="proc-conn-chip-x" title="Remove">×</button></span>`;
-      }
-      h += `</div>`;
-      h += `<input type="text" class="proc-conn-input" data-proc-key="${esc(entry.key)}" placeholder="Add character…" autocomplete="off">`;
-      h += `<div class="proc-conn-dropdown" style="display:none"></div>`;
-      h += `</div></div>`;
-    }
-  }
-
   // ── ST Pool Builder ──
   {
     const char = projChar;
@@ -8207,6 +8188,32 @@ function renderNormalisedCard(entry, review) {
   }
 
   // ── Close left + right panel ──
+  // ── Connected Characters ──
+  {
+    const connectedChars = rev.connected_chars || [];
+    const connectedSet   = new Set(connectedChars);
+    const otherChars = characters
+      .filter(c => !c.retired)
+      .map(c => ({ key: sortName(c), label: c.moniker || c.name }))
+      .filter(({ key }) => key !== entry.charName.toLowerCase())
+      .sort((a, b) => a.key.localeCompare(b.key));
+    if (otherChars.length > 0) {
+      h += `<div class="proc-connected-section">`;
+      h += `<div class="proc-detail-label">Connected Characters</div>`;
+      h += `<div class="proc-conn-typeahead" data-proc-key="${esc(entry.key)}">`;
+      h += `<div class="proc-conn-input-row">`;
+      h += `<input type="text" class="proc-conn-input" data-proc-key="${esc(entry.key)}" placeholder="Add character…" autocomplete="off">`;
+      h += `<div class="proc-conn-dropdown" style="display:none"></div>`;
+      h += `</div>`;
+      h += `<div class="proc-conn-chips">`;
+      for (const { key: cKey, label } of otherChars.filter(c => connectedSet.has(c.key))) {
+        h += `<span class="proc-conn-chip" data-char-name="${esc(cKey)}">${esc(label)}<button type="button" class="proc-conn-chip-x" title="Remove">×</button></span>`;
+      }
+      h += `</div>`;
+      h += `</div></div>`;
+    }
+  }
+
   h += '</div>'; // proc-feed-left
   h += _renderProjRightPanel(entry, projChar, rev);
   h += '</div>'; // proc-feed-layout

--- a/public/js/data/helpers.js
+++ b/public/js/data/helpers.js
@@ -173,7 +173,7 @@ export function displayNameRaw(c) {
 /** Sort key: moniker || name (no honorific). Not redacted — used only for
  *  internal sort order, never rendered to the DOM. */
 export function sortName(c) {
-  return (c.moniker || c.name).toLowerCase();
+  return (c.moniker || c.name || '').toLowerCase();
 }
 
 /** Dropdown option label: moniker || name (no honorific, no redaction).

--- a/public/js/dt-proto-boot.js
+++ b/public/js/dt-proto-boot.js
@@ -17,6 +17,8 @@ const [submissions, cycles, territories, chars] = await Promise.all([
 
 document.getElementById('proto-loading').remove();
 
+console.info('[dt-proto] data loaded — subs:', submissions.length, '| cycles:', cycles.length, '| chars:', chars.length);
+
 // ── 2. Fetch shim — intercepts /api/ calls, returns static data ─────────────
 const _realFetch = window.fetch.bind(window);
 
@@ -40,6 +42,8 @@ window.fetch = function shimFetch(url, opts = {}) {
     return ok(body, status);
   };
 
+  console.debug(`[shim] ${method} ${apiPath}`);
+
   if (method === 'GET') {
     if (seg[0] === 'downtime_cycles') return ok(cycles);
 
@@ -48,6 +52,7 @@ window.fetch = function shimFetch(url, opts = {}) {
       const result = cycleId
         ? submissions.filter(s => String(s.cycle_id) === String(cycleId))
         : submissions;
+      console.debug(`[shim] downtime_submissions → ${result.length} results (cycle_id=${cycleId})`);
       return ok(result);
     }
 

--- a/public/js/dt-proto-boot.js
+++ b/public/js/dt-proto-boot.js
@@ -1,0 +1,88 @@
+// DT Prototype boot — fetch shim + static data + initDowntimeView.
+// Committed on this branch; the data it loads (public/dt-proto-data/) is gitignored.
+
+const DATA = '/dt-proto-data';
+
+// ── 1. Load static data (real fetch, before shim is installed) ──────────────
+const [submissions, cycles, territories, chars] = await Promise.all([
+  fetch(`${DATA}/submissions.json`).then(r => r.json()),
+  fetch(`${DATA}/cycles.json`).then(r => r.json()),
+  fetch(`${DATA}/territories.json`).then(r => r.json()),
+  fetch(`${DATA}/characters.json`).then(r => r.json()),
+]).catch(err => {
+  document.getElementById('proto-loading').textContent =
+    `Failed to load proto data: ${err.message}. Make sure public/dt-proto-data/ exists.`;
+  throw err;
+});
+
+document.getElementById('proto-loading').remove();
+
+// ── 2. Fetch shim — intercepts /api/ calls, returns static data ─────────────
+const _realFetch = window.fetch.bind(window);
+
+window.fetch = function shimFetch(url, opts = {}) {
+  const urlStr = String(typeof url === 'string' ? url : url.url ?? url);
+  if (!urlStr.includes('/api/')) return _realFetch(url, opts);
+
+  const method = (opts.method || 'GET').toUpperCase();
+  const apiPath = urlStr.replace(/^.*\/api\//, '');
+  const seg = apiPath.split('?')[0].split('/');
+
+  const ok = (body, status = 200) =>
+    Promise.resolve(new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    }));
+  const noContent = () =>
+    Promise.resolve(new Response(null, { status: 204 }));
+  const echo = (status = 200) => {
+    const body = opts.body ? (() => { try { return JSON.parse(opts.body); } catch { return {}; } })() : {};
+    return ok(body, status);
+  };
+
+  if (method === 'GET') {
+    if (seg[0] === 'downtime_cycles') return ok(cycles);
+
+    if (seg[0] === 'downtime_submissions') {
+      const cycleId = new URL(urlStr, location.href).searchParams.get('cycle_id');
+      const result = cycleId
+        ? submissions.filter(s => String(s.cycle_id) === String(cycleId))
+        : submissions;
+      return ok(result);
+    }
+
+    if (seg[0] === 'territories') return ok(territories);
+    if (seg[0] === 'characters') return ok(chars);
+
+    if (seg[0] === 'players') {
+      if (seg[1] === 'display-names') {
+        return ok(chars.filter(c => c.player).map(c => ({
+          character_id: String(c._id),
+          display_name: c.player,
+        })));
+      }
+      return ok([]);
+    }
+
+    // Shim out everything else as empty
+    if (seg[0] === 'st_mods') return ok([]);
+    if (seg[0] === 'game_sessions') return ok([]);
+    if (seg[0] === 'npc_personas') return ok([]);
+    if (seg[0] === 'settings') return ok({});
+    if (seg[0] === 'project_invitations') return ok([]);
+    if (seg[0] === 'tickets') return ok([]);
+    if (seg[0] === 'tracker_state') return ok(null, 404);
+    if (seg[0] === 'auth') return ok({ role: 'st', username: 'Proto ST' });
+
+    console.warn('[dt-proto shim] unhandled GET:', apiPath);
+    return ok([]);
+  }
+
+  if (method === 'DELETE') return noContent();
+  if (method === 'POST') return echo(201);
+  return echo(200); // PUT, PATCH
+};
+
+// ── 3. Import and init ───────────────────────────────────────────────────────
+const { initDowntimeView } = await import('./admin/downtime-views.js');
+await initDowntimeView(chars);

--- a/specs/stories/fix.491.skill-acquisition-outcome-card.story.md
+++ b/specs/stories/fix.491.skill-acquisition-outcome-card.story.md
@@ -1,0 +1,172 @@
+---
+id: fix.491
+title: Skill acquisition actions render Outcome card, not Validation Status
+status: review
+issue: 491
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/491
+branch: ms/issue-491-skill-acquisition-outcome
+type: bug
+---
+
+## Story
+
+As an ST processing downtimes, I want skill acquisition actions to show an Outcome card (Approved / Partial / Failed + narrative), so I can record what happened and have it surface in the Allies & Asset Summary the same way merit actions do.
+
+## Acceptance criteria
+
+- [x] Skill acquisition action rows render an Outcome card (Approved / Partial / Failed + narrative input), not a Validation Status card
+- [x] Clicking Approved / Partial / Failed saves `merit_outcome` + `pool_status: 'resolved'` to `acquisitions_resolved[actionIdx]` (existing save path — no new wiring needed)
+- [x] Typing in the narrative input saves `outcome_summary` to `acquisitions_resolved[actionIdx]`
+- [x] The Allies & Asset Summary in the DT story shows the recorded `outcome_summary` for skill acquisitions (not "— Outcome not yet recorded —")
+- [x] Merit-based action outcomes are unaffected
+
+---
+
+## Dev notes
+
+### Prototype context
+
+This fix lives entirely in the DT processing prototype on branch `ms/dt-processing-proto`. Entry point: `public/dt-proto.html`. All changes are in:
+
+- `public/js/admin/downtime-views.js` — rendering fix
+- `public/js/admin/downtime-story.js` — summary lookup fix
+
+No server-side changes. No new CSS needed (all required classes exist).
+
+---
+
+### Part 1 — downtime-views.js: replace Validation Status with Outcome card
+
+#### Why skill acquisitions hit Validation Status
+
+At **downtime-views.js:9108**:
+
+```js
+if (entry.source !== 'feeding' && entry.source !== 'project' && !isSorcery && entry.source !== 'merit') {
+  // renders Validation Status card
+```
+
+Skill acquisitions have `entry.source === 'acquisition'`, so they fall through this condition and get the Validation Status card. Only `entry.source === 'merit'` was excluded.
+
+#### The fix — two-part change at line 9108
+
+**Step A:** Extend the Validation Status condition to also exclude skill acquisitions:
+
+```js
+// BEFORE (line 9108):
+if (entry.source !== 'feeding' && entry.source !== 'project' && !isSorcery && entry.source !== 'merit') {
+
+// AFTER:
+const isSkillAcq = entry.source === 'acquisition' && entry.actionType === 'skill_acquisitions';
+if (entry.source !== 'feeding' && entry.source !== 'project' && !isSorcery && entry.source !== 'merit' && !isSkillAcq) {
+```
+
+**Step B:** Render the Outcome card for skill acquisitions. Insert this block immediately after the closing `}` at line 9092 (end of the `if (entry.actionType === 'skill_acquisitions')` pool display block):
+
+```js
+// After the pool columns block (line 9091-9092):
+  h += '</div>'; // proc-detail-grid
+}
+
+// ADD THIS:
+if (isSkillAcq) {
+  h += _renderMeritOutcomeZone(entry, rev);
+}
+```
+
+Note: `isSkillAcq` is defined in Step A before the Validation Status block. Make sure it's in scope here (move the `const isSkillAcq` declaration before the acquisition section if needed, not just before line 9108).
+
+#### `_renderMeritOutcomeZone` — what it renders and how it saves
+
+Function at **downtime-views.js:7028**. It emits:
+- `.proc-merit-outcome-btn` buttons (Approved / Partial / Failed)
+- `.proc-outcome-summary-input` text input
+
+Both are already wired at **lines 6055–6073**:
+
+```js
+// line 6062 — saves merit_outcome + pool_status:'resolved' via saveEntryReview
+// line 6073 — saves outcome_summary via saveEntryReview
+```
+
+`saveEntryReview` for acquisition entries (**line 3655**) routes to `acquisitions_resolved[entry.actionIdx]`. No new wiring needed — the existing handlers cover skill acquisitions automatically once the HTML is rendered.
+
+The function needs `entry.meritCategory` for the MERIT_MATRIX lookup, but if it's absent, `mode` defaults to `'auto'` and the card renders fine. Skill acquisitions don't need to be blocked or auto-resolved.
+
+---
+
+### Part 2 — downtime-story.js: fix outcome lookup in renderMeritSummary
+
+#### Why the summary shows "— Outcome not yet recorded —"
+
+`buildMeritActions()` (**downtime-story.js:2015**) builds a synthetic `actions` array that includes skill acquisitions appended at the end (line 2159–2188). This result is assigned to `sub.merit_actions` in memory at load time (**line 171**).
+
+`renderMeritSummary` (**line 2305**) iterates this array with:
+
+```js
+const actions  = sub?.merit_actions || [];
+const resolved = sub?.merit_actions_resolved || [];
+```
+
+For a skill acquisition at index `i` in `actions`, `resolved[i]` reads `merit_actions_resolved[i]` — but skill acquisition outcomes are saved to `acquisitions_resolved[actionIdx]`, not `merit_actions_resolved`. So `resolved[i]` is `undefined`, and `outcome_summary` is always blank.
+
+Note: `deriveMeritCategory('Skill Acquisition')` returns `'resources'` (matches `/skill/` regex at line 2206). So in the summary, skill acquisitions are grouped under the 'resources' category. The blocking-check code at line 2373 already has a resources-specific branch that reads `acqRes[0]?.pool_status` — awareness of this split already exists.
+
+#### The fix — downtime-story.js:2321
+
+In `renderMeritSummary`, when building `outcome` for a 'resources' category entry, also check `acquisitions_resolved` for `outcome_summary`:
+
+```js
+// BEFORE (line 2321):
+let outcome = rev.outcome_summary?.trim() || '';
+if (cat === 'resources') {
+  const thread = (Array.isArray(rev.notes_thread) && rev.notes_thread.length ? rev.notes_thread : null)
+    || (Array.isArray(sub?.acquisitions_resolved?.[0]?.notes_thread) && sub.acquisitions_resolved[0].notes_thread.length
+      ? sub.acquisitions_resolved[0].notes_thread : null);
+  if (thread) outcome = thread[thread.length - 1]?.text?.trim() || '';
+}
+
+// AFTER:
+let outcome = rev.outcome_summary?.trim() || '';
+if (cat === 'resources') {
+  // For skill acquisitions, outcome_summary is in acquisitions_resolved, not merit_actions_resolved
+  if (!outcome) outcome = sub?.acquisitions_resolved?.[0]?.outcome_summary?.trim() || '';
+  // Fallback: last ST notes thread entry (Resources acquisition legacy path)
+  if (!outcome) {
+    const thread = (Array.isArray(rev.notes_thread) && rev.notes_thread.length ? rev.notes_thread : null)
+      || (Array.isArray(sub?.acquisitions_resolved?.[0]?.notes_thread) && sub.acquisitions_resolved[0].notes_thread.length
+        ? sub.acquisitions_resolved[0].notes_thread : null);
+    if (thread) outcome = thread[thread.length - 1]?.text?.trim() || '';
+  }
+}
+```
+
+This reads `acquisitions_resolved[0].outcome_summary` first (the skill acquisition outcome saved by the new Outcome card), then falls through to the existing notes thread fallback for Resources acquisitions.
+
+#### Assumption: single skill acquisition per submission
+
+The current form has one skill acquisition row per submission (PR #187 context at line 2159). `acquisitions_resolved[0]` is correct. If multiple rows are ever supported, this needs revisiting — but that's out of scope here.
+
+---
+
+### What to verify in the browser
+
+1. Open `http://localhost:8080/dt-proto.html`
+2. Navigate to a submission with a skill acquisition (e.g. "Air of Menace")
+3. The action row's detail panel should show an **Outcome** card (Approved / Partial / Failed + text input), not a Validation Status card
+4. Click "Approved" → pool_status should save as 'resolved', merit_outcome as 'approved'
+5. Enter a narrative → outcome_summary saves to acquisitions_resolved[0]
+6. Open the DT Story panel for the same submission
+7. The Allies & Asset Summary should show the narrative in the skill acquisition row (not "— Outcome not yet recorded —")
+8. Check that merit action outcomes (e.g. Allies, Contacts) still save and display correctly — unaffected
+
+---
+
+## Files to change
+
+| File | Change |
+|------|--------|
+| `public/js/admin/downtime-views.js` | ~line 9092: declare `isSkillAcq`; extend Validation Status condition; render Outcome card after pool columns |
+| `public/js/admin/downtime-story.js` | ~line 2321: read `acquisitions_resolved[0].outcome_summary` for resources category before notes-thread fallback |
+
+No CSS changes, no new functions, no API changes.

--- a/tests/fix-491-skill-acquisition-outcome-card.spec.js
+++ b/tests/fix-491-skill-acquisition-outcome-card.spec.js
@@ -1,0 +1,408 @@
+/**
+ * Regression tests for fix #491 — Skill acquisition actions show Outcome card
+ * instead of Validation Status card, and outcome_summary flows to Allies & Asset Summary.
+ *
+ * Root causes:
+ *   A. downtime-views.js:9108 — Validation Status condition included `entry.source === 'acquisition'`
+ *      because only `entry.source === 'merit'` was excluded. Skill acquisitions fell through
+ *      and got Validation Status (Pending/Validated/No Roll Needed/Skip) instead of Outcome
+ *      (Approved/Partial/Failed + narrative).
+ *   B. downtime-story.js:2321 — renderMeritSummary read outcome_summary from merit_actions_resolved[i]
+ *      for skill acquisitions, but the processing panel saves outcomes to acquisitions_resolved[0].
+ *      The lookup hit the wrong array → always blank → "Outcome not yet recorded".
+ *
+ * Fix A: `isSkillAcq` guard added to Validation Status condition; _renderMeritOutcomeZone
+ *        called after pool columns for skill acquisitions.
+ * Fix B: renderMeritSummary now reads acquisitions_resolved[0].outcome_summary first for
+ *        resources-category entries, before falling through to notes_thread fallback.
+ *
+ * Test coverage:
+ *   Part 1 — DT Story panel (downtime-story.js fix B)
+ *     AC-1: Skill acq with acquisitions_resolved[0].outcome_summary → outcome shown in Resources group
+ *     AC-2: Skill acq without outcome_summary → "Outcome not yet recorded" placeholder shown
+ *     AC-3: Skill acq with outcome_summary + pool_status validated → "All outcomes recorded" badge
+ *     AC-4: Allies with outcome_summary still reads from merit_actions_resolved (regression guard)
+ *
+ *   Part 2 — DT Processing panel (downtime-views.js fix A)
+ *     AC-5: Skill acq action row → renders .proc-merit-outcome-zone (Outcome card)
+ *     AC-6: Skill acq action row → does NOT render .proc-val-status (Validation Status)
+ *     AC-7: Resources (non-skill) acq action row → still renders .proc-val-status (no regression)
+ *
+ * NOTE: initDtStory always rebuilds merit_actions via buildMeritActions(sub) at load time.
+ * Do NOT pre-populate merit_actions in fixtures — use responses/acq fields that buildMeritActions reads.
+ * buildMeritActions reads `resp['skill_acquisitions']` (blob) or `resp['acq_skill_rows']` (JSON).
+ * Skill acquisitions → deriveMeritCategory('Skill Acquisition') = 'resources' → 'Resources' group.
+ * Skill acquisitions go to phaseNum 7 → PHASE_NUM_TO_LABEL[7] = 'misc' → 'Step 10 — Miscellaneous'.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Shared fixtures ───────────────────────────────────────────────────────────
+
+const ST_USER = {
+  id: '123000491', username: 'test_st_491', global_name: 'Test ST 491',
+  avatar: null, role: 'st', player_id: 'p-491', character_ids: [], is_dual_role: false,
+};
+
+const ACTIVE_CYCLE = {
+  _id: 'cycle-491', cycle_number: 3, status: 'active',
+  phase_signoff: {}, confirmed_ambience: {},
+};
+
+const CHAR = {
+  _id: 'char-491',
+  name: 'Menace Test', moniker: null, honorific: null,
+  clan: 'Daeva', covenant: 'Invictus', player: 'Test Player',
+  blood_potency: 2, humanity: 6, humanity_base: 7, court_title: null,
+  home_territory: null, retired: false,
+  status: { city: 1, clan: 1, covenant: { Invictus: 1 } },
+  attributes: {
+    Strength:      { dots: 2, bonus: 0 }, Dexterity:     { dots: 2, bonus: 0 }, Stamina:    { dots: 2, bonus: 0 },
+    Intelligence:  { dots: 2, bonus: 0 }, Wits:          { dots: 2, bonus: 0 }, Resolve:    { dots: 2, bonus: 0 },
+    Presence:      { dots: 3, bonus: 0 }, Manipulation:  { dots: 2, bonus: 0 }, Composure:  { dots: 2, bonus: 0 },
+  },
+  skills: { Intimidation: { dots: 3, bonus: 0, specs: [], nine_again: false } },
+  disciplines: {},
+  merits: [
+    { name: 'Allies',    category: 'influence', rating: 2, qualifier: 'Police' },
+    { name: 'Resources', category: 'general',   rating: 2 },
+  ],
+  powers: [], ordeals: [],
+};
+
+// ── Submission builders ───────────────────────────────────────────────────────
+
+function baseSub(id) {
+  return {
+    _id: id,
+    cycle_id: 'cycle-491',
+    character_id: 'char-491',
+    character_name: 'Menace Test',
+    player_name: 'Test Player',
+    status: 'submitted',
+    responses: {},
+    _raw: { sphere_actions: [], contact_actions: { requests: [] }, retainer_actions: { actions: [] } },
+    projects_resolved: [],
+    merit_actions_resolved: [],
+    acquisitions_resolved: [],
+    st_review: {},
+    st_narrative: { story_moment: { status: 'complete' } },
+    feeding_review: { pool_status: 'no_feed' },
+  };
+}
+
+// ── Part 1 fixtures (story panel) ─────────────────────────────────────────────
+
+// AC-1: Skill acquisition with outcome_summary recorded in acquisitions_resolved.
+// buildMeritActions reads responses['skill_acquisitions'] blob → merit_actions contains
+// { merit_type: 'Skill Acquisition', action_type: 'acquisition' }.
+// renderMeritSummary fix: reads acquisitions_resolved[0].outcome_summary for resources category.
+const SUB_SKILL_ACQ_WITH_OUTCOME = {
+  ...baseSub('sub-491-skill-outcome'),
+  responses: { skill_acquisitions: 'Air of Menace' },
+  acquisitions_resolved: [
+    { outcome_summary: 'Mastered the intimidating stance without incident.' },
+  ],
+  merit_actions_resolved: [],
+};
+
+// AC-2: Skill acquisition with no outcome recorded yet → "not yet recorded" shown.
+const SUB_SKILL_ACQ_NO_OUTCOME = {
+  ...baseSub('sub-491-skill-no-outcome'),
+  responses: { skill_acquisitions: 'Air of Menace' },
+  acquisitions_resolved: [],
+  merit_actions_resolved: [],
+};
+
+// AC-3: Skill acquisition with outcome_summary AND pool_status validated
+// → meritSummaryComplete returns true → "All outcomes recorded" badge.
+const SUB_SKILL_ACQ_VALIDATED = {
+  ...baseSub('sub-491-skill-validated'),
+  responses: { skill_acquisitions: 'Air of Menace' },
+  acquisitions_resolved: [
+    { pool_status: 'validated', outcome_summary: 'Air of Menace successfully acquired.' },
+  ],
+  merit_actions_resolved: [],
+};
+
+// AC-4: Allies merit with outcome_summary in merit_actions_resolved[0].
+// buildMeritActions reads sphere_1_* → merit_actions[0] = Allies.
+// merit_actions_resolved[0].outcome_summary must still drive the Allies group display.
+const SUB_ALLIES_ONLY = {
+  ...baseSub('sub-491-allies-only'),
+  responses: {
+    sphere_1_merit:   'Allies ●● (Police)',
+    sphere_1_action:  'patrol_scout',
+    sphere_1_outcome: 'Scout the harbour district',
+    sphere_1_description: 'Watch the docks.',
+  },
+  merit_actions_resolved: [
+    { pool_status: 'confirmed', outcome_summary: 'Police allies reported suspicious vessel activity.' },
+  ],
+  acquisitions_resolved: [],
+};
+
+// ── Part 2 fixtures (processing panel) ───────────────────────────────────────
+
+// AC-5/6: Skill acquisition → .proc-merit-outcome-zone must be present, .proc-val-status absent.
+const SUB_PROC_SKILL_ACQ = {
+  ...baseSub('sub-491-proc-skill'),
+  responses: {
+    skill_acquisitions: 'Air of Menace',
+    skill_acq_pool_skill: 'Intimidation',
+  },
+  _raw: {
+    sphere_actions: [],
+    contact_actions: { requests: [] },
+    retainer_actions: { actions: [] },
+    acquisitions: { skill_acquisitions: 'Air of Menace' },
+  },
+  acquisitions_resolved: [],
+  merit_actions_resolved: [],
+};
+
+// AC-7: Resources (non-skill) acquisition → .proc-val-status still present (no regression).
+const SUB_PROC_RESOURCE_ACQ = {
+  ...baseSub('sub-491-proc-resource'),
+  responses: { resources_acquisitions: 'Buy a Retainer' },
+  _raw: {
+    sphere_actions: [],
+    contact_actions: { requests: [] },
+    retainer_actions: { actions: [] },
+    acquisitions: { resource_acquisitions: 'Buy a Retainer' },
+  },
+  acquisitions_resolved: [],
+  merit_actions_resolved: [],
+};
+
+// ── Setup helpers ─────────────────────────────────────────────────────────────
+
+async function setupStoryPanel(page, submissions) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER });
+
+  await page.route('**/api/auth/me', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(ST_USER) })
+  );
+  await page.route(/\/api\/characters$/, route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([CHAR]) })
+  );
+  await page.route('**/api/characters/names', route =>
+    route.fulfill({ status: 200, contentType: 'application/json',
+      body: JSON.stringify([{ _id: CHAR._id, name: CHAR.name, moniker: CHAR.moniker, honorific: CHAR.honorific }]) })
+  );
+  await page.route('**/api/downtime_cycles*', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([ACTIVE_CYCLE]) })
+  );
+  await page.route('**/api/downtime_submissions*', route => {
+    if (['PATCH', 'PUT', 'POST'].includes(route.request().method()))
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ ok: true }) });
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(submissions) });
+  });
+  await page.route('**/api/territories*', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+  );
+  await page.route('**/api/game_sessions*', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+  );
+  await page.route('**/api/session_logs*', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+  );
+  await page.route('**/api/st_mods*', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+  );
+
+  await page.goto('/admin.html');
+  await page.waitForSelector('#admin-app', { state: 'visible', timeout: 10000 });
+  await page.click('[data-domain="downtime"]');
+  await page.waitForSelector('button[data-phase="story"]', { state: 'visible', timeout: 10000 });
+  await page.click('button[data-phase="story"]');
+  await page.waitForSelector('#dt-story-nav-rail', { timeout: 10000 });
+  await page.click('.dt-story-pill');
+  await page.waitForSelector('.dt-story-char-content', { timeout: 5000 });
+  await page.waitForTimeout(300);
+}
+
+async function setupProcessingPanel(page, submissions) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'local-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url = route.request().url();
+    const method = route.request().method();
+    const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+
+    if (method === 'PUT' || method === 'PATCH' || method === 'POST') return ok({ ok: true });
+
+    if (url.includes('/api/downtime_submissions'))  return ok(submissions);
+    if (url.includes('/api/downtime_cycles'))        return ok([ACTIVE_CYCLE]);
+    if (url.includes('/api/characters/names'))       return ok([{ _id: CHAR._id, name: CHAR.name, moniker: CHAR.moniker, honorific: CHAR.honorific }]);
+    if (url.includes('/api/characters'))             return ok([CHAR]);
+    if (url.includes('/api/territories'))            return ok([]);
+    if (url.includes('/api/game_sessions'))          return ok([]);
+    if (url.includes('/api/session_logs'))           return ok([]);
+    return ok([]);
+  });
+
+  await page.goto('/admin.html');
+  await page.waitForSelector('#admin-app', { state: 'visible', timeout: 10000 });
+  await page.click('[data-domain="downtime"]');
+  await page.waitForTimeout(1000);
+}
+
+async function openFirstActionInPhase(page, phaseLabel) {
+  await page.waitForSelector('.proc-phase-section', { timeout: 8000 });
+  const phaseHeader = page.locator('.proc-phase-header').filter({ hasText: phaseLabel }).first();
+  const toggle = phaseHeader.locator('.proc-phase-toggle');
+  const toggleText = await toggle.textContent().catch(() => '');
+  if (toggleText.includes('Show')) await phaseHeader.click();
+  await page.waitForTimeout(200);
+  const phase = page.locator('.proc-phase-section').filter({ hasText: phaseLabel }).first();
+  const firstRow = phase.locator('.proc-action-row').first();
+  await firstRow.click();
+  await page.waitForTimeout(400);
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function getMeritGroupHtml(page, label) {
+  return page.evaluate((lbl) => {
+    const groups = document.querySelectorAll('.dt-merit-summary-group');
+    for (const g of groups) {
+      if (g.querySelector('.dt-merit-summary-group-label')?.textContent?.trim() === lbl) {
+        return g.innerHTML;
+      }
+    }
+    return null;
+  }, label);
+}
+
+async function getMeritSummaryHtml(page) {
+  return page.evaluate(() => {
+    const el = document.querySelector('.dt-story-section[data-section="merit_summary"]');
+    return el ? el.innerHTML : null;
+  });
+}
+
+// ── Part 1: DT Story panel tests ─────────────────────────────────────────────
+
+test.describe('fix.491 Part 1: DT Story — skill acquisition outcome_summary display', () => {
+
+  // AC-1 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-1: skill acq with acquisitions_resolved[0].outcome_summary → outcome shown in Resources group', async ({ page }) => {
+    await setupStoryPanel(page, [SUB_SKILL_ACQ_WITH_OUTCOME]);
+
+    const resourcesHtml = await getMeritGroupHtml(page, 'Resources');
+    expect(resourcesHtml).not.toBeNull();
+    expect(resourcesHtml).toContain('Mastered the intimidating stance without incident.');
+    expect(resourcesHtml).not.toContain('Outcome not yet recorded');
+  });
+
+  // AC-2 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-2: skill acq with no outcome_summary → "Outcome not yet recorded" shown in Resources group', async ({ page }) => {
+    await setupStoryPanel(page, [SUB_SKILL_ACQ_NO_OUTCOME]);
+
+    const resourcesHtml = await getMeritGroupHtml(page, 'Resources');
+    expect(resourcesHtml).not.toBeNull();
+    expect(resourcesHtml).toContain('Outcome not yet recorded');
+  });
+
+  // AC-3 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-3: skill acq with outcome_summary + pool_status validated → "All outcomes recorded" badge', async ({ page }) => {
+    await setupStoryPanel(page, [SUB_SKILL_ACQ_VALIDATED]);
+
+    const html = await getMeritSummaryHtml(page);
+    expect(html).not.toBeNull();
+    expect(html).toContain('All outcomes recorded');
+
+    const resourcesHtml = await getMeritGroupHtml(page, 'Resources');
+    expect(resourcesHtml).toContain('Air of Menace successfully acquired.');
+    expect(resourcesHtml).not.toContain('Outcome not yet recorded');
+  });
+
+  // AC-4 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-4: Allies outcome still reads from merit_actions_resolved (regression guard)', async ({ page }) => {
+    await setupStoryPanel(page, [SUB_ALLIES_ONLY]);
+
+    const alliesHtml = await getMeritGroupHtml(page, 'Allies');
+    expect(alliesHtml).not.toBeNull();
+    expect(alliesHtml).toContain('Police allies reported suspicious vessel activity.');
+    expect(alliesHtml).not.toContain('Outcome not yet recorded');
+
+    const html = await getMeritSummaryHtml(page);
+    expect(html).toContain('All outcomes recorded');
+  });
+
+});
+
+// ── Part 2: DT Processing panel tests ────────────────────────────────────────
+
+test.describe('fix.491 Part 2: DT Processing — skill acquisition renders Outcome card', () => {
+
+  // AC-5 / AC-6 ───────────────────────────────────────────────────────────────
+
+  test('AC-5/6: skill acq action row → Outcome card present, Validation Status absent', async ({ page }) => {
+    await setupProcessingPanel(page, [SUB_PROC_SKILL_ACQ]);
+    // Skill acquisitions → phaseNum 7 → 'Step 10 — Miscellaneous'
+    await openFirstActionInPhase(page, 'Step 10 — Miscellaneous');
+
+    const detailHtml = await page.evaluate(() => {
+      const panel = document.querySelector('.proc-detail-panel') || document.querySelector('.proc-entry-detail');
+      return panel ? panel.innerHTML : document.querySelector('.proc-action-detail')?.innerHTML || null;
+    });
+
+    // Fallback: check within any expanded detail area
+    const hasOutcomeZone = await page.evaluate(() =>
+      !!document.querySelector('.proc-merit-outcome-zone')
+    );
+    const hasValStatus = await page.evaluate(() =>
+      !!document.querySelector('.proc-val-status')
+    );
+
+    expect(hasOutcomeZone).toBe(true);
+    expect(hasValStatus).toBe(false);
+  });
+
+  // AC-6 variant: Outcome card has the right buttons ──────────────────────────
+
+  test('AC-6: skill acq Outcome card has Approved / Partial / Failed buttons', async ({ page }) => {
+    await setupProcessingPanel(page, [SUB_PROC_SKILL_ACQ]);
+    await openFirstActionInPhase(page, 'Step 10 — Miscellaneous');
+
+    const outcomeZone = page.locator('.proc-merit-outcome-zone').first();
+    await expect(outcomeZone).toBeVisible({ timeout: 5000 });
+    await expect(outcomeZone.locator('.proc-merit-outcome-btn', { hasText: 'Approved' })).toBeVisible();
+    await expect(outcomeZone.locator('.proc-merit-outcome-btn', { hasText: 'Partial' })).toBeVisible();
+    await expect(outcomeZone.locator('.proc-merit-outcome-btn', { hasText: 'Failed' })).toBeVisible();
+    await expect(outcomeZone.locator('.proc-outcome-summary-input')).toBeVisible();
+  });
+
+  // AC-7 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-7: resources (non-skill) acq action row → Validation Status still present (regression guard)', async ({ page }) => {
+    await setupProcessingPanel(page, [SUB_PROC_RESOURCE_ACQ]);
+    // Resources acquisitions → phaseNum 14 → PHASE_NUM_TO_LABEL[14] = 'resources' → 'Resources'
+    await openFirstActionInPhase(page, 'Resources');
+
+    const hasValStatus = await page.evaluate(() =>
+      !!document.querySelector('.proc-val-status')
+    );
+    const hasOutcomeZone = await page.evaluate(() =>
+      !!document.querySelector('.proc-merit-outcome-zone')
+    );
+
+    expect(hasValStatus).toBe(true);
+    expect(hasOutcomeZone).toBe(false);
+  });
+
+});


### PR DESCRIPTION
## Summary

- Skill acquisition actions in the DT processing panel now render an **Outcome card** (Approved / Partial / Failed + narrative) instead of a Validation Status card
- The narrative typed into that card now surfaces in the Allies & Asset Summary in the DT Story panel
- Root cause (views): `entry.source === 'acquisition'` fell through the Validation Status condition; fix adds an `isSkillAcq` guard and renders `_renderMeritOutcomeZone` for skill acquisitions
- Root cause (story): `renderMeritSummary` was reading `merit_actions_resolved[i]` for skill acquisitions, but their outcomes save to `acquisitions_resolved[0]`; fix reads the correct array first

## Closes

- Closes #491

## Story

- specs/stories/fix.491.skill-acquisition-outcome-card.story.md

## Test plan

- [x] 7 Playwright tests passing (`tests/fix-491-skill-acquisition-outcome-card.spec.js`)
- [ ] CI green
- [ ] Manual: open `dt-proto.html`, navigate to a skill acquisition submission, confirm Outcome card appears; record outcome + narrative; open DT Story panel and verify Allies & Asset Summary shows the narrative

## Branch flow

- From: `ms/issue-491-skill-acquisition-outcome`
- Into: `dev`

> **Note**: this branch was cut from `ms/dt-processing-proto`; the diff against `dev` includes the full prototype build. The fix-491 change is isolated to the `fix(491): skill acquisitions render Outcome card, not Validation Status` commit.