### PR TITLE
fix: skill acquisition outcomes surface in player Allies & Asset Summary

### DIFF
--- a/public/js/tabs/story-tab.js
+++ b/public/js/tabs/story-tab.js
@@ -523,6 +523,7 @@ function _deriveMeritCat(meritTypeStr) {
   if (/retainer/.test(s))  return 'retainer';
   if (/contacts?/.test(s)) return 'contacts';
   if (/resources?/.test(s)) return 'resources';
+  if (/skill/.test(s))     return 'resources';
   return 'misc';
 }
 
@@ -541,7 +542,11 @@ function renderMeritSummarySection(sub) {
   const actions  = buildPlayerMeritActions(sub);
   const resolved = sub.merit_actions_resolved || [];
 
-  const hasOutcomeSummaries = resolved.some(rev => rev?.outcome_summary?.trim());
+  const acqRes = sub.acquisitions_resolved || [];
+
+  const hasOutcomeSummaries =
+    resolved.some(rev => rev?.outcome_summary?.trim()) ||
+    acqRes.some(rev => rev?.outcome_summary?.trim());
 
   if (!hasOutcomeSummaries) {
     return renderMeritActionCards(sub);
@@ -552,7 +557,12 @@ function renderMeritSummarySection(sub) {
   actions.forEach((a, i) => {
     const rev = resolved[i] || {};
     if (rev.pool_status === 'skipped') return;
-    const summary = rev.outcome_summary?.trim();
+    // Skill acquisitions save to acquisitions_resolved[0], not merit_actions_resolved[i].
+    // Mirror ST-side downtime-story.js:2323 fallback.
+    let summary = rev.outcome_summary?.trim();
+    if (!summary && a.merit_type === 'Skill Acquisition' && a.action_type === 'acquisition') {
+      summary = acqRes[0]?.outcome_summary?.trim() || '';
+    }
     if (!summary) return;
     const cat = _deriveMeritCat(a.merit_type);
     if (!groups[cat]) groups[cat] = [];
@@ -644,6 +654,14 @@ function buildPlayerMeritActions(sub) {
   const resBlob = raw.acquisitions?.resource_acquisitions || resp['resources_acquisitions'] || '';
   if (resBlob.trim()) {
     actions.push({ merit_type: 'Resources', action_type: 'acquisition' });
+  }
+
+  // Skill Acquisitions (mirror ST-side buildMeritActions at downtime-story.js:2159-2188).
+  // Appended last so its index aligns with acquisitions_resolved[0] under the
+  // current single-acquisition-per-submission constraint (PR #187 context).
+  const skillAcqBlob = raw.acquisitions?.skill_acquisitions || resp['skill_acquisitions'] || '';
+  if (skillAcqBlob.trim()) {
+    actions.push({ merit_type: 'Skill Acquisition', action_type: 'acquisition' });
   }
 
   return actions;

--- a/tests/fix-player-skill-acq-outcome.spec.js
+++ b/tests/fix-player-skill-acq-outcome.spec.js
@@ -1,0 +1,180 @@
+/**
+ * Regression tests for the player-side counterpart of fix #491 / #493.
+ *
+ * Context: The ST processing panel saves skill acquisition outcomes to
+ * acquisitions_resolved[0].outcome_summary. PR #492 / #494 fixed the ST-side
+ * DT Story preview to surface those. The PLAYER-side renderer
+ * (renderMeritSummarySection in story-tab.js) was not updated and still
+ * read only merit_actions_resolved, so players never saw the outcome.
+ *
+ * This spec verifies the player-side fix:
+ *   AC-1: Skill acquisition with acquisitions_resolved[0].outcome_summary →
+ *         narrative appears in the player's Allies & Asset Summary, under Resources
+ *   AC-2: Skill acquisition with NO outcome → not shown (no false placeholder)
+ *   AC-3: Allies merit outcome from merit_actions_resolved unaffected (regression guard)
+ *
+ * The merit summary is live-rendered, so no backfill is needed — as soon as
+ * the saved data is correct, the player sees it on next view.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const PLAYER_USER = {
+  id: '987000901', username: 'test_player_skillacq', global_name: 'Test Player SkillAcq',
+  avatar: null, role: 'player', player_id: 'p-skillacq',
+  character_ids: ['char-skillacq'], is_dual_role: false,
+};
+
+const ACTIVE_CYCLE = {
+  _id: 'cycle-skillacq', cycle_number: 3, status: 'closed',
+  deadline: new Date(Date.now() - 86400000).toISOString(),
+  confirmed_ambience: {}, narrative_notes: '',
+};
+
+const CHAR = {
+  _id: 'char-skillacq', name: 'Test Acquirer', moniker: null, honorific: null,
+  clan: 'Daeva', covenant: 'Invictus', player: 'Test Player SkillAcq',
+  blood_potency: 2, humanity: 6, humanity_base: 7, court_title: null,
+  retired: false, regent_territory: null,
+  status: { city: 1, clan: 1, covenant: { Invictus: 1 } },
+  attributes: {
+    Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+    Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+    Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: { Intimidation: { dots: 3, bonus: 0, specs: [], nine_again: false } },
+  disciplines: {}, merits: [], powers: [], ordeals: [],
+};
+
+function publishedSub(id, extras = {}) {
+  return {
+    _id: id,
+    cycle_id: 'cycle-skillacq',
+    character_id: 'char-skillacq',
+    character_name: 'Test Acquirer',
+    player_name: 'Test Player SkillAcq',
+    status: 'submitted',
+    responses: {},
+    _raw: { sphere_actions: [], contact_actions: { requests: [] }, retainer_actions: { actions: [] } },
+    projects_resolved: [],
+    merit_actions_resolved: [],
+    acquisitions_resolved: [],
+    feeding_review: { pool_status: 'no_feed' },
+    st_review: { outcome_text: '', outcome_visibility: 'published' },
+    st_narrative: {},
+    published_outcome: '',
+    ...extras,
+  };
+}
+
+async function setup(page, submissions) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: PLAYER_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url = route.request().url();
+    const method = route.request().method();
+    const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+    if (method === 'POST' || method === 'PUT' || method === 'PATCH') return ok({ ok: true });
+    if (url.includes('/api/auth/me'))             return ok(PLAYER_USER);
+    if (url.includes('/api/downtime_cycles'))      return ok([ACTIVE_CYCLE]);
+    if (url.includes('/api/downtime_submissions')) return ok(submissions);
+    if (url.includes('/api/characters/names'))     return ok([{ _id: CHAR._id, name: CHAR.name, moniker: CHAR.moniker, honorific: CHAR.honorific }]);
+    if (url.includes('/api/characters'))           return ok([CHAR]);
+    if (url.includes('/api/territories'))          return ok([]);
+    if (url.includes('/api/game_sessions'))        return ok([]);
+    if (url.includes('/api/session_logs'))         return ok([]);
+    if (url.includes('/api/ordeal-responses'))     return ok([]);
+    return ok([]);
+  });
+
+  await page.goto('/');
+  await page.waitForSelector('#app', { state: 'visible', timeout: 15000 });
+  await page.waitForFunction(() => typeof window.goTab === 'function', { timeout: 8000 });
+  // renderPastOutcomes is wired to the Info tab (app.js:427), targeting #misc-past-outcomes
+  await page.evaluate(() => window.goTab('info'));
+  await page.waitForTimeout(800);
+}
+
+async function expandPastOutcome(page) {
+  // renderPastOutcomes builds <details class="dt-history-row"> rows inside #misc-past-outcomes.
+  await page.waitForSelector('#misc-past-outcomes .dt-history-row', { timeout: 5000 });
+  await page.evaluate(() => {
+    const row = document.querySelector('#misc-past-outcomes .dt-history-row');
+    if (row) row.open = true;
+  });
+  await page.waitForTimeout(200);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('Player merit summary: skill acquisition outcome surfaces', () => {
+
+  test('AC-1: skill acquisition outcome_summary appears in player Resources group', async ({ page }) => {
+    const sub = publishedSub('sub-skillacq-with-outcome', {
+      responses: { skill_acquisitions: 'Air of Menace' },
+      acquisitions_resolved: [
+        { pool_status: 'resolved', outcome_summary: 'You acquired Air of Menace; victims hesitate.' },
+      ],
+      // Ensure published_outcome is non-empty so the past outcome row renders
+      published_outcome: '## Story Moment\n\nA tense night.',
+      st_review: { outcome_text: '## Story Moment\n\nA tense night.', outcome_visibility: 'published' },
+    });
+    await setup(page, [sub]);
+    await expandPastOutcome(page);
+
+    const meritSection = page.locator('.merit-summary-section');
+    await expect(meritSection).toBeVisible({ timeout: 5000 });
+    await expect(meritSection).toContainText('Resources');
+    await expect(meritSection).toContainText('Skill Acquisition');
+    await expect(meritSection).toContainText('You acquired Air of Menace; victims hesitate.');
+  });
+
+  test('AC-2: skill acquisition with no outcome_summary is not shown', async ({ page }) => {
+    const sub = publishedSub('sub-skillacq-no-outcome', {
+      responses: { skill_acquisitions: 'Air of Menace' },
+      acquisitions_resolved: [], // no outcome saved yet
+      published_outcome: '## Story Moment\n\nA quiet cycle.',
+      st_review: { outcome_text: '## Story Moment\n\nA quiet cycle.', outcome_visibility: 'published' },
+    });
+    await setup(page, [sub]);
+    await expandPastOutcome(page);
+
+    // No merit-summary-section at all (nothing to show — falls back to renderMeritActionCards
+    // which only outputs for actions with action_type, but skill acquisitions in legacy
+    // cards path aren't surfaced either). Either way: no "Skill Acquisition" text leaks.
+    const body = page.locator('.dt-narrative-panel').first();
+    await expect(body).not.toContainText('You acquired');
+  });
+
+  test('AC-3: Allies merit outcome from merit_actions_resolved unaffected', async ({ page }) => {
+    const sub = publishedSub('sub-allies-regression', {
+      responses: {
+        sphere_1_merit: 'Allies ●● (Police)',
+        sphere_1_action: 'patrol_scout',
+      },
+      _raw: {
+        sphere_actions: [{ action_type: 'patrol_scout' }],
+        contact_actions: { requests: [] },
+        retainer_actions: { actions: [] },
+      },
+      merit_actions_resolved: [
+        { pool_status: 'confirmed', outcome_summary: 'Police allies reported a quiet harbour.' },
+      ],
+      acquisitions_resolved: [],
+      published_outcome: '## Story Moment\n\nThe docks were calm.',
+      st_review: { outcome_text: '## Story Moment\n\nThe docks were calm.', outcome_visibility: 'published' },
+    });
+    await setup(page, [sub]);
+    await expandPastOutcome(page);
+
+    const meritSection = page.locator('.merit-summary-section');
+    await expect(meritSection).toBeVisible({ timeout: 5000 });
+    await expect(meritSection).toContainText('Allies');
+    await expect(meritSection).toContainText('Police allies reported a quiet harbour.');
+  });
+
+});


### PR DESCRIPTION
## Summary

- Player-side counterpart to fix #491 / #493. The ST processing panel saves skill acquisition outcomes to `acquisitions_resolved[0].outcome_summary`, the ST DT Story preview reads them, but the **player** view did not — so players still saw nothing for their skill acquisitions
- `renderMeritSummarySection` in `public/js/tabs/story-tab.js` is **live-rendered** on every player view (no snapshot, no `compilePushOutcome` involvement), so this fix lands as soon as it deploys — **no backfill needed**
- Three small edits in one file + three new Playwright tests; 31/31 passing across fix-491 + fix-493 + new + player-smoke regression

## Closes

_None — discovered during follow-up to PR #494; no separate issue filed_

## Story

_No formal story file — diagnostic was scoped inline; fix is the inverse of fix #491 / #493 on the player render path._

## Test plan

- [x] `tests/fix-player-skill-acq-outcome.spec.js` — 3 new tests covering: AC-1 outcome appears in player Resources group; AC-2 no false placeholder when outcome absent; AC-3 Allies (non-acquisition) merits unaffected
- [x] Full regression: `fix-491` + `fix-493` + `downtime-player-smoke` all green (31 tests)
- [ ] CI green
- [ ] Manual: as a player with a completed skill acquisition cycle, open Info tab → Past Outcomes → expand the cycle. The narrative typed in the ST Outcome card should appear under Allies & Asset Summary → Resources

## Branch flow

- From: `ms/player-skill-acq-outcome`
- Into: `dev`