### PR TITLE
fix(devlog): style admin devlog with canonical admin CSS

### DIFF
--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -204,6 +204,40 @@ body {
 }
 .btn-sm:hover { background: var(--surf3); }
 
+/* ── Devlog admin ──
+   The form fields reuse the canonical .form-* primitives (components.css);
+   these rules cover the devlog-specific toolbar, form shell, entry cards and
+   meta chips, which had no styling and fell back to browser defaults. */
+.dl-admin-toolbar { margin-bottom: 16px; }
+.dl-admin-list { display: flex; flex-direction: column; gap: 12px; }
+.dl-form {
+  display: flex; flex-direction: column; gap: 12px;
+  background: var(--surf1); border: 1px solid var(--bdr);
+  border-radius: 8px; padding: 16px; margin-bottom: 16px;
+}
+.dl-form-actions { display: flex; align-items: center; gap: 8px; }
+.dl-form-actions .btn-sm { margin-left: 0; }
+.dl-form-error { margin-left: auto; font-family: var(--ft); font-size: 13px; color: var(--crim); }
+
+.dl-card {
+  display: flex; flex-direction: column; gap: 8px;
+  background: var(--surf1); border: 1px solid var(--bdr);
+  border-radius: 8px; padding: 14px 16px;
+}
+.dl-card-meta { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.dl-type-chip, .dl-status-chip {
+  font-family: var(--fl); font-size: 10px; font-weight: 600;
+  letter-spacing: .08em; text-transform: uppercase;
+  padding: 3px 8px; border-radius: 4px;
+  background: var(--surf2); border: 1px solid var(--bdr); color: var(--txt3);
+}
+.dl-status-chip { color: var(--accent); border-color: var(--accent-a40); }
+.dl-target { margin-left: auto; font-family: var(--fl); font-size: 11px; color: var(--txt3); }
+.dl-card-title { font-family: var(--fh); font-size: 16px; color: var(--txt); }
+.dl-card-body { font-family: var(--ft); font-size: 14px; color: var(--txt2); white-space: pre-wrap; }
+.dl-card-actions { display: flex; gap: 8px; }
+.dl-card-actions .btn-sm { margin-left: 0; }
+
 .placeholder {
   color: var(--txt3);
   font-style: italic;

--- a/public/js/admin/devlog-admin.js
+++ b/public/js/admin/devlog-admin.js
@@ -51,23 +51,32 @@ function _form(entry) {
   ).join('');
   return `
     <form class="dl-form" data-id="${esc(id)}">
-      <div class="dl-form-row">
-        <label>Type <select name="type">${typeOpts}</select></label>
-        <label>Status <select name="status">${statusOpts}</select></label>
+      <div class="form-grid">
+        <div class="form-row">
+          <label class="form-label">Type</label>
+          <select class="form-select" name="type">${typeOpts}</select>
+        </div>
+        <div class="form-row">
+          <label class="form-label">Status</label>
+          <select class="form-select" name="status">${statusOpts}</select>
+        </div>
       </div>
-      <div class="dl-form-row">
-        <label>Title <input type="text" name="title" value="${esc(entry?.title || '')}" required></label>
+      <div class="form-row">
+        <label class="form-label">Title</label>
+        <input class="form-input" type="text" name="title" value="${esc(entry?.title || '')}" required>
       </div>
-      <div class="dl-form-row">
-        <label>Body <textarea name="body" rows="3">${esc(entry?.body || '')}</textarea></label>
+      <div class="form-row">
+        <label class="form-label">Body</label>
+        <textarea class="form-input" name="body" rows="4">${esc(entry?.body || '')}</textarea>
       </div>
-      <div class="dl-form-row">
-        <label>Target cycle <input type="text" name="target_cycle" value="${esc(entry?.target_cycle || '')}" placeholder="e.g. Game 4"></label>
+      <div class="form-row">
+        <label class="form-label">Target cycle</label>
+        <input class="form-input" type="text" name="target_cycle" value="${esc(entry?.target_cycle || '')}" placeholder="e.g. Game 4">
       </div>
       <div class="dl-form-actions">
         <button type="submit" class="btn-sm">${entry ? 'Save' : 'Create'}</button>
         <button type="button" class="btn-sm dl-cancel-btn">Cancel</button>
-        <span class="dl-form-error" style="color:var(--crim)"></span>
+        <span class="dl-form-error"></span>
       </div>
     </form>`;
 }


### PR DESCRIPTION
## Summary

- The admin Devlog form rendered as unstyled browser defaults because it used bespoke `dl-*` classes that had no CSS anywhere.
- The form fields now reuse the existing themed admin primitives (`.form-row` / `.form-label` / `.form-input` / `.form-select`); field `name` attributes are unchanged, so create/edit logic is untouched.
- Added a small token-based block in `admin-layout.css` for the devlog-specific bits with no existing primitive: toolbar, form shell, entry cards, and Type/Status chips. All colours/fonts come from `:root` tokens, so it adapts to both the parchment and dark themes.

## Test plan

- [ ] Hard-refresh the admin app Devlog section: form fields, buttons, and (once entries exist) cards/chips render in the admin theme, not browser defaults.
- [ ] Toggle parchment/dark theme — devlog styling follows.

## Branch flow

- From: `Morningstar`
- Into: `dev`

## Note

The player-facing devlog tab (`devlog-tab.js`) has the same missing-CSS gap (`.devlog-*` classes) and is not addressed here.