### PR TITLE
fix(devlog): recover player-facing devlog CSS + per-status chip colours

### DIFF
--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -232,6 +232,13 @@ body {
   background: var(--surf2); border: 1px solid var(--bdr); color: var(--txt3);
 }
 .dl-status-chip { color: var(--accent); border-color: var(--accent-a40); }
+/* Per-status RAG colours (recovered from #502 commit 30f0490; 'drafted'
+   reconciled to the live schema's 'in_progress'). Theme vars cover both themes. */
+.dl-status--considering { background: var(--crim-a8);        color: var(--crim2);       border-color: var(--crim-a15); }
+.dl-status--in_progress { background: var(--warn-orange-bg); color: var(--warn-orange); border-color: var(--warn-orange-bdr); }
+.dl-status--confirmed   { background: var(--green-dk-bg);    color: var(--green-dk);    border-color: var(--green-dk-bdr); }
+.dl-status--implemented { background: var(--green-dk-bg);    color: var(--txt3);        border-color: var(--bdr); }
+.dl-status--deferred    { background: transparent;           color: var(--txt3);        border-color: var(--bdr2); }
 .dl-target { margin-left: auto; font-family: var(--fl); font-size: 11px; color: var(--txt3); }
 .dl-card-title { font-family: var(--fh); font-size: 16px; color: var(--txt); }
 .dl-card-body { font-family: var(--ft); font-size: 14px; color: var(--txt2); white-space: pre-wrap; }

--- a/public/css/suite.css
+++ b/public/css/suite.css
@@ -2509,3 +2509,53 @@ body.desktop-mode.sidebar-collapsed .sb-collapse-btn { width: 100%; justify-cont
 .dm-hist-res.e { color: var(--accent); }
 .dm-hist-res.f { color: var(--err); }
 .dm-hist-res.d { color: var(--dmg-agg); }
+
+/* ── Devlog Tab (player-facing) ──
+   Recovered from issue #502 (commit 30f0490, never merged). Status names
+   reconciled to the live schema: the orphaned 'drafted' becomes 'in_progress'
+   (same amber treatment). All colours are theme vars, so it works in both the
+   dark and parchment themes. */
+.devlog-tab { padding: 16px 18px 32px; max-width: 700px; }
+.devlog-section { margin-bottom: 32px; }
+.devlog-section-heading {
+  font-family: var(--fl); font-size: 11px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: .14em; color: var(--gold2);
+  border-bottom: 1px solid var(--bdr2); padding-bottom: 6px; margin: 0 0 14px;
+}
+.devlog-card {
+  background: var(--surf2); border: 1px solid var(--bdr2);
+  border-left: 3px solid var(--bdr3); border-radius: 6px;
+  padding: 13px 16px 11px; margin-bottom: 10px;
+}
+.devlog-card-header {
+  display: flex; align-items: flex-start; justify-content: space-between;
+  gap: 10px; margin-bottom: 8px;
+}
+.devlog-title {
+  font-family: var(--fh); font-size: 14px; font-weight: 600;
+  color: var(--txt); line-height: 1.35; flex: 1;
+}
+.devlog-status {
+  flex-shrink: 0; align-self: flex-start; display: inline-block;
+  padding: 3px 9px; border-radius: 4px; font-family: var(--fl);
+  font-size: 10px; font-weight: 700; text-transform: uppercase;
+  letter-spacing: .4px; white-space: nowrap;
+}
+/* Left-border accent matches status colour. */
+.devlog-card:has(.devlog-status--considering) { border-left-color: var(--crim); }
+.devlog-card:has(.devlog-status--in_progress) { border-left-color: var(--warn-orange); }
+.devlog-card:has(.devlog-status--confirmed)   { border-left-color: var(--green-dk); }
+/* RAG status chips. */
+.devlog-status--considering { background: var(--crim-a8);        color: var(--crim2);       border: 1px solid var(--crim-a15); }
+.devlog-status--in_progress { background: var(--warn-orange-bg); color: var(--warn-orange); border: 1px solid var(--warn-orange-bdr); }
+.devlog-status--confirmed   { background: var(--green-dk-bg);    color: var(--green-dk);    border: 1px solid var(--green-dk-bdr); }
+.devlog-status--implemented { background: var(--green-dk-bg);    color: var(--txt3);        border: 1px solid var(--bdr); }
+.devlog-status--deferred    { background: transparent;           color: var(--txt3);        border: 1px solid var(--bdr2); }
+.devlog-body { font-size: 13px; color: var(--txt2); line-height: 1.65; margin: 0 0 8px; }
+.devlog-target { font-family: var(--fl); font-size: 11px; color: var(--txt3); letter-spacing: .03em; }
+.devlog-resolved { margin-top: 4px; border-top: 1px solid var(--bdr); padding-top: 16px; }
+.devlog-resolved-toggle {
+  font-family: var(--fl); font-size: 12px; color: var(--txt3);
+  cursor: pointer; user-select: none; letter-spacing: .04em; padding-bottom: 10px;
+}
+.devlog-resolved .devlog-card { opacity: .68; border-left-color: var(--bdr2) !important; }


### PR DESCRIPTION
## Summary

- Recovers devlog styling developed in #502 (commit `30f0490`) that was never merged — it landed on the branch three days after the #502 merges and was orphaned.
- `suite.css`: the player-facing `.devlog-*` styles (sectioned cards, left-border status accent, RAG status chips, collapsible Resolved group). The player devlog tab previously had **no CSS at all**.
- `admin-layout.css`: per-status RAG colours folded into the `.dl-status--*` chips from #517.

## Reconciliation

- The orphaned `drafted` status becomes `in_progress` (same amber treatment) to match the live 5-status schema.
- All colours use theme tokens (verified present for both themes), so dark + parchment are covered.
- The orphaned commit's old `.dl-form-row` markup rules and schema/fixtures changes are intentionally excluded (superseded by #517 / stale).

## Test plan

- [ ] Player game app (index.html) Devlog tab: cards, RAG status chips, and Resolved toggle render styled.
- [ ] Admin Devlog: Status chips show per-status colours.
- [ ] Toggle parchment/dark — colours follow.

## Branch flow

- From: `Morningstar`
- Into: `dev`