### PR TITLE
fix(devlog): Implemented status chips read as full green

### DIFF
--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -237,7 +237,7 @@ body {
 .dl-status--considering { background: var(--crim-a8);        color: var(--crim2);       border-color: var(--crim-a15); }
 .dl-status--in_progress { background: var(--warn-orange-bg); color: var(--warn-orange); border-color: var(--warn-orange-bdr); }
 .dl-status--confirmed   { background: var(--green-dk-bg);    color: var(--green-dk);    border-color: var(--green-dk-bdr); }
-.dl-status--implemented { background: var(--green-dk-bg);    color: var(--txt3);        border-color: var(--bdr); }
+.dl-status--implemented { background: var(--green-dk-bg);    color: var(--green-dk);    border-color: var(--green-dk-bdr); }
 .dl-status--deferred    { background: transparent;           color: var(--txt3);        border-color: var(--bdr2); }
 .dl-target { margin-left: auto; font-family: var(--fl); font-size: 11px; color: var(--txt3); }
 .dl-card-title { font-family: var(--fh); font-size: 16px; color: var(--txt); }

--- a/public/css/suite.css
+++ b/public/css/suite.css
@@ -2549,7 +2549,7 @@ body.desktop-mode.sidebar-collapsed .sb-collapse-btn { width: 100%; justify-cont
 .devlog-status--considering { background: var(--crim-a8);        color: var(--crim2);       border: 1px solid var(--crim-a15); }
 .devlog-status--in_progress { background: var(--warn-orange-bg); color: var(--warn-orange); border: 1px solid var(--warn-orange-bdr); }
 .devlog-status--confirmed   { background: var(--green-dk-bg);    color: var(--green-dk);    border: 1px solid var(--green-dk-bdr); }
-.devlog-status--implemented { background: var(--green-dk-bg);    color: var(--txt3);        border: 1px solid var(--bdr); }
+.devlog-status--implemented { background: var(--green-dk-bg);    color: var(--green-dk);    border: 1px solid var(--green-dk-bdr); }
 .devlog-status--deferred    { background: transparent;           color: var(--txt3);        border: 1px solid var(--bdr2); }
 .devlog-body { font-size: 13px; color: var(--txt2); line-height: 1.65; margin: 0 0 8px; }
 .devlog-target { font-family: var(--fl); font-size: 11px; color: var(--txt3); letter-spacing: .03em; }


### PR DESCRIPTION
## Summary

- Implemented chips had a faint green background but grey text/border, so they read as grey, not green.
- Switched text + border to the green tokens (`--green-dk` / `--green-dk-bdr`) in both the player (`suite.css`) and admin (`admin-layout.css`) views, matching the Confirmed treatment.

## Branch flow

- From: `Morningstar`
- Into: `dev`