### PR TITLE
feat(devlog): Recently Shipped section via a highlight flag

### DIFF
--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -244,6 +244,16 @@ body {
 .dl-card-body { font-family: var(--ft); font-size: 14px; color: var(--txt2); white-space: pre-wrap; }
 .dl-card-actions { display: flex; gap: 8px; }
 .dl-card-actions .btn-sm { margin-left: 0; }
+.dl-new-chip {
+  font-family: var(--fl); font-size: 10px; font-weight: 600;
+  letter-spacing: .08em; text-transform: uppercase;
+  padding: 3px 8px; border-radius: 4px;
+  background: var(--accent-a8); color: var(--gold2); border: 1px solid var(--accent-a40);
+}
+.dl-check-label {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--fl); font-size: 12px; color: var(--txt2); cursor: pointer;
+}
 
 .placeholder {
   color: var(--txt3);

--- a/public/css/suite.css
+++ b/public/css/suite.css
@@ -2559,3 +2559,8 @@ body.desktop-mode.sidebar-collapsed .sb-collapse-btn { width: 100%; justify-cont
   cursor: pointer; user-select: none; letter-spacing: .04em; padding-bottom: 10px;
 }
 .devlog-resolved .devlog-card { opacity: .68; border-left-color: var(--bdr2) !important; }
+
+/* "Recently Shipped" — prominent, full-opacity, gold-accented so just-shipped
+   entries read as news rather than archive (issue: implemented = looks old). */
+.devlog-recent-heading { color: var(--gold); }
+.devlog-recent .devlog-card { border-left-color: var(--gold2); }

--- a/public/js/admin/devlog-admin.js
+++ b/public/js/admin/devlog-admin.js
@@ -73,6 +73,10 @@ function _form(entry) {
         <label class="form-label">Target cycle</label>
         <input class="form-input" type="text" name="target_cycle" value="${esc(entry?.target_cycle || '')}" placeholder="e.g. Game 4">
       </div>
+      <label class="dl-check-label">
+        <input type="checkbox" name="highlight"${entry?.highlight ? ' checked' : ''}>
+        Highlight as new (show in the player "Recently Shipped" section)
+      </label>
       <div class="dl-form-actions">
         <button type="submit" class="btn-sm">${entry ? 'Save' : 'Create'}</button>
         <button type="button" class="btn-sm dl-cancel-btn">Cancel</button>
@@ -89,6 +93,7 @@ function _card(entry) {
       <div class="dl-card-meta">
         <span class="dl-type-chip">${esc(typeLabel)}</span>
         <span class="dl-status-chip dl-status--${esc(entry.status)}">${esc(statusLabel)}</span>
+        ${entry.highlight ? `<span class="dl-new-chip">New</span>` : ''}
         ${entry.target_cycle ? `<span class="dl-target">Target: ${esc(entry.target_cycle)}</span>` : ''}
       </div>
       <div class="dl-card-title">${esc(entry.title)}</div>
@@ -140,6 +145,9 @@ function _bindEvents(root) {
       const errEl = form.querySelector('.dl-form-error');
       const id    = form.dataset.id;
       const data  = Object.fromEntries(new FormData(form));
+      // FormData omits an unchecked box and gives "on" when checked; the schema
+      // wants a real boolean, so read the element directly.
+      data.highlight = !!form.elements.highlight?.checked;
       try {
         if (!id) {
           const created = await apiPost('/api/devlog', data);

--- a/public/js/tabs/devlog-tab.js
+++ b/public/js/tabs/devlog-tab.js
@@ -19,10 +19,23 @@ export async function renderDevlogTab(el) {
     return;
   }
 
-  const active   = entries.filter(e => e.status !== 'implemented' && e.status !== 'deferred');
-  const resolved = entries.filter(e => e.status === 'implemented' || e.status === 'deferred');
+  // Highlighted entries surface in a prominent "Recently Shipped" section at
+  // the top regardless of status, instead of falling into the collapsed
+  // Resolved group — so a just-implemented change reads as news. Everything
+  // else partitions by status as before. Each entry appears in one place only.
+  const highlighted = entries.filter(e => e.highlight);
+  const rest        = entries.filter(e => !e.highlight);
+  const active   = rest.filter(e => e.status !== 'implemented' && e.status !== 'deferred');
+  const resolved = rest.filter(e => e.status === 'implemented' || e.status === 'deferred');
 
   let h = '<div class="devlog-tab">';
+
+  if (highlighted.length) {
+    h += `<div class="devlog-section devlog-recent">`;
+    h += `<h3 class="devlog-section-heading devlog-recent-heading">Recently Shipped</h3>`;
+    for (const entry of highlighted) h += _renderCard(entry);
+    h += `</div>`;
+  }
 
   h += _renderSection('Rule Changes',    active.filter(e => e.type === 'rule_change'));
   h += _renderSection('App Development', active.filter(e => e.type === 'app_feature'));
@@ -35,7 +48,7 @@ export async function renderDevlogTab(el) {
     h += `</details>`;
   }
 
-  if (!active.length && !resolved.length) {
+  if (!entries.length) {
     h += '<p class="placeholder-msg">Nothing posted yet.</p>';
   }
 
@@ -47,17 +60,20 @@ function _renderSection(heading, items) {
   if (!items.length) return '';
   let h = `<div class="devlog-section">`;
   h += `<h3 class="devlog-section-heading">${esc(heading)}</h3>`;
-  for (const entry of items) {
-    const statusLabel = DEVLOG_STATUS_LABELS[entry.status] || entry.status;
-    h += `<div class="devlog-card">`;
-    h += `<div class="devlog-card-header">`;
-    h += `<span class="devlog-title">${esc(entry.title)}</span>`;
-    h += `<span class="devlog-status devlog-status--${esc(entry.status)}">${esc(statusLabel)}</span>`;
-    h += `</div>`;
-    if (entry.body) h += `<p class="devlog-body">${esc(entry.body)}</p>`;
-    if (entry.target_cycle) h += `<div class="devlog-target">Target: ${esc(entry.target_cycle)}</div>`;
-    h += `</div>`;
-  }
+  for (const entry of items) h += _renderCard(entry);
+  h += `</div>`;
+  return h;
+}
+
+function _renderCard(entry) {
+  const statusLabel = DEVLOG_STATUS_LABELS[entry.status] || entry.status;
+  let h = `<div class="devlog-card">`;
+  h += `<div class="devlog-card-header">`;
+  h += `<span class="devlog-title">${esc(entry.title)}</span>`;
+  h += `<span class="devlog-status devlog-status--${esc(entry.status)}">${esc(statusLabel)}</span>`;
+  h += `</div>`;
+  if (entry.body) h += `<p class="devlog-body">${esc(entry.body)}</p>`;
+  if (entry.target_cycle) h += `<div class="devlog-target">Target: ${esc(entry.target_cycle)}</div>`;
   h += `</div>`;
   return h;
 }

--- a/server/schemas/devlog_entry.schema.js
+++ b/server/schemas/devlog_entry.schema.js
@@ -9,6 +9,10 @@ export const devlogEntrySchema = {
     title:        { type: 'string', minLength: 1 },
     body:         { type: 'string' },
     status:       { type: 'string', enum: ['considering', 'confirmed', 'in_progress', 'implemented', 'deferred'] },
+    // When true, the entry is surfaced in the player tab's prominent
+    // "Recently Shipped" section regardless of status, instead of falling into
+    // the collapsed Resolved group. Lets a just-implemented change read as news.
+    highlight:    { type: 'boolean' },
     target_cycle: { type: 'string' },
     created_at:   { type: 'string' },
     updated_at:   { type: 'string' },

--- a/server/tests/api-devlog.test.js
+++ b/server/tests/api-devlog.test.js
@@ -136,6 +136,23 @@ describe('AC#2 — POST creates entry (ST only)', () => {
     expect(res.status).toBe(400);
   });
 
+  it('accepts and round-trips the boolean highlight flag', async () => {
+    const res = await request(app)
+      .post('/api/devlog')
+      .set('X-Test-User', stUser())
+      .send({ ...VALID_ENTRY, title: 'Test highlight flag', highlight: true });
+    expect(res.status).toBe(201);
+    expect(res.body.highlight).toBe(true);
+  });
+
+  it('400 when highlight is not a boolean', async () => {
+    const res = await request(app)
+      .post('/api/devlog')
+      .set('X-Test-User', stUser())
+      .send({ ...VALID_ENTRY, highlight: 'yes' });
+    expect(res.status).toBe(400);
+  });
+
   // expose createdId for PATCH / DELETE suites
   afterAll(() => {
     globalThis._devlogTestId = createdId;


### PR DESCRIPTION
## Summary

- Implemented entries were auto-shunted into the dimmed, collapsed Resolved group, so a just-shipped change looked like old news.
- Entries can now be flagged **highlight**, surfacing them in a prominent gold-accented **Recently Shipped** section at the top of the player devlog, regardless of status. Untick to return the entry to its normal status placement.

## Changes

- `devlog_entry.schema.js`: new boolean `highlight` field.
- `devlog-admin.js`: "Highlight as new" checkbox (coerced to a real boolean on save) + a gold "New" chip on flagged entries.
- `devlog-tab.js`: partitions highlighted entries into a top "Recently Shipped" section; card markup extracted into a shared `_renderCard` helper.
- `suite.css` / `admin-layout.css`: Recently Shipped styling (player) and New chip / checkbox styling (admin), from existing theme tokens.
- `api-devlog.test.js`: highlight round-trips on POST; non-boolean rejected.

## Test plan

- [ ] `cd server && npx vitest run tests/api-devlog.test.js` (19 pass)
- [ ] Admin: tick "Highlight as new" on an entry; it shows a New chip.
- [ ] Player: flagged entry appears in "Recently Shipped" at top, gold-accented, not dimmed; unticking returns it to its status section/Resolved.

## Branch flow

- From: `Morningstar`
- Into: `dev`