### PR TITLE
fix(downtime): guard renderForm against a null/detached container

### DIFF
--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -1954,6 +1954,12 @@ async function handleSubmitFinalConfirm(container) {
 }
 
 function renderForm(container) {
+  // Guard against a detached/missing container: renderDowntimeTab renders into
+  // `document.getElementById('dt-container')`, which is briefly null if the tab
+  // is re-rendered while a prior async render is still in flight. No container
+  // means nothing to draw (a newer render owns the live DOM); bail rather than
+  // throw an uncaught TypeError on container.querySelectorAll.
+  if (!container) return;
   const saved = responseDoc?.responses || {};
   const status = responseDoc?.status || 'new';
   const isST = isSTRole();


### PR DESCRIPTION
## Summary

- `renderDowntimeTab` renders into `document.getElementById('dt-container')`, which is briefly `null` when the downtime tab is re-rendered while a prior async render is still in flight. `renderForm` then threw an uncaught `TypeError` on `container.querySelectorAll` (`downtime-form.js:2215`).
- Guard: `renderForm` no-ops on a null container (a newer render owns the live DOM in that case).

Pre-existing race surfaced while testing #522 on dev; not caused by #522.

## Branch flow

- From: `Morningstar`
- Into: `dev`