### PR TITLE
fix: snapshot character_name in ordeal-responses/all for retired chars

### DIFF
--- a/server/routes/ordeal-responses.js
+++ b/server/routes/ordeal-responses.js
@@ -188,6 +188,23 @@ router.get('/all', requireRole('st'), async (req, res) => {
     });
   }
 
+  // Snapshot character_name for all docs that have a character_id — includes
+  // retired characters which may not appear in the admin's active chars[] array.
+  const charIds = [...new Set(docs.filter(d => d.character_id).map(d => d.character_id))];
+  if (charIds.length) {
+    const charDocs = await getCollection('characters').find(
+      { _id: { $in: charIds } },
+      { projection: { _id: 1, name: 1, moniker: 1, honorific: 1 } }
+    ).toArray();
+    const charMap = new Map(charDocs.map(c => [String(c._id), c]));
+    docs.forEach(d => {
+      if (d.character_id && !d.character_name) {
+        const c = charMap.get(String(d.character_id));
+        if (c) d.character_name = [c.honorific, c.moniker || c.name].filter(Boolean).join(' ');
+      }
+    });
+  }
+
   res.json(docs);
 });
 


### PR DESCRIPTION
## Summary

- GET /api/ordeal-responses/all now resolves and snapshots `character_name` for every doc that has a `character_id`, after the existing null-character_id enrichment step
- Uses a batch character lookup (one query), including retired characters — `charNameForSub()` already falls back to `sub.character_name` before 'Unknown', so no frontend change needed
- Fixes "Unknown" for Humongulous (retired) and any other retired character whose `character_id` may not appear in the admin's active `chars[]` array

## Test plan

- [ ] 27 existing tests green (no new tests needed — name snapshot is additive)
- [ ] Manual: reload admin Ordeals tab after Render redeploys — Humongulous's submission should show the correct name

## Branch flow

- From: `Morningstar`
- Into: `dev`
- Server change — confirm after merge to main