### PR TITLE
fix: allow current field in character schema (STM tracker overlay)

### DIFF
--- a/server/schemas/character.schema.js
+++ b/server/schemas/character.schema.js
@@ -55,6 +55,7 @@ export const characterSchema = {
     retired:          { type: 'boolean' },
     pending_approval: { type: 'boolean' },
     created_at:       { type: 'string' },
+    current:          { type: ['object', 'null'], additionalProperties: true },
 
     clan: {
       type: ['string', 'null'],


### PR DESCRIPTION
## Summary

- `character.schema.js` has `additionalProperties: false` at root — the STM tracker writes `c.current.*` (willpower, vitae) onto some character docs, causing 400 on any save for those characters
- Adds `current` as an allowed nullable object property (no further type constraint — tracker writes varied shapes here)
- Unblocks unretiring Humongulous and any other character with tracker state stored on the doc

## Test plan

- [ ] Retry unretiring Humongulous — save should succeed

## Branch flow

- From: `Morningstar` → `dev`
- Server change — needs merge to main to take effect