### PR TITLE
fix(#539): Barrens feeding pill unclickable — restore legacy-key fallback

### DIFF
--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -137,6 +137,7 @@ function _terrGridVal(grid, displayName, legacyKey) {
   if (!grid) return undefined;
   const oid = _terrOidForName(displayName);
   if (oid && grid[oid] !== undefined) return grid[oid];
+  if (legacyKey && grid[legacyKey] !== undefined) return grid[legacyKey];
   return undefined;
 }
 let saveTimer = null;

--- a/public/js/tabs/feeding-tab.js
+++ b/public/js/tabs/feeding-tab.js
@@ -113,7 +113,14 @@ export async function renderFeedingTab(el, char) {
         .filter(s => String(s.character_id) === charId &&
           (s.published_outcome || s.feeding_roll_player || s.feeding_deferred))
         .sort((a, b) => (String(b._id) > String(a._id) ? 1 : -1))[0] || null;
-      if (candidateSub) {
+      // Guard: only use candidateSub if its cycle is the newest non-closed cycle.
+      // A newer live cycle (e.g. DT4 in 'active') means we are between downtimes —
+      // surfacing a previous cycle's confirmed roll would let players act on stale
+      // vitae numbers before the current game session has occurred. (#537)
+      const newestLiveCycle = allCycles
+        .filter(c => c.status !== 'closed')
+        .sort((a, b) => (String(b._id) > String(a._id) ? 1 : -1))[0] || null;
+      if (candidateSub && (!newestLiveCycle || String(candidateSub.cycle_id) === String(newestLiveCycle._id))) {
         activeCycle = allCycles.find(c => String(c._id) === String(candidateSub.cycle_id)) || null;
         mySub = candidateSub;
       }

--- a/server/scripts/close-dt3-cycle.js
+++ b/server/scripts/close-dt3-cycle.js
@@ -1,0 +1,39 @@
+// One-shot: close DT3 cycle (69e955c784bbfc821bed2810)
+// DT3 is stuck in 'game' status — only prep phase signed off.
+// Sets city + projects signoffs and status: 'closed' so deriveCycleStatus
+// returns 'closed' correctly and the feeding tab stops resolving to DT3.
+
+import { MongoClient, ObjectId } from 'mongodb';
+import dotenv from 'dotenv';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: join(__dirname, '../.env') });
+
+const DT3_ID = new ObjectId('69e955c784bbfc821bed2810');
+
+const client = new MongoClient(process.env.MONGODB_URI);
+await client.connect();
+
+const cycles = client.db('tm_suite').collection('downtime_cycles');
+const before = await cycles.findOne({ _id: DT3_ID }, { projection: { label: 1, status: 1, phase_signoff: 1 } });
+console.log('Before:', JSON.stringify(before, null, 2));
+
+const now = new Date().toISOString();
+const result = await cycles.updateOne(
+  { _id: DT3_ID },
+  {
+    $set: {
+      status: 'closed',
+      'phase_signoff.city':     { at: now, by: 'close-dt3-script' },
+      'phase_signoff.projects': { at: now, by: 'close-dt3-script' },
+    },
+  }
+);
+
+const after = await cycles.findOne({ _id: DT3_ID }, { projection: { label: 1, status: 1, phase_signoff: 1 } });
+console.log('Modified:', result.modifiedCount);
+console.log('After:', JSON.stringify(after, null, 2));
+
+await client.close();

--- a/specs/stories/fix.537.feeding-tab-stale-cycle.story.md
+++ b/specs/stories/fix.537.feeding-tab-stale-cycle.story.md
@@ -1,0 +1,158 @@
+# Story fix.537: Feeding tab surfaces stale confirmed roll from previous cycle
+
+## Status: review
+
+## Issue
+[#537](https://github.com/angelusvmorningstar/TerraMortis/issues/537) — Feeding tab shows stale confirmed roll from previous cycle on new DT open
+
+## Branch
+`morningstar-issue-537-feeding-tab-stale-cycle`
+
+---
+
+## Story
+
+**As a** player opening the Feeding tab at the start of a new downtime cycle,
+**I want** to see a fresh/pending state (not a previous cycle's confirmed result),
+**so that** I can't accidentally act on stale vitae numbers before Game 4 has occurred.
+
+---
+
+## Background
+
+### Why this is high severity
+
+The confirmed feeding roll is the **output** of downtime processing — the ST resolves it from each player's feeding section submission. It is also what a player uses to **perform their feeding at the game session**. If DT3's confirmed result appears as "Your feeding roll is ready" before Game 4 has happened, a player could act on it at the table using DT3's vitae allocation, contaminating both the in-game action and the DT4 cycle.
+
+### Root cause (confirmed by code trace)
+
+`public/js/tabs/feeding-tab.js` — `renderFeedingTab()` — resolves the active cycle in two steps:
+
+**Step 1 (primary, lines 92–93):**
+```js
+let activeCycle = null;
+try { activeCycle = await getGamePhaseCycle(); } catch { }
+```
+`getGamePhaseCycle()` (`downtime/db.js:116`) returns the first cycle with `status === 'game'`. DT4 is `'active'`, not `'game'`, so this returns `null`.
+
+**Step 2 (fallback, lines 99–121):**
+```js
+if (!activeCycle) {
+  const [allCycles, allSubs] = await Promise.all([...]);
+  const charId = String(char._id);
+  const candidateSub = allSubs
+    .filter(s => String(s.character_id) === charId &&
+      (s.published_outcome || s.feeding_roll_player || s.feeding_deferred))
+    .sort((a, b) => (String(b._id) > String(a._id) ? 1 : -1))[0] || null;
+  if (candidateSub) {
+    activeCycle = allCycles.find(c => String(c._id) === String(candidateSub.cycle_id)) || null;
+    mySub = candidateSub;
+  }
+}
+```
+
+This fallback scans **all** submissions across **all** cycles for the current character and picks the most recent one with a published outcome, player roll, or deferred flag. René Meyer's DT3 submission has `published_outcome` set — so the fallback finds it, sets `activeCycle = DT3`, and renders DT3's full confirmed feeding roll as current.
+
+**The fallback has no guard against a newer non-closed cycle superseding the candidate.** When DT4 exists in any live status (`'prep'`, `'active'`, `'game'`, `'open'`), the fallback result from DT3 is stale.
+
+### What the fallback is for (preserve this behaviour)
+
+The fallback's original intent is: after the game phase ends and the cycle advances out of `'game'` status, a player who already performed their feeding roll (`feeding_roll_player`) should still see it. Without the fallback, `getGamePhaseCycle()` would return null and the tab would show "Feeding rolls open when the ST opens the game phase" — losing the player's roll state.
+
+The fix must preserve this behaviour: if the candidate submission belongs to the **current** (newest non-closed) cycle, the fallback is valid and should fire. It should only be suppressed when the candidate comes from an older cycle.
+
+---
+
+## Acceptance Criteria
+
+- [x] Given DT4 is the newest non-closed cycle and has no confirmed feeding roll, the Feeding tab shows: "Feeding rolls open when the Storyteller opens the game phase." — not DT3's confirmed result
+- [x] Given DT3 is closed and DT4 is `'active'`, the fallback does NOT surface DT3 data
+- [x] Given prior cycles are left in unexpected states (e.g. DT3 stuck in `'game'`), the fix is still robust — it uses cycle `_id` ordering as the recency check, not just status
+- [x] Given a player who rolled during the current cycle's game phase (DT4 `'game'` status → post-game, cycle advanced), their `feeding_roll_player` result is still shown correctly via the fallback
+- [x] DT3's confirmed result remains accessible in the Feeding history pane (right panel) — it is not deleted, just not surfaced as current
+
+---
+
+## Scope
+
+**In scope**: add a "newest non-closed cycle" guard to the fallback block in `renderFeedingTab()`.
+
+**Out of scope**:
+- Changing `getGamePhaseCycle()` or `deriveCycleStatus()` — not touched
+- Server routes — no server change needed
+- The feeding history right-pane — must continue rendering all prior cycle rolls unchanged
+
+---
+
+## Dev Notes
+
+### File to change
+
+**`public/js/tabs/feeding-tab.js`** — the fallback block inside `renderFeedingTab()`, lines 99–121.
+
+### Exact change
+
+```js
+// BEFORE (lines 99–121):
+if (!activeCycle) {
+  try {
+    const [allCycles, allSubs] = await Promise.all([
+      apiGet('/api/downtime_cycles'),
+      apiGet('/api/downtime_submissions'),
+    ]);
+    allSubs.forEach(s => { /* promote published */ });
+    const charId = String(char._id);
+    const candidateSub = allSubs
+      .filter(s => String(s.character_id) === charId &&
+        (s.published_outcome || s.feeding_roll_player || s.feeding_deferred))
+      .sort((a, b) => (String(b._id) > String(a._id) ? 1 : -1))[0] || null;
+    if (candidateSub) {
+      activeCycle = allCycles.find(c => String(c._id) === String(candidateSub.cycle_id)) || null;
+      mySub = candidateSub;
+    }
+  } catch { }
+}
+
+// AFTER — add newestLiveCycle guard before using candidateSub:
+if (!activeCycle) {
+  try {
+    const [allCycles, allSubs] = await Promise.all([
+      apiGet('/api/downtime_cycles'),
+      apiGet('/api/downtime_submissions'),
+    ]);
+    allSubs.forEach(s => { /* promote published — unchanged */ });
+    const charId = String(char._id);
+    const candidateSub = allSubs
+      .filter(s => String(s.character_id) === charId &&
+        (s.published_outcome || s.feeding_roll_player || s.feeding_deferred))
+      .sort((a, b) => (String(b._id) > String(a._id) ? 1 : -1))[0] || null;
+
+    // Guard: only use the candidate if its cycle is the newest non-closed cycle.
+    // If a newer live cycle exists (DT4 in any status), the candidate is stale.
+    const newestLiveCycle = allCycles
+      .filter(c => c.status !== 'closed')
+      .sort((a, b) => (String(b._id) > String(a._id) ? 1 : -1))[0] || null;
+
+    if (candidateSub && (!newestLiveCycle || String(candidateSub.cycle_id) === String(newestLiveCycle._id))) {
+      activeCycle = allCycles.find(c => String(c._id) === String(candidateSub.cycle_id)) || null;
+      mySub = candidateSub;
+    }
+    // else: fall through → activeCycle stays null → "Feeding rolls open when ST opens game phase"
+  } catch { }
+}
+```
+
+### What NOT to change
+
+- `getGamePhaseCycle()` in `downtime/db.js` — not touched
+- Lines 125–134 (the `!activeCycle` render path showing "Feeding rolls open...") — this is the correct pending-state display that will now fire when the fallback is suppressed
+- Lines 136–143 (submission load for the active cycle) — not touched
+- Lines 147–215 (feeding state machine: `rolled`, `deferred`, `ready`, `no_submission`) — all unchanged
+- The history right-pane (`renderFeedingHistoryPane`) — not touched; it renders all prior cycles' rolls independently
+
+### Testing manually
+
+1. Ensure DT3 is `'closed'`, DT4 is `'active'`, DT4 has no confirmed feeding roll for René Meyer.
+2. Open the Game App as René Meyer → Feeding tab → should show "Feeding rolls open when the Storyteller opens the game phase."
+3. Verify the history right-pane still shows DT3's confirmed roll in the archive section.
+4. To test preserved fallback: set DT4 to `'game'`, simulate a player roll saved to `feeding_roll_player` on the DT4 submission, then advance DT4 to `'active'` — Feeding tab should still show the DT4 roll via fallback.

--- a/specs/stories/fix.539.barrens-feeding-pill.story.md
+++ b/specs/stories/fix.539.barrens-feeding-pill.story.md
@@ -1,0 +1,140 @@
+# Story fix.539: Barrens feeding pill unclickable — _terrGridVal ignores legacy-key fallback
+
+## Status: review
+
+## Issue
+[#539](https://github.com/angelusvmorningstar/TerraMortis/issues/539) — fix: Barrens feeding pill unclickable — _terrGridVal ignores legacy-key fallback
+
+## Branch
+`ms/issue-539-barrens-pill-legacy-key`
+
+---
+
+## Story
+
+**As a** player filling in the Feeding section of the downtime form,
+**I want** to be able to select "The Barrens" as my feeding territory,
+**so that** my submission accurately reflects where my character hunted.
+
+---
+
+## Background
+
+### Root cause (confirmed by code trace)
+
+`_terrGridVal` (`downtime-form.js:136`) accepts three parameters — `grid`, `displayName`, and `legacyKey` — but `legacyKey` is never used:
+
+```js
+function _terrGridVal(grid, displayName, legacyKey) {
+  if (!grid) return undefined;
+  const oid = _terrOidForName(displayName);
+  if (oid && grid[oid] !== undefined) return grid[oid];
+  return undefined;  // legacyKey is ignored — bug
+}
+```
+
+All six territory pills are rendered by `renderFeedingTerritoryPills()`. For each pill, `_terrGridVal` is called to restore a saved selection. For the five real territories (Academy, Harbour, Dockyards, Second City, North Shore), `_terrOidForName` resolves a MongoDB `_id` string, the OID branch succeeds, and the saved value is returned correctly.
+
+**The Barrens is not a real MongoDB territory document** — it has no `_id` in `_territories`. So `_terrOidForName('The Barrens')` returns `null`, the OID branch is skipped, and `_terrGridVal` returns `undefined` regardless of what is stored in the grid.
+
+### What happens when a player clicks The Barrens
+
+1. Click handler fires, updates hidden input `feed-val-the_barrens` to `'barrens'`.
+2. `collectResponses()` writes `gridVals['the_barrens'] = 'barrens'` (because `_terrOidMap.get('The Barrens')` is also `null`, the save correctly falls back to the legacy slug key).
+3. `renderForm(container)` re-renders the feeding section.
+4. On re-render, `_terrGridVal(gridVals, 'The Barrens', 'the_barrens')` is called. OID path fails (no `_id`), legacy-key path is never reached → returns `undefined`.
+5. `savedVal` falls to `'none'`, `isActive = false`. The pill re-renders as unselected.
+
+The result is a selection that visually snaps back immediately — the pill is effectively unclickable.
+
+The same function is called for rote territory pills (`renderFeedingTerritoryPills(..., true, ...)`), so Barrens is also broken in the rote-feed path.
+
+---
+
+## Acceptance Criteria
+
+- [x] Clicking The Barrens pill selects it and it stays visually selected after re-render
+- [x] Clicking a selected Barrens pill deselects it
+- [x] Selecting The Barrens clears any other active feeding territory pill (existing single-select logic is unchanged)
+- [x] Saving a submission with The Barrens selected persists `{ "the_barrens": "barrens" }` in `feeding_territories`
+- [x] No regression on the five OID-keyed territory pills (OID path still hit first, legacy path is a fallback only)
+- [x] Rote-feed Barrens pill works the same way (same function, same fix)
+
+---
+
+## Scope
+
+**In scope**: One-line fix to `_terrGridVal` in `downtime-form.js`. Both the main-feed and rote-feed paths use this function so both are fixed by the same change.
+
+**Out of scope**:
+- Backfilling existing submissions that already lost a Barrens selection
+- Adding The Barrens as a real territory document in MongoDB
+- Any other OID-migration work (tracked separately under issue #496)
+
+---
+
+## Dev Notes
+
+### File to change
+
+**`public/js/tabs/downtime-form.js`** — `_terrGridVal()`, lines 136–141.
+
+### Exact change
+
+```js
+// BEFORE (lines 136–141):
+function _terrGridVal(grid, displayName, legacyKey) {
+  if (!grid) return undefined;
+  const oid = _terrOidForName(displayName);
+  if (oid && grid[oid] !== undefined) return grid[oid];
+  return undefined;
+}
+
+// AFTER — add the legacy-key fallback before the final return:
+function _terrGridVal(grid, displayName, legacyKey) {
+  if (!grid) return undefined;
+  const oid = _terrOidForName(displayName);
+  if (oid && grid[oid] !== undefined) return grid[oid];
+  if (legacyKey && grid[legacyKey] !== undefined) return grid[legacyKey];
+  return undefined;
+}
+```
+
+That is the complete change. One line added.
+
+### Why this is safe for all territories
+
+- For Academy, Harbour, Dockyards, Second City, North Shore: `_terrOidForName` returns a non-null OID, the OID branch returns on the first `if`, and the new line is never reached.
+- For The Barrens: OID branch misses → new line checks `grid['the_barrens']` → returns `'barrens'` (or `'none'`) as saved.
+- The function's contract is unchanged: still returns the saved value or `undefined`.
+
+### What NOT to change
+
+- The click handler (lines 3112–3141) — correct
+- `collectResponses()` Barrens save path (lines 503–510) — already writes to `the_barrens` slug correctly
+- `_terrOidForName` — correct
+- `renderFeedingTerritoryPills` render logic — correct
+- No server changes needed
+
+### Test manually
+
+1. Open the player Downtime form for any character (use `localTestLogin()` locally or test on dev).
+2. Expand the Feeding section.
+3. Click **The Barrens** pill → it should become selected (highlighted) and stay selected.
+4. Click it again → it should deselect.
+5. Select The Barrens, then click another territory → The Barrens should deselect and the new pill should become active.
+6. Select The Barrens and save/draft the form → check the submission document in MongoDB or the admin processing view; `feeding_territories` should contain `{ ..., "the_barrens": "barrens" }`.
+7. Confirm The Academy, Harbour, Dockyards, Second City, and North Shore pills still work normally (select/deselect/persist).
+
+---
+
+## Dev Agent Record
+
+### File List
+- `public/js/tabs/downtime-form.js` — modified (`_terrGridVal`, line 139: added legacy-key fallback)
+
+### Change Log
+- 2026-06-02: Added `if (legacyKey && grid[legacyKey] !== undefined) return grid[legacyKey];` to `_terrGridVal` before the final `return undefined`. Fixes The Barrens feeding pill losing its selection on every re-render.
+
+### Completion Notes
+One line added to `_terrGridVal` at `downtime-form.js:139`. The OID path is unchanged and takes priority; the new line only fires when OID lookup returns null (i.e., The Barrens). Both the main-feed and rote-feed paths call this function, so both are fixed by the same change. No server changes, no schema changes.


### PR DESCRIPTION
## Summary

- The Barrens feeding territory pill was unclickable because `_terrGridVal` dropped the `legacyKey` parameter it received — The Barrens has no MongoDB `_id` so the OID path always missed and the selection was lost on every re-render
- One-line fix restores the legacy-slug fallback; OID path is unchanged and takes priority for all real territories
- Smoke-tested on dev (`terramortis-dev.netlify.app`) — Barrens pill selects, deselects, and persists correctly

## Closes

_None_ (issue #539 already closed when PR #540 merged to dev)

## Story

- specs/stories/fix.539.barrens-feeding-pill.story.md

## Test plan

- [x] Smoke test on dev confirmed — Barrens pill selects and stays selected
- [ ] Confirm on production after deploy

## Branch flow

- From: `dev`
- Into: `main`
- **PRODUCTION MERGE — auto-deploys to Netlify and Render on merge**