### PR TITLE
feat(#544): session switcher dropdown in check-in header

### DIFF
--- a/public/css/suite.css
+++ b/public/css/suite.css
@@ -1121,6 +1121,7 @@ body.desktop-mode .sh-powers-grid > .sh-sec{break-inside:avoid;}
 .si-rate-label { font-family: var(--fl); font-size: 12px; color: var(--txt3); text-transform: uppercase; letter-spacing: 0.08em; display: flex; align-items: center; gap: 8px; }
 .si-rate-input { width: 80px; background: var(--surf); border: 1px solid var(--bdr); border-radius: 5px; color: var(--txt); font-family: var(--fl); font-size: 13px; padding: 6px 8px; min-height: 36px; text-transform: none; letter-spacing: 0; }
 .si-footer { padding: 10px 16px; border-top: 1px solid var(--bdr); font-family: var(--fl); font-size: 12px; color: var(--txt2); background: var(--surf2); }
+.si-session-sel { background: var(--surf2); border: 1px solid var(--bdr); border-radius: 5px; color: var(--txt); font-family: var(--fl); font-size: 12px; padding: 6px 8px; flex: 1; min-height: 36px; cursor: pointer; }
 
 /* ── Finance Tab ── */
 #t-finance.active { display: flex; flex-direction: column; overflow-y: auto; padding: 12px; }

--- a/public/js/game/signin-tab.js
+++ b/public/js/game/signin-tab.js
@@ -48,6 +48,7 @@ function calcEminence(session, chars) {
 }
 
 let _session = null;
+let _sessions = [];
 let _chars = [];
 let _saveTimer = null;
 let _el = null;
@@ -126,7 +127,8 @@ export async function initSignIn(el, chars) {
 
   try {
     const sessions = await apiGet('/api/game_sessions');
-    _session = sessions.sort((a, b) => b.session_date.localeCompare(a.session_date))[0] || null;
+    _sessions = sessions.sort((a, b) => b.session_date.localeCompare(a.session_date));
+    _session  = _sessions[0] || null;
   } catch {
     el.innerHTML = '<div class="si-empty">Could not load sessions. Check your connection.</div>';
     return;
@@ -162,6 +164,7 @@ async function handleNewSession() {
     attendance:   [],
   });
   _session = created;
+  _sessions.unshift(created);
   await Promise.all([loadPlayerNames(), loadLastCycleData()]);
   render();
 }
@@ -208,12 +211,6 @@ function render() {
 
   const attendedCount = roster.filter(c => entryByCharId.get(String(c._id))?.attended).length;
 
-  const parts = [];
-  if (_session.game_number != null) parts.push(`Game ${_session.game_number}`);
-  if (_session.session_date) parts.push(_session.session_date);
-  if (_session.title) parts.push(_session.title);
-  const label = parts.join(' — ');
-
   const { eminence, ascendancy } = calcEminence(_session, _chars);
   const fmtTop = (arr) => arr.length
     ? arr.map(e => `${esc(e.name)} (${e.total})`).join(' · ')
@@ -221,8 +218,18 @@ function render() {
 
   const rate = Number.isFinite(_session.session_rate) ? _session.session_rate : DEFAULT_RATE;
 
+  const sessionOpts = _sessions.map(s => {
+    const p = [];
+    if (s.game_number != null) p.push(`Game ${s.game_number}`);
+    if (s.session_date)        p.push(s.session_date);
+    if (s.title)               p.push(s.title);
+    const lbl = p.join(' — ');
+    const sel = String(s._id) === String(_session._id) ? ' selected' : '';
+    return `<option value="${esc(String(s._id))}"${sel}>${esc(lbl)}</option>`;
+  }).join('');
+
   let h = `<div class="si-header">
-    <span class="si-session-label">${esc(label)}</span>
+    <select class="si-session-sel" id="si-session-sel">${sessionOpts}</select>
     <span class="si-stat">${attendedCount} / ${roster.length} attended</span>
     <span class="si-status"></span>
   </div>
@@ -355,6 +362,17 @@ function wireEvents() {
       render();
     });
   });
+
+  const sessSel = _el.querySelector('#si-session-sel');
+  if (sessSel) {
+    sessSel.addEventListener('change', () => {
+      const chosen = _sessions.find(s => String(s._id) === sessSel.value);
+      if (chosen) {
+        _session = chosen;
+        render();
+      }
+    });
+  }
 
   const rateInput = _el.querySelector('#si-session-rate');
   if (rateInput) {


### PR DESCRIPTION
## Summary

- Replaces the static session label in the Check-In header with a `<select>` dropdown listing all sessions most-recent-first
- Session switch is synchronous — all data already in memory from the initial fetch; no extra API calls
- New sessions created via "+ New Session" are prepended to the dropdown immediately

## Closes

- Closes #544

## Story

- specs/stories/feature.544.checkin-session-switcher.story.md

## Test plan

- [ ] Check-In tab header shows a dropdown defaulting to the most recent session
- [ ] Switching to a historical session re-renders roster, attendance, payment, eminence, and footer for that session
- [ ] Writes (attendance tick, payment method, rate) save against the selected session
- [ ] CI green
- [ ] Manual: smoke-check on dev — switch sessions and confirm panel updates correctly

## Branch flow

- From: `ms/issue-544-checkin-session-switcher`
- Into: `dev`