### PR TITLE
feat(#550): add 'transfer' as a first-class payment method

### DIFF
--- a/public/js/admin/attendance.js
+++ b/public/js/admin/attendance.js
@@ -30,7 +30,7 @@ function esc(s) {
   return d.innerHTML;
 }
 
-const PAYMENT_METHODS = ['', 'Cash', 'PayPal', 'PayID (Symon)', 'Transfer (Lyn)', 'Exiles', 'Waived'];
+const PAYMENT_METHODS = ['', 'Cash', 'PayPal', 'PayID (Symon)', 'Transfer', 'Exiles', 'Waived'];
 
 export async function initAttendance(charList) {
   chars = charList.filter(c => !c.retired);

--- a/public/js/game/finance-tab.js
+++ b/public/js/game/finance-tab.js
@@ -42,16 +42,16 @@ export async function initFinanceTab(el) {
 // ── Derived calculations ────────────────────────────────────────────────────
 
 function derivePayments(session) {
-  const byMethod = { cash: 0, payid: 0, paypal: 0, exiles: 0 };
-  const counts  = { cash: 0, payid: 0, paypal: 0, exiles: 0, waived: 0 };
+  const byMethod = { cash: 0, payid: 0, paypal: 0, transfer: 0, exiles: 0 };
+  const counts  = { cash: 0, payid: 0, paypal: 0, transfer: 0, exiles: 0, waived: 0 };
   for (const entry of session.attendance || []) {
     const { method, amount } = readPayment(entry);
     if (!method) continue;
     counts[method] = (counts[method] || 0) + 1;
     if (byMethod[method] !== undefined) byMethod[method] += amount;
   }
-  // Exiles is offset/credit, not real cash collected
-  const collected = byMethod.cash + byMethod.payid + byMethod.paypal;
+  // Exiles is offset/credit, not real cash collected. Transfer is collected.
+  const collected = byMethod.cash + byMethod.payid + byMethod.paypal + byMethod.transfer;
   return { byMethod, counts, collected };
 }
 
@@ -122,6 +122,7 @@ function render() {
         <div class="fin-row"><span>Cash</span><span>$${byMethod.cash}</span></div>
         <div class="fin-row"><span>PayID</span><span>$${byMethod.payid}</span></div>
         <div class="fin-row"><span>PayPal</span><span>$${byMethod.paypal}</span></div>
+        <div class="fin-row"><span>Transfer</span><span>$${byMethod.transfer}</span></div>
         <div class="fin-row fin-row-dim"><span>Exiles (offset)</span><span>${counts.exiles}</span></div>
         <div class="fin-row fin-row-dim"><span>Waived</span><span>${counts.waived}</span></div>
         <div class="fin-row fin-row-total"><span>Collected</span><span>$${collected}</span></div>

--- a/public/js/game/payment-helpers.js
+++ b/public/js/game/payment-helpers.js
@@ -21,6 +21,7 @@ export function normalisePaymentMethod(val) {
   if (s.startsWith('payid')) return 'payid';
   if (s.startsWith('paypal')) return 'paypal';
   if (s.startsWith('exiles')) return 'exiles';
+  if (s.startsWith('transfer')) return 'transfer';
   if (s.startsWith('waived')) return 'waived';
   // Legacy "did not attend" collapses to unrecorded — the attendance checkbox
   // is the canonical signal that a player wasn't there (FIN-6).

--- a/public/js/game/signin-tab.js
+++ b/public/js/game/signin-tab.js
@@ -17,15 +17,16 @@ import { readPayment } from './payment-helpers.js';
 
 // fin.2 schema enum. Display labels paired with stored values.
 const PAYMENT_METHODS = [
-  { value: '',       label: '— Not recorded' },
-  { value: 'cash',   label: 'Cash' },
-  { value: 'payid',  label: 'PayID' },
-  { value: 'paypal', label: 'PayPal' },
-  { value: 'exiles', label: 'Exiles (offset)' },
-  { value: 'waived', label: 'Waived' },
+  { value: '',         label: '— Not recorded' },
+  { value: 'cash',     label: 'Cash' },
+  { value: 'payid',    label: 'PayID' },
+  { value: 'paypal',   label: 'PayPal' },
+  { value: 'transfer', label: 'Transfer' },
+  { value: 'exiles',   label: 'Exiles (offset)' },
+  { value: 'waived',   label: 'Waived' },
 ];
 // FIN-7: paid methods inherit session.session_rate; everything else is $0.
-const PAID_METHODS = new Set(['cash', 'payid', 'paypal']);
+const PAID_METHODS = new Set(['cash', 'payid', 'paypal', 'transfer']);
 const DEFAULT_RATE = 15;
 
 function calcEminence(session, chars) {

--- a/server/schemas/game_session.schema.js
+++ b/server/schemas/game_session.schema.js
@@ -54,7 +54,7 @@ export const gameSessionSchema = {
             properties: {
               method: {
                 type: 'string',
-                enum: ['cash', 'payid', 'paypal', 'exiles', 'waived', ''],
+                enum: ['cash', 'payid', 'paypal', 'transfer', 'exiles', 'waived', ''],
               },
               amount: { type: 'number', minimum: 0 },
               note:   { type: ['string', 'null'] },


### PR DESCRIPTION
## Summary

- Legacy "Transfer (Lyn)" payments dropped out of finance entirely — 16 in Game 2, 12 in Game 3 contributing $0 to collected totals
- Adds `transfer` as a distinct fin.2 enum value (normaliser maps `transfer*` including the legacy string)
- Finance Takings card now shows a Transfer row; transfer counts toward collected; check-in treats it as a paid method ($15, sets `paid=true`)
- Prerequisite for the attendance data merge (#552) which will write `method: 'transfer'` to the DB

## Closes

- Closes #550

## Story

- specs/stories/feature.550.transfer-payment-method.story.md

## Test plan

- [ ] Transfer option appears in check-in payment dropdown; selecting it shows $15 and sets Paid
- [ ] Finance Takings card shows a Transfer row with correct dollar amount
- [ ] `normalisePaymentMethod('Transfer (Lyn)')` returns `'transfer'`
- [ ] Existing cash/payid/paypal/exiles/waived paths unchanged
- [ ] CI green
- [ ] Manual: smoke-check on dev after merge

## Branch flow

- From: `ms/issue-550-add-transfer-payment-method`
- Into: `dev`