### PR TITLE
fix(#551): select attendance session by game_number field, not array position

### DIFF
--- a/server/routes/attendance.js
+++ b/server/routes/attendance.js
@@ -7,15 +7,14 @@ const col = () => getCollection('game_sessions');
 
 // GET /api/attendance?character_id=X[&game_number=N]
 // Player-accessible: returns attendance status and attendee list.
-// If game_number provided, looks up the Nth game session (sorted by date); otherwise uses the most recent.
+// If game_number provided, selects the session whose game_number field equals N; otherwise uses the most recent.
 router.get('/', async (req, res) => {
   const charId = req.query.character_id ? String(req.query.character_id) : null;
   const gameNumber = req.query.game_number ? parseInt(req.query.game_number, 10) : null;
 
   let latest;
   if (gameNumber && Number.isInteger(gameNumber) && gameNumber > 0) {
-    const all = await col().find({}).sort({ session_date: 1 }).toArray();
-    latest = all[gameNumber - 1] || null;
+    latest = await col().findOne({ game_number: gameNumber }) || null;
   } else {
     const sessions = await col().find({}).sort({ session_date: -1 }).limit(1).toArray();
     latest = sessions[0] || null;


### PR DESCRIPTION
## Summary

- `GET /api/attendance?game_number=N` was selecting the session by array position (Nth by date sort), not by the `game_number` field
- This was the root cause of Einar/Hodge's DT4 "not at game" report — orphan sessions shifted the index onto an empty record
- Fix: replace `all[gameNumber-1]` with `findOne({ game_number: gameNumber })` — one line, fully independent of session count or order
- Fallback (no game_number supplied) unchanged

## Closes

- Closes #551

## Story

- specs/stories/fix.551.attendance-game-number-lookup.story.md

## Test plan

- [ ] Downtime form for a character who attended Game N correctly shows "attended" with the fixed query
- [ ] Adding or removing sessions doesn't misalign DT attendance gates
- [ ] CI green
- [ ] Manual: smoke-check on dev after merge

## Branch flow

- From: `ms/issue-551-attendance-game-number-fix`
- Into: `dev`