### PR TITLE
docs: data hygiene audit + campaign outcome — Piatra review

### DIFF
--- a/server/scripts/audit-data-hygiene.js
+++ b/server/scripts/audit-data-hygiene.js
@@ -1,0 +1,222 @@
+/**
+ * audit-data-hygiene.js — READ ONLY.
+ *
+ * Comprehensive data-hygiene sweep across every collection in tm_suite.
+ * Goal: find FRAGMENTATION — the same logical value stored in inconsistent
+ * shapes — which is the root cause behind the territory-key (#496), cycle_id
+ * (#497), attendance (#551/#552) and payment_method (#547/#550) bug classes.
+ *
+ * For every field path in every collection it records:
+ *   - the set of BSON types seen           -> TYPE fragmentation when >1
+ *   - for string values, a format class    -> FORMAT fragmentation when >1
+ *       (objectid_hex / iso_datetime / snake_slug / flat_lower /
+ *        display_name / numeric_string / json_string / email / discord_id / other)
+ *   - when a string parses as a JSON object, the format classes of its KEYS
+ *     (this is how influence_spend / feeding_territories key-format drift is caught)
+ *
+ * Indexed/dynamic key segments are collapsed (project_1_territory,
+ * project_2_territory -> project_N_territory) so the report stays signal-dense.
+ *
+ * Output:
+ *   - a ranked console summary (most-fragmented fields first)
+ *   - a full JSON report written to st-working/audit/data-hygiene-<date>.json
+ *
+ * Run (same way as the other audit scripts, with .env loaded):
+ *   node -r dotenv/config server/scripts/audit-data-hygiene.js
+ *   (or: MONGODB_URI=... node server/scripts/audit-data-hygiene.js)
+ *
+ * Touches nothing. No writes to the database.
+ */
+
+import { MongoClient } from 'mongodb';
+import { mkdirSync, writeFileSync } from 'fs';
+import { dirname } from 'path';
+
+// Optional: auto-load .env if dotenv is present; harmless if it isn't.
+try { await import('dotenv/config'); } catch { /* env already set by caller */ }
+
+const MONGO_URI = process.env.MONGO_URI || process.env.MONGODB_URI;
+if (!MONGO_URI) { console.error('MONGO_URI / MONGODB_URI not set'); process.exit(1); }
+const DB_NAME = 'tm_suite';
+
+// Scan all docs for collections at/under this size; sample for larger ones.
+const FULL_SCAN_LIMIT = 5000;
+const SAMPLE_SIZE = 3000;
+// Stop descending past this depth to bound runtime on deep docs.
+const MAX_DEPTH = 6;
+
+// ── string format classifier ────────────────────────────────────────────
+function classifyString(s) {
+  if (s === '') return 'empty_string';
+  if (/^[a-f0-9]{24}$/i.test(s)) return 'objectid_hex';
+  if (/^\d{17,20}$/.test(s)) return 'discord_id';          // snowflake (check before numeric)
+  if (/^-?\d+$/.test(s)) return 'numeric_string';
+  if (/^-?\d+\.\d+$/.test(s)) return 'numeric_string';
+  if (/^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2})?/.test(s)) return 'iso_datetime';
+  if (/^[{\[]/.test(s)) { try { JSON.parse(s); return 'json_string'; } catch { /* not json */ } }
+  if (/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(s)) return 'email';
+  if (/^[a-z0-9]+(_[a-z0-9]+)+$/.test(s)) return 'snake_slug';      // the_north_shore
+  if (/^[a-z0-9]+$/.test(s)) return 'flat_lower';                   // northshore
+  if (/^[a-z0-9]+(-[a-z0-9]+)+$/.test(s)) return 'kebab_slug';
+  if (/[A-Z]/.test(s) || /\s/.test(s)) return 'display_name';       // "The North Shore"
+  return 'other_string';
+}
+
+// Collapse indexed/dynamic segments so paths aggregate. project_1_territory
+// -> project_N_territory; pure-number array indices -> [].
+function normSeg(seg) {
+  if (/^\d+$/.test(seg)) return '[]';
+  return seg.replace(/\d+/g, 'N');
+}
+
+function bsonType(v) {
+  if (v === null) return 'null';
+  if (Array.isArray(v)) return 'array';
+  if (v instanceof Date) return 'date';
+  const t = typeof v;
+  if (t === 'object') {
+    if (v._bsontype === 'ObjectID' || v._bsontype === 'ObjectId') return 'objectId';
+    if (v._bsontype) return v._bsontype.toLowerCase();
+    return 'object';
+  }
+  return t; // string | number | boolean
+}
+
+// acc: Map<normPath, { types:Map<type,count>, formats:Map<fmt,count>,
+//                      keyFormats:Map<fmt,count>, examples:Set, total:count }>
+function rec(acc, path, kind, key, example) {
+  let e = acc.get(path);
+  if (!e) { e = { types: new Map(), formats: new Map(), keyFormats: new Map(), examples: new Map(), total: 0 }; acc.set(path, e); }
+  const bucket = e[kind];
+  bucket.set(key, (bucket.get(key) || 0) + 1);
+  if (kind === 'types') e.total++;
+  if (example !== undefined && e.examples.size < 60) {
+    const exKey = kind === 'types' ? key : `${kind}:${key}`;
+    if (!e.examples.has(exKey)) e.examples.set(exKey, String(example).slice(0, 80));
+  }
+}
+
+function walk(acc, path, value, depth) {
+  const t = bsonType(value);
+  rec(acc, path, 'types', t, t === 'string' ? value : undefined);
+
+  if (t === 'string') {
+    const fmt = classifyString(value);
+    rec(acc, path, 'formats', fmt, value);
+    // Descend into JSON-string objects to profile their KEY formats (#496 class).
+    if (fmt === 'json_string') {
+      try {
+        const parsed = JSON.parse(value);
+        if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+          for (const k of Object.keys(parsed)) rec(acc, path, 'keyFormats', classifyString(k), k);
+        }
+      } catch { /* ignore */ }
+    }
+    return;
+  }
+  if (depth >= MAX_DEPTH) return;
+  if (t === 'array') {
+    for (const item of value) walk(acc, path + '.[]', item, depth + 1);
+    return;
+  }
+  if (t === 'object') {
+    for (const [k, v] of Object.entries(value)) {
+      walk(acc, path === '' ? normSeg(k) : path + '.' + normSeg(k), v, depth + 1);
+    }
+  }
+}
+
+function nonNullTypeCount(types) {
+  return [...types.keys()].filter(k => k !== 'null').length;
+}
+function nonTrivialFormatCount(formats) {
+  return [...formats.keys()].filter(k => k !== 'empty_string').length;
+}
+
+async function main() {
+  const client = new MongoClient(MONGO_URI);
+  await client.connect();
+  const db = client.db(DB_NAME);
+
+  const collInfos = await db.listCollections().toArray();
+  const collNames = collInfos.map(c => c.name).filter(n => !n.startsWith('system.')).sort();
+
+  const report = { db: DB_NAME, generated: new Date().toISOString(), collections: [] };
+
+  for (const name of collNames) {
+    const coll = db.collection(name);
+    const total = await coll.estimatedDocumentCount();
+    const scan = total <= FULL_SCAN_LIMIT;
+    const cursor = scan
+      ? coll.find({})
+      : coll.aggregate([{ $sample: { size: SAMPLE_SIZE } }]);
+    const acc = new Map();
+    let scanned = 0;
+    for await (const doc of cursor) { walk(acc, '', doc, 0); scanned++; }
+
+    const fields = [];
+    for (const [path, e] of acc) {
+      const typeCount = nonNullTypeCount(e.types);
+      const fmtCount = nonTrivialFormatCount(e.formats);
+      const keyFmtCount = nonTrivialFormatCount(e.keyFormats);
+      const typeFrag = typeCount > 1;
+      const formatFrag = fmtCount > 1;
+      const keyFrag = keyFmtCount > 1;
+      if (!typeFrag && !formatFrag && !keyFrag) continue; // only report fragmented fields
+      // Severity heuristic: type frag worst, then key frag (JSON blob keys), then value format frag.
+      const severity = (typeFrag ? 100 : 0) + (keyFrag ? 50 : 0) + (formatFrag ? 25 : 0)
+        + Math.min(typeCount + fmtCount + keyFmtCount, 20);
+      fields.push({
+        path,
+        observed: e.total,
+        typeFrag, formatFrag, keyFrag, severity,
+        types: Object.fromEntries(e.types),
+        formats: Object.fromEntries(e.formats),
+        keyFormats: keyFmtCount ? Object.fromEntries(e.keyFormats) : undefined,
+        examples: Object.fromEntries(e.examples),
+      });
+    }
+    fields.sort((a, b) => b.severity - a.severity);
+    report.collections.push({ name, total, scanned, scanMode: scan ? 'full' : 'sample', fragmentedFields: fields });
+  }
+
+  await client.close();
+
+  // ── console summary ─────────────────────────────────────────────────
+  console.log('\n' + '='.repeat(96));
+  console.log(`DATA HYGIENE AUDIT — ${DB_NAME} — ${report.generated}`);
+  console.log('='.repeat(96));
+  const allFrag = report.collections.flatMap(c => c.fragmentedFields.map(f => ({ coll: c.name, ...f })));
+  allFrag.sort((a, b) => b.severity - a.severity);
+  console.log(`Collections: ${report.collections.length}   Fragmented fields found: ${allFrag.length}\n`);
+  console.log('SEV  KIND          COLLECTION.field                                          shapes');
+  console.log('-'.repeat(96));
+  for (const f of allFrag) {
+    const kind = [f.typeFrag && 'TYPE', f.keyFrag && 'KEY', f.formatFrag && 'FMT'].filter(Boolean).join('+');
+    const shapes = f.typeFrag
+      ? Object.entries(f.types).filter(([k]) => k !== 'null').map(([k, n]) => `${k}:${n}`).join(' ')
+      : f.keyFrag
+        ? 'keys=' + Object.keys(f.keyFormats).join('/')
+        : Object.keys(f.formats).filter(k => k !== 'empty_string').join('/');
+    console.log(
+      `${String(f.severity).padStart(3)}  ${kind.padEnd(12)}  ${(f.coll + '.' + f.path).slice(0, 54).padEnd(54)}  ${shapes.slice(0, 30)}`
+    );
+  }
+  console.log('-'.repeat(96));
+  console.log('Per-collection field counts (only collections with fragmentation):');
+  for (const c of report.collections) {
+    if (c.fragmentedFields.length) {
+      console.log(`  ${c.name.padEnd(28)} ${String(c.total).padStart(7)} docs (${c.scanMode})  ${c.fragmentedFields.length} fragmented fields`);
+    }
+  }
+
+  // ── JSON artifact ───────────────────────────────────────────────────
+  const stamp = report.generated.slice(0, 10);
+  const outPath = `st-working/audit/data-hygiene-${stamp}.json`;
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, JSON.stringify(report, null, 2));
+  console.log(`\nFull JSON report written to: ${outPath}`);
+  console.log('(hand that file back to Claude to build the ranked hygiene doc)');
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/specs/data-hygiene-audit-2026-06-03.md
+++ b/specs/data-hygiene-audit-2026-06-03.md
@@ -21,6 +21,32 @@ schema-shape fragmentation only.
 
 ---
 
+## Update 2026-06-03 (post-investigation) — some findings were TEST POLLUTION
+
+Acting on this audit surfaced a key caveat: the audit script counted **test and
+orphaned docs as production data**, inflating some counts. A read-only sweep
+(`server/scripts/sweep-test-orphan-data.js`) was added to separate fixtures and
+orphans from real fragmentation. Outcome so far:
+
+- **Tier 1.2 (`territories.regent_id` / `lieutenant_id`) and Tier 2.3
+  (`territories.slug`) were entirely test pollution, NOT production drift.** The
+  `territories` collection held 5 clean production rows plus **8 orphaned
+  "Regent Save Test" fixtures** carrying all the non-canonical values. Deleting
+  them (#560) left all 5 real territories canonical. **#559 closed** as resolved
+  by the same cleanup. Disregard the Tier 1.2 / 2.3 fragmentation counts below.
+- **Separate finding (#567):** 19 orphaned `downtime_submissions` — 4 DT1 records
+  relinked to current ObjectIds (real history), 12 empty test subs + 3
+  dead-cycle drafts deleted. Not in the original audit's "fragmentation" framing
+  but the same hygiene class.
+- **Still valid (real production fragmentation):** Tier 1.1 (`character_id`),
+  Tier 3 (enums), Tier 4 (schema-shape), Tier 5 (attribution). The sweep
+  confirmed test/orphan pollution did **not** inflate these.
+
+**Lesson for the remaining issues:** run the test/orphan sweep on a collection
+before treating its audit counts as production work.
+
+---
+
 ## Tier 1 — FK / identity TYPE fragmentation (silent-drop bug class)
 
 These are the highest-impact: a field stored as two different BSON types means

--- a/specs/data-hygiene-audit-2026-06-03.md
+++ b/specs/data-hygiene-audit-2026-06-03.md
@@ -1,0 +1,166 @@
+# Data Hygiene Audit — tm_suite — 2026-06-03
+
+**Goal:** map every *fragmentation* in the live database — the same logical value
+stored in inconsistent shapes — because that is the shared root cause behind the
+recent player/ST-facing bugs (#496 territory keys, #497 cycle_id, #551/#552
+attendance, #547/#550 payment). Each fragmentation charges a tax on every read:
+a normaliser, a compat layer, or a relink. The fix pattern is always the same —
+pick one canonical shape, migrate the data, delete the normaliser.
+
+**Method:** `server/scripts/audit-data-hygiene.js` (read-only) profiled every
+field path across all 20 fragmented collections for **type fragmentation** (one
+field, multiple BSON types) and **format fragmentation** (string values spanning
+multiple format classes), descending into JSON-string blobs to profile their
+keys. Full data: `st-working/audit/data-hygiene-2026-06-03.json`. Re-runnable as
+hygiene progresses.
+
+**Noise excluded:** format-class mixing on free-text fields (names, reasons,
+mobiles, narrative authors) is expected variance, not fragmentation. Those are
+filtered out below; the findings here are identifier, FK, key, enum, and
+schema-shape fragmentation only.
+
+---
+
+## Tier 1 — FK / identity TYPE fragmentation (silent-drop bug class)
+
+These are the highest-impact: a field stored as two different BSON types means
+type-strict Mongo queries (`find({fk: oid})`) silently drop the mismatched docs.
+This is the exact class that already bit feeding-rights (#497).
+
+### 1.1 `downtime_submissions.character_id` — string (29) vs ObjectId (76) — **NOT YET FIXED**
+- The direct sibling of #497, which canonicalised `cycle_id` only. `character_id`
+  was noted as "already coerced on POST + dual-read on GET" in the #497 notes,
+  but the stored data is still mixed: 29 string, 76 ObjectId.
+- **Impact:** any type-strict `find({character_id: ObjectId})` drops the 29
+  string-typed submissions (DT1-era). Player "my submissions" and ST per-character
+  views can silently miss history.
+- **Fix:** one-time migration to coerce all `character_id` to ObjectId (model on
+  `migrate-submission-cycle-id-to-oid.js` from #497); then the dual-read tolerance
+  can eventually be removed. Audit + migrate.
+
+### 1.2 `territories.regent_id` (objectid_hex 5 / kebab_slug 6) and `territories.lieutenant_id` (objectid_hex 4 / kebab_slug 2)
+- Territory office FKs stored as ObjectId-hex strings in some docs, kebab-slug
+  character refs in others. Both formats are *strings* (so no BSON-type flag) but
+  semantically two different identifier systems.
+- **Impact:** player/ST-facing — regent and lieutenant resolution on the territory
+  panel and city overview. A kebab-slug ref won't join to a character `_id`.
+- **Fix:** canonicalise to ObjectId-hex (or true ObjectId). Migrate the ~8
+  kebab-slug values; confirm the resolver only needs one path afterward.
+
+---
+
+## Tier 2 — Territory key residual (#496, quantified)
+
+The #496 submission migration shipped (PR #498) but is **partial**, and CSV
+import keeps reintroducing legacy keys (confirmed: the import path writes raw
+slug/display-name keys; normalisation is read-time only).
+
+### 2.1 `downtime_submissions.responses.feeding_territories` — keys objectid_hex (325) / other_string (65)
+### 2.2 `downtime_submissions.responses.feeding_territories_rote` — keys objectid_hex (70) / other_string (14)
+- **79 legacy-format territory keys remain live** across feeding blobs. These are
+  exactly what `TERRITORY_SLUG_MAP` / `resolveTerrId` exist to bridge.
+- **Impact:** feeding matrix, feeding-rights lock, ambience tallies. Every read
+  goes through the normaliser; an unmapped variant silently mis-resolves.
+- **Fix:** this is the gated cleanup already written into the rescoped **#496**.
+  Gate = re-key the 79 residual keys; Block 1 = fix CSV import to emit ObjectId
+  (else they regrow); then delete the normaliser.
+
+### 2.3 `territories.slug` — flat_lower (5) / snake_slug (8)
+- The *canonical* slug field is itself inconsistent: `northshore` vs `north_shore`.
+  This is the seed of the whole territory-normaliser problem — the map has to
+  bridge formats partly because the source-of-truth slug isn't uniform.
+- **Fix:** pick one slug convention, migrate the 13 territory docs, and align
+  `TERRITORY_DATA`. Small (13 docs) but foundational — do before 2.1/2.2.
+
+---
+
+## Tier 3 — Enum value drift (DT-processing correctness)
+
+Status/action enums stored in mixed casing/slug form. This is the class behind
+the DT-processing-status bugs (#454/#456/#460): a consumer comparing against one
+spelling silently misses the other.
+
+| Field | Shapes (counts) |
+|-------|-----------------|
+| `downtime_submissions.responses.project_N_action` | snake_slug 104 / flat_lower 100 |
+| `downtime_submissions.responses.sphere_N_action` | snake_slug 27 / flat_lower 32 |
+| `downtime_submissions.responses.status_N_action` | snake_slug 3 / flat_lower 8 |
+| `downtime_submissions.projects_resolved[].pool_status` | flat_lower 177 / snake_slug 21 |
+| `downtime_submissions.merit_actions_resolved[].pool_status` | flat_lower 158 / snake_slug 8 |
+| `downtime_submissions.sorcery_review[].pool_status` | flat_lower 16 / snake_slug 1 |
+| `ordeal_submissions.marking.status` | flat_lower 28 / snake_slug 21 |
+| `purchasable_powers.prereq.type` (+ `.all[].type`) | flat_lower 765+ / snake_slug 2-6 (near-clean) |
+
+- **Impact:** action/status matching in DT processing and ordeal marking. The
+  near-even splits (project_N_action 104/100) are the dangerous ones — neither
+  spelling is rare, so any single-spelling comparison is half-wrong.
+- **Fix:** decide the canonical enum spelling per field (recommend snake_slug to
+  match rule collections), migrate, and add a schema enum so writes can't drift.
+  Needs a values-enumeration pass first (what are the actual distinct strings?).
+
+---
+
+## Tier 4 — Schema-shape drift (few docs, schema-guard gaps)
+
+Low document counts, but each is a latent render/crash risk where a consumer
+assumes one shape.
+
+- `downtime_submissions.st_narrative.letter_from_home` — object (29) / string (2)
+- `downtime_submissions.st_narrative.touchstone` — object (29) / string (2)
+  - Mostly structured objects; 2 docs each hold a bare string. A renderer doing
+    `.field` on the object form will read `undefined` on the string form.
+- `downtime_submissions._raw.projects[].xp_spend` — string (42) / number (12)
+  - XP math on a string silently concatenates or NaNs. Coerce to number.
+- `rule_grant.pool_targets` — array (3) / string (1) — one rule_grant doc has a
+  scalar where an array is expected; an evaluator iterating it will mis-handle.
+- `relationships.history[].fields[].before` / `.after` — string / boolean —
+  **likely accept:** this is a polymorphic audit-log value (records arbitrary
+  field changes), so mixed type is by design. Flagged for completeness only.
+
+---
+
+## Tier 5 — Identity name drift (matching / attribution, lower urgency)
+
+Name/attribution strings stored as display-name in some docs, lowercased in
+others. Cosmetic-to-moderate: affects name-based matching and "who did this"
+attribution, but no silent data loss.
+
+- `downtime_submissions.feeding_review.pool_validated_by` / `pool_committed_by` /
+  `pool_confirmed_by`, `projects_resolved[].pool_*_by`, `merit_actions_resolved[].pool_committed_by`,
+  `st_narrative.territory_reports[].author` — display_name vs flat_lower.
+- `st_mods.created_by.discord_id` / `st_mod_audit.created_by.discord_id` —
+  field named `discord_id` but holds an actual snowflake in ~9 cases and a
+  kebab-slug in ~88. Misnamed + fragmented; ST attribution only.
+- `tickets.submitted_by` — display_name (41) / flat_lower (10).
+- **Fix:** lower priority. Where these are meant to be identity FKs, migrate to a
+  stable id (player_id / ObjectId) rather than a name string; otherwise leave.
+
+---
+
+## Recommended sequence
+
+Ordered by impact-per-effort and dependency:
+
+1. **2.3 `territories.slug`** (13 docs) — foundational; uniform slug first.
+2. **1.1 `character_id` coercion** — finishes the #497 sibling; small migration,
+   removes a silent-drop path. High value.
+3. **1.2 `territories.regent_id` / `lieutenant_id`** (~8 values) — player-facing FK.
+4. **2.1 / 2.2 territory key residual** — the rescoped **#496**; gated on fixing
+   CSV import write-side first (Block 1) or the 79 keys regrow.
+5. **Tier 3 enum drift** — one values-enumeration pass, then per-field
+   canonicalise + schema enum. Biggest correctness win for DT processing.
+6. **Tier 4 schema-shape** — cheap one-off coercions + schema guards.
+7. **Tier 5** — opportunistic, when touching those collections anyway.
+
+Every fix is: pick canonical shape → migrate (read-only audit script → dry-run
+migration → `--apply` with backup) → tighten schema so it can't regrow →
+delete the read-time normaliser. The schema-guard step is what makes hygiene
+*stick* instead of regrowing (the CSV-import lesson from #496).
+
+---
+
+## Artifacts
+
+- Audit engine (re-runnable): `server/scripts/audit-data-hygiene.js`
+- Full JSON: `st-working/audit/data-hygiene-2026-06-03.json`
+- Related issues: #496 (territory keys, rescoped), #497 (cycle_id, done)

--- a/specs/data-hygiene-audit-2026-06-03.md
+++ b/specs/data-hygiene-audit-2026-06-03.md
@@ -21,43 +21,54 @@ schema-shape fragmentation only.
 
 ---
 
-## Update 2026-06-03 (post-investigation) — some findings were TEST POLLUTION
+## Update 2026-06-03 — CAMPAIGN COMPLETE (outcome + lessons, for Piatra review)
 
-Acting on this audit surfaced a key caveat: the audit script counted **test and
-orphaned docs as production data**, inflating some counts. A read-only sweep
-(`server/scripts/sweep-test-orphan-data.js`) was added to separate fixtures and
-orphans from real fragmentation. Outcome so far:
+This audit kicked off a full pass; **all 8 filed issues plus a bonus orphan
+finding are now resolved.** The headline for review: **the audit over-flagged by
+roughly 3×.** Two systematic causes, both now mitigated:
 
-- **Tier 1.2 (`territories.regent_id` / `lieutenant_id`) and Tier 2.3
-  (`territories.slug`) were entirely test pollution, NOT production drift.** The
-  `territories` collection held 5 clean production rows plus **8 orphaned
-  "Regent Save Test" fixtures** carrying all the non-canonical values. Deleting
-  them (#560) left all 5 real territories canonical. **#559 closed** as resolved
-  by the same cleanup. Disregard the Tier 1.2 / 2.3 fragmentation counts below.
-- **Separate finding (#567):** 19 orphaned `downtime_submissions` — 4 DT1 records
-  relinked to current ObjectIds (real history), 12 empty test subs + 3
-  dead-cycle drafts deleted. Not in the original audit's "fragmentation" framing
-  but the same hygiene class.
-- **Tier 1.1 (`character_id`) — DONE (#558).** 29 string values coerced to
-  ObjectId; write paths already coerced, so it cannot regrow.
-- **Tier 3 (enums) was a FALSE POSITIVE — closed #561/#562/#563.** Enumerating the
-  actual values showed these are coherent enums, not drift: `pool_status` =
-  validated/resolved/no_roll/pending/skipped; `project_N_action` = 12 distinct
-  actions; `marking.status` = unmarked/in_progress. The format classifier counts
-  a two-word value (`no_roll`, `in_progress`) as `snake_slug` and a one-word value
-  (`resolved`) as `flat_lower`, so a clean enum with mixed word-counts reads as
-  "fragmented." It is not. (Optional future hardening: schema enums to lock the
-  valid sets.)
-- **Still valid (real production work):** Tier 4 (schema-shape — `letter_from_home`,
-  `touchstone`, `xp_spend`, `pool_targets`) and parts of Tier 5 (attribution).
+1. **It counted test/orphan docs as production data.** A read-only sweep
+   (`server/scripts/sweep-test-orphan-data.js`) now separates fixtures/orphans
+   from real fragmentation. (The entire `territories` "fragmentation" was 8
+   `Regent Save Test` fixtures; the `created_by.discord_id` "misnaming" was 88
+   `test-st-001` `st_mods`/audit rows.)
+2. **Its format classifier counts word-count as format.** A two-word enum value
+   (`no_roll`, `in_progress`) classes as `snake_slug`, a one-word value
+   (`resolved`) as `flat_lower` — so a coherent enum reads as "fragmented."
+   Always enumerate the **distinct values** before trusting the format flag.
 
-**Two lessons for the remaining issues:** (1) run the test/orphan sweep on a
-collection before treating its audit counts as production work; (2) for any
-string field, enumerate the **distinct values** before trusting the format-class
-"fragmentation" flag — multi-word enum values trip it. Net: of 8 filed issues,
-only Tier 4 + parts of Tier 5 are real fragmentation; the rest were test
-pollution (#559/#560), a separate orphan finding (#567), one real coercion
-(#558), or enum false positives (#561/#562/#563).
+### Outcome by issue
+
+| Issue | Verdict | Resolution |
+|---|---|---|
+| #558 `character_id` | Real fragmentation | 29 string → ObjectId; write paths already coerce, so it can't regrow |
+| #564 schema-shape | Real (partial) | 2 narrative `{response,author,status}` wraps + 1 `pool_targets` array; `xp_spend` excluded (archival `_raw`, "n/a" is legit) |
+| #559 + #560 territories | Test pollution | 8 `Regent Save Test` docs deleted; the 5 real territories were already canonical |
+| #565 attribution | Test pollution + false positive | 88 test `st_mods`/audit rows deleted; `pool_*_by`/`author`/`submitted_by` are intentional free-text "who did it" labels, left as-is |
+| #561 / #562 / #563 enums | False positives | Closed, no migration (coherent enums; word-count ≠ drift) |
+| #567 orphan submissions (bonus) | Real | 4 DT1 records relinked to current ObjectIds; 12 empty test subs + 3 dead-cycle drafts deleted |
+
+**Net: only ~2 of 8 filed issues were genuine fragmentation.** Every data change
+was applied live, each **backed up to `st-working/audit/`** (recoverable).
+Dry-run/guarded tooling lives in `server/scripts/` (`audit-data-hygiene`,
+`sweep-test-orphan-data`, and seven targeted migration/cleanup scripts).
+
+### For Piatra — advisory asks
+
+1. **The audit engine's false-positive tendencies** (test/orphan inclusion;
+   word-count-as-format). Worth hardening the classifier — e.g. skip enum-like
+   fields, exclude obvious test rows — or is the *sweep-first + enumerate-first*
+   discipline enough on its own?
+2. **Still-pending real item:** #496 territory-key residual (79 legacy feeding
+   keys remain; gated on fixing the CSV-import write side so they don't regrow).
+   Where does that sit against your schema-refactor / purge+reimport direction?
+3. **The fix loop** (canonical shape → migrate → tighten schema so it can't
+   regrow → delete the normaliser) — anything you'd change, especially the
+   schema-guard step that #496 originally skipped?
+
+_The tiers below are the ORIGINAL audit findings, kept as the raw record. Read
+them through the lens of the outcome table above — several were test pollution
+or false positives, not production fragmentation._
 
 ---
 

--- a/specs/data-hygiene-audit-2026-06-03.md
+++ b/specs/data-hygiene-audit-2026-06-03.md
@@ -38,12 +38,26 @@ orphans from real fragmentation. Outcome so far:
   relinked to current ObjectIds (real history), 12 empty test subs + 3
   dead-cycle drafts deleted. Not in the original audit's "fragmentation" framing
   but the same hygiene class.
-- **Still valid (real production fragmentation):** Tier 1.1 (`character_id`),
-  Tier 3 (enums), Tier 4 (schema-shape), Tier 5 (attribution). The sweep
-  confirmed test/orphan pollution did **not** inflate these.
+- **Tier 1.1 (`character_id`) — DONE (#558).** 29 string values coerced to
+  ObjectId; write paths already coerced, so it cannot regrow.
+- **Tier 3 (enums) was a FALSE POSITIVE — closed #561/#562/#563.** Enumerating the
+  actual values showed these are coherent enums, not drift: `pool_status` =
+  validated/resolved/no_roll/pending/skipped; `project_N_action` = 12 distinct
+  actions; `marking.status` = unmarked/in_progress. The format classifier counts
+  a two-word value (`no_roll`, `in_progress`) as `snake_slug` and a one-word value
+  (`resolved`) as `flat_lower`, so a clean enum with mixed word-counts reads as
+  "fragmented." It is not. (Optional future hardening: schema enums to lock the
+  valid sets.)
+- **Still valid (real production work):** Tier 4 (schema-shape — `letter_from_home`,
+  `touchstone`, `xp_spend`, `pool_targets`) and parts of Tier 5 (attribution).
 
-**Lesson for the remaining issues:** run the test/orphan sweep on a collection
-before treating its audit counts as production work.
+**Two lessons for the remaining issues:** (1) run the test/orphan sweep on a
+collection before treating its audit counts as production work; (2) for any
+string field, enumerate the **distinct values** before trusting the format-class
+"fragmentation" flag — multi-word enum values trip it. Net: of 8 filed issues,
+only Tier 4 + parts of Tier 5 are real fragmentation; the rest were test
+pollution (#559/#560), a separate orphan finding (#567), one real coercion
+(#558), or enum false positives (#561/#562/#563).
 
 ---
 


### PR DESCRIPTION
## For Piatra — data hygiene campaign review (now COMPLETE)

This started as a mid-flight advisory PR; the campaign has since run to completion. **All 8 filed issues + a bonus orphan finding are resolved**, applied live (each backed up to `st-working/audit/`). This PR carries the audit doc and the read-only audit engine — read the **"Update 2026-06-03 — CAMPAIGN COMPLETE"** section at the top of `specs/data-hygiene-audit-2026-06-03.md` for the outcome-by-issue table and lessons.

**Not for merge unless you want it on dev** — it's docs + a read-only script; kept open for your review.

## Headline

The audit **over-flagged by ~3x.** Two systematic causes:
1. It counted **test/orphan docs as production data** (territories "fragmentation" = 8 `Regent Save Test` fixtures; `discord_id` "misnaming" = 88 `test-st-001` rows). Added `server/scripts/sweep-test-orphan-data.js` to separate them.
2. Its format classifier counts **word-count as format** — a two-word enum value (`no_roll`, `in_progress`) reads as `snake_slug`, one-word (`resolved`) as `flat_lower`, so coherent enums look "fragmented."

**Net: only ~2 of 8 were real fragmentation** (`character_id` migrated; schema-shape). The rest were test pollution (#559/#560/#565) or false positives (#561/#562/#563), plus the bonus #567 orphan cleanup.

## Asks for you

1. **Harden the audit engine** vs. rely on the discipline (sweep-first + enumerate-distinct-values-first)? The classifier could skip enum-like fields and exclude obvious test rows.
2. **#496 territory-key residual** (79 legacy feeding keys, gated on the CSV-import write fix) — sequencing against your schema-refactor / purge+reimport direction?
3. **The fix loop** (canonical -> migrate -> schema-guard -> delete normaliser) — anything you'd change, especially the schema-guard step #496 skipped?

## In this PR
- `specs/data-hygiene-audit-2026-06-03.md` — findings + final outcome
- `server/scripts/audit-data-hygiene.js` — re-runnable read-only audit engine

(The seven migration/cleanup scripts landed on dev via the per-issue PRs #566/#568/#569/#570/#571.)

## How to review
- Read the doc, or `git fetch && git checkout morningstar-data-hygiene-audit` and re-run `node server/scripts/audit-data-hygiene.js`.
- Inline comments on the report file are easiest.
