### PR TITLE
chore(#560): remove orphaned Regent Save Test territory docs + sweep tooling

### DIFF
--- a/server/scripts/delete-test-territories.js
+++ b/server/scripts/delete-test-territories.js
@@ -1,0 +1,102 @@
+/**
+ * delete-test-territories.js — destructive (DRY-RUN by default).
+ *
+ * Removes the orphaned "Regent Save Test" fixture docs polluting the live
+ * tm_suite.territories collection (issue #560). These 8 docs are leftover from
+ * regent-save feature testing; they carry the only non-canonical slug and
+ * regent/lieutenant values in the collection, and the data-hygiene audit
+ * mis-counted them as production fragmentation.
+ *
+ * Safety:
+ *   - DRY-RUN by default; prints what would be deleted. Pass --apply to execute.
+ *   - Re-verifies at runtime that NO other doc references the targets
+ *     (territory_residency, characters.home_territory, other territories'
+ *     regent_id/lieutenant_id, downtime_submissions territory refs). Aborts
+ *     (exit 2) if any reference is found.
+ *   - On --apply: backs up the deleted docs to
+ *     st-working/audit/deleted-test-territories-<date>.json before deleting.
+ *
+ * Run:
+ *   node server/scripts/delete-test-territories.js            # dry-run
+ *   node server/scripts/delete-test-territories.js --apply    # execute
+ */
+
+import { MongoClient } from 'mongodb';
+import { mkdirSync, writeFileSync } from 'fs';
+import { dirname } from 'path';
+try { await import('dotenv/config'); } catch { /* env already set */ }
+
+const MONGO_URI = process.env.MONGO_URI || process.env.MONGODB_URI;
+if (!MONGO_URI) { console.error('MONGO_URI / MONGODB_URI not set'); process.exit(1); }
+const DB_NAME = 'tm_suite';
+const APPLY = process.argv.includes('--apply');
+const FILTER = { name: 'Regent Save Test' };
+
+async function main() {
+  const client = new MongoClient(MONGO_URI);
+  await client.connect();
+  const db = client.db(DB_NAME);
+
+  const targets = await db.collection('territories').find(FILTER).toArray();
+  console.log(`Matched ${targets.length} territories where name === "Regent Save Test":`);
+  targets.forEach(t => console.log(`  ${String(t._id)}  slug=${JSON.stringify(t.slug)}  regent_id=${t.regent_id ?? '-'}`));
+  if (!targets.length) { console.log('Nothing to delete.'); await client.close(); return; }
+
+  const ids = targets.map(t => String(t._id));
+  const slugs = [...new Set(targets.map(t => t.slug))];
+  const idSet = new Set(ids), slugSet = new Set(slugs);
+
+  // ── runtime reference guard ─────────────────────────────────────────
+  console.log('\nReference guard (must be all zero):');
+  let refs = 0;
+  async function check(coll, label, extract) {
+    let n = 0;
+    for await (const d of db.collection(coll).find({})) {
+      for (const v of extract(d)) {
+        const s = v == null ? '' : String(v);
+        if (idSet.has(s) || slugSet.has(s)) n++;
+      }
+    }
+    console.log(`  ${label}: ${n}`);
+    refs += n;
+  }
+  await check('territory_residency', 'territory_residency.territory_id', d => [d.territory_id]);
+  await check('characters', 'characters.home_territory', d => [d.home_territory]);
+  await check('territories', 'other territories regent_id/lieutenant_id', d => idSet.has(String(d._id)) ? [] : [d.regent_id, d.lieutenant_id]);
+  await check('downtime_submissions', 'downtime_submissions territory refs', d => {
+    const r = d.responses || {}, out = [];
+    for (const k of Object.keys(r)) {
+      if (/territory|ambience_target/.test(k)) out.push(r[k]);
+      if (/feeding_territories/.test(k)) { try { const o = JSON.parse(r[k]); if (o && typeof o === 'object') out.push(...Object.keys(o)); } catch { /* */ } }
+    }
+    return out;
+  });
+
+  if (refs > 0) {
+    console.error(`\nABORT: ${refs} reference(s) to the target docs found. Not safe to delete.`);
+    await client.close();
+    process.exit(2);
+  }
+  console.log('  -> 0 references. Safe to delete.');
+
+  if (!APPLY) {
+    console.log('\nDRY-RUN. Re-run with --apply to back up and delete these 8 docs.');
+    await client.close();
+    return;
+  }
+
+  // ── apply: backup then delete ───────────────────────────────────────
+  const stamp = new Date().toISOString().slice(0, 10);
+  const backup = `st-working/audit/deleted-test-territories-${stamp}.json`;
+  mkdirSync(dirname(backup), { recursive: true });
+  writeFileSync(backup, JSON.stringify(targets, null, 2));
+  console.log(`\nBacked up ${targets.length} docs to ${backup}`);
+
+  const res = await db.collection('territories').deleteMany({ _id: { $in: targets.map(t => t._id) } });
+  console.log(`Deleted ${res.deletedCount} territories.`);
+  const remaining = await db.collection('territories').countDocuments({});
+  console.log(`territories now holds ${remaining} docs (expected 5 production territories).`);
+  await client.close();
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/server/scripts/sweep-test-orphan-data.js
+++ b/server/scripts/sweep-test-orphan-data.js
@@ -1,0 +1,107 @@
+/**
+ * sweep-test-orphan-data.js — READ ONLY.
+ *
+ * Finds test fixtures and orphaned documents polluting the live tm_suite
+ * collections. The data-hygiene audit (audit-data-hygiene.js) counts these as
+ * production data, which inflates fragmentation counts (e.g. the territories
+ * collection's "fragmentation" was 8 orphaned Regent Save Test docs). Run this
+ * first; purge what it finds; then re-run the audit for true counts.
+ *
+ * Two detectors:
+ *   1. TEST MARKERS — docs whose string values match obvious test patterns
+ *      (regent_save, alice-char-id, bob-char-id, "Buggy Keeper", standalone
+ *      "test"/"dummy"/"sample"/"placeholder" in a name-ish field).
+ *   2. ORPHANED FKs — docs whose foreign keys point at a parent that no longer
+ *      exists (submissions -> character/cycle, residency -> territory,
+ *      character.home_territory -> territory, attendance -> character).
+ *
+ * Run:  node -r dotenv/config server/scripts/sweep-test-orphan-data.js
+ *       (or: MONGODB_URI=... node server/scripts/sweep-test-orphan-data.js)
+ * Touches nothing.
+ */
+
+import { MongoClient } from 'mongodb';
+try { await import('dotenv/config'); } catch { /* env already set */ }
+
+const MONGO_URI = process.env.MONGO_URI || process.env.MONGODB_URI;
+if (!MONGO_URI) { console.error('MONGO_URI / MONGODB_URI not set'); process.exit(1); }
+const DB_NAME = 'tm_suite';
+
+const TEST_VALUE = /regent_save|alice-char-id|bob-char-id|buggy keeper/i;
+const TEST_NAME  = /\b(test|dummy|sample|placeholder|foobar|xxx)\b/i;
+const NAME_FIELDS = ['name', 'title', 'label', 'character_name', 'display_name'];
+
+function* strings(v, depth = 0) {
+  if (depth > 5 || v == null) return;
+  if (typeof v === 'string') { yield v; return; }
+  if (Array.isArray(v)) { for (const x of v) yield* strings(x, depth + 1); return; }
+  if (typeof v === 'object' && !v._bsontype && !(v instanceof Date)) {
+    for (const x of Object.values(v)) yield* strings(x, depth + 1);
+  }
+}
+
+async function main() {
+  const client = new MongoClient(MONGO_URI);
+  await client.connect();
+  const db = client.db(DB_NAME);
+  const names = (await db.listCollections().toArray()).map(c => c.name).filter(n => !n.startsWith('system.')).sort();
+
+  // ── 1. test-marker scan ────────────────────────────────────────────
+  console.log('\n' + '='.repeat(90));
+  console.log('TEST-MARKER DOCS (obvious fixtures in the live DB)');
+  console.log('='.repeat(90));
+  const testHits = {};
+  for (const name of names) {
+    const docs = await db.collection(name).find({}).toArray();
+    const hits = [];
+    for (const d of docs) {
+      const nameVal = NAME_FIELDS.map(f => d[f]).find(v => typeof v === 'string' && TEST_NAME.test(v));
+      let valHit = null;
+      for (const s of strings(d)) { if (TEST_VALUE.test(s)) { valHit = s; break; } }
+      if (nameVal || valHit) hits.push({ _id: String(d._id), why: nameVal ? `name~"${nameVal}"` : `value~"${valHit}"` });
+    }
+    if (hits.length) {
+      testHits[name] = hits;
+      console.log(`\n  ${name}  (${hits.length})`);
+      hits.slice(0, 12).forEach(h => console.log(`    ${h._id.slice(-6)}  ${h.why}`));
+      if (hits.length > 12) console.log(`    ...and ${hits.length - 12} more`);
+    }
+  }
+  if (!Object.keys(testHits).length) console.log('  (none)');
+
+  // ── 2. orphaned-FK scan ────────────────────────────────────────────
+  console.log('\n' + '='.repeat(90));
+  console.log('ORPHANED FOREIGN KEYS (ref points at a missing parent)');
+  console.log('='.repeat(90));
+  const charIds = new Set((await db.collection('characters').find({}, { projection: { _id: 1 } }).toArray()).map(c => String(c._id)));
+  const terrIds = new Set((await db.collection('territories').find({}, { projection: { _id: 1 } }).toArray()).map(t => String(t._id)));
+  const cycleIds = new Set((await db.collection('downtime_cycles').find({}, { projection: { _id: 1 } }).toArray()).map(c => String(c._id)));
+
+  async function orphanCheck(coll, label, parentSet, extract) {
+    const docs = await db.collection(coll).find({}).toArray();
+    const orphans = [];
+    for (const d of docs) {
+      for (const ref of extract(d)) {
+        if (ref == null || ref === '') continue;
+        if (!parentSet.has(String(ref))) orphans.push({ _id: String(d._id), ref: String(ref) });
+      }
+    }
+    console.log(`\n  ${label}: ${orphans.length} orphaned`);
+    orphans.slice(0, 8).forEach(o => console.log(`    doc ${o._id.slice(-6)}  ->  missing ${o.ref.slice(-12)}`));
+    if (orphans.length > 8) console.log(`    ...and ${orphans.length - 8} more`);
+    return orphans.length;
+  }
+
+  await orphanCheck('downtime_submissions', 'downtime_submissions.character_id -> characters', charIds, d => [d.character_id]);
+  await orphanCheck('downtime_submissions', 'downtime_submissions.cycle_id -> downtime_cycles', cycleIds, d => [d.cycle_id]);
+  await orphanCheck('territory_residency', 'territory_residency.territory_id -> territories', terrIds, d => [d.territory_id]);
+  await orphanCheck('characters', 'characters.home_territory -> territories', terrIds, d => [d.home_territory].filter(Boolean));
+  await orphanCheck('game_sessions', 'game_sessions.attendance[].character_id -> characters', charIds, d => (d.attendance || []).map(a => a.character_id));
+
+  await client.close();
+  console.log('\nNote: orphaned character_id can be a *type* mismatch (string vs ObjectId) rather than a true');
+  console.log('orphan — cross-check against the data-hygiene audit before deleting. Test markers are safe deletes');
+  console.log('once confirmed unreferenced (see the per-doc reference check).');
+}
+
+main().catch(err => { console.error(err); process.exit(1); });


### PR DESCRIPTION
## Summary

- Picking up #560 ("canonicalise territories.slug") revealed the slug fragmentation was **test-data pollution, not production drift**: the live `territories` collection held 5 clean production territories + 8 orphaned `Regent Save Test` fixtures. Those 8 carried all the non-canonical slug and regent/lieutenant values — and were the entire source of #559 too.
- The 8 docs were confirmed fully unreferenced and **deleted from the live DB** (backed up first to `st-working/`). `territories` now holds 5; all slugs `flat_lower`, all `regent_id`/`lieutenant_id` ObjectId. The data fix is already live — this PR lands the tooling.

## Closes

- Closes #560
- (#559 already closed as resolved by this cleanup)

## What's in the diff

- `server/scripts/sweep-test-orphan-data.js` — read-only: finds test fixtures + orphaned FKs across collections (also surfaced 7 orphaned `downtime_submissions`, flagged for separate test-vs-real triage)
- `server/scripts/delete-test-territories.js` — dry-run default, runtime reference guard, backs up before delete on `--apply`

## Test plan

- [x] Dry-run + reference guard (0 references) confirmed safe
- [x] `--apply` run against live DB: 8 deleted, backup written, count == 5
- [x] Re-audit: territories slug all `flat_lower`, regent/lieutenant all ObjectId — no fragmentation
- [ ] CI green

## Branch flow

- From: `morningstar-issue-560-territories-slug-format`
- Into: `dev`

_Note: the data change is already applied to production; merging this only lands the cleanup scripts (same pattern as prior migration scripts)._