### PR TITLE
chore(#567): triage + clean 19 orphaned downtime_submissions

### DIFF
--- a/server/scripts/delete-deadcycle-draft-submissions.js
+++ b/server/scripts/delete-deadcycle-draft-submissions.js
@@ -1,0 +1,57 @@
+/**
+ * delete-deadcycle-draft-submissions.js — destructive (DRY-RUN by default).
+ *
+ * Group C of the orphaned-submission triage (2026-06-03). A few DRAFT
+ * submissions point at cycle_ids that no longer exist — the test DT cycles
+ * cleaned up in #546. Their characters are real (Alice Vunder, Livia) but the
+ * cycle is gone, the draft was never published, and it is stranded.
+ *
+ * Guard (ALL must hold per doc): cycle_id is non-null, cycle_id is NOT a current
+ * downtime_cycle, status is draft, and not published. Aborts otherwise.
+ * --apply backs up first.
+ *
+ * NOTE: only deletes drafts whose cycle is genuinely missing. A draft on a LIVE
+ * cycle, or a published/submitted record, is never touched.
+ *
+ * Run:
+ *   node server/scripts/delete-deadcycle-draft-submissions.js          # dry-run
+ *   node server/scripts/delete-deadcycle-draft-submissions.js --apply  # execute
+ */
+
+import { MongoClient } from 'mongodb';
+import { mkdirSync, writeFileSync } from 'fs';
+import { dirname } from 'path';
+try { await import('dotenv/config'); } catch { /* env already set */ }
+
+const MONGO_URI = process.env.MONGO_URI || process.env.MONGODB_URI;
+if (!MONGO_URI) { console.error('MONGO_URI / MONGODB_URI not set'); process.exit(1); }
+const DB_NAME = 'tm_suite';
+const APPLY = process.argv.includes('--apply');
+
+async function main() {
+  const client = new MongoClient(MONGO_URI); await client.connect();
+  const db = client.db(DB_NAME);
+
+  const cycleIds = new Set((await db.collection('downtime_cycles').find({}, { projection: { _id: 1 } }).toArray()).map(c => String(c._id)));
+  const chars = new Map((await db.collection('characters').find({}, { projection: { name: 1 } }).toArray()).map(c => [String(c._id), c.name]));
+  const all = await db.collection('downtime_submissions').find({}).toArray();
+
+  const targets = all.filter(d => d.cycle_id != null && d.cycle_id !== '' && !cycleIds.has(String(d.cycle_id)) && d.status === 'draft' && !d.published_outcome);
+
+  console.log(`Draft submissions on a MISSING cycle (unpublished): ${targets.length}`);
+  targets.forEach(d => console.log(`  ${String(d._id).slice(-6)}  char=${chars.get(String(d.character_id)) || String(d.character_id).slice(-8)}  dead-cycle=${String(d.cycle_id).slice(-8)}  status=${d.status}`));
+
+  const bad = targets.filter(d => cycleIds.has(String(d.cycle_id)) || d.status !== 'draft' || d.published_outcome);
+  if (bad.length) { console.error(`\nABORT: ${bad.length} target(s) fail the dead-cycle/draft/unpublished guard.`); await client.close(); process.exit(2); }
+
+  if (!APPLY) { console.log(`\nDRY-RUN. --apply backs up + deletes the ${targets.length} dead-cycle drafts.`); await client.close(); return; }
+
+  const stamp = new Date().toISOString().slice(0, 10);
+  const backup = `st-working/audit/deleted-deadcycle-drafts-${stamp}.json`;
+  mkdirSync(dirname(backup), { recursive: true });
+  writeFileSync(backup, JSON.stringify(targets, null, 2));
+  const res = await db.collection('downtime_submissions').deleteMany({ _id: { $in: targets.map(d => d._id) } });
+  console.log(`\nDeleted ${res.deletedCount}. Backup: ${backup}`);
+  await client.close();
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/server/scripts/delete-yusuf-empty-submissions.js
+++ b/server/scripts/delete-yusuf-empty-submissions.js
@@ -1,0 +1,69 @@
+/**
+ * delete-yusuf-empty-submissions.js — destructive (DRY-RUN by default).
+ *
+ * Group B of the orphaned-submission triage (2026-06-03). The character
+ * "Yusuf Kalusicj" (69d720427fdd1b1f9498b0d4, Peter's char) carries a set of
+ * empty test/dev submissions with NO cycle_id and no content (draft+submitted
+ * pairs) left over from exercising the DT form. Delete only those — Yusuf's
+ * real, cycle-bound submissions are untouched.
+ *
+ * Guard (ALL must hold per doc): character_id == Yusuf, cycle_id null/absent,
+ * not published, and no feeding/project/sphere/story content. --apply backs up
+ * first. Aborts if any matched doc fails the guard.
+ *
+ * Run:
+ *   node server/scripts/delete-yusuf-empty-submissions.js          # dry-run
+ *   node server/scripts/delete-yusuf-empty-submissions.js --apply  # execute
+ */
+
+import { MongoClient } from 'mongodb';
+import { mkdirSync, writeFileSync } from 'fs';
+import { dirname } from 'path';
+try { await import('dotenv/config'); } catch { /* env already set */ }
+
+const MONGO_URI = process.env.MONGO_URI || process.env.MONGODB_URI;
+if (!MONGO_URI) { console.error('MONGO_URI / MONGODB_URI not set'); process.exit(1); }
+const DB_NAME = 'tm_suite';
+const APPLY = process.argv.includes('--apply');
+const YUSUF = '69d720427fdd1b1f9498b0d4';
+
+function hasContent(d) {
+  const r = d.responses || {};
+  for (const k of Object.keys(r)) {
+    if (/personal_story|story_moment/.test(k) && r[k]) return true;
+    if (/project_\d+_|sphere_\d+_/.test(k) && r[k]) return true;
+    if (/feeding_territories/.test(k) && r[k] && r[k] !== '{}' && r[k] !== '') return true;
+  }
+  return false;
+}
+
+async function main() {
+  const client = new MongoClient(MONGO_URI); await client.connect();
+  const db = client.db(DB_NAME);
+
+  const all = await db.collection('downtime_submissions').find({}).toArray();
+  const yusufAll = all.filter(d => String(d.character_id) === YUSUF);
+  const targets = yusufAll.filter(d => (d.cycle_id == null || d.cycle_id === '') && !d.published_outcome && !hasContent(d));
+  const kept = yusufAll.filter(d => !targets.includes(d));
+
+  console.log(`Yusuf submissions total: ${yusufAll.length}`);
+  console.log(`  -> DELETE (no cycle, empty, unpublished): ${targets.length}`);
+  targets.forEach(d => console.log(`     ${String(d._id).slice(-6)}  status=${d.status || '-'}  cycle=${d.cycle_id ?? 'null'}`));
+  console.log(`  -> KEEP (cycle-bound / has content / published): ${kept.length}`);
+  kept.forEach(d => console.log(`     ${String(d._id).slice(-6)}  status=${d.status || '-'}  cycle=${String(d.cycle_id ?? 'null').slice(-6)}  content=${hasContent(d)}  pub=${!!d.published_outcome}`));
+
+  // guard
+  const bad = targets.filter(d => (d.cycle_id != null && d.cycle_id !== '') || d.published_outcome || hasContent(d));
+  if (bad.length) { console.error(`\nABORT: ${bad.length} target(s) fail the empty/no-cycle/unpublished guard.`); await client.close(); process.exit(2); }
+
+  if (!APPLY) { console.log(`\nDRY-RUN. --apply backs up + deletes the ${targets.length} empty Yusuf test subs.`); await client.close(); return; }
+
+  const stamp = new Date().toISOString().slice(0, 10);
+  const backup = `st-working/audit/deleted-yusuf-empty-${stamp}.json`;
+  mkdirSync(dirname(backup), { recursive: true });
+  writeFileSync(backup, JSON.stringify(targets, null, 2));
+  const res = await db.collection('downtime_submissions').deleteMany({ _id: { $in: targets.map(d => d._id) } });
+  console.log(`\nDeleted ${res.deletedCount}. Backup: ${backup}`);
+  await client.close();
+}
+main().catch(e => { console.error(e); process.exit(1); });

--- a/server/scripts/relink-dt1-orphan-submissions.js
+++ b/server/scripts/relink-dt1-orphan-submissions.js
@@ -1,0 +1,72 @@
+/**
+ * relink-dt1-orphan-submissions.js — data recovery (DRY-RUN by default).
+ *
+ * Group A of the orphaned-submission triage (2026-06-03). Some DT1 submissions
+ * still point at OLD character _ids (the eb9962xx scheme) from a pre-reimport
+ * character set; those characters were recreated with new _ids (5897a4xx) but
+ * these submissions were never relinked. They are real, published DT1 history.
+ *
+ * Strategy: for every submission whose character_id does NOT resolve to a
+ * current character, look up the current character by the submission's stored
+ * name. If exactly one matches, relink character_id to that current _id (as an
+ * ObjectId — which also moves it onto the canonical type for #558).
+ *
+ * Safety: DRY-RUN by default. Only relinks on a UNIQUE name match; anything
+ * ambiguous or nameless is skipped and reported. --apply backs up the affected
+ * submissions first.
+ *
+ * Run:
+ *   node server/scripts/relink-dt1-orphan-submissions.js           # dry-run
+ *   node server/scripts/relink-dt1-orphan-submissions.js --apply   # execute
+ */
+
+import { MongoClient } from 'mongodb';
+import { mkdirSync, writeFileSync } from 'fs';
+import { dirname } from 'path';
+try { await import('dotenv/config'); } catch { /* env already set */ }
+
+const MONGO_URI = process.env.MONGO_URI || process.env.MONGODB_URI;
+if (!MONGO_URI) { console.error('MONGO_URI / MONGODB_URI not set'); process.exit(1); }
+const DB_NAME = 'tm_suite';
+const APPLY = process.argv.includes('--apply');
+
+const nameOf = d => (d.character_name || d.name || (d.responses && d.responses.character_name) || '').toString().toLowerCase().trim();
+
+async function main() {
+  const client = new MongoClient(MONGO_URI); await client.connect();
+  const db = client.db(DB_NAME);
+
+  const chars = await db.collection('characters').find({}).project({ name: 1 }).toArray();
+  const idSet = new Set(chars.map(c => String(c._id)));
+  const byName = new Map();
+  for (const c of chars) { const k = (c.name || '').toLowerCase().trim(); if (!k) continue; if (!byName.has(k)) byName.set(k, []); byName.get(k).push(c); }
+
+  const subs = await db.collection('downtime_submissions').find({}).toArray();
+  const relinkable = [], skipped = [];
+  for (const d of subs) {
+    const cid = d.character_id != null ? String(d.character_id) : '';
+    if (idSet.has(cid)) continue;            // character resolves -> not an orphan
+    const nm = nameOf(d);
+    const m = nm ? byName.get(nm) : null;
+    if (m && m.length === 1) relinkable.push({ _id: d._id, short: String(d._id).slice(-6), from: cid, to: m[0]._id, name: d.character_name || d.name, cycle: String(d.cycle_id || '') });
+    else skipped.push({ short: String(d._id).slice(-6), from: cid, reason: !nm ? 'no name on doc' : (m ? `ambiguous x${m.length}` : 'no current char by that name') });
+  }
+
+  console.log(`Character-orphaned submissions: ${relinkable.length + skipped.length}\n`);
+  console.log(`RELINKABLE (unique name match) — ${relinkable.length}:`);
+  relinkable.forEach(p => console.log(`  sub ${p.short}  ${String(p.from).slice(-8)} -> ${String(p.to).slice(-8)}  (${p.name})  cycle=${p.cycle.slice(-6) || '-'}`));
+  console.log(`\nSKIPPED — ${skipped.length}:`);
+  skipped.forEach(p => console.log(`  sub ${p.short}  from ${String(p.from).slice(-8)}  [${p.reason}]`));
+
+  if (!APPLY) { console.log(`\nDRY-RUN. --apply backs up + relinks the ${relinkable.length} matched subs (sets character_id to the current ObjectId).`); await client.close(); return; }
+
+  const stamp = new Date().toISOString().slice(0, 10);
+  const backup = `st-working/audit/relink-dt1-orphans-${stamp}.json`;
+  mkdirSync(dirname(backup), { recursive: true });
+  writeFileSync(backup, JSON.stringify(relinkable.map(p => ({ sub: String(p._id), from: p.from, to: String(p.to), name: p.name })), null, 2));
+  let n = 0;
+  for (const p of relinkable) { await db.collection('downtime_submissions').updateOne({ _id: p._id }, { $set: { character_id: p.to } }); n++; }
+  console.log(`\nRelinked ${n} submissions to current ObjectId character_ids. Backup: ${backup}`);
+  await client.close();
+}
+main().catch(e => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary

- The data-hygiene sweep found 19 orphaned `downtime_submissions`. Triaged into three groups and **resolved each on the live DB (backed up first)**:
  - **Group A (4)** — relinked DT1 records (Eve, Ivana, Kirk Grimm, Tegan) from dead pre-reimport character ids to current ObjectIds. Real published history preserved.
  - **Group B (12)** — deleted empty no-cycle test submissions on Yusuf (Peter's char); his 3 real submissions kept.
  - **Group C (3)** — deleted unpublished drafts stranded on deleted test cycles.
- `downtime_submissions` 105 → 90; re-check shows 0 orphans of any kind.

## Closes
- Closes #567

## Diff
Three guarded, dry-run-default scripts (the data change is already applied; this lands the tooling):
- `relink-dt1-orphan-submissions.js`, `delete-yusuf-empty-submissions.js`, `delete-deadcycle-draft-submissions.js`

## Test plan
- [x] Dry-runs reviewed; guards verified (kept Yusuf's 3 real subs, 0 ambiguous relinks)
- [x] `--apply` run live; each group backed up to `st-working/`
- [x] Post-check: 0 character-orphans, 0 cycle-orphans, 0 cycle-less subs
- [ ] CI green

## Branch flow
- From: `morningstar-orphan-submissions-cleanup`
- Into: `dev`