### PR TITLE
fix(nav): show Dice tab to players (#579)

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -260,7 +260,7 @@ const NAV_ALIAS = {
 // Icons are inlined (not referencing _svg) to avoid declaration-order issues.
 const NAV_ITEMS = [
   // Sheet split into Stats / Skills / Powers for phone UX
-  { id: 'dice',      label: 'Dice',      icon: '<svg viewBox="0 0 24 24"><rect x="2" y="2" width="20" height="20" rx="4"/><circle cx="7" cy="7" r="1.5" fill="currentColor"/><circle cx="17" cy="7" r="1.5" fill="currentColor"/><circle cx="12" cy="12" r="1.5" fill="currentColor"/><circle cx="7" cy="17" r="1.5" fill="currentColor"/><circle cx="17" cy="17" r="1.5" fill="currentColor"/></svg>', goTab: 'dice', stOnly: true },
+  { id: 'dice',      label: 'Dice',      icon: '<svg viewBox="0 0 24 24"><rect x="2" y="2" width="20" height="20" rx="4"/><circle cx="7" cy="7" r="1.5" fill="currentColor"/><circle cx="17" cy="7" r="1.5" fill="currentColor"/><circle cx="12" cy="12" r="1.5" fill="currentColor"/><circle cx="7" cy="17" r="1.5" fill="currentColor"/><circle cx="17" cy="17" r="1.5" fill="currentColor"/></svg>', goTab: 'dice' },
   { id: 'stats',     label: 'Stats',     icon: '<svg viewBox="0 0 24 24"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>', goTab: 'stats' },
   { id: 'skills',    label: 'Skills',    icon: '<svg viewBox="0 0 24 24"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>', goTab: 'skills' },
   { id: 'powers',    label: 'Powers',    icon: '<svg viewBox="0 0 24 24"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>', goTab: 'powers' },


### PR DESCRIPTION
## Summary

One-property fix. The Dice item in `NAV_ITEMS` (`public/js/app.js:261`) carried `stOnly: true`, which hid the bottom-nav button from players. The dice tab content and rolling logic — `dice-modal.js`, `roll.js`, the `#t-dice` div in `index.html` — are fully role-agnostic and already work end-to-end; only the nav button's visibility was gated.

Dropping `stOnly: true` restores player access. Confirmed by grep across `public/js/` and `server/tests/` that no other dice-path role gate exists.

## Tests

- Full regression: **1215/1215 pass.**
- No existing test asserts Dice is `stOnly` (grep returns nothing in `server/tests/`), so nothing to invert.

## Test plan
- [ ] Log in as a non-ST player on `dev` → Dice tab appears in the bottom nav.
- [ ] Tap it → tab opens, rolls work end-to-end.
- [ ] Log in as ST → Dice tab still present (unchanged from before).

Closes #579