### PR TITLE
feat(nav): phone bottom-nav polish — +25% size, safe-area, edge-fade affordance (#596)

### DIFF
--- a/public/css/suite.css
+++ b/public/css/suite.css
@@ -77,11 +77,23 @@ body.desktop-mode .view-toggle-btn{display:inline-flex !important;}
 #t-dice.active,#t-roll.active,#t-st.active{display:flex;}
 
 /* ── BOTTOM NAV ── */
-#bnav{flex-shrink:0;display:flex;background:var(--surf2);border-top:1px solid var(--bdr);z-index:20;position:relative;overflow-x:auto;overflow-y:hidden;-webkit-overflow-scrolling:touch;scrollbar-width:none;padding:0 2px;overscroll-behavior-x:contain;touch-action:pan-x;}
+/* Phone bottom nav (issue #596): +25% size, safe-area-inset reservation, and an
+ * edge-gradient scroll affordance. Affordance is pure CSS (mask-image, option b
+ * in the issue) — no JS, no z-index/pointer-events trap on the nav buttons. The
+ * fade is phone-scoped (≤599px) so the ≥600px flex-start layout doesn't get a
+ * cosmetic fade over its empty right gutter. Safe-area uses the .cr-box pattern
+ * at line 683; on desktop the inset evaluates to 0 so only the 8px buffer adds. */
+#bnav{flex-shrink:0;display:flex;background:var(--surf2);border-top:1px solid var(--bdr);z-index:20;position:relative;overflow-x:auto;overflow-y:hidden;-webkit-overflow-scrolling:touch;scrollbar-width:none;padding:0 2px calc(8px + env(safe-area-inset-bottom));overscroll-behavior-x:contain;touch-action:pan-x;}
 @media (min-width: 600px) { #bnav { justify-content: flex-start; } }
+@media (max-width: 599px) {
+  #bnav {
+    -webkit-mask-image: linear-gradient(to right, transparent 0, #000 16px, #000 calc(100% - 16px), transparent 100%);
+            mask-image: linear-gradient(to right, transparent 0, #000 16px, #000 calc(100% - 16px), transparent 100%);
+  }
+}
 #bnav::-webkit-scrollbar{display:none;}
-.nbtn{flex:0 0 68px;min-height:56px;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:10px 4px 12px;gap:4px;background:none;border:none;cursor:pointer;font-family:var(--fl);font-size:9px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--txt3);-webkit-tap-highlight-color:transparent;position:relative;z-index:21;}
-.nbtn svg{width:20px;height:20px;stroke:currentColor;fill:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;}
+.nbtn{flex:0 0 85px;min-height:70px;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:12px 5px 15px;gap:5px;background:none;border:none;cursor:pointer;font-family:var(--fl);font-size:11px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--txt3);-webkit-tap-highlight-color:transparent;position:relative;z-index:21;}
+.nbtn svg{width:25px;height:25px;stroke:currentColor;fill:none;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;}
 .nbtn:hover{color:var(--txt2);}
 .nbtn-disabled{opacity:.3;cursor:default;pointer-events:none;}
 .nbtn-seasonal{color:var(--crim);}.nbtn-seasonal svg{stroke:var(--crim);}


### PR DESCRIPTION
## Summary

Three-part UX polish for `#bnav`. CSS-only change.

1. **+25% size.** `.nbtn` width 68→85px, min-height 56→70px; `.nbtn svg` 20→25px; label 9→11px; padding 10/4/12 → 12/5/15 to keep vertical centring balanced. Variants (`.nbtn.on`, `.nbtn-seasonal`, `.nbtn-admin-tier`) are colour-only so the size bump propagates proportionally without per-variant rewrites.

2. **Safe-area inset.** `#bnav` `padding-bottom: calc(8px + env(safe-area-inset-bottom))` — row sits clear of the iOS home-indicator zone. Mirrors the `.cr-box` precedent. On desktop the inset evaluates to 0, only the 8px buffer adds.

3. **Scroll affordance: option (b) — pure-CSS edge gradient.** `mask-image: linear-gradient(...transparent → black at 16px → black → transparent...)` on `#bnav`, scoped to `@media (max-width: 599px)` so the ≥600px `flex-start` layout doesn't get a cosmetic fade over its empty right gutter.

### Why (b) over (a) / (c)

- The fade itself signals scrollability, no JS needed.
- `mask-image` does **not** affect pointer events, so the AC "must NOT interfere with click/tap routing" holds without a z-index/pointer-events workaround.
- Chevrons (a / c) would need a scroll-listener + class toggles on `#bnav` for the at-start/at-end states; this trade was explicitly Khepri's call. Going minimal kept the diff to a single CSS hunk.

## Regression check

- `body.desktop-mode #bnav { display: none !important; }` (now line 1952) is untouched; the new mask is overridden by `display: none`.
- 1215/1215 server tests pass.
- Variants only use colour/background, so all NAV_ITEMS render at the new size correctly.

## Limitation (flagged)

I do not have a tall-aspect device emulator available in this session, so I could not visually verify on an iPhone 15 Pro per the issue AC. Per CLAUDE.md flagging rather than claiming success. Peter can smoke on dev after Netlify auto-deploys.

## Test plan
- [ ] iPhone Safari (home-indicator device): `#bnav` sits ~8px above the home-indicator zone; buttons are visibly larger; horizontal scroll edges show a soft fade.
- [ ] Tap routing: every nav button still responds to taps at the new size and with the mask applied.
- [ ] Desktop (`body.desktop-mode`): `#bnav` is hidden as before — no leaked styling.
- [ ] Variants (`.nbtn.on`, `.nbtn-seasonal`, `.nbtn-admin-tier`) all scale visually with the base size.

Closes #596