### PR TITLE
test(qa): retroactive coverage top-ups for the review batch

### DIFF
--- a/tests/feature-583-investigate-lead-card.spec.js
+++ b/tests/feature-583-investigate-lead-card.spec.js
@@ -169,4 +169,22 @@ test.describe('Feature #583 — investigate lead on the Details card', () => {
     await expect(leadField).toHaveCount(0);
   });
 
+  // QA top-up (AC3 empty-state): a lead-only action (no title, no description) shows
+  // the Lead row and must NOT fall through to "— No details recorded".
+  test('lead-only action shows the Lead row, not the empty-state', async ({ page }) => {
+    const leadOnly = investigateSub();
+    leadOnly._raw.projects[0].title = '';
+    leadOnly._raw.projects[0].desired_outcome = '';
+    leadOnly._raw.projects[0].detail = '';
+    leadOnly.responses.project_1_title = '';
+    leadOnly.responses.project_1_description = '';
+    // keep project_1_investigate_lead
+    await setup(page, [leadOnly]);
+    await openActionDetail(page, 'Investigate');
+
+    const view = page.locator('.proc-action-detail .proc-feed-desc-view').first();
+    await expect(view.locator('.proc-proj-field', { hasText: 'Lead' }).first()).toContainText(LEAD_TEXT);
+    await expect(view).not.toContainText('No details recorded');
+  });
+
 });

--- a/tests/fix-586-target-prepopulate.spec.js
+++ b/tests/fix-586-target-prepopulate.spec.js
@@ -39,7 +39,8 @@ function mkChar(id, name) {
 const EINAR = mkChar('char-einar', 'Einar Test');
 const RYAN  = mkChar('char-ryan',  'Ryan Ambrose');
 const EVE   = mkChar('char-eve',   'Eve Test');
-const ALL_CHARS = [EINAR, RYAN, EVE];
+const RETIRED = mkChar('char-retired', 'Old Ghost'); RETIRED.retired = true;
+const ALL_CHARS = [EINAR, RYAN, EVE, RETIRED];
 
 const TEST_CYCLE = { _id: 'cycle-586', cycle_number: 3, status: 'active', confirmed_ambience: {}, narrative_notes: '' };
 
@@ -151,6 +152,22 @@ test.describe('Fix #586 — target pre-population', () => {
     const group = page.locator('.proc-action-detail .proc-targeting-group').first();
     await expect(group).toContainText('Submitted target');
     await expect(group).toContainText('The Harbour');
+  });
+
+  // QA top-up (AC4 graceful degrade): an unresolvable character id (e.g. a deleted
+  // character) must not crash the card and must produce no seeded chip.
+  test('unresolved character id degrades gracefully (no chip, no crash)', async ({ page }) => {
+    await setup(page, [projectSub({ targetValue: 'char-ghost' })]);
+    await openAction(page, 'Hunting the Hunter'); // resolves only if the detail rendered
+    await expect(page.locator('.proc-action-detail .proc-targeting-group').first()).toBeVisible();
+    await expect(targetChip(page, 'investigate_target_char')).toHaveCount(0);
+  });
+
+  // QA top-up (AC4): a retired character target is skipped the same way (no chip).
+  test('retired character target is not seeded (no chip)', async ({ page }) => {
+    await setup(page, [projectSub({ targetValue: 'char-retired' })]);
+    await openAction(page, 'Hunting the Hunter');
+    await expect(targetChip(page, 'investigate_target_char')).toHaveCount(0);
   });
 
 });

--- a/tests/fix-587-css-tokens.spec.js
+++ b/tests/fix-587-css-tokens.spec.js
@@ -1,0 +1,129 @@
+/**
+ * Feature #587 — admin button/input CSS token normalisation (QA top-up).
+ *
+ * #587 had no automated coverage (visual smoke only). These tests assert the
+ * RENDERED result, theme-aware, by resolving the parchment tokens at runtime via
+ * probe elements and comparing element computed styles:
+ *   - the dark-on-dark button bases were lifted from --surf2 to --surf (so a button
+ *     no longer matches the panel fill);
+ *   - the targeting-group fill-in input uses the light --bg, not --surf2.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const ST_USER = {
+  id: '123000587', username: 'test_st_587', global_name: 'Test ST 587',
+  avatar: null, role: 'st', player_id: 'p-587', character_ids: [], is_dual_role: false,
+};
+
+const CHAR = {
+  _id: 'char-587', name: 'Einar Test', moniker: null, honorific: null,
+  clan: 'Gangrel', covenant: 'Invictus', player: 'P', blood_potency: 2,
+  humanity: 6, humanity_base: 7, court_title: null, retired: false,
+  status: { city: 1, clan: 1, covenant: { 'Carthian Movement': 0, 'Circle of the Crone': 0, 'Invictus': 1, 'Lancea et Sanctum': 0, 'Ordo Dracul': 0 } },
+  attributes: {
+    Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+    Intelligence: { dots: 3, bonus: 0 }, Wits: { dots: 3, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+    Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: { Investigation: { dots: 3, bonus: 0, specs: [], nine_again: false } },
+  disciplines: { Auspex: { dots: 2 } }, merits: [], powers: [], ordeals: [],
+};
+
+const TEST_CYCLE = { _id: 'cycle-587', cycle_number: 3, status: 'active', confirmed_ambience: {}, narrative_notes: '' };
+const TITLE = 'Hunting the Hunter';
+
+function investigateSub() {
+  return {
+    _id: 'sub-587',
+    cycle_id: 'cycle-587',
+    character_name: 'Einar Test',
+    character_id: 'char-587',
+    player_name: 'P',
+    submitted_at: '2026-06-05T00:00:00Z',
+    _raw: {
+      projects: [{ action_type: 'investigate', title: TITLE, desired_outcome: TITLE, detail: 'Scour.', primary_pool: { expression: 'Wits 3 + Investigation 3 = 6' } }],
+      feeding: null, sphere_actions: [], contact_actions: { requests: [] }, retainer_actions: { actions: [] },
+    },
+    responses: {
+      project_1_action: 'investigate',
+      project_1_title: TITLE,
+      project_1_description: 'Scour.',
+      project_1_pool_expr: 'Wits 3 + Investigation 3 = 6',
+    },
+    projects_resolved: [], feeding_review: null, merit_actions_resolved: [],
+    st_review: { territory_overrides: {} },
+  };
+}
+
+async function setup(page) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'local-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url = route.request().url();
+    const method = route.request().method();
+    const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+    if (method === 'PUT' || method === 'PATCH' || method === 'POST') return ok({ ok: true });
+    if (url.includes('/api/downtime_submissions')) return ok([investigateSub()]);
+    if (url.includes('/api/downtime_cycles'))      return ok([TEST_CYCLE]);
+    if (url.includes('/api/characters/names'))     return ok([{ _id: CHAR._id, name: CHAR.name, moniker: CHAR.moniker, honorific: CHAR.honorific }]);
+    if (url.includes('/api/characters'))           return ok([CHAR]);
+    return ok([]);
+  });
+
+  await page.goto('/admin.html');
+  await page.waitForSelector('#admin-app', { state: 'visible', timeout: 10000 });
+  await page.click('[data-domain="downtime"]');
+  await page.waitForTimeout(1000);
+  await page.waitForSelector('.proc-action-row', { timeout: 8000 });
+  await page.locator('.proc-action-row', { hasText: TITLE }).first().click();
+  await page.waitForSelector('.proc-action-detail', { timeout: 8000 });
+}
+
+// Resolve a CSS token to its computed rgb, and read element bgs — all in one pass.
+async function probe(page) {
+  return page.evaluate(() => {
+    const resolve = (token) => {
+      const el = document.createElement('div');
+      el.style.backgroundColor = `var(${token})`;
+      document.body.appendChild(el);
+      const c = getComputedStyle(el).backgroundColor;
+      el.remove();
+      return c;
+    };
+    const detail = document.querySelector('.proc-action-detail');
+    const btn = detail?.querySelector('.proc-rote-chip') || detail?.querySelector('.proc-roll-mode-btn');
+    const input = detail?.querySelector('.proc-targeting-group .proc-conn-input');
+    return {
+      btnBg:   btn   ? getComputedStyle(btn).backgroundColor   : null,
+      inputBg: input ? getComputedStyle(input).backgroundColor : null,
+      surf:  resolve('--surf'),
+      surf2: resolve('--surf2'),
+      bg:    resolve('--bg'),
+    };
+  });
+}
+
+test.describe('Feature #587 — CSS token normalisation', () => {
+
+  test('button base is lifted off the dark panel fill (--surf, not --surf2)', async ({ page }) => {
+    await setup(page);
+    const r = await probe(page);
+    expect(r.btnBg).not.toBeNull();
+    expect(r.btnBg).toBe(r.surf);       // raised onto --surf
+    expect(r.btnBg).not.toBe(r.surf2);  // no longer the dark panel fill
+  });
+
+  test('targeting-group fill-in input uses the light --bg fill', async ({ page }) => {
+    await setup(page);
+    const r = await probe(page);
+    expect(r.inputBg).not.toBeNull();
+    expect(r.inputBg).toBe(r.bg);        // light/editable parchment
+    expect(r.inputBg).not.toBe(r.surf2); // not the dark override
+  });
+
+});

--- a/tests/fix-594-dossier-target-read.spec.js
+++ b/tests/fix-594-dossier-target-read.spec.js
@@ -112,4 +112,22 @@ test.describe('Fix #594 — dossier target read', () => {
     await expect(snapshot(page)).not.toContainText('Target: Ryan Ambrose');
   });
 
+  // QA top-up: the dossier handles BOTH investigate and attack — cover attack too.
+  test('attack: player-seeded target shows in the dossier', async ({ page }) => {
+    const attackSub = {
+      _id: 'sub-594-atk', cycle_id: 'cycle-594',
+      character_name: 'Einar Test', character_id: 'char-einar', player_name: 'P',
+      submitted_at: '2026-06-05T00:00:00Z',
+      _raw: { projects: [{ action_type: 'attack', title: 'Ambush', desired_outcome: 'Ambush', detail: 'Strike.', primary_pool: { expression: 'Strength 2 + Brawl 2 = 4' } }], feeding: null, sphere_actions: [], contact_actions: { requests: [] }, retainer_actions: { actions: [] } },
+      responses: { project_1_action: 'attack', project_1_title: 'Ambush', project_1_description: 'Strike.', project_1_target_type: 'character', project_1_target_value: 'char-ryan' },
+      projects_resolved: [], feeding_review: null, merit_actions_resolved: [], st_review: { territory_overrides: {} },
+    };
+    await setup(page, [attackSub]);
+    await page.waitForSelector('.proc-action-row', { timeout: 8000 });
+    await page.locator('.proc-action-row', { hasText: 'Ambush' }).first().click();
+    await page.waitForSelector('.proc-action-detail .proc-snapshot-panel', { timeout: 8000 });
+    await expect(snapshot(page)).toContainText('Target: Ryan Ambrose');
+    await expect(snapshot(page).locator('.proc-snap-ti-unset')).toHaveCount(0);
+  });
+
 });

--- a/tests/fix-595-roll-validate-gate.spec.js
+++ b/tests/fix-595-roll-validate-gate.spec.js
@@ -130,4 +130,42 @@ test.describe('Fix #595 — roll validation gate', () => {
     await expect(rollCard(page)).not.toContainText('No roll needed');
   });
 
+  // QA top-up: ST Override is the other rolling mode and must validate the same way.
+  test('selecting ST Override also validates the pool and enables the roll', async ({ page }) => {
+    await setup(page, [stuckSub()]);
+    await openInvestigate(page);
+    await page.locator('.proc-roll-mode-btn[data-roll-mode="st_override"]').first().click();
+    await page.waitForTimeout(500);
+    await expect(rollCard(page).locator('.proc-proj-roll-btn')).toHaveCount(1);
+    await expect(rollCard(page)).not.toContainText('Validate pool first');
+  });
+
+  // QA top-up (safety-critical): the `!rev.roll` guard must PRESERVE a real roll
+  // result — re-selecting a roll mode on an already-rolled action must NOT reset it.
+  test('re-selecting a mode does NOT clobber an existing roll result', async ({ page }) => {
+    const rolledSub = {
+      ...stuckSub(),
+      projects_resolved: [{
+        action_type: 'investigate',
+        pool_player: POOL,
+        pool_validated: POOL,
+        pool_status: 'rolled',
+        roll_mode: 'player',
+        roll: { dice_string: '8,9,10', successes: 3, exceptional: false },
+        notes_thread: [],
+      }],
+    };
+    await setup(page, [rolledSub]);
+    await openInvestigate(page);
+
+    // The roll result is shown.
+    await expect(rollCard(page)).toContainText('3 success');
+
+    // Re-select Player Pool — the existing result must survive (not "Validate pool first").
+    await page.locator('.proc-roll-mode-btn[data-roll-mode="player"]').first().click();
+    await page.waitForTimeout(500);
+    await expect(rollCard(page)).toContainText('3 success');
+    await expect(rollCard(page)).not.toContainText('Validate pool first');
+  });
+
 });

--- a/tests/fix-601-maintenance-target-details.spec.js
+++ b/tests/fix-601-maintenance-target-details.spec.js
@@ -143,4 +143,27 @@ test.describe('Feature #601 — maintenance target on Details card', () => {
     await expect(descView(page).locator('.proc-feed-lbl', { hasText: /^Target$/ })).toHaveCount(0);
   });
 
+  // QA top-up: the other maintainable merit (MCI) resolves the same way.
+  test('maintenance MCI resolves to "Mystery Cult Initiation"', async ({ page }) => {
+    const sub = maintenanceSub();
+    sub.responses.project_1_target_value = 'Mystery Cult Initiation_3';
+    await setup(page, [sub]);
+    await openRow(page, 'Maintenance');
+
+    const target = descView(page).locator('.proc-proj-field', { hasText: 'Target' }).first();
+    await expect(target).toContainText('Mystery Cult Initiation');
+    await expect(descView(page)).not.toContainText('Mystery Cult Initiation_3');
+  });
+
+  // QA top-up: a maintenance action with no asset selected -> no stray Target row.
+  test('maintenance with no asset shows no Target row (Description still shows)', async ({ page }) => {
+    const sub = maintenanceSub();
+    sub.responses.project_1_target_value = '';
+    await setup(page, [sub]);
+    await openRow(page, 'Maintenance');
+
+    await expect(descView(page).locator('.proc-feed-lbl', { hasText: /^Target$/ })).toHaveCount(0);
+    await expect(descView(page)).toContainText(MAINT_DESC);
+  });
+
 });


### PR DESCRIPTION
Quinn QA pass (BMAD `bmad-agent-qa`) over the 7 stories merged to dev this session (583, 585, 586, 587, 594, 595, 601), all at `review`. **Tests only — no product code.** Full batch: **38 passed, 0 failed**.

## Gaps closed (+10 cases)

| Story | Added |
|---|---|
| #595 | re-select must NOT clobber an existing roll (`!rev.roll`); ST Override validates like Player Pool |
| #587 | **new spec** (was zero coverage) — rendered, theme-aware token assertions (button off panel fill, input on `--bg`) |
| #594 | attack variant of the override-aware dossier read |
| #601 | MCI maintainable merit resolves; empty target shows no stray Target row |
| #583 | lead-only action shows the Lead row, not the empty-state |
| #586 | unresolved id + retired character degrade gracefully (no chip, no crash) |

585 is the test suite itself (13 green). The known-broken `feature96.spec.js` is excluded (tracked in #602).

🤖 Generated with [Claude Code](https://claude.com/claude-code)