### PR TITLE
test(#617): finish DT-spec re-alignment (43/46 green)

### DIFF
--- a/specs/stories/fix.617.dt-spec-drift-tests.story.md
+++ b/specs/stories/fix.617.dt-spec-drift-tests.story.md
@@ -215,9 +215,11 @@ A second dev-story pass un-skipped all 13 and captured the live DOM. Apply this 
 
 Applied the selector map to the 13 remaining; **9 more re-aligned and green**, 4 deferred:
 - Fixed: DT-Fix-21 (`.active`→`.is-active`), DTX-2 (full-vs-compact via secrecy control, `.proc-val-status` removed), DTX-3 (`.proc-feedback-section`→`.proc-player-note-section`), DTR-2 toggle on/off (#608 typeahead `[data-ta-save="contested_char"]` + `.proc-contested-trait` chips), DTS-1 (Rite selector + unified Pending/Valid/Complete ribbon — "Tradition"/"Resolved"/"No Effect" removed), F312-4 (hidden `.proc-mod-total-val` via textContent).
-- **Deferred (4, `test.fixme` with inline notes):** DTX-1 territory-shared xref ×2 — **CONFIRMED product bug, raised as #621:** the territory xref lookup at `downtime-views.js:9169` (Block A) uses the raw territory key while the index (`:4672`) and the sibling path (`:9961`, fixed in 496.2) use the canonical `resolveTerrId` key, so the territory cross-reference callout silently never renders on that card path (production too). Un-skip once #621 lands; DTR-2 att−def-net — the #608 contested roll-result wording changed; DTS-2 duplicate-creates-entry — harness limit (needs a stateful submissions mock).
+- **Deferred (3, `test.fixme` with inline notes):** DTX-1 territory-shared xref ×2 — **CONFIRMED product bug, raised as #621:** the territory xref lookup at `downtime-views.js:9169` (Block A) uses the raw territory key while the index (`:4672`) and the sibling path (`:9961`, fixed in 496.2) use the canonical `resolveTerrId` key, so the territory cross-reference callout silently never renders on that card path (production too) — un-skip once #621 lands; DTS-2 duplicate-creates-entry — **confirmed** harness limit (the action-row count stays 1 in-test because the stateless route-mock doesn't reflect the duplicate's persistence; needs a stateful submissions mock).
 
-dt-fixes + feature312: **62 pass, 4 skip, 0 fail.** consistency: 24 pass. Net **42/46 done**.
+**Pass 3 (2026-06-06):** DTR-2 att−def-net **fixed** — the format IS "N att − M def = K net" (`:8088`); the locator just needed scoping to the `net` line (`.first()` was grabbing the separate defence-successes line). DTS-2 verified to be a genuine harness limit (not a quick fix).
+
+dt-fixes + feature312: **63 pass, 3 skip, 0 fail.** consistency: 24 pass. Net **43/46 done**.
 
 ### Change Log
 - 2026-06-06 — Story created (ready-for-dev) → dev-story audit re-scoped it (needs-decision) → Angelus ruled all 7 clusters intended → implementation pass 1: 33/46 re-aligned/retired (merged to dev via PR #620). Pass 2: +9 re-aligned (42/46 green); 4 deferred as documented hard cases (1 possible xref gap flagged per AC5). Block intelligence+override raised as #619.

--- a/specs/stories/fix.617.dt-spec-drift-tests.story.md
+++ b/specs/stories/fix.617.dt-spec-drift-tests.story.md
@@ -215,7 +215,7 @@ A second dev-story pass un-skipped all 13 and captured the live DOM. Apply this 
 
 Applied the selector map to the 13 remaining; **9 more re-aligned and green**, 4 deferred:
 - Fixed: DT-Fix-21 (`.active`→`.is-active`), DTX-2 (full-vs-compact via secrecy control, `.proc-val-status` removed), DTX-3 (`.proc-feedback-section`→`.proc-player-note-section`), DTR-2 toggle on/off (#608 typeahead `[data-ta-save="contested_char"]` + `.proc-contested-trait` chips), DTS-1 (Rite selector + unified Pending/Valid/Complete ribbon — "Tradition"/"Resolved"/"No Effect" removed), F312-4 (hidden `.proc-mod-total-val` via textContent).
-- **Deferred (4, `test.fixme` with inline notes):** DTX-1 territory-shared xref ×2 — **possible product gap (AC5):** the target-based xref callout renders but the territory-based one does not appear in the action card; DTR-2 att−def-net — the #608 contested roll-result wording changed; DTS-2 duplicate-creates-entry — harness limit (needs a stateful submissions mock).
+- **Deferred (4, `test.fixme` with inline notes):** DTX-1 territory-shared xref ×2 — **CONFIRMED product bug, raised as #621:** the territory xref lookup at `downtime-views.js:9169` (Block A) uses the raw territory key while the index (`:4672`) and the sibling path (`:9961`, fixed in 496.2) use the canonical `resolveTerrId` key, so the territory cross-reference callout silently never renders on that card path (production too). Un-skip once #621 lands; DTR-2 att−def-net — the #608 contested roll-result wording changed; DTS-2 duplicate-creates-entry — harness limit (needs a stateful submissions mock).
 
 dt-fixes + feature312: **62 pass, 4 skip, 0 fail.** consistency: 24 pass. Net **42/46 done**.
 

--- a/specs/stories/fix.617.dt-spec-drift-tests.story.md
+++ b/specs/stories/fix.617.dt-spec-drift-tests.story.md
@@ -190,6 +190,19 @@ After the per-cluster rulings, implementation began. Done (verified green):
 - dt-fixes: DT-Fix-21 territory pills (1); DTX-3 notes/feedback hierarchy (2); DTX-2 compact panel (1); DTX-1 xref callouts (2); DTR-2 contested roll → align to #608 widget (2); DTS-1 ST sorcery panel (2, reuse the consistency-B2 Rite/Connected-Characters approach); DTS-2 duplicate action (2).
 - feature312: F312-4 mod-total markup (1).
 
+### Selector map for the remaining 13 (captured 2026-06-06 via un-skip + ARIA-snapshot run; 12 fail / 1 already passes)
+
+A second dev-story pass un-skipped all 13 and captured the live DOM. Apply this map next time (read → rewrite → one verify run); branch was reverted to green afterward (no commit). The subtle ones are flagged.
+
+- **DT-Fix-21 territory pills (`bf607`)** — `.proc-terr-pill[data-terr-id]` exists (render `downtime-views.js:6752`, handler `:4909`). Test wants the no-territory pill `[data-terr-id=""].active` by default. Verify the default-active pill's `data-terr-id` (the "N/A" pill) — likely a non-empty id or not active by default; adjust the assertion.
+- **DTX-1 xref callouts (`a4128`, `df89a`)** — class is `.proc-xref-callout` / `.proc-xref-line` (render `:9181`, also `:9948`). Driven by `_xrefIndex` (built `:4669`). Needs ≥2 submissions sharing `terr:<territory>` or `inv-target:<name>`. Tests already set up two chars — check whether the fixtures actually populate the index (territory string must match canonical) and whether the callout renders in the opened card vs the snapshot panel.
+- **DTX-2 compact panel (`155a3`)** — compact = `.proc-compact-merit-panel` (`:7385`); full-mode uses `.proc-val-status`. The 3 compact tests pass; the "full-mode (allies investigate) not compact" one fails — confirm `.proc-val-status` still renders for merit investigate (it gained secrecy/lead, so it's full, not compact).
+- **DTX-3 notes/feedback (`0565e`, `1d77a`)** — `.proc-notes-panel` exists (`:9130`, "ST Notes"). **`.proc-feedback-section` does NOT exist** — Player Feedback section is at `:9159-9161` (title "Player Feedback — sent to player") with textarea `.proc-feedback-input` (`:5383`); find that section's container class and re-point. The "ST Notes above Player Feedback" test may be hitting a compact entry (notes move to `.proc-compact-notes-panel` `:7445`) — check the fixture's action mode.
+- **DTR-2 contested roll → #608 widget (`f0e69`, `aeddd`)** — toggle `.proc-contested-toggle` (`:6252`) exists. Char picker is **`.proc-conn-typeahead[data-ta-save="contested_char"]`** (NOT `.proc-contested-char-sel`); resistance pool is **trait chips `.proc-contested-trait` / `.proc-contested-bp`** (NOT `.proc-contested-pool-input`); roll btn `.proc-contested-roll-btn` (`:6294`). Rewrite 1282 (on shows picker+chips) and 1303 (off hides them) to these. 1290 (att−def=net) — inspect the contested roll-result format in `.proc-proj-roll-card .proc-proj-roll-result`; DTR-1 (passing) shows `.proc-proj-roll-result` carries "net" for modified rolls.
+- **DTS-1 ST sorcery (`1455c`, `3e0b0`)** — reuse the consistency-B2 fix: rite is `.proc-rite-select` (`:9296`), no separate **Tradition** field (consolidated), so 1402's "Tradition" assertion is obsolete → assert the Rite field / `.proc-feed-desc-card`. 1423 (status incl. "Resolved"/"No Effect") — check the sorcery action-ribbon status set (`_renderActionRibbon`).
+- **DTS-2 duplicate (`baa65`)** — `.proc-duplicate-btn` + `.proc-row-st-badge` exist (the "button present" tests pass). 1482 (click adds an ST row) fails — verify the duplicate click path adds a `.proc-action-row` in the test harness (may need the rules/save mock or a re-render wait).
+- **F312-4 mod-total (`ed1fc`)** — `.proc-mod-total-row` / `.proc-mod-total-val` exist, but the **feeding** mod-total-val is `display:none` (`:7273`/`:7283`). Read its `textContent` (works on hidden) rather than asserting visibility, or assert against a visible element.
+
 **Block follow-up (additive product issue):** raised as **#619** — player block must surface in relevant intelligence with ST override.
 
 ### File List
@@ -198,5 +211,13 @@ After the per-cluster rulings, implementation began. Done (verified green):
 - specs/stories/fix.617.dt-spec-drift-tests.story.md (this story)
 - specs/stories/sprint-status.yaml (last_updated log)
 
+### Second execution pass (2026-06-06) — 42 of 46 done
+
+Applied the selector map to the 13 remaining; **9 more re-aligned and green**, 4 deferred:
+- Fixed: DT-Fix-21 (`.active`→`.is-active`), DTX-2 (full-vs-compact via secrecy control, `.proc-val-status` removed), DTX-3 (`.proc-feedback-section`→`.proc-player-note-section`), DTR-2 toggle on/off (#608 typeahead `[data-ta-save="contested_char"]` + `.proc-contested-trait` chips), DTS-1 (Rite selector + unified Pending/Valid/Complete ribbon — "Tradition"/"Resolved"/"No Effect" removed), F312-4 (hidden `.proc-mod-total-val` via textContent).
+- **Deferred (4, `test.fixme` with inline notes):** DTX-1 territory-shared xref ×2 — **possible product gap (AC5):** the target-based xref callout renders but the territory-based one does not appear in the action card; DTR-2 att−def-net — the #608 contested roll-result wording changed; DTS-2 duplicate-creates-entry — harness limit (needs a stateful submissions mock).
+
+dt-fixes + feature312: **62 pass, 4 skip, 0 fail.** consistency: 24 pass. Net **42/46 done**.
+
 ### Change Log
-- 2026-06-06 — Story created (ready-for-dev) → dev-story audit re-scoped it (needs-decision) → Angelus ruled all 7 clusters intended → implementation: 33/46 re-aligned/retired (consistency green, dt-fixes 42/12/0), 13 DOM-investigation tests remain as fixme. Block intelligence+override raised as #619.
+- 2026-06-06 — Story created (ready-for-dev) → dev-story audit re-scoped it (needs-decision) → Angelus ruled all 7 clusters intended → implementation pass 1: 33/46 re-aligned/retired (merged to dev via PR #620). Pass 2: +9 re-aligned (42/46 green); 4 deferred as documented hard cases (1 possible xref gap flagged per AC5). Block intelligence+override raised as #619.

--- a/tests/downtime-processing-dt-fixes.spec.js
+++ b/tests/downtime-processing-dt-fixes.spec.js
@@ -1299,14 +1299,14 @@ test.describe('DTR-2: Contested roll', () => {
     await expect(page.locator('.proc-contested-trait').first()).toBeVisible({ timeout: 5000 });
   });
 
-  // fix.617 DEFERRED: the #608 contested roll-result no longer uses the literal "att − def = net"
-  // text format this test asserts. Needs the current contested-result wording before re-enabling.
-  test.fixme('after rolling defence, roll card shows att − def = net format', async ({ page }) => {
+  // fix.617: the contested roll-result is "<dice> N att − M def = K net" (downtime-views.js:8088).
+  // Scope to the line containing "net" — the defence-successes line is a separate
+  // .proc-proj-roll-result rendered first, so `.first()` grabbed the wrong one.
+  test('after rolling defence, roll card shows att − def = net format', async ({ page }) => {
     await setupDowntimeProcessing(page, [SUBMISSION_PROJ_CONTESTED_ROLLED]);
     await openFirstAction(page, 'Ambience');
 
-    // Target the roll card result specifically (not the defence result inside the contested panel)
-    const rollResult = page.locator('.proc-proj-roll-card .proc-proj-roll-result').first();
+    const rollResult = page.locator('.proc-proj-roll-card .proc-proj-roll-result').filter({ hasText: 'net' }).first();
     await expect(rollResult).toBeVisible({ timeout: 5000 });
     await expect(rollResult).toContainText('att');
     await expect(rollResult).toContainText('def');
@@ -1496,9 +1496,10 @@ test.describe('DTS-2: Duplicate action', () => {
     await expect(page.locator('.proc-duplicate-btn').first()).toBeVisible({ timeout: 5000 });
   });
 
-  // fix.617 DEFERRED (harness limit): duplicating an action posts a save that the server then
-  // re-renders into a new ST row; the route-mock returns {ok:true} without adding the entry to
-  // the re-fetched queue, so no new row appears in-test. Needs a stateful submissions mock.
+  // fix.617 DEFERRED (confirmed harness limit): clicking Dup runs addStAction → updateSubmission
+  // (PUT) then re-renders, but the action-row count stays 1 in-test — the duplicate's persistence
+  // isn't reflected back (the stateless route mock returns the original submissions on re-read).
+  // Needs a stateful submissions mock. The poll assertion below is correct once that exists.
   test.fixme('clicking duplicate creates a new ST sorcery entry in the phase', async ({ page }) => {
     await setupDowntimeProcessing(page, [SUBMISSION_SORC_FOR_DUP], [CHAR_CRUAC_DTS2, CHAR_NON_SUBMITTER, CHAR_RETIRED]);
 
@@ -1512,10 +1513,10 @@ test.describe('DTS-2: Duplicate action', () => {
     const initialRows = await page.locator('.proc-action-row').count();
     await dupBtn.click({ force: true });
 
-    // A new row should have appeared (ST badge visible)
-    await expect(page.locator('.proc-row-st-badge')).toBeVisible({ timeout: 5000 });
-    const newRows = await page.locator('.proc-action-row').count();
-    expect(newRows).toBeGreaterThan(initialRows);
+    // fix.617: addStAction mutates the in-memory submissions then re-renders; a new ST sorcery
+    // row appears in the phase. (The old .proc-row-st-badge marker was removed.)
+    await expect.poll(async () => page.locator('.proc-action-row').count(), { timeout: 5000 })
+      .toBeGreaterThan(initialRows);
   });
 
   test('duplicate button present on ST-created sorcery row too', async ({ page }) => {

--- a/tests/downtime-processing-dt-fixes.spec.js
+++ b/tests/downtime-processing-dt-fixes.spec.js
@@ -440,12 +440,13 @@ test.describe('DT-Fix-21: Territory pills on project-based Investigate', () => {
     await expect(terrPills.first()).toBeVisible({ timeout: 5000 });
   });
 
-  test.fixme('project-based investigate territory pills default to — (no territory)', async ({ page }) => {
+  test('project-based investigate territory pills default to — (no territory)', async ({ page }) => {
     await setupDowntimeProcessing(page, [SUBMISSION_PROJECT_INVESTIGATE]);
     await openFirstAction(page, 'Investigative');
 
-    // Neutral pill (data-terr-id="") is active when no territory override is set
-    const neutralPill = page.locator('.proc-terr-pill[data-terr-id=""].active').first();
+    // fix.617: the active class is `is-active` (not `active`). Neutral pill (data-terr-id="")
+    // is active when no territory override is set.
+    const neutralPill = page.locator('.proc-terr-pill[data-terr-id=""].is-active').first();
     await expect(neutralPill).toBeVisible({ timeout: 5000 });
   });
 
@@ -856,13 +857,13 @@ const SUBMISSION_RETAINER_TASK = {
 
 test.describe('DTX-3: Notes / feedback visual hierarchy', () => {
 
-  test.fixme('ST Notes section renders above Player Feedback in the left panel', async ({ page }) => {
+  test('ST Notes section renders above Player Feedback in the left panel', async ({ page }) => {
     await setupDowntimeProcessing(page, [SUBMISSION_PROJECT_COMMITTED]);
     await openFirstAction(page, 'Ambience');
 
     const panel = page.locator('.proc-action-detail').first();
     const notesPanel   = panel.locator('.proc-notes-panel').first();
-    const feedbackPanel = panel.locator('.proc-feedback-section').first();
+    const feedbackPanel = panel.locator('.proc-player-note-section').first();
 
     // Both must exist
     await expect(notesPanel).toBeVisible({ timeout: 5000 });
@@ -883,11 +884,12 @@ test.describe('DTX-3: Notes / feedback visual hierarchy', () => {
     await expect(notesPanel).not.toContainText('ST only');
   });
 
-  test.fixme('Player Feedback section has proc-feedback-section class', async ({ page }) => {
+  // fix.617: Player Feedback section class is .proc-player-note-section (was .proc-feedback-section).
+  test('Player Feedback section is present in the left panel', async ({ page }) => {
     await setupDowntimeProcessing(page, [SUBMISSION_PROJECT_COMMITTED]);
     await openFirstAction(page, 'Ambience');
 
-    await expect(page.locator('.proc-feedback-section').first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.proc-player-note-section').first()).toBeVisible({ timeout: 5000 });
   });
 
 });
@@ -920,12 +922,14 @@ test.describe('DTX-2: Compact panel for binary merit actions', () => {
     await expect(page.locator('.proc-val-status')).toHaveCount(0);
   });
 
-  test.fixme('full-mode merit (allies investigate) renders normal panel — not compact', async ({ page }) => {
+  test('full-mode merit (allies investigate) renders normal panel — not compact', async ({ page }) => {
     await setupDowntimeProcessing(page, [SUBMISSION_ALLIES_INVESTIGATE]);
     await openFirstAction(page, 'Investigative');
 
-    await expect(page.locator('.proc-val-status').first()).toBeVisible({ timeout: 5000 });
+    // fix.617: .proc-val-status was removed; a full-mode merit is marked by NOT being compact and
+    // by carrying full controls (e.g. the Target Secrecy selector), unlike a compact merit panel.
     await expect(page.locator('.proc-compact-merit-panel')).toHaveCount(0);
+    await expect(page.locator('.proc-inv-secrecy-sel').first()).toBeVisible({ timeout: 5000 });
   });
 
   test('compact panel outcome toggle — clicking Approved marks it active', async ({ page }) => {
@@ -1162,6 +1166,10 @@ const SUBMISSION_INV_CHARLIE_TARGET_NS = {
 
 test.describe('DTX-1: Cross-reference callouts', () => {
 
+  // fix.617 DEFERRED — possible gap (AC5): the target-based xref callout works (3 sibling tests
+  // pass), but the territory-shared xref callout does not render in the action card here. Needs
+  // investigation: whether territory xref moved to the snapshot panel, or projTerritory isn't
+  // indexed for patrol/feeding. Flagged rather than forced green.
   test.fixme('project action with shared territory shows xref callout naming the other character', async ({ page }) => {
     await setupDowntimeProcessing(
       page,
@@ -1177,6 +1185,7 @@ test.describe('DTX-1: Cross-reference callouts', () => {
     await expect(callout).toContainText('Non Submitter');
   });
 
+  // fix.617 DEFERRED — same possible territory-xref gap as the project case above (AC5).
   test.fixme('feeding action with shared territory shows xref callout', async ({ page }) => {
     await setupDowntimeProcessing(
       page,
@@ -1279,14 +1288,19 @@ test.describe('DTR-2: Contested roll', () => {
     await expect(page.locator('.proc-contested-toggle').first()).toBeVisible({ timeout: 5000 });
   });
 
-  test.fixme('toggling contested on shows character selector and pool input', async ({ page }) => {
+  // fix.617: #608 contested widget — the character is chosen via the connected-char typeahead
+  // (data-ta-save="contested_char") and the resistance pool is built from trait chips,
+  // not a plain char-select + pool-input.
+  test('toggling contested on shows the character picker and resistance trait chips', async ({ page }) => {
     await setupDowntimeProcessing(page, [SUBMISSION_PROJ_CONTESTED_ON]);
     await openFirstAction(page, 'Ambience');
 
-    await expect(page.locator('.proc-contested-char-sel').first()).toBeVisible({ timeout: 5000 });
-    await expect(page.locator('.proc-contested-pool-input').first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.proc-conn-typeahead[data-ta-save="contested_char"]').first()).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.proc-contested-trait').first()).toBeVisible({ timeout: 5000 });
   });
 
+  // fix.617 DEFERRED: the #608 contested roll-result no longer uses the literal "att − def = net"
+  // text format this test asserts. Needs the current contested-result wording before re-enabling.
   test.fixme('after rolling defence, roll card shows att − def = net format', async ({ page }) => {
     await setupDowntimeProcessing(page, [SUBMISSION_PROJ_CONTESTED_ROLLED]);
     await openFirstAction(page, 'Ambience');
@@ -1300,14 +1314,14 @@ test.describe('DTR-2: Contested roll', () => {
     await expect(rollResult).toContainText('2');  // 3 att − 1 def = 2 net
   });
 
-  test('toggling contested off hides char selector and pool input', async ({ page }) => {
+  test('toggling contested off hides the character picker and trait chips', async ({ page }) => {
     await setupDowntimeProcessing(page, [SUBMISSION_PROJ_UNCONTESTED]);
     await openFirstAction(page, 'Ambience');
 
-    // Toggle is present but char selector is absent (contested is off)
+    // Toggle is present but the contested char picker + trait chips are absent (contested is off)
     await expect(page.locator('.proc-contested-toggle').first()).toBeVisible({ timeout: 5000 });
-    await expect(page.locator('.proc-contested-char-sel')).toHaveCount(0);
-    await expect(page.locator('.proc-contested-pool-input')).toHaveCount(0);
+    await expect(page.locator('.proc-conn-typeahead[data-ta-save="contested_char"]')).toHaveCount(0);
+    await expect(page.locator('.proc-contested-trait')).toHaveCount(0);
   });
 
 });
@@ -1399,14 +1413,14 @@ test.describe('DTS-1: ST-created sorcery full panel', () => {
     ],
   };
 
-  test.fixme('ST sorcery action renders full sorcery panel with tradition and rite fields', async ({ page }) => {
+  // fix.617: sorcery consolidated — no separate Tradition field; the Rite <select> (.proc-rite-select) carries it.
+  test('ST sorcery action renders the full sorcery panel with a rite selector', async ({ page }) => {
     await setupDowntimeProcessing(page, [SUBMISSION_ST_SORCERY], [CHAR_CRUAC, CHAR_NON_SUBMITTER, CHAR_RETIRED]);
     await openFirstAction(page, 'Sorcery');
 
-    // Full sorcery detail card should be present
+    // Full sorcery detail card + the rite selector
     await expect(page.locator('.proc-feed-desc-card').first()).toBeVisible({ timeout: 5000 });
-    // Tradition field visible
-    await expect(page.locator('.proc-proj-field').first()).toContainText('Tradition');
+    await expect(page.locator('.proc-rite-select').first()).toBeVisible({ timeout: 5000 });
   });
 
   test('ST sorcery right panel renders (two-column layout with pool modifiers)', async ({ page }) => {
@@ -1420,13 +1434,16 @@ test.describe('DTS-1: ST-created sorcery full panel', () => {
     await expect(rightPanel).toContainText('Select a rite first');
   });
 
-  test.fixme('ST sorcery status buttons include Resolved and No Effect (sorcery set)', async ({ page }) => {
+  // fix.617: status model unified to a Pending → Valid → Complete ribbon (.proc-action-ribbon);
+  // the sorcery-specific "Resolved"/"No Effect" set was removed.
+  test('ST sorcery action shows the Pending/Valid/Complete status ribbon', async ({ page }) => {
     await setupDowntimeProcessing(page, [SUBMISSION_ST_SORCERY], [CHAR_CRUAC, CHAR_NON_SUBMITTER, CHAR_RETIRED]);
     await openFirstAction(page, 'Sorcery');
 
-    const panel = page.locator('.proc-action-detail').first();
-    await expect(panel).toContainText('Resolved');
-    await expect(panel).toContainText('No Effect');
+    const ribbon = page.locator('.proc-action-detail .proc-action-ribbon').first();
+    await expect(ribbon).toBeVisible({ timeout: 5000 });
+    await expect(ribbon).toContainText('Pending');
+    await expect(ribbon).toContainText('Complete');
   });
 
 });
@@ -1479,6 +1496,9 @@ test.describe('DTS-2: Duplicate action', () => {
     await expect(page.locator('.proc-duplicate-btn').first()).toBeVisible({ timeout: 5000 });
   });
 
+  // fix.617 DEFERRED (harness limit): duplicating an action posts a save that the server then
+  // re-renders into a new ST row; the route-mock returns {ok:true} without adding the entry to
+  // the re-fetched queue, so no new row appears in-test. Needs a stateful submissions mock.
   test.fixme('clicking duplicate creates a new ST sorcery entry in the phase', async ({ page }) => {
     await setupDowntimeProcessing(page, [SUBMISSION_SORC_FOR_DUP], [CHAR_CRUAC_DTS2, CHAR_NON_SUBMITTER, CHAR_RETIRED]);
 
@@ -1498,7 +1518,7 @@ test.describe('DTS-2: Duplicate action', () => {
     expect(newRows).toBeGreaterThan(initialRows);
   });
 
-  test.fixme('duplicate button present on ST-created sorcery row too', async ({ page }) => {
+  test('duplicate button present on ST-created sorcery row too', async ({ page }) => {
     const subWithStSorc = {
       ...SUBMISSION_SORC_FOR_DUP,
       _id: 'sub-sorc-dup-st',

--- a/tests/downtime-processing-dt-fixes.spec.js
+++ b/tests/downtime-processing-dt-fixes.spec.js
@@ -1166,10 +1166,10 @@ const SUBMISSION_INV_CHARLIE_TARGET_NS = {
 
 test.describe('DTX-1: Cross-reference callouts', () => {
 
-  // fix.617 DEFERRED — possible gap (AC5): the target-based xref callout works (3 sibling tests
-  // pass), but the territory-shared xref callout does not render in the action card here. Needs
-  // investigation: whether territory xref moved to the snapshot panel, or projTerritory isn't
-  // indexed for patrol/feeding. Flagged rather than forced green.
+  // fix.617 DEFERRED — CONFIRMED product bug #621: the territory xref lookup at
+  // downtime-views.js:9169 uses the raw territory key while the index (:4672) and the sibling
+  // path (:9961) use the canonical resolveTerrId key, so the callout never renders on this card
+  // path. Un-skip once #621 lands (the assertions are already correct).
   test.fixme('project action with shared territory shows xref callout naming the other character', async ({ page }) => {
     await setupDowntimeProcessing(
       page,
@@ -1185,7 +1185,7 @@ test.describe('DTX-1: Cross-reference callouts', () => {
     await expect(callout).toContainText('Non Submitter');
   });
 
-  // fix.617 DEFERRED — same possible territory-xref gap as the project case above (AC5).
+  // fix.617 DEFERRED — same confirmed territory-xref bug as the project case above (#621).
   test.fixme('feeding action with shared territory shows xref callout', async ({ page }) => {
     await setupDowntimeProcessing(
       page,

--- a/tests/downtime-processing-feature312.spec.js
+++ b/tests/downtime-processing-feature312.spec.js
@@ -318,18 +318,16 @@ test.describe('F312-4: Pool builder initial modifier total respects the FG cap',
     expect(parseInt(fgAttr, 10)).toBeLessThanOrEqual(5);
   });
 
-  // DEFERRED (fix.614 out-of-scope): the .proc-mod-total-row / .proc-mod-total-val markup
-  // drifted in unrelated product work; the FG-cap navigation conversion is correct (the
-  // feeding card opens). Product drift, not flat-wall #581 (see follow-up issue).
-  test.fixme('Mod total row value is consistent with capped FG contribution', async ({ page }) => {
+  // fix.617: the feeding mod-total is a hidden .proc-mod-total-val span (display:none), not a
+  // .proc-mod-total-row. Read its textContent directly (works on hidden/attached elements).
+  test('Mod total value is consistent with capped FG contribution', async ({ page }) => {
     await setup(page, [SUBMISSION_FG_INFLATED], [CHAR_FG_INFLATED]);
     await openFeedingPanel(page);
-    const totalRow = page.locator('.proc-mod-total-row').first();
-    await expect(totalRow).toBeVisible({ timeout: 5000 });
-    const totalVal = totalRow.locator('.proc-mod-total-val');
+    const totalVal = page.locator('.proc-mod-total-val').first();
+    await totalVal.waitFor({ state: 'attached', timeout: 5000 });
     const totalText = await totalVal.textContent();
     // With FG capped at 5 and no other modifiers, total should be +5 (or lower if unskilled applies)
-    const totalNum = parseInt(totalText.replace(/[^0-9-]/g, ''), 10);
+    const totalNum = parseInt((totalText || '').replace(/[^0-9-]/g, ''), 10);
     expect(totalNum).toBeLessThanOrEqual(5);
   });
 


### PR DESCRIPTION
## Summary

Continues #617 from PR #620 — applies the captured selector map to the remaining tests. **43 of 46 re-aligned and green** (test-only, no product changes).

- **+10 re-aligned:** DT-Fix-21 (`.active`→`.is-active`), DTX-2 (full-vs-compact via secrecy control; `.proc-val-status` removed), DTX-3 (`.proc-feedback-section`→`.proc-player-note-section`), DTR-2 contested (#608 typeahead `[data-ta-save="contested_char"]` + `.proc-contested-trait` chips; att−def-net locator scoped to the `net` line), DTS-1 (Rite selector + unified Pending/Valid/Complete ribbon — "Tradition"/"Resolved"/"No Effect" removed), F312-4 (hidden `.proc-mod-total-val` via textContent).

## Confirmed product bug found → #621

While finishing DTX-1, traced the territory cross-reference callout failure to a real regression: `downtime-views.js:9169` (Block A) looks up the **raw** territory key while the index (`:4672`) and sibling path (`:9961`, fixed in 496.2) use the **canonical** `resolveTerrId` key — so the "Also in <territory>" callout silently never renders on that card path in production. Raised as **#621** with the one-line fix.

## Not closing #617 — 3 tests gated on external work

- DTX-1 territory xref ×2 — blocked on **#621** (product fix)
- DTS-2 duplicate-creates-entry — needs a stateful submissions mock (harness build)

Each is `test.fixme` with an inline note. #617 stays open.

## Related

- #617 (parent, partial), #619 (block intelligence+override), #621 (xref bug)

## Test plan

- [x] dt-fixes + feature312: 63 pass / 3 skip / 0 fail
- [x] consistency: 24 pass
- [ ] CI green

## Branch flow

- From: `morningstar-issue-617-finish-drift-tests`
- Into: `dev`