### PR TITLE
feat(624): Ranked/Political mode toggle for ST ranking aggregate

### DIFF
--- a/public/css/suite.css
+++ b/public/css/suite.css
@@ -2327,7 +2327,43 @@ body.desktop-mode.sidebar-collapsed .sb-collapse-btn { width: 100%; justify-cont
   color: var(--txt3);
   font-style: italic;
 }
-/* ST aggregate */
+/* ST aggregate — mode toggle */
+.rank-mode-toggle { display: flex; gap: 4px; margin-left: auto; }
+.rank-mode-btn {
+  font-family: var(--fl); font-size: 10px; font-weight: 600; letter-spacing: .06em;
+  text-transform: uppercase; padding: 3px 10px; border: 1px solid var(--bdr2);
+  border-radius: 20px; background: var(--surf2); color: var(--txt2); cursor: pointer;
+  transition: background .12s, color .12s, border-color .12s;
+}
+.rank-mode-btn.active { background: var(--gold-a12); border-color: var(--bdr3); color: var(--gold); }
+/* ST aggregate — org sections + pill switcher */
+.rank-org-section { padding: 14px; border-bottom: 1px solid var(--bdr); }
+.rank-org-section:last-child { border-bottom: none; }
+.rank-org-label {
+  font-family: var(--fl); font-size: 11px; font-weight: 700; letter-spacing: .06em;
+  text-transform: uppercase; color: var(--txt2); margin-bottom: 8px;
+}
+.rank-pills { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 12px; }
+.rank-pill {
+  font-family: var(--fl); font-size: 11px; font-weight: 600; letter-spacing: .05em;
+  padding: 4px 12px; border: 1px solid var(--bdr2); border-radius: 20px;
+  background: var(--surf2); color: var(--txt2); cursor: pointer;
+  transition: background .12s, border-color .12s, color .12s;
+}
+.rank-pill:hover { border-color: var(--bdr3); color: var(--txt); }
+.rank-pill.active { background: var(--gold-a12); border-color: var(--bdr3); color: var(--gold); }
+.rank-member-list { display: flex; flex-direction: column; }
+.rank-member-row {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 8px; padding: 5px 10px;
+}
+.rank-member-name { font-size: 13px; color: var(--txt); }
+.rank-member-pts {
+  font-family: var(--fh); font-size: 14px; font-weight: 700;
+  color: var(--accent); flex-shrink: 0;
+}
+.rank-member-pts.zero { color: var(--txt3); font-size: 12px; font-family: var(--fl); font-weight: 400; }
+/* ST aggregate (legacy — kept for reference) */
 .status-ranking-agg-grid { display: flex; }
 .status-ranking-agg-col {
   flex: 1;

--- a/public/css/suite.css
+++ b/public/css/suite.css
@@ -2252,6 +2252,7 @@ body.desktop-mode.sidebar-collapsed .sb-collapse-btn { width: 100%; justify-cont
   margin-bottom: 0;
   background: var(--surf2);
   border-bottom: 1px solid var(--bdr);
+  align-items: center;
 }
 .status-ranking-grid {
   display: flex;

--- a/public/js/tabs/status-ranking.js
+++ b/public/js/tabs/status-ranking.js
@@ -52,47 +52,100 @@ function renderRankingBallot(me, clanMembers, covMembers, ballot, activeId, hasC
   return h + `</div>`;
 }
 
-function renderRankingAggregate(chars, agg) {
-  const byId = new Map(chars.map(c => [String(c._id), c]));
-
-  function groupByOrg(points, orgKey) {
-    const groups = new Map();
-    for (const [id, pts] of Object.entries(points || {})) {
-      const c = byId.get(id);
-      if (!c || !pts) continue;
-      const org = c[orgKey] || 'Unknown';
-      if (!groups.has(org)) groups.set(org, []);
-      groups.get(org).push({ c, pts });
-    }
-    for (const rows of groups.values())
-      rows.sort((a, b) => b.pts - a.pts || sortName(a.c).localeCompare(sortName(b.c)));
-    return groups;
+// Returns Map<orgName, [{name, pts}]> — ALL chars in that org, pts desc then alpha.
+function buildOrgGroups(points, chars, orgKey) {
+  const orgs = new Map();
+  for (const c of chars) {
+    const org = c[orgKey];
+    if (!org) continue;
+    if (!orgs.has(org)) orgs.set(org, []);
+    orgs.get(org).push({ name: sortName(c), pts: Number((points || {})[String(c._id)] || 0) });
   }
+  for (const members of orgs.values())
+    members.sort((a, b) => b.pts - a.pts || a.name.localeCompare(b.name));
+  return orgs;
+}
 
-  function renderGroups(groups) {
-    if (!groups.size) return `<p class="placeholder-msg status-empty">No ballots cast yet.</p>`;
-    let h = '';
-    for (const [name, rows] of [...groups].sort((a, b) => a[0].localeCompare(b[0]))) {
-      h += `<div class="status-ranking-agg-group">`;
-      h += `<div class="status-ranking-agg-group-head">${esc(name)}</div>`;
-      h += `<div class="status-ranking-agg-list">`;
-      for (const r of rows)
-        h += `<div class="status-ranking-agg-row"><span class="status-ranking-agg-name">${esc(displayName(r.c))}</span><span class="status-ranking-agg-pts">${r.pts}</span></div>`;
-      h += `</div></div>`;
-    }
-    return h;
-  }
+function renderAggMemberList(members) {
+  if (!members || !members.length) return `<p class="placeholder-msg status-empty">No members.</p>`;
+  return members.map(m =>
+    `<div class="rank-member-row"><span class="rank-member-name">${esc(m.name)}</span><span class="rank-member-pts${m.pts === 0 ? ' zero' : ''}">${m.pts}</span></div>`
+  ).join('');
+}
 
-  const clanGroups = groupByOrg(agg.clan_points, 'clan');
-  const covGroups  = groupByOrg(agg.covenant_points, 'covenant');
-
+function renderRankingAggShell() {
   let h = `<div class="status-ranking-section">`;
-  h += `<div class="status-section-head"><span class="status-section-title">Ranking Points — this cycle</span>`;
-  h += `<span class="status-section-caps">ST only · 1st=5 2nd=4 3rd=3 4th=2 5th=1</span></div>`;
-  h += `<div class="status-ranking-agg-grid">`;
-  h += `<div class="status-ranking-agg-col"><div class="status-ranking-col-head">Clan points</div>${renderGroups(clanGroups)}</div>`;
-  h += `<div class="status-ranking-agg-col"><div class="status-ranking-col-head">Covenant points</div>${renderGroups(covGroups)}</div>`;
-  return h + `</div></div>`;
+  h += `<div class="status-section-head">`;
+  h += `<span class="status-section-title">Ranking Points — this cycle</span>`;
+  h += `<span class="status-section-caps">ST only</span>`;
+  h += `<div class="rank-mode-toggle">`;
+  h += `<button class="rank-mode-btn active" data-mode="ranked">Ranked</button>`;
+  h += `<button class="rank-mode-btn" data-mode="political">Political</button>`;
+  h += `</div></div>`;
+  h += `<div class="rank-org-section"><div class="rank-org-label">Clan</div>`;
+  h += `<div class="rank-pills" id="rank-clan-pills"></div>`;
+  h += `<div class="rank-member-list" id="rank-clan-list"></div></div>`;
+  h += `<div class="rank-org-section"><div class="rank-org-label">Covenant</div>`;
+  h += `<div class="rank-pills" id="rank-cov-pills"></div>`;
+  h += `<div class="rank-member-list" id="rank-cov-list"></div></div>`;
+  return h + `</div>`;
+}
+
+function wireRankingAggregate(sectionEl, chars, rankedAgg, politicalAgg) {
+  let mode       = 'ranked';
+  let activeClan = null;
+  let activeCov  = null;
+
+  const clanPillsEl = sectionEl.querySelector('#rank-clan-pills');
+  const clanListEl  = sectionEl.querySelector('#rank-clan-list');
+  const covPillsEl  = sectionEl.querySelector('#rank-cov-pills');
+  const covListEl   = sectionEl.querySelector('#rank-cov-list');
+
+  function getAgg() { return mode === 'ranked' ? rankedAgg : politicalAgg; }
+
+  function refreshPills(pillsEl, listEl, groups, activeKey, onSelect) {
+    const keys = [...groups.keys()].sort();
+    pillsEl.innerHTML = keys.map(k =>
+      `<button class="rank-pill${k === activeKey ? ' active' : ''}" data-key="${esc(k)}">${esc(k)}</button>`
+    ).join('');
+    pillsEl.querySelectorAll('.rank-pill').forEach(btn => {
+      btn.addEventListener('click', () => {
+        pillsEl.querySelectorAll('.rank-pill').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        onSelect(btn.dataset.key);
+      });
+    });
+    listEl.innerHTML = renderAggMemberList(groups.get(activeKey) || []);
+  }
+
+  function refresh() {
+    const agg        = getAgg();
+    const clanGroups = buildOrgGroups(agg.clan_points,     chars, 'clan');
+    const covGroups  = buildOrgGroups(agg.covenant_points, chars, 'covenant');
+    const firstClan  = [...clanGroups.keys()].sort()[0] || null;
+    const firstCov   = [...covGroups.keys()].sort()[0]  || null;
+    if (!activeClan || !clanGroups.has(activeClan)) activeClan = firstClan;
+    if (!activeCov  || !covGroups.has(activeCov))   activeCov  = firstCov;
+
+    refreshPills(clanPillsEl, clanListEl, clanGroups, activeClan, key => {
+      activeClan = key;
+      clanListEl.innerHTML = renderAggMemberList(clanGroups.get(key) || []);
+    });
+    refreshPills(covPillsEl, covListEl, covGroups, activeCov, key => {
+      activeCov = key;
+      covListEl.innerHTML = renderAggMemberList(covGroups.get(key) || []);
+    });
+  }
+
+  sectionEl.querySelectorAll('.rank-mode-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      mode = btn.dataset.mode;
+      sectionEl.querySelectorAll('.rank-mode-btn').forEach(b => b.classList.toggle('active', b === btn));
+      refresh();
+    });
+  });
+
+  refresh();
 }
 
 function wireRankingSave(el, voterId, cycleId) {
@@ -138,16 +191,23 @@ async function resolveActiveCycleId() {
 export async function appendRankingSection(el, { chars, activeChar, isST }) {
   if (!el) return;
   const cycleId = await resolveActiveCycleId();
-  let html = '';
 
   if (isST) {
-    // ST aggregate is global (all characters' points) — no active char required.
-    if (!cycleId) return; // no cycle → nothing to aggregate
-    let agg = { clan_points: {}, covenant_points: {} };
-    try { agg = await apiGet(`/api/ranking_ballots/aggregate?cycle_id=${encodeURIComponent(cycleId)}`); } catch { /* ignore */ }
-    html = renderRankingAggregate(chars, agg);
+    if (!cycleId) return;
+    let rankedAgg    = { clan_points: {}, covenant_points: {} };
+    let politicalAgg = { clan_points: {}, covenant_points: {} };
+    try {
+      [rankedAgg, politicalAgg] = await Promise.all([
+        apiGet(`/api/ranking_ballots/aggregate?cycle_id=${encodeURIComponent(cycleId)}&mode=ranked`),
+        apiGet(`/api/ranking_ballots/aggregate?cycle_id=${encodeURIComponent(cycleId)}&mode=political`),
+      ]);
+    } catch { /* ignore */ }
+    const wrap = document.createElement('div');
+    wrap.innerHTML = renderRankingAggShell();
+    const node = wrap.firstElementChild;
+    if (node) { el.appendChild(node); wireRankingAggregate(node, chars, rankedAgg, politicalAgg); }
   } else {
-    if (!activeChar) return; // player ballot needs the voter
+    if (!activeChar) return;
     const activeId = String(activeChar._id);
     const me = resolveActiveChar(chars, activeChar);
     const clanMembers = (me?.clan ? clanRowsFor(chars, me.clan, sortName) : []).map(r => r.c).filter(c => String(c._id) !== activeId);
@@ -156,13 +216,11 @@ export async function appendRankingSection(el, { chars, activeChar, isST }) {
     if (cycleId) {
       try { ballot = await apiGet(`/api/ranking_ballots/mine?cycle_id=${encodeURIComponent(cycleId)}&voter=${encodeURIComponent(activeId)}`); } catch { /* ignore */ }
     }
-    html = renderRankingBallot(me || activeChar, clanMembers, covMembers, ballot, activeId, !!cycleId);
+    const html = renderRankingBallot(me || activeChar, clanMembers, covMembers, ballot, activeId, !!cycleId);
+    const wrap = document.createElement('div');
+    wrap.innerHTML = html;
+    const node = wrap.firstElementChild;
+    if (node) el.appendChild(node);
+    if (cycleId && activeChar) wireRankingSave(el, activeId, cycleId);
   }
-
-  if (!html) return;
-  const wrap = document.createElement('div');
-  wrap.innerHTML = html;
-  const node = wrap.firstElementChild;
-  if (node) el.appendChild(node);
-  if (!isST && cycleId && activeChar) wireRankingSave(el, String(activeChar._id), cycleId);
 }

--- a/public/ranking-preview.html
+++ b/public/ranking-preview.html
@@ -192,15 +192,17 @@ h1 { font-family: var(--fh); font-size: 16px; letter-spacing: .08em; color: var(
     <div class="status-ranking-section">
       <div class="status-section-head">
         <span class="status-section-title">Ranking Points — this cycle</span>
-        <span class="status-section-caps">ST only · 1st=5 2nd=4 3rd=3 4th=2 5th=1</span>
+        <span class="status-section-caps">ST only</span>
+        <div class="rank-mode-toggle">
+          <button class="rank-mode-btn active" onclick="setMode('ranked',this)">Ranked</button>
+          <button class="rank-mode-btn" onclick="setMode('political',this)">Political</button>
+        </div>
       </div>
-
       <div class="rank-org-section">
         <div class="rank-org-label">Clan</div>
         <div class="rank-pills" id="clan-pills"></div>
         <div class="rank-member-list" id="clan-list"></div>
       </div>
-
       <div class="rank-org-section">
         <div class="rank-org-label">Covenant</div>
         <div class="rank-pills" id="cov-pills"></div>
@@ -212,44 +214,81 @@ h1 { font-family: var(--fh); font-size: 16px; letter-spacing: .08em; color: var(
 </div>
 
 <script>
-const CLANS = {
+// Ranked: 5/4/3/2/1 by position
+const CLANS_RANKED = {
   'Daeva':    [['Eve Lockridge',9],['Cyrus Reynolds',5],['René Meyer',3],['Aleksei',0],['Livia',0]],
   'Gangrel':  [['Brandy LaRoux',8],['Doc',6],['Ryan Ambrose',2],['Tegan Groves',0],['Ivana Horvat',0]],
   'Mekhet':   [['Dr Cazz',4],['Reed Justice',2],['Einar Solveig',0],['Xavier Boussade',0]],
-  'Nosferatu':[['Tegan Groves',7],['Ivana Horvat',4],['Laura',1],['Clarence von Schmidt',0],['Etsy',0],['Lord Gel',0],['Humongulus',0]],
+  'Nosferatu':[['Tegan Groves',7],['Ivana Horvat',4],['Laura',1],['Clarence von Schmidt',0],['Etsy',0],['Gel',0],['Humongulus',0]],
   'Ventrue':  [['Carver',10],['René St. Dominique',6],['Einar Solveig',3],['Reed Justice',0],['Hazel',0],['Benedict Wiesel',0],['Charles Mercer-Willows',0]],
 };
-const COVENANTS = {
+const COVS_RANKED = {
   'Carthian Movement':  [['Eve Lockridge',8],['Mac',5],['Dr Cazz',2],['Aleksei',0],['René Meyer',0]],
   'Circle of the Crone':[['Anichka',9],['Brandy LaRoux',4],['Keeper',2],['Jack Fallow',0]],
   'Invictus':           [['Jack Fallow',11],['Carver',7],['René St. Dominique',3],['Einar Solveig',0],['Livia',0]],
   'Lancea et Sanctum':  [['Edna Judge',12],['Carver',6],['Conrad Sondergaard',3],['Hazel',1],['Magda',0],['Tegan Groves',0],['Benedict Wiesel',0],['Julia Dolancia',0]],
 };
+// Political: weight = voter's status in the org (regardless of position)
+// e.g. Carver (Ventrue 4, Invictus 3) voting bumps every pick by 4/3 respectively
+const CLANS_POLITICAL = {
+  'Daeva':    [['Eve Lockridge',6],['Cyrus Reynolds',4],['René Meyer',4],['Aleksei',2],['Livia',0]],
+  'Gangrel':  [['Brandy LaRoux',7],['Doc',5],['Ryan Ambrose',3],['Tegan Groves',1],['Ivana Horvat',0]],
+  'Mekhet':   [['Dr Cazz',5],['Reed Justice',3],['Einar Solveig',1],['Xavier Boussade',0]],
+  'Nosferatu':[['Tegan Groves',5],['Ivana Horvat',3],['Laura',3],['Clarence von Schmidt',1],['Etsy',0],['Gel',0],['Humongulus',0]],
+  'Ventrue':  [['Carver',8],['René St. Dominique',6],['Einar Solveig',4],['Reed Justice',0],['Hazel',0],['Benedict Wiesel',0],['Charles Mercer-Willows',0]],
+};
+const COVS_POLITICAL = {
+  'Carthian Movement':  [['Eve Lockridge',6],['Mac',4],['Dr Cazz',2],['Aleksei',0],['René Meyer',0]],
+  'Circle of the Crone':[['Anichka',7],['Brandy LaRoux',4],['Keeper',2],['Jack Fallow',0]],
+  'Invictus':           [['Jack Fallow',9],['Carver',7],['René St. Dominique',5],['Einar Solveig',0],['Livia',0]],
+  'Lancea et Sanctum':  [['Edna Judge',10],['Carver',7],['Conrad Sondergaard',3],['Hazel',2],['Magda',0],['Tegan Groves',0],['Benedict Wiesel',0],['Julia Dolancia',0]],
+};
+
+let currentMode = 'ranked';
+let activeClan = 'Daeva';
+let activeCov  = 'Carthian Movement';
+
+function getClanData()  { return currentMode === 'ranked' ? CLANS_RANKED  : CLANS_POLITICAL; }
+function getCovData()   { return currentMode === 'ranked' ? COVS_RANKED   : COVS_POLITICAL; }
 
 function renderList(el, rows) {
-  el.innerHTML = rows.map(([name, pts]) => `
-    <div class="rank-member-row">
-      <span class="rank-member-name">${name}</span>
-      <span class="rank-member-pts${pts === 0 ? ' zero' : ''}">${pts}</span>
-    </div>`).join('');
+  el.innerHTML = rows.map(([name, pts]) =>
+    `<div class="rank-member-row"><span class="rank-member-name">${name}</span><span class="rank-member-pts${pts === 0 ? ' zero' : ''}">${pts}</span></div>`
+  ).join('');
 }
 
-function buildPills(pillEl, listEl, data, defaultKey) {
-  pillEl.innerHTML = Object.keys(data).map(k =>
-    `<button class="rank-pill${k === defaultKey ? ' active' : ''}" data-key="${k}">${k}</button>`
+function buildPills(pillsEl, listEl, data, activeKey, onSelect) {
+  pillsEl.innerHTML = Object.keys(data).map(k =>
+    `<button class="rank-pill${k === activeKey ? ' active' : ''}" data-key="${k}">${k}</button>`
   ).join('');
-  pillEl.querySelectorAll('.rank-pill').forEach(btn => {
+  pillsEl.querySelectorAll('.rank-pill').forEach(btn => {
     btn.addEventListener('click', () => {
-      pillEl.querySelectorAll('.rank-pill').forEach(b => b.classList.remove('active'));
+      pillsEl.querySelectorAll('.rank-pill').forEach(b => b.classList.remove('active'));
       btn.classList.add('active');
-      renderList(listEl, data[btn.dataset.key]);
+      onSelect(btn.dataset.key);
     });
   });
-  renderList(listEl, data[defaultKey]);
+  renderList(listEl, data[activeKey]);
 }
 
-buildPills(document.getElementById('clan-pills'), document.getElementById('clan-list'), CLANS, 'Daeva');
-buildPills(document.getElementById('cov-pills'), document.getElementById('cov-list'), COVENANTS, 'Carthian Movement');
+function refresh() {
+  buildPills(
+    document.getElementById('clan-pills'), document.getElementById('clan-list'),
+    getClanData(), activeClan, key => { activeClan = key; renderList(document.getElementById('clan-list'), getClanData()[key]); }
+  );
+  buildPills(
+    document.getElementById('cov-pills'), document.getElementById('cov-list'),
+    getCovData(), activeCov, key => { activeCov = key; renderList(document.getElementById('cov-list'), getCovData()[key]); }
+  );
+}
+
+function setMode(mode, btn) {
+  currentMode = mode;
+  document.querySelectorAll('.rank-mode-btn').forEach(b => b.classList.toggle('active', b === btn));
+  refresh();
+}
+
+refresh();
 
 function show(view) {
   document.getElementById('view-player').style.display = view === 'player' ? '' : 'none';

--- a/public/ranking-preview.html
+++ b/public/ranking-preview.html
@@ -33,7 +33,7 @@ h1 { font-family: var(--fh); font-size: 16px; letter-spacing: .08em; color: var(
   background: var(--surf); overflow: hidden; margin: 8px 0;
 }
 .status-section-head {
-  display: flex; align-items: baseline; gap: 12px;
+  display: flex; align-items: center; gap: 12px;
   padding: 10px 14px; background: var(--surf2); border-bottom: 1px solid var(--bdr);
 }
 .status-section-title {
@@ -102,6 +102,17 @@ h1 { font-family: var(--fh); font-size: 16px; letter-spacing: .08em; color: var(
   color: var(--accent); flex-shrink: 0;
 }
 .rank-member-pts.zero { color: var(--txt3); font-size: 12px; font-family: var(--fl); font-weight: 400; }
+
+.rank-mode-toggle { display: flex; gap: 4px; margin-left: auto; }
+.rank-mode-btn {
+  font-family: var(--fl); font-size: 11px; font-weight: 600; letter-spacing: .06em;
+  text-transform: uppercase; padding: 4px 12px;
+  border: 1px solid var(--bdr2); border-radius: 4px;
+  background: var(--surf); color: var(--txt2); cursor: pointer;
+  transition: background .12s, border-color .12s, color .12s;
+}
+.rank-mode-btn:hover { border-color: var(--bdr3); color: var(--txt); }
+.rank-mode-btn.active { background: var(--gold-a12); border-color: var(--bdr3); color: var(--gold); }
 </style>
 </head>
 <body>

--- a/server/routes/ranking_ballots.js
+++ b/server/routes/ranking_ballots.js
@@ -43,22 +43,47 @@ router.get('/mine', async (req, res) => {
   res.json(doc || null);
 });
 
-// GET /api/ranking_ballots/aggregate?cycle_id= — ST ONLY: per-character points totals.
+// GET /api/ranking_ballots/aggregate?cycle_id=&mode= — ST ONLY: per-character points totals.
+// mode=ranked (default): 5/4/3/2/1 by slot position.
+// mode=political: each pick earns the voter's clan/covenant status regardless of position.
 // Computed at request time (derived-never-stored). Players have NO read path here.
 router.get('/aggregate', requireRole('st'), async (req, res) => {
   const cycleId = String(req.query.cycle_id || '');
+  const mode    = req.query.mode === 'political' ? 'political' : 'ranked';
   if (!cycleId) return res.status(400).json({ error: 'BAD_REQUEST', message: 'cycle_id is required' });
+
   const ballots = await col().find({ cycle_id: cycleId }).toArray();
   const clan_points = {};
   const covenant_points = {};
-  for (const b of ballots) {
-    for (const [slot, cid] of Object.entries(b.clan_ranking || {})) {
-      if (cid) clan_points[cid] = (clan_points[cid] || 0) + (SLOT_POINTS[slot] || 0);
+
+  if (mode === 'ranked') {
+    for (const b of ballots) {
+      for (const [slot, cid] of Object.entries(b.clan_ranking || {})) {
+        if (cid) clan_points[cid] = (clan_points[cid] || 0) + (SLOT_POINTS[slot] || 0);
+      }
+      for (const [slot, cid] of Object.entries(b.covenant_ranking || {})) {
+        if (cid) covenant_points[cid] = (covenant_points[cid] || 0) + (SLOT_POINTS[slot] || 0);
+      }
     }
-    for (const [slot, cid] of Object.entries(b.covenant_ranking || {})) {
-      if (cid) covenant_points[cid] = (covenant_points[cid] || 0) + (SLOT_POINTS[slot] || 0);
+  } else {
+    // Political: weight = voter's clan/covenant status; position is irrelevant.
+    const voterIds = [...new Set(ballots.map(b => b.voter_character_id))].map(toOid).filter(Boolean);
+    const voterDocs = voterIds.length ? await charCol().find({ _id: { $in: voterIds } }).toArray() : [];
+    const voterById = new Map(voterDocs.map(d => [String(d._id), d]));
+    for (const b of ballots) {
+      const voter = voterById.get(String(b.voter_character_id));
+      if (!voter) continue;
+      const clanWeight = voter.status?.clan || 0;
+      const covWeight  = voter.status?.covenant?.[voter.covenant] || 0;
+      for (const cid of Object.values(b.clan_ranking || {})) {
+        if (cid) clan_points[String(cid)] = (clan_points[String(cid)] || 0) + clanWeight;
+      }
+      for (const cid of Object.values(b.covenant_ranking || {})) {
+        if (cid) covenant_points[String(cid)] = (covenant_points[String(cid)] || 0) + covWeight;
+      }
     }
   }
+
   res.json({ clan_points, covenant_points });
 });
 


### PR DESCRIPTION
## Summary
- Adds a Ranked/Political toggle to the ST aggregate ranking view
- **Ranked**: 5/4/3/2/1 points by ballot slot position (existing behaviour, top-5)
- **Political**: each pick earns points equal to the voter's current clan or covenant status, regardless of position — zero-status voters contribute nothing
- Both datasets fetched in parallel at render time; mode toggle swaps without a network round-trip
- Backend: `GET /api/ranking_ballots/aggregate?mode=political` computes status-weighted points via one batched character lookup
- Mockup (`ranking-preview.html`) updated with mode toggle and political fake data
- Fixed toggle button CSS missing from mockup style block; `status-section-head` changed to `align-items:center` so buttons sit flush in the header row

## Test plan
- [ ] Open Status tab as ST — "Ranked" button active by default, showing 5/4/3/2/1 totals
- [ ] Click "Political" — scores update to status-weighted totals, no reload
- [ ] Pill switching (clan/covenant) works in both modes
- [ ] Player view (Player Mode on) sees ballot form, not the toggle
- [ ] Preview: `ranking-preview.html` — ST view shows both modes, switching works

🤖 Generated with [Claude Code](https://claude.com/claude-code)