### PR TITLE
fix(624): use moniker||name for display in ranking aggregate

### DIFF
--- a/public/js/tabs/status-ranking.js
+++ b/public/js/tabs/status-ranking.js
@@ -59,10 +59,11 @@ function buildOrgGroups(points, chars, orgKey) {
     const org = c[orgKey];
     if (!org) continue;
     if (!orgs.has(org)) orgs.set(org, []);
-    orgs.get(org).push({ name: sortName(c), pts: Number((points || {})[String(c._id)] || 0) });
+    const label = c.moniker || c.name || '';
+    orgs.get(org).push({ name: label, pts: Number((points || {})[String(c._id)] || 0) });
   }
   for (const members of orgs.values())
-    members.sort((a, b) => b.pts - a.pts || a.name.localeCompare(b.name));
+    members.sort((a, b) => b.pts - a.pts || a.name.toLowerCase().localeCompare(b.name.toLowerCase()));
   return orgs;
 }
 


### PR DESCRIPTION
## Summary
- `sortName()` calls `.toLowerCase()` — documented as internal-sort-only, never for DOM rendering
- `buildOrgGroups` was using it as the display label, lowercasing every character name
- Fix: use `c.moniker || c.name` directly; sort comparator does its own `toLowerCase()`

## Test plan
- [ ] ST ranking aggregate shows properly-cased names (e.g. "Alice Vunder", not "alice vunder")

🤖 Generated with [Claude Code](https://claude.com/claude-code)