### PR TITLE
fix(645): regent confirm-feeding fails and Regency tab inaccessible for non-active cycle

### DIFF
--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -4834,8 +4834,12 @@ function renderRegencySection() {
     h += `<p class="qf-desc">As regent, you must confirm <strong>this downtime</strong> who has feeding rights in ${esc(terrName)}. Manage your feeding-rights slots in the Regency tab; once your selections are set, return here and confirm to lock them in for the cycle.</p>`;
     h += '<div class="qf-actions">';
     h += '<button type="button" class="qf-btn qf-btn-secondary" data-open-regency-tab>Open Regency tab</button>';
-    h += '<button type="button" class="qf-btn qf-btn-submit" id="dt-btn-confirm-regency">Confirm regency this cycle</button>';
-    h += '<span id="dt-regency-confirm-status" class="qf-save-status"></span>';
+    if (currentCycle?.status === 'active') {
+      h += '<button type="button" class="qf-btn qf-btn-submit" id="dt-btn-confirm-regency">Confirm regency this cycle</button>';
+      h += '<span id="dt-regency-confirm-status" class="qf-save-status"></span>';
+    } else {
+      h += '<p class="qf-desc">Downtimes are not yet open - use the Regency tab to prepare your feeding-rights selections.</p>';
+    }
     h += '</div>';
   }
 

--- a/public/js/tabs/regency-tab.js
+++ b/public/js/tabs/regency-tab.js
@@ -71,7 +71,7 @@ export async function renderRegencyTab(container, char, territories) {
   try {
     const cycles = await apiGet('/api/downtime_cycles');
     const sorted = cycles.sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''));
-    _activeCycle = sorted.find(c => c.status === 'active') || null;
+    _activeCycle = sorted.find(c => ['active', 'game', 'prep'].includes(c.status)) || null;
   } catch { _activeCycle = null; }
 
   // Compute locked character IDs from this cycle's submitted downtimes
@@ -180,7 +180,7 @@ function render(container) {
   let h = '<div class="regency-wrap">';
 
   // CTA banner — show when cycle gate is pending and this Regent hasn't confirmed
-  if (_activeCycle && !cycleConfirmed && !myConfirmation) {
+  if (_activeCycle && _activeCycle.status === 'active' && !cycleConfirmed && !myConfirmation) {
     h += `<div class="reg-cta-banner">`;
     h += `<strong>Action required:</strong> The feeding rights gate for <em>${esc(_activeCycle.label || 'this cycle')}</em> is waiting on your confirmation. Use the "Confirm Feeding Rights" button below to lock in your territory's rights for this cycle.`;
     h += `</div>`;
@@ -251,9 +251,9 @@ function render(container) {
     h += '<button id="reg-add-right" class="qf-btn qf-btn-secondary">+ Add Feeding Right</button>';
   }
   h += '<button id="reg-save" class="qf-btn qf-btn-submit">Save Feeding Rights</button>';
-  if (_activeCycle && !cycleConfirmed) {
+  if (_activeCycle && _activeCycle.status === 'active' && !cycleConfirmed) {
     h += '<button id="reg-confirm" class="qf-btn qf-btn-secondary">Confirm Feeding Rights</button>';
-  } else if (_activeCycle && cycleConfirmed && myConfirmation) {
+  } else if (_activeCycle && _activeCycle.status === 'active' && cycleConfirmed && myConfirmation) {
     h += '<span class="reg-confirmed-badge">Feeding rights confirmed for this cycle</span>';
   }
   h += '<span id="reg-save-status" class="qf-save-status"></span>';

--- a/specs/stories/fix.645.regent-confirm-regency-tab.story.md
+++ b/specs/stories/fix.645.regent-confirm-regency-tab.story.md
@@ -1,0 +1,167 @@
+# Story fix.645: Regent confirm-feeding fails and Regency tab inaccessible when cycle is not 'active'
+
+## Status: review
+
+## Metadata
+
+```yaml
+issue: 645
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/645
+branch: ms/issue-645-regent-confirm-regency-tab
+```
+
+## Story
+
+**As a** player who is Regent of a territory,
+**I want** the Regency tab to be usable and the "Confirm regency this cycle" button to only appear when confirmation is actually possible,
+**so that** I am never shown an action that fails, and I can manage feeding rights regardless of cycle phase.
+
+## Background
+
+Reported by Rene's player (Regent of The Second City) during DT4. Two symptoms observed:
+
+1. "Confirm regency this cycle" in the DT form returns **"Confirm failed: Cycle is not active"**
+2. The Regency tab is inaccessible / renders without useful cycle context
+
+**Root cause — three mismatched cycle-status checks:**
+
+| Location | What it does | Behaviour when cycle is 'game' |
+|---|---|---|
+| `downtime-form.js:1380` | Loads `currentCycle` using `LIVE_STATUSES = ['active', 'game', 'prep']` | Finds the cycle → shows Regency section including confirm button |
+| `server/routes/downtime.js:102` | Rejects confirm-feeding if `cycle.status !== 'active'` | Returns 409 "Cycle is not active" |
+| `regency-tab.js:74` | Picks cycle with `c.status === 'active'` only | `_activeCycle` is null → no CTA banner, no confirm button, no cycle context |
+
+When a cycle is `'game'` status (game phase open, city sign-off not yet done), the DT form finds and shows the Regency section including the confirm button, but both the server and the regency tab require `status === 'active'`. Result: the button fails and the tab appears broken.
+
+**The server check is correct** — confirm-feeding is only valid when downtimes are open (`'active'`). The client-side code needs to align with it.
+
+**Saving feeding rights is NOT affected** — `PATCH /api/territories/:id/feeding-rights` has no cycle-status gate. Regents can always save feeding-rights selections; only the confirmation is gated.
+
+## Acceptance Criteria
+
+1. **Given** the DT cycle is in `'game'` or `'prep'` status: the DT form Regency section shows the territory name and feeding-rights prompt, but **does not** show "Confirm regency this cycle". Instead, a note reads: *"Downtimes are not yet open — use the Regency tab to prepare your feeding-rights selections."*
+2. **Given** the DT cycle is in `'active'` status: the confirm button appears and works end-to-end (server accepts, section updates to confirmed state).
+3. **Given** the DT cycle is in `'game'` or `'prep'` status: the Regency tab (`regency-tab.js`) loads with the current live cycle in context (feeding-rights rows populated, but confirm button hidden/absent).
+4. **Given** the DT cycle is `'active'`: the Regency tab's "Confirm Feeding Rights" button is present and functions.
+5. **Given** no live cycle exists: the Regency tab renders the feeding-rights grid as today (no CTA banner, no confirm button) — no regression.
+6. **Given** the cycle is `'active'` and the regent has already confirmed: the confirmed-badge and locked slots render correctly — no regression.
+7. **"Open Regency tab"** button in the DT form navigates to the Regency tab in a usable state in all cycle-status scenarios.
+8. No regression to `_computeLocked` (locked-character guard), the lieutenant save flow, or the append-only confirmation check on the server.
+
+## Tasks / Subtasks
+
+- [x] **Task 1:** `regency-tab.js` — fix cycle picker (AC: 3, 4, 5)
+  - [x] Line ~74: change `sorted.find(c => c.status === 'active')` to:
+    ```js
+    sorted.find(c => ['active', 'game', 'prep'].includes(c.status)) || null
+    ```
+  - [x] This aligns `_activeCycle` discovery with the same `LIVE_STATUSES` logic used in `downtime-form.js:1380`. The variable name `_activeCycle` remains unchanged — it now means "the current live cycle" not "strictly-active cycle".
+
+- [x] **Task 2:** `regency-tab.js` — gate CTA banner and confirm button on `status === 'active'` (AC: 3, 4, 5, 6)
+  - [x] Line ~183 (CTA banner) — add `_activeCycle.status === 'active'` guard:
+    ```js
+    if (_activeCycle && _activeCycle.status === 'active' && !cycleConfirmed && !myConfirmation) {
+    ```
+  - [x] Line ~254 (confirm button) — add same guard:
+    ```js
+    if (_activeCycle && _activeCycle.status === 'active' && !cycleConfirmed) {
+    ```
+  - [x] Line ~256 (confirmed badge) — add same guard:
+    ```js
+    } else if (_activeCycle && _activeCycle.status === 'active' && cycleConfirmed && myConfirmation) {
+    ```
+  - [x] When `_activeCycle` exists but `status !== 'active'` and regent hasn't confirmed: the tab shows no confirm button and no CTA banner. The feeding-rights grid renders normally so the regent can set up their selections in advance.
+
+- [x] **Task 3:** `downtime-form.js` — gate confirm button in `renderRegencySection()` on `status === 'active'` (AC: 1, 2)
+  - [x] In `renderRegencySection()` (~line 4832–4840), replace the unconditional confirm button block with a status-aware split:
+    ```js
+    if (currentCycle?.status === 'active') {
+      h += '<button type="button" class="qf-btn qf-btn-submit" id="dt-btn-confirm-regency">Confirm regency this cycle</button>';
+    } else {
+      h += '<p class="qf-desc">Downtimes are not yet open - use the Regency tab to prepare your feeding-rights selections.</p>';
+    }
+    ```
+  - [x] The "Open Regency tab" button remains in both branches (so the regent can navigate to the tab regardless of cycle status).
+  - [x] The `<span id="dt-regency-confirm-status">` status element only needs to be present when the confirm button is rendered — include it only in the `status === 'active'` branch.
+
+- [x] **Task 4:** No server changes. `server/routes/downtime.js:102` check (`cycle.status !== 'active'`) is correct and stays.
+
+## Dev Notes
+
+### Cycle status model
+
+From `public/js/downtime/db.js:67-79` (`deriveCycleStatus`):
+
+| Status | Meaning | Downtimes open? |
+|---|---|---|
+| `'prep'` | Prep phase not yet signed off | No |
+| `'game'` | Prep signed, city not yet signed | No |
+| `'active'` | Both prep + city signed (or `manual_open: true`) | **Yes** |
+| `'closed'` | Projects signed off | No |
+
+The cycle status is derived from `phase_signoff` fields and written to MongoDB by `signoffPhase()` and `setManualOpen()`. The `status` field on the cycle document is the authoritative value — the server reads it directly.
+
+### Saving feeding rights vs confirming
+
+- **Save** (`PATCH /api/territories/:id/feeding-rights`) — no cycle-status gate. Always succeeds for the regent. The locked-character guard only applies if an active cycle exists — it prevents removing characters who have already fed, but does not prevent saves in general.
+- **Confirm** (`POST /api/downtime_cycles/:id/confirm-feeding`) — gated to `status === 'active'` only.
+
+This distinction is intentional: regents should be able to prepare their feeding-rights list before downtimes formally open.
+
+### `_activeCycle` semantics after Task 1
+
+After the fix, `_activeCycle` in `regency-tab.js` means "the current live cycle (any non-closed, non-prep status)" — not "strictly active". This is consistent with how the DT form uses `currentCycle`. Code that checks `_activeCycle?.status === 'active'` explicitly is intentional gating for confirm-only behaviour.
+
+### Confirm button in DT form — only in unconfirmed branch
+
+In `renderRegencySection()`, the confirm button is already inside the `else` branch (regent hasn't confirmed yet). The status check goes inside that branch. The post-confirmation branch (showing the confirmed-date and "Open Regency tab" only) does not change.
+
+### `#dt-regency-confirm-status` span
+
+This span is referenced by the click handler at `downtime-form.js:2335`. It only matters when the confirm button exists. Keep the span adjacent to the confirm button; omit it in the non-active branch.
+
+### No CSS changes expected
+
+The note text in the non-active branch (`qf-desc qf-desc--muted`) uses existing classes from `downtime-form.js`. If `qf-desc--muted` doesn't exist, use `qf-desc` with inline style or add a one-line rule to the appropriate CSS file (check `public/css/downtime-form.css` first).
+
+### Testing
+
+- Set DT cycle to `'game'` status in MongoDB (e.g., via `openGamePhase()` call or direct update) and verify:
+  - DT form Regency section shows "not yet open" note, no confirm button
+  - Regency tab loads feeding-rights rows, no CTA banner, no confirm button
+  - Regent can still save feeding-rights changes via "Save Feeding Rights"
+  - "Open Regency tab" navigates correctly
+- Set DT cycle to `'active'` and verify:
+  - DT form shows confirm button; clicking it succeeds
+  - Regency tab shows CTA banner and "Confirm Feeding Rights" button; clicking confirms
+- Set DT cycle to `'closed'` and verify no regression (form and tab should show no confirm UI today and continue to do so)
+- Verify the locked-character guard still prevents removing fed residents when cycle is active
+
+---
+
+## Change Log
+
+| Date | Version | Description | Author |
+|------|---------|-------------|--------|
+| 2026-06-09 | 1.0 | Initial draft from issue #645 | Bob (SM) |
+| 2026-06-09 | 1.1 | Implementation complete | Dev Agent |
+
+## Dev Agent Record
+
+### Agent Model Used
+claude-sonnet-4-6
+
+### Debug Log References
+None — all changes were surgical edits to two files, no runtime debugging needed.
+
+### Completion Notes List
+- Task 1: `regency-tab.js:74` — widened cycle picker from `status === 'active'` to `['active', 'game', 'prep'].includes(c.status)`. `_activeCycle` now means "current live cycle" not "strictly-active cycle".
+- Task 2: Added `_activeCycle.status === 'active'` guard to CTA banner (line 183), confirm button (line 254), and confirmed-badge (line 256) in `regency-tab.js`. When cycle is `'game'`/`'prep'`, feeding-rights grid renders normally but no confirm UI appears.
+- Task 3: `downtime-form.js` `renderRegencySection()` — confirm button and status span now only render when `currentCycle?.status === 'active'`. Non-active branch renders a `qf-desc` note: "Downtimes are not yet open - use the Regency tab to prepare your feeding-rights selections." "Open Regency tab" button present in both branches.
+- Task 4: Server unchanged — `downtime.js:102` gate is correct.
+- No CSS changes needed — `qf-desc` already provides italic + muted styling.
+- Both changed files parse-checked clean (node ESM, exit 0).
+
+### File List
+- `public/js/tabs/regency-tab.js`
+- `public/js/tabs/downtime-form.js`

--- a/tests/fix-645-regent-confirm-regency-tab.spec.js
+++ b/tests/fix-645-regent-confirm-regency-tab.spec.js
@@ -1,0 +1,225 @@
+/**
+ * fix.645 — Regent confirm-feeding and Regency tab cycle-status gating.
+ *
+ * Root cause: three-way mismatch — DT form used LIVE_STATUSES to find the cycle but showed
+ * the confirm button unconditionally; regency-tab.js only picked 'active' cycles so the tab
+ * rendered nothing useful for 'game'/'prep' cycles; server gated confirm to 'active' only.
+ *
+ * Fixes:
+ *   regency-tab.js  — widens cycle picker to LIVE_STATUSES; gates confirm button / CTA banner
+ *                     on status === 'active' explicitly.
+ *   downtime-form.js — gates confirm button in renderRegencySection() on currentCycle.status
+ *                      === 'active'; non-active branch shows "not yet open" note instead.
+ *
+ * NOTE — localhost dev bypass (downtime-form.js:1391):
+ *   The DT form coerces any non-active cycle to 'active' on localhost for dev convenience.
+ *   Therefore AC-1 (game cycle → no confirm button in DT form) cannot be verified through
+ *   Playwright on localhost. That acceptance criterion is instead covered by the regency tab
+ *   tests below, which have no equivalent bypass.
+ */
+
+const { test, expect } = require('@playwright/test');
+const { bootApp, goToTab } = require('./helpers/unified-app.js');
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const PLAYER_USER = {
+  id: '987645321', username: 'test_regent_645', global_name: 'Test Regent',
+  avatar: null, role: 'player', player_id: 'p-645',
+  character_ids: ['char-645'], is_dual_role: false,
+};
+
+const CHAR_REGENT = {
+  _id: 'char-645', name: 'Rene', moniker: null, honorific: null,
+  clan: 'Ventrue', covenant: 'Invictus', player: 'Rene Player',
+  blood_potency: 3, humanity: 7, humanity_base: 7, court_title: null, retired: false,
+  status: {
+    city: 2, clan: 1,
+    covenant: { 'Carthian Movement': 0, 'Circle of the Crone': 0, 'Invictus': 2, 'Lancea et Sanctum': 0, 'Ordo Dracul': 0 },
+  },
+  attributes: {
+    Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+    Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 3, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+    Presence: { dots: 3, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: {}, disciplines: {}, merits: [], powers: [], ordeals: [],
+};
+
+// Non-regent: same shape but no territory has regent_id pointing to this char.
+const CHAR_NON_REGENT = { ...CHAR_REGENT, _id: 'char-646', name: 'Other' };
+
+// Territory whose regent_id matches CHAR_REGENT._id — triggers the regency section.
+const TERRITORY_645 = {
+  _id: 'terr-645', name: 'The Second City', slug: 'secondcity',
+  regent_id: 'char-645', lieutenant_id: null,
+  feeding_rights: [], ambience: 'urban',
+};
+
+const CYCLE_GAME = {
+  _id: 'cycle-645g', cycle_number: 4, status: 'game', label: 'DT4',
+  feeding_rights_confirmed: false, regent_confirmations: [],
+  phase_signoff: {}, created_at: '2026-06-01T00:00:00Z',
+};
+
+const CYCLE_ACTIVE = {
+  _id: 'cycle-645a', cycle_number: 4, status: 'active', label: 'DT4',
+  feeding_rights_confirmed: false, regent_confirmations: [],
+  phase_signoff: {}, created_at: '2026-06-01T00:00:00Z',
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function setupRegent(page, { cycle, char = CHAR_REGENT, territories = [TERRITORY_645] } = {}) {
+  const cycles = cycle ? [cycle] : [];
+  const charNames = [{ _id: char._id, name: char.name, moniker: char.moniker, honorific: char.honorific }];
+  const user = { ...PLAYER_USER, character_ids: [char._id] };
+
+  await bootApp(page, user, {
+    routes: async (p) => {
+      await p.route(/\/api\/downtime_cycles/, r => r.fulfill({
+        status: 200, contentType: 'application/json', body: JSON.stringify(cycles),
+      }));
+      await p.route(/\/api\/downtime_submissions/, r => r.fulfill({
+        status: 200, contentType: 'application/json', body: '[]',
+      }));
+      await p.route(/\/api\/characters\/names/, r => r.fulfill({
+        status: 200, contentType: 'application/json', body: JSON.stringify(charNames),
+      }));
+      await p.route(/\/api\/characters/, r => r.fulfill({
+        status: 200, contentType: 'application/json', body: JSON.stringify([char]),
+      }));
+      await p.route(/\/api\/territories/, r => r.fulfill({
+        status: 200, contentType: 'application/json', body: JSON.stringify(territories),
+      }));
+    },
+  });
+}
+
+async function openDtTab(page) {
+  await page.evaluate(() => window.goTab('downtime'));
+  await page.waitForSelector('#t-downtime.active', { timeout: 5000 });
+  // Wait for the async form init to complete — regency section is one of the last sections.
+  await page.waitForTimeout(1500);
+}
+
+async function openRegencyTab(page) {
+  await page.evaluate(() => window.goTab('regency'));
+  await page.waitForSelector('#t-regency.active', { timeout: 5000 });
+  // renderRegencyTab is async: fetches /api/characters/names, /api/downtime_cycles,
+  // /api/downtime_submissions. Wait for the feeding-rights grid to confirm render complete.
+  await page.waitForSelector('#t-regency .regency-wrap, #t-regency .dt-residency-grid', { timeout: 6000 });
+}
+
+// ── DT form Regency section ───────────────────────────────────────────────────
+
+test.describe('fix.645: DT form Regency section — cycle status gating', () => {
+
+  test('active cycle: confirm button is present for unconfirmed regent', async ({ page }) => {
+    await setupRegent(page, { cycle: CYCLE_ACTIVE });
+    await openDtTab(page);
+
+    // The regency section should render for this regent.
+    await expect(page.locator('[data-section-key="regency"]')).toBeVisible();
+    // Confirm button must be present when status is 'active'.
+    await expect(page.locator('#dt-btn-confirm-regency')).toBeVisible();
+    // "Open Regency tab" button always present for regent.
+    await expect(page.locator('[data-open-regency-tab]').first()).toBeVisible();
+    // The "not yet open" note must NOT appear.
+    await expect(page.locator('[data-section-key="regency"]')).not.toContainText('not yet open');
+  });
+
+  test('non-regent char: regency section is absent entirely', async ({ page }) => {
+    // No territory has regent_id matching CHAR_NON_REGENT — section must not render.
+    await setupRegent(page, { cycle: CYCLE_ACTIVE, char: CHAR_NON_REGENT, territories: [] });
+    await openDtTab(page);
+
+    await expect(page.locator('[data-section-key="regency"]')).toHaveCount(0);
+    await expect(page.locator('#dt-btn-confirm-regency')).toHaveCount(0);
+  });
+
+});
+
+// ── Regency tab ───────────────────────────────────────────────────────────────
+
+test.describe('fix.645: Regency tab — cycle status gating', () => {
+
+  test('game cycle: feeding-rights grid renders; no confirm button; no CTA banner', async ({ page }) => {
+    await setupRegent(page, { cycle: CYCLE_GAME });
+    await openRegencyTab(page);
+
+    // Feeding-rights grid must render (regent can prepare selections).
+    await expect(page.locator('.dt-residency-grid')).toBeVisible();
+    // Save button always present.
+    await expect(page.locator('#reg-save')).toBeVisible();
+    // Confirm button must NOT appear — cycle is not active.
+    await expect(page.locator('#reg-confirm')).toHaveCount(0);
+    // CTA banner must NOT appear — only shown when status is 'active'.
+    await expect(page.locator('.reg-cta-banner')).toHaveCount(0);
+    // Confirmed-badge must NOT appear.
+    await expect(page.locator('.reg-confirmed-badge')).toHaveCount(0);
+  });
+
+  test('active cycle: confirm button and CTA banner are present when unconfirmed', async ({ page }) => {
+    await setupRegent(page, { cycle: CYCLE_ACTIVE });
+    await openRegencyTab(page);
+
+    // Feeding-rights grid must render.
+    await expect(page.locator('.dt-residency-grid')).toBeVisible();
+    // Confirm button must be present.
+    await expect(page.locator('#reg-confirm')).toBeVisible();
+    // CTA action-required banner must be present.
+    await expect(page.locator('.reg-cta-banner')).toBeVisible();
+    await expect(page.locator('.reg-cta-banner')).toContainText('Action required');
+    // Save button still present.
+    await expect(page.locator('#reg-save')).toBeVisible();
+  });
+
+  test('no cycle: tab renders without crash; no confirm button', async ({ page }) => {
+    await setupRegent(page, { cycle: null });
+    await openRegencyTab(page);
+
+    // The grid renders (regent can view their territory even without a cycle).
+    await expect(page.locator('.dt-residency-grid')).toBeVisible();
+    // No confirm button — no cycle to confirm against.
+    await expect(page.locator('#reg-confirm')).toHaveCount(0);
+    // No CTA banner.
+    await expect(page.locator('.reg-cta-banner')).toHaveCount(0);
+  });
+
+  test('prep cycle: feeding-rights grid renders; no confirm button; no CTA banner', async ({ page }) => {
+    const CYCLE_PREP = { ...CYCLE_GAME, _id: 'cycle-645p', status: 'prep', label: 'DT4 Prep' };
+    await setupRegent(page, { cycle: CYCLE_PREP });
+    await openRegencyTab(page);
+
+    await expect(page.locator('.dt-residency-grid')).toBeVisible();
+    await expect(page.locator('#reg-confirm')).toHaveCount(0);
+    await expect(page.locator('.reg-cta-banner')).toHaveCount(0);
+  });
+
+  test('active cycle already confirmed: confirmed-badge shown, no confirm button', async ({ page }) => {
+    // feeding_rights_confirmed: true = the ST has globally closed the feeding gate.
+    // regent_confirmations entry for this territory = this regent confirmed individually.
+    // Both are needed for the badge branch: cycleConfirmed && myConfirmation.
+    const CYCLE_CONFIRMED = {
+      ...CYCLE_ACTIVE,
+      _id: 'cycle-645c',
+      feeding_rights_confirmed: true,
+      regent_confirmations: [{
+        territory_id: 'terr-645',
+        confirmed_by: 'char-645',
+        confirmed_at: '2026-06-09T10:00:00Z',
+        rights: [],
+      }],
+    };
+    await setupRegent(page, { cycle: CYCLE_CONFIRMED });
+    await openRegencyTab(page);
+
+    // Confirm button should not be present (regent already confirmed).
+    await expect(page.locator('#reg-confirm')).toHaveCount(0);
+    // CTA banner should not be present (no pending action).
+    await expect(page.locator('.reg-cta-banner')).toHaveCount(0);
+    // Confirmed-badge should be visible.
+    await expect(page.locator('.reg-confirmed-badge')).toBeVisible();
+  });
+
+});


### PR DESCRIPTION
## Summary

- **`regency-tab.js`**: widened cycle picker from strict `status === 'active'` to `LIVE_STATUSES` (`['active', 'game', 'prep']`), so the tab loads with feeding-rights grid populated for all live cycles. Added explicit `status === 'active'` guards to the CTA banner, confirm button, and confirmed-badge so those only appear when confirmation is actually possible.
- **`downtime-form.js`**: gated the "Confirm regency this cycle" button in `renderRegencySection()` on `currentCycle.status === 'active'`. Non-active cycles show a `qf-desc` note ("Downtimes are not yet open — use the Regency tab to prepare your feeding-rights selections.") instead. "Open Regency tab" button remains in both branches.
- Server unchanged -- `downtime.js:102` gate (`status !== 'active'` -> 409) is correct and intentional.

## Test plan

- [x] 7 Playwright tests in `tests/fix-645-regent-confirm-regency-tab.spec.js` -- all pass
  - DT form: active cycle shows confirm button; non-regent has no regency section
  - Regency tab: game/prep cycles render grid without confirm or CTA; active cycle shows both; no-cycle renders without crash; globally-confirmed cycle shows badge not button
- [ ] Smoke check on dev: load as a regent character, verify Regency tab opens with feeding-rights grid in game-phase cycle
- [ ] Confirm button works end-to-end once DT4 cycle is set to active

Closes #645

Generated with [Claude Code](https://claude.com/claude-code)