### PR TITLE
feat(656): EQ-2 — Equipment & Assets read-only sheet display

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -36,7 +36,6 @@ import {
   shEditStandMerit, shEditStandAssetSkill,
   shToggleMCI, shTogglePT, shEditMCIDot, shRemoveStandMerit, shAddStandMCI, shAddStandPT,
   shEditMeritPt, shStepMeritRating, shEditXP, shAdjAttrBonus, shAdjMeritBonus, shAdjSkillBonus,
-  shAddEquip, shEditEquip, shRemoveEquip,
   registerCallbacks as registerEditCallbacks
 } from './editor/edit.js';
 import { renderIdentityTab, updField, updStatus, registerCallbacks as registerIdentityCallbacks } from './editor/identity.js';
@@ -1140,7 +1139,6 @@ Object.assign(window, {
   shEditMCIDot, shRemoveStandMerit, shAddStandMCI, shAddStandPT,
   shEditMeritPt, shStepMeritRating,
   shEditXP,
-  shAddEquip, shEditEquip, shRemoveEquip,
 
   // Editor attributes & skills tab
   clickAttrDot,

--- a/public/js/editor/edit.js
+++ b/public/js/editor/edit.js
@@ -1035,32 +1035,3 @@ export function shEditMeritPt(realIdx, field, val) {
 
 
 // ── Equipment (nav.10) ────────────────────────────────────────────────────────
-export function shAddEquip(type) {
-  if (state.editIdx < 0) return;
-  const c = state.chars[state.editIdx];
-  if (!c.equipment) c.equipment = [];
-  if (type === 'weapon') {
-    c.equipment.push({ type: 'weapon', name: '', damage_rating: 0, damage_type: 'L', attack_skill: 'Weaponry' });
-  } else {
-    c.equipment.push({ type: 'armour', name: '', general_ar: 0, ballistic_ar: 0, mobility_penalty: 0 });
-  }
-  _markDirty();
-  _renderSheet(c);
-}
-
-export function shEditEquip(i, field, val) {
-  if (state.editIdx < 0) return;
-  const c = state.chars[state.editIdx];
-  if (!c.equipment || !c.equipment[i]) return;
-  c.equipment[i][field] = val;
-  _markDirty();
-}
-
-export function shRemoveEquip(i) {
-  if (state.editIdx < 0) return;
-  const c = state.chars[state.editIdx];
-  if (!c.equipment) return;
-  c.equipment.splice(i, 1);
-  _markDirty();
-  _renderSheet(c);
-}

--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -19,6 +19,7 @@ import { auditCharacter } from '../data/audit.js';
 // removed; free-text Name + Description only).
 import { powersForDisc } from '../suite/sheet-helpers.js';
 import { markerFor } from './st-mod-popover.js';
+import { getCatalogueEntry } from '../data/equipment-data.js';
 
 // Build legacy-format shims from rules cache for remaining deep consumers.
 // These produce arrays/objects in the old DEVOTIONS_DB/MERITS_DB/MAN_DB shape.
@@ -1728,39 +1729,98 @@ export function shRenderManoeuvres(c, editMode) {
   return h;
 }
 
-// ── Equipment renderer (nav.10) ───────────────────────────────────────────────
+// ── Equipment & Assets renderer (EQ-2, issue #656) ───────────────────────────
+// Renders catalogue-ref equipment[] and freeform assets[] read-only.
+// Edit mode shows the same view -- equipment is managed via the ST CRUD API (EQ-1).
 export function shRenderEquipment(c, editMode) {
-  const equip = c.equipment || [];
-  if (!editMode && !equip.length) return '';
-  const SKILLS = ['Brawl', 'Weaponry', 'Firearms'];
-  const TYPES  = ['weapon', 'armour'];
-  let h = '<div class="sh-sec"><div class="sh-sec-title">Equipment</div><div class="merit-list">';
-  if (editMode) {
-    equip.forEach((e, i) => {
-      const isWeapon = e.type === 'weapon';
-      const skillOpts = SKILLS.map(s => `<option${e.attack_skill === s ? ' selected' : ''}>${s}</option>`).join('');
-      const dmgOpts = ['B','L','A'].map(d => `<option${e.damage_type === d ? ' selected' : ''}>${d}</option>`).join('');
-      h += `<div class="equip-edit-row">`;
-      h += `<select class="gen-qual-input" style="width:70px" onchange="shEditEquip(${i},'type',this.value)"><option${e.type==='weapon'?' selected':''}>weapon</option><option${e.type==='armour'?' selected':''}>armour</option></select>`;
-      h += `<input class="sh-edit-input" value="${esc(e.name||'')}" placeholder="Name" onchange="shEditEquip(${i},'name',this.value)" style="flex:1">`;
-      if (isWeapon) {
-        h += `<select class="gen-qual-input" style="width:80px" onchange="shEditEquip(${i},'attack_skill',this.value)">${skillOpts}</select>`;
-        h += `<input class="attr-bd-input" type="number" value="${e.damage_rating||0}" title="Dmg bonus" onchange="shEditEquip(${i},'damage_rating',+this.value)" style="width:40px">`;
-        h += `<select class="gen-qual-input" style="width:40px" onchange="shEditEquip(${i},'damage_type',this.value)">${dmgOpts}</select>`;
-      } else {
-        h += `<input class="attr-bd-input" type="number" value="${e.general_ar||0}" title="General AR" onchange="shEditEquip(${i},'general_ar',+this.value)" style="width:40px">`;
-        h += `<input class="attr-bd-input" type="number" value="${e.ballistic_ar||0}" title="Ballistic AR" onchange="shEditEquip(${i},'ballistic_ar',+this.value)" style="width:40px">`;
-        h += `<input class="attr-bd-input" type="number" value="${e.mobility_penalty||0}" title="Mobility penalty" onchange="shEditEquip(${i},'mobility_penalty',+this.value)" style="width:40px">`;
-      }
-      h += `<button class="dev-rm-btn" onclick="shRemoveEquip(${i})" title="Remove">&times;</button>`;
-      h += `</div>`;
-    });
-    h += `<div class="dev-add-row"><button class="dev-add-btn" onclick="shAddEquip('weapon')">+ Weapon</button><button class="dev-add-btn" onclick="shAddEquip('armour')" style="margin-left:4px">+ Armour</button></div>`;
-  } else {
-    equip.forEach(e => {
-      h += `<div class="merit-plain"><div class="trait-row"><div class="trait-main"><span class="trait-name">${esc(e.name)}</span><div class="trait-right"><span class="trait-qual" style="font-size:10px">${e.type === 'weapon' ? `${e.attack_skill||''} +${e.damage_rating||0}${e.damage_type||'L'}` : `AR ${e.general_ar||0}/${e.ballistic_ar||0}`}</span></div></div></div></div>`;
-    });
+  const equip  = c.equipment || [];
+  const assets = c.assets    || [];
+  if (!equip.length && !assets.length) return '';
+
+  const STATE_LABELS = { carried: 'Carried', worn: 'Worn', stashed: 'Stashed', lost: 'Lost', active: 'Active' };
+  const DMGTYPE      = { lethal: 'Lethal', bashing: 'Bashing', aggravated: 'Aggravated' };
+  const WPNTYPE      = { melee: 'Melee', ranged: 'Ranged', thrown: 'Thrown' };
+  const cycleLabel   = n  => n === 0 ? 'Pre-campaign' : `Cycle ${n}`;
+  const stateChip    = st => `<span class="gen-granted-tag-view">${STATE_LABELS[st] || st}</span>`;
+
+  let h = '<div class="sh-sec"><div class="sh-sec-title">Equipment &amp; Assets</div><div class="merit-list">';
+
+  // Group equipment items by bucket
+  const byBucket = { weapon: [], armour: [], equipment: [] };
+  for (const item of equip) {
+    const entry  = getCatalogueEntry(item.catalogue_id) || {};
+    const bucket = (entry.bucket && byBucket[entry.bucket]) ? entry.bucket : 'equipment';
+    byBucket[bucket].push({ item, entry });
   }
+
+  // ── Weapons ──
+  if (byBucket.weapon.length) {
+    h += '<div class="sh-sub-title">Weapons</div>';
+    for (const { item, entry } of byBucket.weapon) {
+      const name  = entry.name || item.catalogue_id;
+      const parts = [
+        entry.damage_mod != null ? `+${entry.damage_mod}` : null,
+        DMGTYPE[entry.damage_type] || entry.damage_type || null,
+        WPNTYPE[entry.weapon_type] || entry.weapon_type || null,
+      ].filter(Boolean);
+      const qual = parts.join(' · ');
+      h += `<div class="merit-plain"><div class="trait-row">` +
+        `<div class="trait-main"><span class="trait-name">${esc(name)}</span><div class="trait-right">${stateChip(item.state)}</div></div>` +
+        `<div class="trait-sub">${qual ? `<span class="trait-qual">${esc(qual)}</span>` : ''}${item.notes ? `<span class="trait-qual dim">${esc(item.notes)}</span>` : ''}</div>` +
+        `</div></div>`;
+    }
+  }
+
+  // ── Armour ──
+  if (byBucket.armour.length) {
+    h += '<div class="sh-sub-title">Armour</div>';
+    const baseDefence = calcDefence(c);
+    for (const { item, entry } of byBucket.armour) {
+      const name  = entry.name || item.catalogue_id;
+      const parts = [
+        entry.armour_value   != null ? `AR ${entry.armour_value}` : null,
+        entry.defence_penalty != null ? `Defence ${baseDefence}(${baseDefence - entry.defence_penalty})` : null,
+      ].filter(Boolean);
+      const qual = parts.join(' · ');
+      h += `<div class="merit-plain"><div class="trait-row">` +
+        `<div class="trait-main"><span class="trait-name">${esc(name)}</span><div class="trait-right">${stateChip(item.state)}</div></div>` +
+        (qual || item.notes ? `<div class="trait-sub">${qual ? `<span class="trait-qual">${esc(qual)}</span>` : ''}${item.notes ? `<span class="trait-qual dim">${esc(item.notes)}</span>` : ''}</div>` : '') +
+        `</div></div>`;
+    }
+  }
+
+  // ── Equipment (tools / tech) ──
+  if (byBucket.equipment.length) {
+    h += '<div class="sh-sub-title">Equipment</div>';
+    for (const { item, entry } of byBucket.equipment) {
+      const name = entry.name || item.catalogue_id;
+      const pool = (entry.skill_domain && entry.bonus_dice != null)
+        ? `${entry.skill_domain} +${entry.bonus_dice} dice` : '';
+      h += `<div class="merit-plain"><div class="trait-row">` +
+        `<div class="trait-main"><span class="trait-name">${esc(name)}</span><div class="trait-right">${stateChip(item.state)}</div></div>` +
+        (pool || item.notes ? `<div class="trait-sub">${pool ? `<span class="trait-qual">${esc(pool)}</span>` : ''}${item.notes ? `<span class="trait-qual dim">${esc(item.notes)}</span>` : ''}</div>` : '') +
+        `</div></div>`;
+    }
+  }
+
+  // ── Assets ──
+  if (assets.length) {
+    h += '<div class="sh-sub-title">Assets</div>';
+    for (const asset of assets) {
+      const meta = [
+        asset.location       || null,
+        asset.mechanical_effect || null,
+        cycleLabel(asset.acquired_cycle),
+        asset.notes          || null,
+      ].filter(Boolean).join(' · ');
+      h += `<div class="merit-plain"><div class="trait-row">` +
+        `<div class="trait-main"><span class="trait-name">${esc(asset.name)}</span><div class="trait-right"><span class="gen-granted-tag-view">Asset</span></div></div>` +
+        `<div class="trait-sub"><span class="trait-qual">${esc(asset.description)}</span></div>` +
+        (meta ? `<div class="trait-sub"><span class="trait-qual dim">${esc(meta)}</span></div>` : '') +
+        `</div></div>`;
+    }
+  }
+
   h += '</div></div>';
   return h;
 }

--- a/specs/stories/feature.656.eq2-equipment-assets-sheet-display.story.md
+++ b/specs/stories/feature.656.eq2-equipment-assets-sheet-display.story.md
@@ -1,0 +1,231 @@
+# Story feature.656: EQ-2 — Equipment & Assets Sheet Display
+
+## Status: review
+
+---
+issue: 656
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/656
+branch: ms/issue-656-eq2-equipment-assets-sheet
+---
+
+## Story
+
+**As a** player viewing my character sheet,
+**I want** my equipment and assets to be displayed clearly, grouped by type, with resolved names and relevant mechanical details,
+**so that** I can see what my character is carrying or owns without needing to cross-reference the catalogue separately.
+
+## Background
+
+EQ-1 (#654) established the four-bucket equipment taxonomy (`weapon` | `armour` | `equipment` | `asset`), the static `EQUIPMENT_CATALOGUE` module at `public/js/data/equipment-data.js`, and the character schema extension (`character.equipment[]` + `character.assets[]`).
+
+The lean ref design stores only `{ catalogue_id, state, acquired_cycle, notes }` on the character. Stats (name, bonus_dice, damage_mod, armour_value, etc.) are resolved from `EQUIPMENT_CATALOGUE` at render time.
+
+EQ-2 is the first user-visible story: rewriting `shRenderEquipment()` to render the new catalogue-ref schema across all four buckets.
+
+## Acceptance Criteria
+
+1. `shRenderEquipment(c, editMode)` in `public/js/editor/sheet.js` renders equipment and assets for a character with items.
+
+2. Equipment items are grouped into sub-sections by bucket (`Weapons`, `Armour`, `Equipment`, `Assets`), each with a `.sh-sub-title` header. Sub-sections with no items are omitted.
+
+3. Each equipment item resolves its stats via `getCatalogueEntry(item.catalogue_id)` from `public/js/data/equipment-data.js`. If `getCatalogueEntry` returns `undefined` (unknown/legacy id), the item still renders using `item.catalogue_id` as the fallback display name without crashing.
+
+4. `state` values render as human-readable labels: `carried` → `Carried`, `worn` → `Worn`, `stashed` → `Stashed`, `lost` → `Lost`, `active` → `Active`.
+
+5. Weapon entries display: name, state chip, damage info (`+N · lethal · melee` etc.), notes if present.
+
+6. Armour entries display: name, state chip, `AR N` value, and defence in `base(reduced)` format — e.g. base Defence 3 with `defence_penalty: -1` renders as `3(2)`. `defence_penalty` is never passed to `calcDefence()`.
+
+7. Equipment entries (tools/tech) display: name, state chip, `skill_domain +bonus_dice dice` pool modifier label, notes if present.
+
+8. Asset entries display: name, description, location (if set), `mechanical_effect` (if set), acquired cycle label, notes if present.
+
+9. Characters with no `equipment` field and no `assets` field (legacy documents) render an empty section that is omitted entirely (`return ''`) — no crash, no blank container.
+
+10. Edit mode shows the same read-only display as view mode. The old inline edit controls (type select, attack_skill, damage_rating, general_ar, ballistic_ar, mobility_penalty inputs) are removed. Equipment editing is managed via the ST CRUD API (EQ-1).
+
+11. The old edit handler functions `shAddEquip`, `shEditEquip`, `shRemoveEquip` are removed from `edit.js`. Both import sites in `app.js` (lines ~39 and ~1143) are updated to remove them.
+
+12. `public/js/data/equipment.js` (dead code: `getEquipment`, `weaponPool`, `effectiveDefence`, `weaponPoolLabel`) is deleted. No file imports from it.
+
+13. The suite sheet (`public/js/suite/sheet.js`) imports and calls `shRenderEquipment(c, false)` at line 731 — it receives the updated rendering for free with no changes required.
+
+14. All existing sheet tests and Playwright specs pass after the rewrite. No regressions in other sheet sections.
+
+## Tasks / Subtasks
+
+- [x] Task 1: Add `getCatalogueEntry` import to `public/js/editor/sheet.js`
+  - [x] Add `import { getCatalogueEntry } from '../data/equipment-data.js';` at the top of the file, alongside existing data imports
+
+- [x] Task 2: Rewrite `shRenderEquipment(c, editMode)` in `public/js/editor/sheet.js` (lines 1732–1766)
+  - [x] Declare `STATE_LABELS` map: `{ carried: 'Carried', worn: 'Worn', stashed: 'Stashed', lost: 'Lost', active: 'Active' }`
+  - [x] Read `const equip = c.equipment || []` and `const assets = c.assets || []`
+  - [x] Return `''` early if both are empty
+  - [x] Open section: `<div class="sh-sec"><div class="sh-sec-title">Equipment & Assets</div><div class="merit-list">`
+  - [x] Group equipment items by bucket (weapon, armour, equipment) -- use `getCatalogueEntry(item.catalogue_id) || {}` for fallback safety
+  - [x] For each non-empty bucket, render a `.sh-sub-title` header then `.merit-plain` rows
+  - [x] Weapon rows: name (or catalogue_id fallback), state chip, `+damage_mod · damage_type · weapon_type` qualifier, notes
+  - [x] Armour rows: name, state chip, `AR armour_value`, defence display `base(base - penalty)` format
+  - [x] Equipment rows: name, state chip, `skill_domain +bonus_dice dice` qualifier, notes
+  - [x] Asset rows from `assets[]`: name as `.trait-name`, description, location + mechanical_effect if set, `Cycle acquired_cycle` label, notes
+  - [x] Edit mode: render the same read-only view (no inline inputs); omit old add/remove buttons entirely
+  - [x] Close section: `</div></div>`
+
+- [x] Task 3: Remove old equipment edit handlers from `public/js/editor/edit.js`
+  - [x] Delete `shAddEquip` (lines ~1038-1049)
+  - [x] Delete `shEditEquip` (lines ~1051-1057)
+  - [x] Delete `shRemoveEquip` (lines ~1059-1066)
+  - [x] Confirm no remaining references in `edit.js` to old schema fields (`damage_rating`, `attack_skill`, `general_ar`, `ballistic_ar`, `mobility_penalty`)
+
+- [x] Task 4: Update `public/js/app.js` to remove the three handler imports
+  - [x] Remove `shAddEquip, shEditEquip, shRemoveEquip,` from the `import { ... } from './editor/edit.js'` block (line ~39)
+  - [x] Remove `shAddEquip, shEditEquip, shRemoveEquip,` from the window-object export block (line ~1143)
+
+- [x] Task 5: Delete `public/js/data/equipment.js`
+  - [x] Verify no file imports from it first (`grep -r "from.*equipment\.js"` excluding `equipment-data.js`)
+  - [x] Delete the file
+
+- [ ] Task 6: Smoke-test rendering in browser (manual, on dev after merge)
+  - [ ] A character with weapon + armour + equipment + asset items shows all four sub-sections
+  - [ ] A character with no equipment/assets shows no Equipment & Assets section
+  - [ ] Defence display for armour is correct (`base(reduced)` format)
+  - [ ] Suite sheet (`/index.html`) also renders the section correctly
+
+## Dev Notes
+
+### Architecture: where `shRenderEquipment` sits
+
+The function lives at `public/js/editor/sheet.js:1732`. It is called:
+- Line 1905: `shRenderEquipment(c, editMode)` in the desktop 2-column layout (right column, after Manoeuvres)
+- Line 1908: `shRenderEquipment(c, editMode)` in the mobile single-column layout
+
+No changes to the orchestrator are needed -- just rewrite the function in place.
+
+The suite sheet at `public/js/suite/sheet.js:28` imports `shRenderEquipment` and calls it at line 731 with `(c, false)` (always view-only). It automatically gets the rewritten rendering -- no changes to that file.
+
+### `calcDefence` import path
+
+`sheet.js` line 10 imports `calcDefence` from `'../data/derived.js'` (NOT `accessors.js`):
+```js
+import { calcHealth, calcWillpowerMax, calcSize, calcSpeed, calcDefence } from '../data/derived.js';
+```
+Do NOT add a second import or change this line. `calcDefence` is already available in scope.
+
+### Defence display format for armour
+
+```js
+const base = calcDefence(c);
+const reduced = base + entry.defence_penalty;  // penalty is a negative integer e.g. -1
+const defenceDisplay = `${base}(${reduced})`;  // e.g. "3(2)"
+```
+
+`defence_penalty` is display-only. It is never added to `calcDefence()` internally, now or in any future story without an ADR. Do not add any call path from `calcDefence` to the equipment array.
+
+### Null-guard for unknown catalogue IDs
+
+Legacy data or a typo could produce a `catalogue_id` with no matching entry:
+```js
+const entry = getCatalogueEntry(item.catalogue_id) || {};
+const displayName = entry.name || item.catalogue_id;  // fallback to raw id
+```
+Always guard. Never `.name` on a potentially-undefined result.
+
+### State label map
+
+```js
+const STATE_LABELS = {
+  carried: 'Carried', worn: 'Worn', stashed: 'Stashed', lost: 'Lost', active: 'Active',
+};
+const stateLabel = STATE_LABELS[item.state] || item.state;  // raw enum as fallback
+```
+
+### CSS patterns to use
+
+Follow the existing `.merit-plain` + `.trait-row` pattern used by Manoeuvres (the section immediately above Equipment in the sheet):
+
+```html
+<div class="sh-sub-title">Weapons</div>
+<div class="merit-plain">
+  <div class="trait-row">
+    <div class="trait-main">
+      <span class="trait-name">${esc(displayName)}</span>
+      <div class="trait-right">
+        <span class="gen-granted-tag-view">${stateLabel}</span>
+      </div>
+    </div>
+    <div class="trait-sub">
+      <span class="trait-qual">${qualifier}</span>
+    </div>
+  </div>
+</div>
+```
+
+Do NOT invent new CSS classes. All required classes exist: `.sh-sub-title`, `.merit-plain`, `.trait-row`, `.trait-main`, `.trait-right`, `.trait-name`, `.trait-qual`, `.gen-granted-tag-view`.
+
+### Removing `shAddEquip` / `shEditEquip` / `shRemoveEquip`
+
+These are exported from `edit.js` and imported in **two places** in `app.js`:
+- Line ~39: import statement `import { ..., shAddEquip, shEditEquip, shRemoveEquip, ... } from './editor/edit.js'`
+- Line ~1143: window-object export block
+
+Both must be updated. Leaving one site broken causes a runtime "not exported" error.
+
+There is no `admin.js` file -- the memory note about "two importers" reflects `admin.js` being the old name before it was unified into `app.js`. Only `app.js` needs updating.
+
+### `equipment.js` deletion
+
+`public/js/data/equipment.js` exports four functions (`getEquipment`, `weaponPool`, `effectiveDefence`, `weaponPoolLabel`). None are imported anywhere in the codebase (confirmed in EQ-1 analysis). The file imports from `./accessors.js`, so deleting it causes no cascade.
+
+Verify before deleting:
+```bash
+grep -r "from.*['\"].*equipment['\"]" public/js/ --include="*.js" | grep -v "equipment-data"
+```
+If the output is empty, the delete is safe.
+
+### Edit mode behaviour
+
+EQ-2 scope is **read-only display only**. In edit mode, render the same view as view mode. Remove the old inline edit UI entirely (the select dropdowns, number inputs, add/remove buttons). ST equipment management goes through the CRUD API (EQ-1).
+
+If the character has no equipment/assets, the section is hidden regardless of edit mode -- this is consistent with other sections (general merits, manoeuvres etc. are also hidden when empty).
+
+### `acquired_cycle` display
+
+```js
+const cycleLabel = item.acquired_cycle === 0 ? 'Pre-campaign' : `Cycle ${item.acquired_cycle}`;
+```
+
+### Damage type / weapon type labels
+
+The catalogue stores lowercase strings: `'lethal'`, `'bashing'`, `'aggravated'`; `'melee'`, `'ranged'`, `'thrown'`. Capitalise for display:
+```js
+const DMGTYPE = { lethal: 'Lethal', bashing: 'Bashing', aggravated: 'Aggravated' };
+const WPNTYPE = { melee: 'Melee', ranged: 'Ranged', thrown: 'Thrown' };
+```
+
+### Existing equipment CSS
+
+The old `.equip-edit-row` class was only used by the old edit-mode controls being removed. It is not needed in the rewrite. Do not use it.
+
+## File List
+
+- `public/js/editor/sheet.js` — MODIFY (add import, rewrite shRenderEquipment)
+- `public/js/editor/edit.js` — MODIFY (remove shAddEquip, shEditEquip, shRemoveEquip)
+- `public/js/app.js` — MODIFY (remove three handler exports, two sites)
+- `public/js/data/equipment.js` — DELETE (dead code, no consumers)
+
+## Dev Agent Record
+
+### Completion Notes
+
+- Tasks 1-5 implemented in session; Task 6 is manual smoke-test post-merge.
+- Defence formula corrected: catalogue stores `defence_penalty` as a positive integer (penalty amount). The renderer uses `baseDefence - entry.defence_penalty` to produce `base(reduced)` format (e.g., armoured-vest with penalty 1 at base Defence 2 → "Defence 2(1)"). The story's dev notes assumed a negative-stored value; the catalogue uses positive for clarity.
+- `shRenderEquipment` is identical in view and edit mode (read-only both). Old inline edit controls removed entirely.
+- 9 Playwright tests added covering all ACs including unknown-id fallback and edit-mode guard.
+
+### Change Log
+
+- `public/js/editor/sheet.js`: added `getCatalogueEntry` import; rewrote `shRenderEquipment` (lines 1732+)
+- `public/js/editor/edit.js`: deleted `shAddEquip`, `shEditEquip`, `shRemoveEquip`
+- `public/js/app.js`: removed the three handler names from import and window-export blocks
+- `public/js/data/equipment.js`: deleted (dead code, no consumers)
+- `tests/feature-656-eq2-equipment-sheet.spec.js`: created (9 E2E tests, all passing)

--- a/tests/feature-656-eq2-equipment-sheet.spec.js
+++ b/tests/feature-656-eq2-equipment-sheet.spec.js
@@ -1,0 +1,266 @@
+/**
+ * E2E tests — feature.656 EQ-2: Equipment & Assets character sheet display.
+ *
+ * shRenderEquipment() renders catalogue-ref equipment[] and freeform assets[]
+ * in the character sheet, grouped by bucket with sub-title headers.
+ *
+ * Covered:
+ *   AC-1/2  Section renders with items; grouped sub-sections
+ *   AC-3    Unknown catalogue_id falls back to raw id (no crash)
+ *   AC-4    State chips show human-readable labels
+ *   AC-5/6  Weapon and armour details display correctly
+ *   AC-7    Equipment pool-modifier label
+ *   AC-8    Asset freeform entry
+ *   AC-9    Characters with no equipment/assets: section absent
+ *   AC-10   Edit mode shows same read-only view (no inline inputs)
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Shared auth user ──────────────────────────────────────────────────────────
+
+const ST_USER = {
+  id: '777000656', username: 'test_st656', global_name: 'Test ST 656',
+  avatar: null, role: 'st', player_id: 'p-fix656',
+  character_ids: ['char-eq656-001'], is_dual_role: false,
+};
+
+// ── Character builder ─────────────────────────────────────────────────────────
+
+function buildChar(overrides = {}) {
+  return {
+    _id: 'char-eq656-001',
+    name: 'Equipment Sheet Tester',
+    moniker: null, honorific: null,
+    clan: 'Mekhet', covenant: 'Invictus', player: 'Test Player',
+    blood_potency: 1, humanity: 7, humanity_base: 7,
+    court_title: null, retired: false,
+    status: { city: 1, clan: 1, covenant: {} },
+    attributes: {
+      Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+      Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+      Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+    },
+    skills: {}, disciplines: {}, merits: [], powers: [], ordeals: [],
+    xp_log: { spent: 0 },
+    ...overrides,
+  };
+}
+
+// ── Setup helpers ─────────────────────────────────────────────────────────────
+
+async function setupSuite(page, char) {
+  await page.addInitScript((u) => {
+    localStorage.removeItem('tm-mode');
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 36000000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(u));
+  }, ST_USER);
+
+  await page.route('**/api/**', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.route('**/api/auth/me', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(ST_USER) })
+  );
+  await page.route(/\/api\/characters$/, r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([char]) })
+  );
+  await page.route('**/api/characters/names', r =>
+    r.fulfill({ status: 200, contentType: 'application/json',
+      body: JSON.stringify([{ _id: char._id, name: char.name, moniker: null, honorific: null }]) })
+  );
+  await page.route(new RegExp(`/api/characters/${char._id}$`), r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(char) })
+  );
+  await page.route('**/api/rules', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+
+  await page.goto('/');
+  await page.waitForSelector('#app', { state: 'visible', timeout: 15000 });
+}
+
+async function renderSheetDesktop(page, char) {
+  await page.evaluate(async (c) => {
+    document.body.classList.add('desktop-mode');
+    const stateModule = await import('/js/suite/data.js');
+    const state = stateModule.default;
+    state.chars = [c];
+    const { onSheetChar } = await import('/js/suite/sheet.js');
+    onSheetChar(c.name);
+  }, char);
+  await page.waitForTimeout(200);
+}
+
+function sheetHtml(page) {
+  return page.evaluate(() =>
+    document.querySelector('#sh-content-suite')?.innerHTML || ''
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('feature.656 EQ-2 — Equipment & Assets sheet display', () => {
+
+  test('AC-9: no Equipment & Assets section when character has no equipment or assets', async ({ page }) => {
+    const char = buildChar(); // no equipment / assets fields
+    await setupSuite(page, char);
+    await renderSheetDesktop(page, char);
+
+    const html = await sheetHtml(page);
+    expect(html).not.toContain('Equipment &amp; Assets');
+  });
+
+  test('AC-1/2: section heading and sub-section headers present when items exist', async ({ page }) => {
+    const char = buildChar({
+      equipment: [
+        { catalogue_id: 'knife',        state: 'carried', acquired_cycle: 1, notes: null },
+        { catalogue_id: 'reinforced-clothing', state: 'worn', acquired_cycle: 1, notes: null },
+        { catalogue_id: 'flashlight',   state: 'stashed', acquired_cycle: 2, notes: null },
+      ],
+    });
+    await setupSuite(page, char);
+    await renderSheetDesktop(page, char);
+
+    const html = await sheetHtml(page);
+    expect(html).toContain('Equipment &amp; Assets');
+    expect(html).toContain('Weapons');
+    expect(html).toContain('Armour');
+    expect(html).toContain('Equipment');
+    // no assets -- should not show Assets sub-section
+    expect(html).not.toMatch(/class="sh-sub-title">Assets/);
+  });
+
+  test('AC-4: state chips render human-readable labels', async ({ page }) => {
+    const char = buildChar({
+      equipment: [
+        { catalogue_id: 'knife',          state: 'carried',  acquired_cycle: 1, notes: null },
+        { catalogue_id: 'reinforced-clothing', state: 'worn', acquired_cycle: 1, notes: null },
+        { catalogue_id: 'flashlight',     state: 'stashed',  acquired_cycle: 2, notes: null },
+      ],
+    });
+    await setupSuite(page, char);
+    await renderSheetDesktop(page, char);
+
+    const html = await sheetHtml(page);
+    expect(html).toContain('Carried');
+    expect(html).toContain('Worn');
+    expect(html).toContain('Stashed');
+  });
+
+  test('AC-5: weapon entry shows name, damage qualifier, state chip', async ({ page }) => {
+    const char = buildChar({
+      equipment: [
+        { catalogue_id: 'machete', state: 'carried', acquired_cycle: 1, notes: null },
+      ],
+    });
+    await setupSuite(page, char);
+    await renderSheetDesktop(page, char);
+
+    const html = await sheetHtml(page);
+    // Machete: damage_mod 1, damage_type lethal, weapon_type melee
+    expect(html).toContain('Machete');
+    expect(html).toContain('+1');
+    expect(html).toContain('Lethal');
+    expect(html).toContain('Melee');
+    expect(html).toContain('Carried');
+  });
+
+  test('AC-6: armour entry shows AR value and defence in base(reduced) format', async ({ page }) => {
+    // armoured-vest: armour_value 3, defence_penalty 1
+    // character has Wits 2, Dexterity 2 → calcDefence = min(2,2) = 2
+    // display: "AR 3 · Defence 2(1)"
+    const char = buildChar({
+      equipment: [
+        { catalogue_id: 'armoured-vest', state: 'worn', acquired_cycle: 2, notes: null },
+      ],
+    });
+    await setupSuite(page, char);
+    await renderSheetDesktop(page, char);
+
+    const html = await sheetHtml(page);
+    expect(html).toContain('Armoured Vest');
+    expect(html).toContain('AR 3');
+    // base=2, penalty=1 → 2(1)
+    expect(html).toContain('Defence 2(1)');
+    expect(html).toContain('Worn');
+  });
+
+  test('AC-7: equipment entry shows skill pool modifier label', async ({ page }) => {
+    // flashlight: skill_domain "Investigation", bonus_dice 1
+    const char = buildChar({
+      equipment: [
+        { catalogue_id: 'flashlight', state: 'carried', acquired_cycle: 1, notes: null },
+      ],
+    });
+    await setupSuite(page, char);
+    await renderSheetDesktop(page, char);
+
+    const html = await sheetHtml(page);
+    expect(html).toContain('Flashlight');
+    expect(html).toContain('+1 dice');
+  });
+
+  test('AC-8: asset entry shows name, description, and metadata', async ({ page }) => {
+    const char = buildChar({
+      assets: [{
+        name: 'Warehouse',
+        description: 'A disused warehouse on the docks.',
+        location: 'North Shore',
+        mechanical_effect: 'Feeding roll +2',
+        acquired_cycle: 3,
+        notes: 'Shared with Praxis',
+      }],
+    });
+    await setupSuite(page, char);
+    await renderSheetDesktop(page, char);
+
+    const html = await sheetHtml(page);
+    expect(html).toContain('Assets');
+    expect(html).toContain('Warehouse');
+    expect(html).toContain('disused warehouse on the docks');
+    expect(html).toContain('North Shore');
+    expect(html).toContain('Cycle 3');
+  });
+
+  test('AC-3: unknown catalogue_id renders as fallback display name without crashing', async ({ page }) => {
+    const char = buildChar({
+      equipment: [
+        { catalogue_id: 'legacy-unknown-item', state: 'stashed', acquired_cycle: 0, notes: null },
+      ],
+    });
+    await setupSuite(page, char);
+    await renderSheetDesktop(page, char);
+
+    const html = await sheetHtml(page);
+    // Falls back to rendering catalogue_id as the name; section still present
+    expect(html).toContain('Equipment &amp; Assets');
+    expect(html).toContain('legacy-unknown-item');
+    expect(html).toContain('Stashed');
+  });
+
+  test('AC-10: edit mode shows same read-only view with no inline inputs', async ({ page }) => {
+    const char = buildChar({
+      equipment: [
+        { catalogue_id: 'knife', state: 'carried', acquired_cycle: 1, notes: null },
+      ],
+    });
+    await setupSuite(page, char);
+
+    // Render in edit mode via the editor's sheet function directly
+    const result = await page.evaluate(async (c) => {
+      const { shRenderEquipment } = await import('/js/editor/sheet.js');
+      const html = shRenderEquipment(c, true /* editMode */);
+      const hasInputs = /<input|<select/.test(html);
+      const hasAddBtn = /add.*equip|shAddEquip/i.test(html);
+      return { html, hasInputs, hasAddBtn };
+    }, char);
+
+    expect(result.hasInputs).toBe(false);
+    expect(result.hasAddBtn).toBe(false);
+    expect(result.html).toContain('Knife');
+    expect(result.html).toContain('Carried');
+  });
+
+});


### PR DESCRIPTION
## Summary

- Rewrites `shRenderEquipment(c, editMode)` in `public/js/editor/sheet.js` to render the new catalogue-ref schema, grouping items into Weapons / Armour / Equipment / Assets sub-sections
- Armour displays `Defence base(reduced)` — formula: `base - entry.defence_penalty` (catalogue stores penalty as a positive integer)
- Sheet is read-only in both view and edit mode; ST manages equipment via CRUD API (EQ-1)
- Removes dead flat-schema handlers (`shAddEquip`, `shEditEquip`, `shRemoveEquip`) from `edit.js` and both importer sites in `app.js`
- Deletes `public/js/data/equipment.js` (dead code: old `getEquipment`, `weaponPool`, `effectiveDefence` helpers)

## Test plan

- [x] 9 Playwright E2E tests in `tests/feature-656-eq2-equipment-sheet.spec.js` — all passing
- [x] Covers: bucket grouping, unknown-id fallback, armour Defence base(reduced) display, edit-mode guard (read-only)
- [ ] Smoke on dev: character with equipment renders correctly; no console errors

Closes #656

🤖 Generated with [Claude Code](https://claude.com/claude-code)