### PR TITLE
feat(665): EQ-4 — ST admin UI for assigning equipment and assets to characters

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -36,6 +36,7 @@ import {
   shEditStandMerit, shEditStandAssetSkill,
   shToggleMCI, shTogglePT, shEditMCIDot, shRemoveStandMerit, shAddStandMCI, shAddStandPT,
   shEditMeritPt, shStepMeritRating, shEditXP, shAdjAttrBonus, shAdjMeritBonus, shAdjSkillBonus,
+  shAddEquip, shRemoveEquip, shEquipBucketFilter, shAddAsset, shRemoveAsset,
   registerCallbacks as registerEditCallbacks
 } from './editor/edit.js';
 import { renderIdentityTab, updField, updStatus, registerCallbacks as registerIdentityCallbacks } from './editor/identity.js';
@@ -1139,6 +1140,7 @@ Object.assign(window, {
   shEditMCIDot, shRemoveStandMerit, shAddStandMCI, shAddStandPT,
   shEditMeritPt, shStepMeritRating,
   shEditXP,
+  shAddEquip, shRemoveEquip, shEquipBucketFilter, shAddAsset, shRemoveAsset,
 
   // Editor attributes & skills tab
   clickAttrDot,
@@ -2138,6 +2140,7 @@ async function _loadLifecycleData() {
     const activeCycle = Array.isArray(cycles)
       ? cycles.find(c => c.status === 'open' || c.status === 'active') || null
       : null;
+    editorState.activeCycleNum = activeCycle?.game_number ?? null;
     let mySubmission = null;
     if (activeCycle) {
       const subs = await apiGet('/api/downtime_submissions').catch(() => []);

--- a/public/js/data/state.js
+++ b/public/js/data/state.js
@@ -5,7 +5,8 @@ const state = {
   editIdx: -1,
   dirty: new Set(),
   editMode: false,
-  openExpId: null
+  openExpId: null,
+  activeCycleNum: null,
 };
 
 export default state;

--- a/public/js/editor/edit.js
+++ b/public/js/editor/edit.js
@@ -13,6 +13,7 @@ import { xpToDots, xpEarned, xpSpent } from './xp.js';
 import { meritByCategory, addMerit, removeMerit, ensureMeritSync } from './merits.js';
 import { getPoolTotal, mciPoolTotal, getMCIPoolUsed } from './mci.js';
 import { vmPool, vmUsed, investedPool, investedUsed, lorekeeperPool, lorekeeperUsed, syncMeritRating, pruneContactsSpheres } from './domain.js';
+import { getCatalogueByBucket } from '../data/equipment-data.js';
 import {
   shEditInflMerit, shEditContactSphere, shRemoveInflMerit, shAddInflMerit, shAddVMAllies, shAddLKMerit,
   shEditGenMerit, shRemoveGenMerit, shAddGenMerit,
@@ -1034,4 +1035,90 @@ export function shEditMeritPt(realIdx, field, val) {
 }
 
 
-// ── Equipment (nav.10) ────────────────────────────────────────────────────────
+// ── Equipment (EQ-4, issue #665) ─────────────────────────────────────────────
+
+export function shEquipBucketFilter() {
+  const bucket  = document.getElementById('eq-add-bucket')?.value;
+  const itemSel = document.getElementById('eq-add-item');
+  if (!itemSel) return;
+  const entries = bucket ? getCatalogueByBucket(bucket) : [];
+  itemSel.innerHTML = '<option value="">-- select item --</option>'
+    + entries.map(e => `<option value="${e.id}">${e.name}</option>`).join('');
+}
+
+export async function shAddEquip() {
+  if (state.editIdx < 0) return;
+  const c          = state.chars[state.editIdx];
+  const charId     = String(c._id);
+  const catalogueId = document.getElementById('eq-add-item')?.value;
+  const itemState   = document.getElementById('eq-add-state')?.value;
+  const notes       = document.getElementById('eq-add-notes')?.value?.trim() || null;
+  if (!catalogueId || !itemState) return;
+  const cycle = parseInt(document.getElementById('eq-add-cycle')?.value ?? '0', 10) || 0;
+  try {
+    const result = await apiPost('/api/characters/' + charId + '/equipment', {
+      catalogue_id:   catalogueId,
+      state:          itemState,
+      acquired_cycle: cycle,
+      notes,
+    });
+    c.equipment = result.equipment;
+    c.assets    = result.assets;
+    _renderSheet(c);
+  } catch (err) {
+    console.error('[equipment] add error:', err);
+  }
+}
+
+export async function shRemoveEquip(idx) {
+  if (state.editIdx < 0) return;
+  const c      = state.chars[state.editIdx];
+  const charId = String(c._id);
+  try {
+    const result = await apiDelete('/api/characters/' + charId + '/equipment/' + idx);
+    c.equipment = result.equipment;
+    c.assets    = result.assets;
+    _renderSheet(c);
+  } catch (err) {
+    console.error('[equipment] remove error:', err);
+  }
+}
+
+export async function shAddAsset() {
+  if (state.editIdx < 0) return;
+  const c      = state.chars[state.editIdx];
+  const charId = String(c._id);
+  const name   = document.getElementById('asset-add-name')?.value?.trim();
+  const desc   = document.getElementById('asset-add-desc')?.value?.trim();
+  if (!name || !desc) return;
+  const cycle  = parseInt(document.getElementById('asset-add-cycle')?.value ?? '0', 10) || 0;
+  try {
+    const result = await apiPost('/api/characters/' + charId + '/assets', {
+      name,
+      description:       desc,
+      location:          document.getElementById('asset-add-loc')?.value?.trim()  || null,
+      mechanical_effect: document.getElementById('asset-add-mech')?.value?.trim() || null,
+      acquired_cycle:    cycle,
+      notes:             document.getElementById('asset-add-notes')?.value?.trim() || null,
+    });
+    c.equipment = result.equipment;
+    c.assets    = result.assets;
+    _renderSheet(c);
+  } catch (err) {
+    console.error('[asset] add error:', err);
+  }
+}
+
+export async function shRemoveAsset(idx) {
+  if (state.editIdx < 0) return;
+  const c      = state.chars[state.editIdx];
+  const charId = String(c._id);
+  try {
+    const result = await apiDelete('/api/characters/' + charId + '/assets/' + idx);
+    c.equipment = result.equipment;
+    c.assets    = result.assets;
+    _renderSheet(c);
+  } catch (err) {
+    console.error('[asset] remove error:', err);
+  }
+}

--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -1735,7 +1735,7 @@ export function shRenderManoeuvres(c, editMode) {
 export function shRenderEquipment(c, editMode) {
   const equip  = c.equipment || [];
   const assets = c.assets    || [];
-  if (!equip.length && !assets.length) return '';
+  if (!editMode && !equip.length && !assets.length) return '';
 
   const STATE_LABELS = { carried: 'Carried', worn: 'Worn', stashed: 'Stashed', lost: 'Lost', active: 'Active' };
   const DMGTYPE      = { lethal: 'Lethal', bashing: 'Bashing', aggravated: 'Aggravated' };
@@ -1745,27 +1745,29 @@ export function shRenderEquipment(c, editMode) {
 
   let h = '<div class="sh-sec"><div class="sh-sec-title">Equipment &amp; Assets</div><div class="merit-list">';
 
-  // Group equipment items by bucket
+  // Group equipment items by bucket, preserving flat-array index for remove buttons
   const byBucket = { weapon: [], armour: [], equipment: [] };
-  for (const item of equip) {
+  for (let i = 0; i < equip.length; i++) {
+    const item   = equip[i];
     const entry  = getCatalogueEntry(item.catalogue_id) || {};
     const bucket = (entry.bucket && byBucket[entry.bucket]) ? entry.bucket : 'equipment';
-    byBucket[bucket].push({ item, entry });
+    byBucket[bucket].push({ item, entry, idx: i });
   }
 
   // ── Weapons ──
   if (byBucket.weapon.length) {
     h += '<div class="sh-sub-title">Weapons</div>';
-    for (const { item, entry } of byBucket.weapon) {
+    for (const { item, entry, idx } of byBucket.weapon) {
       const name  = entry.name || item.catalogue_id;
       const parts = [
         entry.damage_mod != null ? `+${entry.damage_mod}` : null,
         DMGTYPE[entry.damage_type] || entry.damage_type || null,
         WPNTYPE[entry.weapon_type] || entry.weapon_type || null,
       ].filter(Boolean);
-      const qual = parts.join(' · ');
+      const qual   = parts.join(' · ');
+      const rmBtn  = editMode ? `<button class="sk-spec-rm" style="float:right;margin-top:2px" onclick="shRemoveEquip(${idx})" title="Remove">× Remove</button>` : '';
       h += `<div class="merit-plain"><div class="trait-row">` +
-        `<div class="trait-main"><span class="trait-name">${esc(name)}</span><div class="trait-right">${stateChip(item.state)}</div></div>` +
+        `<div class="trait-main"><span class="trait-name">${esc(name)}</span><div class="trait-right">${stateChip(item.state)}${rmBtn}</div></div>` +
         `<div class="trait-sub">${qual ? `<span class="trait-qual">${esc(qual)}</span>` : ''}${item.notes ? `<span class="trait-qual dim">${esc(item.notes)}</span>` : ''}</div>` +
         `</div></div>`;
     }
@@ -1775,15 +1777,16 @@ export function shRenderEquipment(c, editMode) {
   if (byBucket.armour.length) {
     h += '<div class="sh-sub-title">Armour</div>';
     const baseDefence = calcDefence(c);
-    for (const { item, entry } of byBucket.armour) {
+    for (const { item, entry, idx } of byBucket.armour) {
       const name  = entry.name || item.catalogue_id;
       const parts = [
-        entry.armour_value   != null ? `AR ${entry.armour_value}` : null,
+        entry.armour_value    != null ? `AR ${entry.armour_value}` : null,
         entry.defence_penalty != null ? `Defence ${baseDefence}(${baseDefence - entry.defence_penalty})` : null,
       ].filter(Boolean);
-      const qual = parts.join(' · ');
+      const qual  = parts.join(' · ');
+      const rmBtn = editMode ? `<button class="sk-spec-rm" style="float:right;margin-top:2px" onclick="shRemoveEquip(${idx})" title="Remove">× Remove</button>` : '';
       h += `<div class="merit-plain"><div class="trait-row">` +
-        `<div class="trait-main"><span class="trait-name">${esc(name)}</span><div class="trait-right">${stateChip(item.state)}</div></div>` +
+        `<div class="trait-main"><span class="trait-name">${esc(name)}</span><div class="trait-right">${stateChip(item.state)}${rmBtn}</div></div>` +
         (qual || item.notes ? `<div class="trait-sub">${qual ? `<span class="trait-qual">${esc(qual)}</span>` : ''}${item.notes ? `<span class="trait-qual dim">${esc(item.notes)}</span>` : ''}</div>` : '') +
         `</div></div>`;
     }
@@ -1792,12 +1795,13 @@ export function shRenderEquipment(c, editMode) {
   // ── Equipment (tools / tech) ──
   if (byBucket.equipment.length) {
     h += '<div class="sh-sub-title">Equipment</div>';
-    for (const { item, entry } of byBucket.equipment) {
-      const name = entry.name || item.catalogue_id;
-      const pool = (entry.skill_domain && entry.bonus_dice != null)
+    for (const { item, entry, idx } of byBucket.equipment) {
+      const name  = entry.name || item.catalogue_id;
+      const pool  = (entry.skill_domain && entry.bonus_dice != null)
         ? `${entry.skill_domain} +${entry.bonus_dice} dice` : '';
+      const rmBtn = editMode ? `<button class="sk-spec-rm" style="float:right;margin-top:2px" onclick="shRemoveEquip(${idx})" title="Remove">× Remove</button>` : '';
       h += `<div class="merit-plain"><div class="trait-row">` +
-        `<div class="trait-main"><span class="trait-name">${esc(name)}</span><div class="trait-right">${stateChip(item.state)}</div></div>` +
+        `<div class="trait-main"><span class="trait-name">${esc(name)}</span><div class="trait-right">${stateChip(item.state)}${rmBtn}</div></div>` +
         (pool || item.notes ? `<div class="trait-sub">${pool ? `<span class="trait-qual">${esc(pool)}</span>` : ''}${item.notes ? `<span class="trait-qual dim">${esc(item.notes)}</span>` : ''}</div>` : '') +
         `</div></div>`;
     }
@@ -1806,19 +1810,54 @@ export function shRenderEquipment(c, editMode) {
   // ── Assets ──
   if (assets.length) {
     h += '<div class="sh-sub-title">Assets</div>';
-    for (const asset of assets) {
-      const meta = [
-        asset.location       || null,
+    for (let ai = 0; ai < assets.length; ai++) {
+      const asset  = assets[ai];
+      const meta   = [
+        asset.location          || null,
         asset.mechanical_effect || null,
         cycleLabel(asset.acquired_cycle),
-        asset.notes          || null,
+        asset.notes             || null,
       ].filter(Boolean).join(' · ');
+      const rmBtn  = editMode ? `<button class="sk-spec-rm" style="float:right;margin-top:2px" onclick="shRemoveAsset(${ai})" title="Remove">× Remove</button>` : '';
       h += `<div class="merit-plain"><div class="trait-row">` +
-        `<div class="trait-main"><span class="trait-name">${esc(asset.name)}</span><div class="trait-right"><span class="gen-granted-tag-view">Asset</span></div></div>` +
+        `<div class="trait-main"><span class="trait-name">${esc(asset.name)}</span><div class="trait-right"><span class="gen-granted-tag-view">Asset</span>${rmBtn}</div></div>` +
         `<div class="trait-sub"><span class="trait-qual">${esc(asset.description)}</span></div>` +
         (meta ? `<div class="trait-sub"><span class="trait-qual dim">${esc(meta)}</span></div>` : '') +
         `</div></div>`;
     }
+  }
+
+  // ── Edit-mode add forms ──
+  if (editMode) {
+    const STATES   = ['carried', 'worn', 'stashed', 'active', 'lost'];
+    const BUCKETS  = ['weapon', 'armour', 'equipment'];
+    const defCycle = state.activeCycleNum ?? 0;
+
+    h += '<div class="sh-sub-title" style="margin-top:10px">Add Equipment Item</div>';
+    h += '<div class="dev-add-row" style="display:flex;flex-wrap:wrap;gap:4px;align-items:center;padding:4px 0">'
+      + '<select id="eq-add-bucket" class="dev-add-btn" onchange="shEquipBucketFilter()">'
+      + '<option value="">Bucket…</option>'
+      + BUCKETS.map(b => `<option value="${b}">${b.charAt(0).toUpperCase() + b.slice(1)}</option>`).join('')
+      + '</select>'
+      + '<select id="eq-add-item" class="dev-add-btn"><option value="">-- select bucket first --</option></select>'
+      + '<select id="eq-add-state" class="dev-add-btn">'
+      + STATES.map(s => `<option value="${s}">${STATE_LABELS[s] || s}</option>`).join('')
+      + '</select>'
+      + `<input id="eq-add-cycle" type="number" min="0" value="${defCycle}" style="width:60px" class="attr-bd-input" title="Acquired cycle">`
+      + '<input id="eq-add-notes" type="text" placeholder="Notes (optional)" style="width:130px" class="spec-input">'
+      + '<button class="sk-spec-add" onclick="shAddEquip()">Add</button>'
+      + '</div>';
+
+    h += '<div class="sh-sub-title" style="margin-top:6px">Add Asset</div>';
+    h += '<div class="dev-add-row" style="display:flex;flex-wrap:wrap;gap:4px;align-items:center;padding:4px 0">'
+      + '<input id="asset-add-name"  type="text" placeholder="Name*"         class="spec-input" style="width:120px">'
+      + '<input id="asset-add-desc"  type="text" placeholder="Description*"  class="spec-input" style="width:150px">'
+      + '<input id="asset-add-loc"   type="text" placeholder="Location"      class="spec-input" style="width:100px">'
+      + '<input id="asset-add-mech"  type="text" placeholder="Mech effect"   class="spec-input" style="width:120px">'
+      + `<input id="asset-add-cycle" type="number" min="0" value="${defCycle}" style="width:60px" class="attr-bd-input" title="Acquired cycle">`
+      + '<input id="asset-add-notes" type="text" placeholder="Notes"         class="spec-input" style="width:100px">'
+      + '<button class="sk-spec-add" onclick="shAddAsset()">Add</button>'
+      + '</div>';
   }
 
   h += '</div></div>';

--- a/specs/stories/feature.665.eq4-st-admin-equipment.story.md
+++ b/specs/stories/feature.665.eq4-st-admin-equipment.story.md
@@ -1,6 +1,6 @@
 # Story feature.665: EQ-4 — ST Admin UI for Assigning Equipment to Characters
 
-## Status: review
+## Status: done
 
 ---
 issue: 665

--- a/specs/stories/feature.665.eq4-st-admin-equipment.story.md
+++ b/specs/stories/feature.665.eq4-st-admin-equipment.story.md
@@ -1,0 +1,378 @@
+# Story feature.665: EQ-4 — ST Admin UI for Assigning Equipment to Characters
+
+## Status: review
+
+---
+issue: 665
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/665
+branch: ms/issue-665-eq4-st-admin-equipment
+---
+
+## Story
+
+**As an** ST using the character editor,
+**I want** to add, update, and remove equipment and assets from a character's record,
+**so that** players can see their gear on the sheet and it can influence roll calculator chips (EQ-2 and EQ-3 are already live; EQ-4 makes them visible by giving STs the management UI).
+
+## Background
+
+EQ-1 (#654) added `character.equipment[]` + `character.assets[]` schema and four CRUD API routes. EQ-2 (#656) renders Equipment & Assets read-only on the sheet. EQ-3 (#662) surfaces equipment dice-bonus chips in the roll calculator. No characters have any equipment data yet — EQ-4 is what actually populates the system.
+
+The API is already implemented and tested. EQ-4 is purely a frontend story: extend the edit-mode sheet to show an inline management panel for the Equipment & Assets section.
+
+## Acceptance Criteria
+
+- [ ] Equipment & Assets collapsible section visible in character editor below the Merits section; edit controls appear **only when `editMode = true`**
+- [ ] Existing `equipment[]` entries display resolved catalogue name, bucket, state, acquired_cycle, notes (same as EQ-2 view mode), with a Remove button in edit mode
+- [ ] Add equipment: inline form with bucket select → item select (filtered by bucket) → state select → notes → Add; writes via `POST /api/characters/:id/equipment`
+- [ ] Remove equipment: Remove button at index N calls `DELETE /api/characters/:id/equipment/:N`; panel updates inline without full reload
+- [ ] Existing `assets[]` entries display name, description, meta (same as EQ-2 view mode), with a Remove button in edit mode
+- [ ] Add asset: inline form with name, description, location, mechanical_effect, acquired_cycle, notes → Add; writes via `POST /api/characters/:id/assets`
+- [ ] Remove asset: Remove button at index N calls `DELETE /api/characters/:id/assets/:N`; panel updates inline
+- [ ] `acquired_cycle` input pre-fills with `state.activeCycleNum ?? 0`; ST can override
+- [ ] Panel is absent on player-facing sheet (EQ-2 read-only path unchanged — `shRenderEquipment(c, false)` is unaffected)
+- [ ] Legacy characters with no `equipment`/`assets` fields show an empty section with the add form visible in edit mode (no crash)
+
+## Tasks / Subtasks
+
+- [x] Task 1: Add `activeCycleNum` to `public/js/data/state.js`
+  - [x] Add `activeCycleNum: null` to the state object (after `openExpId`)
+
+- [x] Task 2: Populate `state.activeCycleNum` in `public/js/app.js`
+  - [x] In `_loadLifecycleData()`, after `activeCycle` is resolved, add: `state.activeCycleNum = activeCycle?.game_number ?? null;`
+  - [x] Import `state` at the top of app.js is already present as `editorState` — use `editorState.activeCycleNum = ...`
+
+- [x] Task 3: Modify `shRenderEquipment(c, editMode)` in `public/js/editor/sheet.js`
+  - [x] When `editMode = false`: behaviour identical to current (view-only, no change)
+  - [x] When `editMode = true` AND section is empty: render the section container and both add forms (early return guard changed to `!editMode &&`)
+  - [x] In edit mode, each equipment row gets an inline Remove button
+  - [x] In edit mode, each asset row gets an inline Remove button
+  - [x] At the bottom of the section in edit mode: inline Add Equipment form + inline Add Asset form
+  - [x] `byBucket` loop now tracks original flat-array index (`idx: i`) for correct remove button indices
+
+- [x] Task 4: Add equipment/asset handlers to `public/js/editor/edit.js`
+  - [x] `shAddEquip()` — reads form DOM values, calls `apiPost`, updates `c.equipment`/`c.assets`, calls `_renderSheet(c)`
+  - [x] `shRemoveEquip(idx)` — calls `apiDelete` with zero-based index, updates character, calls `_renderSheet(c)`
+  - [x] `shEquipBucketFilter()` — DOM-only: re-populates `#eq-add-item` options based on `#eq-add-bucket` value; NO re-render
+  - [x] `shAddAsset()` — reads form DOM values, calls `apiPost`, updates `c.equipment`/`c.assets`, calls `_renderSheet(c)`
+  - [x] `shRemoveAsset(idx)` — calls `apiDelete` with zero-based index, updates character, calls `_renderSheet(c)`
+  - [x] Export all five new functions; `getCatalogueByBucket` imported from `../data/equipment-data.js`
+
+- [x] Task 5: Wire new handlers into `public/js/app.js`
+  - [x] Added `shAddEquip, shRemoveEquip, shEquipBucketFilter, shAddAsset, shRemoveAsset` to the `import { ... } from './editor/edit.js'` block
+  - [x] Added all five to the `window` export block
+
+- [x] Task 6: Playwright E2E tests — `tests/feature-665-eq4-st-admin-equipment.spec.js`
+  - [x] 10 tests: 10/10 passing (20.0s); EQ-1/2/3 regressions: 30/30 clean
+
+---
+
+## Dev Notes
+
+### CRITICAL: DELETE routes use zero-based index, not catalogueId
+
+The issue body incorrectly describes the DELETE route as `DELETE .../equipment/:catalogueId`. The **actual** routes are:
+
+```
+DELETE /api/characters/:id/equipment/:itemIndex   ← zero-based array position
+DELETE /api/characters/:id/assets/:itemIndex      ← zero-based array position
+```
+
+Do NOT pass `catalogue_id` as the URL param. Pass the item's array index. The API comment says "Client must refresh after delete to avoid stale indices" — this is already handled by re-rendering from the API response.
+
+### API response shape
+
+Every mutation endpoint returns the full updated arrays:
+```json
+{ "equipment": [...], "assets": [...] }
+```
+
+After a successful POST or DELETE, update the in-memory character with these arrays before re-rendering:
+```js
+c.equipment = result.equipment;
+c.assets    = result.assets;
+_renderSheet(c);
+```
+
+### Async handler pattern (follow touchstone model)
+
+Do NOT use `_markDirty()` — these write directly to the server and update local state from the response. The pattern to follow is `shTouchstoneRemove` / `shTouchstoneSaveAdd` in `edit.js`:
+
+```js
+export async function shRemoveEquip(idx) {
+  if (state.editIdx < 0) return;
+  const c = state.chars[state.editIdx];
+  const charId = String(c._id);
+  try {
+    const result = await apiDelete('/api/characters/' + charId + '/equipment/' + idx);
+    c.equipment = result.equipment;
+    c.assets    = result.assets;
+    _renderSheet(c);
+  } catch (err) {
+    console.error('[equipment] remove error:', err);
+  }
+}
+
+export async function shAddEquip() {
+  if (state.editIdx < 0) return;
+  const c = state.chars[state.editIdx];
+  const charId = String(c._id);
+  const catalogueId = document.getElementById('eq-add-item')?.value;
+  const itemState   = document.getElementById('eq-add-state')?.value;
+  const notes       = document.getElementById('eq-add-notes')?.value || null;
+  if (!catalogueId || !itemState) return;
+  const cycle = parseInt(document.getElementById('eq-add-cycle')?.value ?? '0', 10) || 0;
+  try {
+    const result = await apiPost('/api/characters/' + charId + '/equipment', {
+      catalogue_id:   catalogueId,
+      state:          itemState,
+      acquired_cycle: cycle,
+      notes,
+    });
+    c.equipment = result.equipment;
+    c.assets    = result.assets;
+    _renderSheet(c);
+  } catch (err) {
+    console.error('[equipment] add error:', err);
+  }
+}
+```
+
+Model `shRemoveAsset` and `shAddAsset` on the same pattern.
+
+### `shEquipBucketFilter()` — no re-render, DOM only
+
+This function is called by the bucket select's `onchange`. It re-populates the item dropdown without triggering a full sheet re-render:
+
+```js
+export function shEquipBucketFilter() {
+  const bucket  = document.getElementById('eq-add-bucket')?.value;
+  const itemSel = document.getElementById('eq-add-item');
+  if (!itemSel) return;
+  const entries = bucket ? getCatalogueByBucket(bucket) : [];
+  itemSel.innerHTML = '<option value="">-- select item --</option>'
+    + entries.map(e => `<option value="${e.id}">${e.name}</option>`).join('');
+}
+```
+
+Import `getCatalogueByBucket` in `edit.js`:
+```js
+import { getCatalogueByBucket } from '../data/equipment-data.js';
+```
+
+### `shRenderEquipment` edit-mode changes
+
+Current EQ-2 implementation: `editMode` is checked but falls through to the same read-only path. EQ-4 changes this.
+
+**Key change 1**: Early return guard. Current code:
+```js
+if (!equip.length && !assets.length) return '';
+```
+In edit mode this must NOT return early — the section still needs to render with the add forms. Change to:
+```js
+if (!editMode && !equip.length && !assets.length) return '';
+```
+
+**Key change 2**: Remove buttons on each item row. Add at the end of each `merit-plain` row in edit mode:
+```js
+const rmBtn = editMode
+  ? `<button class="sk-spec-rm" style="float:right;margin-top:2px" onclick="shRemoveEquip(${idx})" title="Remove">× Remove</button>`
+  : '';
+```
+The index `idx` is the position in the `equip` array (not the bucket sub-array). Track with a counter incremented for each item across all three buckets.
+
+**Key change 3**: Asset remove buttons. Track asset index separately:
+```js
+const rmAssetBtn = editMode
+  ? `<button class="sk-spec-rm" style="float:right;margin-top:2px" onclick="shRemoveAsset(${assetIdx})" title="Remove">× Remove</button>`
+  : '';
+```
+
+**Key change 4**: Add forms at the bottom of the section in edit mode. After the asset rendering block, before closing `</div></div>`:
+
+```js
+if (editMode) {
+  const STATES = ['carried', 'worn', 'stashed', 'active', 'lost'];
+  const BUCKETS = ['weapon', 'armour', 'equipment'];
+  const defaultCycle = state.activeCycleNum ?? 0;
+
+  h += '<div class="sh-sub-title" style="margin-top:10px">Add Equipment Item</div>';
+  h += '<div class="dev-add-row" style="display:flex;flex-wrap:wrap;gap:4px;align-items:center">'
+    + '<select id="eq-add-bucket" class="dev-add-btn" onchange="shEquipBucketFilter()">'
+    + '<option value="">Bucket…</option>'
+    + BUCKETS.map(b => `<option value="${b}">${b.charAt(0).toUpperCase() + b.slice(1)}</option>`).join('')
+    + '</select>'
+    + '<select id="eq-add-item" class="dev-add-btn"><option value="">-- select bucket first --</option></select>'
+    + '<select id="eq-add-state" class="dev-add-btn">'
+    + STATES.map(s => `<option value="${s}">${STATE_LABELS[s] || s}</option>`).join('')
+    + '</select>'
+    + '<input id="eq-add-cycle" type="number" min="0" value="' + defaultCycle + '" style="width:60px" class="attr-bd-input" title="Acquired cycle">'
+    + '<input id="eq-add-notes" type="text" placeholder="Notes (optional)" style="width:130px" class="spec-input">'
+    + '<button class="sk-spec-add" onclick="shAddEquip()">Add</button>'
+    + '</div>';
+
+  h += '<div class="sh-sub-title" style="margin-top:10px">Add Asset</div>';
+  h += '<div class="dev-add-row" style="display:flex;flex-wrap:wrap;gap:4px;align-items:center">'
+    + '<input id="asset-add-name"  type="text" placeholder="Name*"        class="spec-input" style="width:120px">'
+    + '<input id="asset-add-desc"  type="text" placeholder="Description*" class="spec-input" style="width:150px">'
+    + '<input id="asset-add-loc"   type="text" placeholder="Location"     class="spec-input" style="width:100px">'
+    + '<input id="asset-add-mech"  type="text" placeholder="Mech effect"  class="spec-input" style="width:120px">'
+    + '<input id="asset-add-cycle" type="number" min="0" value="' + defaultCycle + '" style="width:60px" class="attr-bd-input" title="Acquired cycle">'
+    + '<input id="asset-add-notes" type="text" placeholder="Notes"        class="spec-input" style="width:100px">'
+    + '<button class="sk-spec-add" onclick="shAddAsset()">Add</button>'
+    + '</div>';
+}
+```
+
+Note: `state` is already imported in `sheet.js` (`import state from '../data/state.js'`). No new import needed for state access.
+
+`shAddAsset()` in `edit.js`:
+```js
+export async function shAddAsset() {
+  if (state.editIdx < 0) return;
+  const c = state.chars[state.editIdx];
+  const charId = String(c._id);
+  const name  = document.getElementById('asset-add-name')?.value?.trim();
+  const desc  = document.getElementById('asset-add-desc')?.value?.trim();
+  if (!name || !desc) return;
+  const cycle = parseInt(document.getElementById('asset-add-cycle')?.value ?? '0', 10) || 0;
+  try {
+    const result = await apiPost('/api/characters/' + charId + '/assets', {
+      name,
+      description:       desc,
+      location:          document.getElementById('asset-add-loc')?.value?.trim()  || null,
+      mechanical_effect: document.getElementById('asset-add-mech')?.value?.trim() || null,
+      acquired_cycle:    cycle,
+      notes:             document.getElementById('asset-add-notes')?.value?.trim() || null,
+    });
+    c.equipment = result.equipment;
+    c.assets    = result.assets;
+    _renderSheet(c);
+  } catch (err) {
+    console.error('[asset] add error:', err);
+  }
+}
+```
+
+### Item index tracking across buckets
+
+The `equip` array is flat. The three rendered bucket sub-sections (weapon, armour, equipment) display items from that same flat array. When building the HTML, you must track the original flat-array index for each item so the Remove button passes the correct index to `shRemoveEquip(idx)`.
+
+Pattern — when iterating to build `byBucket`:
+```js
+const byBucket = { weapon: [], armour: [], equipment: [] };
+for (let i = 0; i < equip.length; i++) {
+  const item  = equip[i];
+  const entry = getCatalogueEntry(item.catalogue_id) || {};
+  const bucket = (entry.bucket && byBucket[entry.bucket]) ? entry.bucket : 'equipment';
+  byBucket[bucket].push({ item, entry, idx: i });  // ← store original index
+}
+```
+
+Then in the render loop:
+```js
+for (const { item, entry, idx } of byBucket.weapon) {
+  // ... build HTML, use idx in remove button
+  const rmBtn = editMode ? `<button class="sk-spec-rm" ... onclick="shRemoveEquip(${idx})">...` : '';
+}
+```
+
+Asset remove buttons track array index the same way using a counter `assetIdx` in the assets loop.
+
+### CSS — do not invent new classes
+
+All required classes already exist in `public/css/suite.css` and/or `public/css/admin-layout.css`:
+- `.sh-sub-title` — sub-section header (already used by EQ-2)
+- `.merit-plain` / `.trait-row` / `.trait-main` / `.trait-right` / `.trait-name` / `.trait-qual` — row styles (EQ-2)
+- `.sk-spec-rm` — small red remove button (used by spec/style remove buttons throughout editor)
+- `.sk-spec-add` — small add button (used by spec add buttons)
+- `.dev-add-row` / `.dev-add-btn` — add-row container + dropdown style (used by manoeuvres/styles add dropdowns)
+- `.attr-bd-input` — small number input (used by attr/skill CP/XP inputs)
+- `.spec-input` — small text input (used by spec add inputs)
+- `.gen-granted-tag-view` — state chip (already used by EQ-2)
+
+Do NOT add any CSS to any stylesheet.
+
+### state.js addition
+
+```js
+const state = {
+  chars: [],
+  editIdx: -1,
+  dirty: new Set(),
+  editMode: false,
+  openExpId: null,
+  activeCycleNum: null,   // ← NEW: populated by app.js from lifecycle load
+};
+```
+
+### app.js — activeCycleNum population
+
+In `_loadLifecycleData()` (around line 2138), after `activeCycle` is resolved:
+
+```js
+const activeCycle = Array.isArray(cycles)
+  ? cycles.find(c => c.status === 'open' || c.status === 'active') || null
+  : null;
+editorState.activeCycleNum = activeCycle?.game_number ?? null;  // ← NEW line
+```
+
+`editorState` is already imported at the top of `app.js` as `import editorState from './data/state.js';`.
+
+### Import change in sheet.js
+
+Current import (line ~1 of `shRenderEquipment` setup):
+```js
+import { getCatalogueEntry } from '../data/equipment-data.js';
+```
+Change to:
+```js
+import { getCatalogueEntry, getCatalogueByBucket } from '../data/equipment-data.js';
+```
+`getCatalogueByBucket` is already exported from `equipment-data.js` (line ~870 of that file).
+
+`getCatalogueByBucket` is only needed in `edit.js` via `shEquipBucketFilter()`. But if the render-side uses it too (for rendering the add form), import in sheet.js. Given the add form builds the bucket dropdown from a static list of strings and the item dropdown is populated by `shEquipBucketFilter()` on demand (DOM-only), `sheet.js` does NOT need `getCatalogueByBucket`. Only `edit.js` does.
+
+**Final import list:**
+- `sheet.js`: no import change needed (uses `getCatalogueEntry` already)
+- `edit.js`: add `import { getCatalogueByBucket } from '../data/equipment-data.js';`
+
+### Player-facing sheet guard
+
+`public/js/suite/sheet.js` calls `shRenderEquipment(c, false)` — always view mode. EQ-4 changes to `shRenderEquipment` are all gated behind `editMode`, so the suite sheet is unaffected.
+
+---
+
+## Playwright Test Plan (10 tests)
+
+Test file: `tests/feature-665-eq4-st-admin-equipment.spec.js`
+
+Boot pattern: use `bootAdmin()` helper (or equivalent ST-auth setup) — the equipment CRUD routes require `requireRole('st')`. All tests work against a character seeded with equipment data or none.
+
+| # | AC | Test description |
+|---|---|---|
+| 1 | AC-1 | Equipment & Assets section visible in editor edit mode |
+| 2 | AC-1 | Section not present in edit mode on player-facing suite sheet (shRenderEquipment called with false) |
+| 3 | AC-2 | Existing equipment entry shows resolved name, state chip, notes |
+| 4 | AC-3 | Add equipment: select bucket → item populates → select item + state → Add → row appears |
+| 5 | AC-4 | Remove equipment: Remove button → item disappears from panel |
+| 6 | AC-5 | Existing asset entry shows name, description, meta |
+| 7 | AC-6 | Add asset: fill name+description+cycle → Add → asset row appears |
+| 8 | AC-7 | Remove asset: Remove button → asset disappears |
+| 9 | AC-8 | acquired_cycle input pre-fills with numeric value (>= 0) |
+| 10 | AC-10 | Legacy character (no equipment/assets): section still shows add forms in edit mode, no crash |
+
+**Important test pattern note (from EQ-3 QA findings):** Always separate `goTab` into its own `page.evaluate` call followed by `waitForSelector('#t-<tab>.active')`, never combined with `loadPool` or other calls. See `tests/helpers/unified-app.js` `goToTab` pattern.
+
+For admin tests: use `localTestLogin()` bypass (or the equivalent `window.localTestLogin()` call in page.evaluate) to get ST auth before interacting with the editor.
+
+---
+
+## File List
+
+- `public/js/data/state.js` — MODIFY (add `activeCycleNum: null`)
+- `public/js/app.js` — MODIFY (set `editorState.activeCycleNum` in `_loadLifecycleData`; add 5 handler imports; add 5 window exports)
+- `public/js/editor/sheet.js` — MODIFY (edit-mode guard on early return; index tracking in byBucket; remove buttons on each row; add forms in edit mode)
+- `public/js/editor/edit.js` — MODIFY (add `getCatalogueByBucket` import; add `shAddEquip`, `shRemoveEquip`, `shEquipBucketFilter`, `shAddAsset`, `shRemoveAsset`)
+- `tests/feature-665-eq4-st-admin-equipment.spec.js` — NEW (10 Playwright E2E tests, 10/10 passing)
+- `tests/feature-656-eq2-equipment-sheet.spec.js` — MODIFY (updated AC-10 assertion to reflect EQ-4 edit mode additions)

--- a/tests/feature-656-eq2-equipment-sheet.spec.js
+++ b/tests/feature-656-eq2-equipment-sheet.spec.js
@@ -240,7 +240,7 @@ test.describe('feature.656 EQ-2 — Equipment & Assets sheet display', () => {
     expect(html).toContain('Stashed');
   });
 
-  test('AC-10: edit mode shows same read-only view with no inline inputs', async ({ page }) => {
+  test('AC-10: edit mode still shows item name and state chip (EQ-4 adds management controls)', async ({ page }) => {
     const char = buildChar({
       equipment: [
         { catalogue_id: 'knife', state: 'carried', acquired_cycle: 1, notes: null },
@@ -248,19 +248,25 @@ test.describe('feature.656 EQ-2 — Equipment & Assets sheet display', () => {
     });
     await setupSuite(page, char);
 
-    // Render in edit mode via the editor's sheet function directly
+    // EQ-4 adds remove buttons + add forms in edit mode; old flat-schema inputs remain absent.
     const result = await page.evaluate(async (c) => {
       const { shRenderEquipment } = await import('/js/editor/sheet.js');
       const html = shRenderEquipment(c, true /* editMode */);
-      const hasInputs = /<input|<select/.test(html);
-      const hasAddBtn = /add.*equip|shAddEquip/i.test(html);
-      return { html, hasInputs, hasAddBtn };
+      return {
+        hasItem:      html.includes('Knife'),
+        hasStateChip: html.includes('Carried'),
+        hasRemoveBtn: html.includes('shRemoveEquip'),
+        hasAddForm:   html.includes('shAddEquip'),
+        // Old flat-schema inputs must not exist
+        hasOldInputs: /type="text".*damage_rating|attack_skill|general_ar/.test(html),
+      };
     }, char);
 
-    expect(result.hasInputs).toBe(false);
-    expect(result.hasAddBtn).toBe(false);
-    expect(result.html).toContain('Knife');
-    expect(result.html).toContain('Carried');
+    expect(result.hasItem).toBe(true);
+    expect(result.hasStateChip).toBe(true);
+    expect(result.hasRemoveBtn).toBe(true);
+    expect(result.hasAddForm).toBe(true);
+    expect(result.hasOldInputs).toBe(false);
   });
 
 });

--- a/tests/feature-665-eq4-st-admin-equipment.spec.js
+++ b/tests/feature-665-eq4-st-admin-equipment.spec.js
@@ -1,0 +1,344 @@
+/**
+ * E2E tests — feature.665 EQ-4: ST admin UI for assigning equipment to characters.
+ *
+ * Tests cover the edit-mode management panel added to shRenderEquipment():
+ * remove buttons on existing items, inline add forms for equipment and assets,
+ * bucket filter DOM manipulation, and CRUD handler behaviour.
+ *
+ * Covered:
+ *   AC-1   Equipment & Assets section renders in edit mode (even when empty)
+ *   AC-2   Player-facing suite sheet still absent when no items (view mode guard unchanged)
+ *   AC-3   Existing equipment entry shows name, state, notes in edit mode
+ *   AC-4   Add equipment form present; bucket filter populates item select
+ *   AC-5   Remove button present for equipment items, correct index
+ *   AC-6   Existing asset entry shows name + description in edit mode
+ *   AC-7   Add asset form present with all fields
+ *   AC-8   Remove button present for asset items, correct index
+ *   AC-9   acquired_cycle input pre-fills with a non-negative integer
+ *   AC-10  Legacy character (no equipment/assets): section renders with add forms, no crash
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Character builder ─────────────────────────────────────────────────────────
+
+function buildChar(overrides = {}) {
+  return {
+    _id: 'char-eq665-001',
+    name: 'EQ4 Admin Tester',
+    moniker: null, honorific: null,
+    clan: 'Mekhet', covenant: 'Invictus', player: 'Test ST',
+    blood_potency: 1, humanity: 7, humanity_base: 7,
+    court_title: null, retired: false,
+    status: { city: 1, clan: 1, covenant: {} },
+    attributes: {
+      Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+      Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+      Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+    },
+    skills: {}, disciplines: {}, merits: [], powers: [], ordeals: [],
+    xp_log: { spent: 0 },
+    ...overrides,
+  };
+}
+
+const ST_USER = {
+  id: '777000665', username: 'test_st665', global_name: 'Test ST 665',
+  avatar: null, role: 'st', player_id: 'p-fix665',
+  character_ids: ['char-eq665-001'], is_dual_role: false,
+};
+
+// ── Base route setup ──────────────────────────────────────────────────────────
+
+async function setupPage(page, char) {
+  await page.addInitScript((u) => {
+    localStorage.removeItem('tm-mode');
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 36000000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(u));
+  }, ST_USER);
+
+  await page.route('**/api/**', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.route('**/api/auth/me', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(ST_USER) })
+  );
+  await page.route(/\/api\/characters$/, r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([char]) })
+  );
+  await page.route('**/api/characters/names', r =>
+    r.fulfill({ status: 200, contentType: 'application/json',
+      body: JSON.stringify([{ _id: char._id, name: char.name, moniker: null, honorific: null }]) })
+  );
+  await page.route(new RegExp(`/api/characters/${char._id}$`), r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(char) })
+  );
+  await page.route('**/api/rules', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+
+  await page.goto('/');
+  await page.waitForSelector('#app', { state: 'visible', timeout: 15000 });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('feature.665 EQ-4 — ST admin equipment management UI', () => {
+
+  // ── AC-1: Section renders in edit mode even when no items ───────────────────
+
+  test('AC-10: legacy char (no equipment/assets) renders section with add forms in edit mode', async ({ page }) => {
+    const char = buildChar(); // no equipment or assets
+    await setupPage(page, char);
+
+    const result = await page.evaluate(async (c) => {
+      const { shRenderEquipment } = await import('/js/editor/sheet.js');
+      const html = shRenderEquipment(c, true);
+      return {
+        hasSectionTitle: html.includes('Equipment &amp; Assets'),
+        hasAddEquipForm: html.includes('shAddEquip'),
+        hasAddAssetForm: html.includes('shAddAsset'),
+        hasError: html.toLowerCase().includes('error') || html.includes('undefined'),
+      };
+    }, char);
+
+    expect(result.hasSectionTitle).toBe(true);
+    expect(result.hasAddEquipForm).toBe(true);
+    expect(result.hasAddAssetForm).toBe(true);
+    expect(result.hasError).toBe(false);
+  });
+
+  // ── AC-2: View mode guard unchanged ────────────────────────────────────────
+
+  test('AC-2: view mode still returns empty string when character has no items', async ({ page }) => {
+    const char = buildChar();
+    await setupPage(page, char);
+
+    const html = await page.evaluate(async (c) => {
+      const { shRenderEquipment } = await import('/js/editor/sheet.js');
+      return shRenderEquipment(c, false);
+    }, char);
+
+    expect(html).toBe('');
+  });
+
+  // ── AC-3: Existing equipment renders correctly in edit mode ─────────────────
+
+  test('AC-3: existing equipment entry shows resolved name, state chip in edit mode', async ({ page }) => {
+    const char = buildChar({
+      equipment: [
+        { catalogue_id: 'machete', state: 'carried', acquired_cycle: 3, notes: 'Sharpened' },
+      ],
+    });
+    await setupPage(page, char);
+
+    const result = await page.evaluate(async (c) => {
+      const { shRenderEquipment } = await import('/js/editor/sheet.js');
+      const html = shRenderEquipment(c, true);
+      return {
+        hasName:  html.includes('Machete'),
+        hasState: html.includes('Carried'),
+        hasNotes: html.includes('Sharpened'),
+      };
+    }, char);
+
+    expect(result.hasName).toBe(true);
+    expect(result.hasState).toBe(true);
+    expect(result.hasNotes).toBe(true);
+  });
+
+  // ── AC-4: Add equipment form + bucket filter ────────────────────────────────
+
+  test('AC-4: add equipment form has bucket select, item select, state select, Add button', async ({ page }) => {
+    const char = buildChar();
+    await setupPage(page, char);
+
+    const result = await page.evaluate(async (c) => {
+      const { shRenderEquipment } = await import('/js/editor/sheet.js');
+      const html = shRenderEquipment(c, true);
+      return {
+        hasBucketSel: html.includes('eq-add-bucket'),
+        hasItemSel:   html.includes('eq-add-item'),
+        hasStateSel:  html.includes('eq-add-state'),
+        hasCycleIn:   html.includes('eq-add-cycle'),
+        hasNotesIn:   html.includes('eq-add-notes'),
+        hasAddBtn:    html.includes('shAddEquip()'),
+        bucketOptions: ['weapon', 'armour', 'equipment'].every(b => html.includes(b)),
+      };
+    }, char);
+
+    expect(result.hasBucketSel).toBe(true);
+    expect(result.hasItemSel).toBe(true);
+    expect(result.hasStateSel).toBe(true);
+    expect(result.hasCycleIn).toBe(true);
+    expect(result.hasNotesIn).toBe(true);
+    expect(result.hasAddBtn).toBe(true);
+    expect(result.bucketOptions).toBe(true);
+  });
+
+  test('AC-4: shEquipBucketFilter populates item select with weapons when bucket=weapon', async ({ page }) => {
+    const char = buildChar();
+    await setupPage(page, char);
+
+    // Inject the add-form DOM so shEquipBucketFilter has elements to manipulate
+    const weaponCount = await page.evaluate(async (c) => {
+      const { shRenderEquipment } = await import('/js/editor/sheet.js');
+      const html = shRenderEquipment(c, true);
+      const container = document.createElement('div');
+      container.innerHTML = html;
+      document.body.appendChild(container);
+
+      const bucketSel = document.getElementById('eq-add-bucket');
+      const itemSel   = document.getElementById('eq-add-item');
+      if (!bucketSel || !itemSel) return -1;
+
+      bucketSel.value = 'weapon';
+      const { shEquipBucketFilter } = await import('/js/editor/edit.js');
+      shEquipBucketFilter();
+
+      const count = itemSel.options.length - 1; // subtract the "-- select --" placeholder
+      document.body.removeChild(container);
+      return count;
+    }, char);
+
+    // Catalogue has weapons; should be > 0
+    expect(weaponCount).toBeGreaterThan(0);
+  });
+
+  // ── AC-5: Remove buttons present with correct index ─────────────────────────
+
+  test('AC-5: remove buttons present for each equipment item with correct index', async ({ page }) => {
+    const char = buildChar({
+      equipment: [
+        { catalogue_id: 'knife',   state: 'carried', acquired_cycle: 1, notes: null },
+        { catalogue_id: 'machete', state: 'carried', acquired_cycle: 1, notes: null },
+      ],
+    });
+    await setupPage(page, char);
+
+    const result = await page.evaluate(async (c) => {
+      const { shRenderEquipment } = await import('/js/editor/sheet.js');
+      const html = shRenderEquipment(c, true);
+      return {
+        hasRemove0: html.includes('shRemoveEquip(0)'),
+        hasRemove1: html.includes('shRemoveEquip(1)'),
+        removeCount: (html.match(/shRemoveEquip\(/g) || []).length,
+      };
+    }, char);
+
+    expect(result.hasRemove0).toBe(true);
+    expect(result.hasRemove1).toBe(true);
+    expect(result.removeCount).toBe(2);
+  });
+
+  // ── AC-6: Existing asset entry in edit mode ─────────────────────────────────
+
+  test('AC-6: existing asset entry shows name and description in edit mode', async ({ page }) => {
+    const char = buildChar({
+      assets: [{
+        name: 'Safe House',
+        description: 'A rented flat in Surry Hills.',
+        location: 'Surry Hills',
+        mechanical_effect: null,
+        acquired_cycle: 4,
+        notes: null,
+      }],
+    });
+    await setupPage(page, char);
+
+    const result = await page.evaluate(async (c) => {
+      const { shRenderEquipment } = await import('/js/editor/sheet.js');
+      const html = shRenderEquipment(c, true);
+      return {
+        hasName: html.includes('Safe House'),
+        hasDesc: html.includes('rented flat'),
+        hasMeta: html.includes('Surry Hills'),
+      };
+    }, char);
+
+    expect(result.hasName).toBe(true);
+    expect(result.hasDesc).toBe(true);
+    expect(result.hasMeta).toBe(true);
+  });
+
+  // ── AC-7: Add asset form present ────────────────────────────────────────────
+
+  test('AC-7: add asset form has all required fields', async ({ page }) => {
+    const char = buildChar();
+    await setupPage(page, char);
+
+    const result = await page.evaluate(async (c) => {
+      const { shRenderEquipment } = await import('/js/editor/sheet.js');
+      const html = shRenderEquipment(c, true);
+      return {
+        hasNameIn:  html.includes('asset-add-name'),
+        hasDescIn:  html.includes('asset-add-desc'),
+        hasLocIn:   html.includes('asset-add-loc'),
+        hasMechIn:  html.includes('asset-add-mech'),
+        hasCycleIn: html.includes('asset-add-cycle'),
+        hasNotesIn: html.includes('asset-add-notes'),
+        hasAddBtn:  html.includes('shAddAsset()'),
+      };
+    }, char);
+
+    expect(result.hasNameIn).toBe(true);
+    expect(result.hasDescIn).toBe(true);
+    expect(result.hasLocIn).toBe(true);
+    expect(result.hasMechIn).toBe(true);
+    expect(result.hasCycleIn).toBe(true);
+    expect(result.hasNotesIn).toBe(true);
+    expect(result.hasAddBtn).toBe(true);
+  });
+
+  // ── AC-8: Remove button for assets with correct index ──────────────────────
+
+  test('AC-8: remove buttons present for each asset with correct index', async ({ page }) => {
+    const char = buildChar({
+      assets: [
+        { name: 'A1', description: 'First', location: null, mechanical_effect: null, acquired_cycle: 1, notes: null },
+        { name: 'A2', description: 'Second', location: null, mechanical_effect: null, acquired_cycle: 2, notes: null },
+      ],
+    });
+    await setupPage(page, char);
+
+    const result = await page.evaluate(async (c) => {
+      const { shRenderEquipment } = await import('/js/editor/sheet.js');
+      const html = shRenderEquipment(c, true);
+      return {
+        hasRemove0: html.includes('shRemoveAsset(0)'),
+        hasRemove1: html.includes('shRemoveAsset(1)'),
+        removeCount: (html.match(/shRemoveAsset\(/g) || []).length,
+      };
+    }, char);
+
+    expect(result.hasRemove0).toBe(true);
+    expect(result.hasRemove1).toBe(true);
+    expect(result.removeCount).toBe(2);
+  });
+
+  // ── AC-9: acquired_cycle pre-fills ──────────────────────────────────────────
+
+  test('AC-9: acquired_cycle inputs pre-fill with a non-negative integer', async ({ page }) => {
+    const char = buildChar();
+    await setupPage(page, char);
+
+    const result = await page.evaluate(async (c) => {
+      const { shRenderEquipment } = await import('/js/editor/sheet.js');
+      const html = shRenderEquipment(c, true);
+      // Extract value="N" from the eq-add-cycle input
+      const eqMatch    = html.match(/id="eq-add-cycle"[^>]*value="(\d+)"/);
+      const assetMatch = html.match(/id="asset-add-cycle"[^>]*value="(\d+)"/);
+      return {
+        eqCycle:    eqMatch    ? parseInt(eqMatch[1], 10)    : null,
+        assetCycle: assetMatch ? parseInt(assetMatch[1], 10) : null,
+      };
+    }, char);
+
+    expect(result.eqCycle).not.toBeNull();
+    expect(result.eqCycle).toBeGreaterThanOrEqual(0);
+    expect(result.assetCycle).not.toBeNull();
+    expect(result.assetCycle).toBeGreaterThanOrEqual(0);
+  });
+
+});


### PR DESCRIPTION
## Summary

- Adds edit-mode management panel to `shRenderEquipment()` so STs can assign equipment and assets to characters without needing direct DB access
- Equipment add form: bucket select → filtered item dropdown → state, cycle, notes → writes via `POST /api/characters/:id/equipment`
- Asset add form: name, description, location, mech effect, cycle, notes → writes via `POST /api/characters/:id/assets`
- Remove buttons on every existing item row (zero-based array index passed to `DELETE .../equipment/:N` / `.../assets/:N`)
- Threads `state.activeCycleNum` from lifecycle load so the acquired-cycle input pre-fills with the current game number

## Closes

- Closes #665

## Story

- specs/stories/feature.665.eq4-st-admin-equipment.story.md

## Test plan

- [x] 10/10 EQ-4 Playwright tests passing (`tests/feature-665-eq4-st-admin-equipment.spec.js`)
- [x] 40/40 full equipment epic regression clean (EQ-1/2/3/4 specs)
- [ ] Smoke: open a character in editor edit mode, confirm Equipment & Assets section appears with add forms; assign an item; verify it appears on the sheet

## Branch flow

- From: `ms/issue-665-eq4-st-admin-equipment`
- Into: `dev`