### PR TITLE
fix(685): shared domain merit min-dot gate + three-tier dot display

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -780,6 +780,7 @@ html:not([data-theme="dark"]) .edit-icon {
 .trait-main{display:flex;align-items:center;justify-content:space-between;gap:6px;}
 .trait-name{font-family:var(--fl);font-size:11px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--label-secondary);}
 .trait-dots{font-size:15px;color:var(--accent);letter-spacing:2.5px;line-height:1;flex-shrink:0;}
+.dot-shared{text-decoration:underline;}
 .trait-sub{display:flex;align-items:center;gap:4px;}
 .trait-qual{font-family:var(--fl);font-size:11px;letter-spacing:.04em;color:var(--txt2);flex:1;}
 .trait-right{display:flex;align-items:center;gap:6px;flex-shrink:0;}

--- a/public/js/data/rules-helpers.js
+++ b/public/js/data/rules-helpers.js
@@ -230,11 +230,13 @@ export function resolveSharingScope(scope, c, chars, rule) {
 export function synthesiseCollectiveOwners(scope, c, chars, _rule) {
   if (!scope || !scope.merit) return null;
   const minDots = scope.min_dots == null ? 1 : scope.min_dots;
+  const scopeMerit = scope.merit.trim().toLowerCase();
   const list = Array.isArray(chars) ? chars : [];
   const owners = list.filter(other => {
     if (!other || !Array.isArray(other.merits)) return false;
     return other.merits.some(m =>
-      m && m.name === scope.merit && ((m.cp || 0) + (m.xp || 0)) >= minDots
+      m && typeof m.name === 'string' && m.name.trim().toLowerCase() === scopeMerit
+        && ((m.cp || 0) + (m.xp || 0)) >= minDots
     );
   });
   if (!owners.includes(c)) return null;

--- a/public/js/editor/domain.js
+++ b/public/js/editor/domain.js
@@ -75,17 +75,19 @@ function domMeritTotalSingle(c, m) {
   const partners = m.shared_with || [];
   const key = domKey(m);
   let partnerTotal = 0;
-  for (const pName of partners) {
-    const p = (state.chars || []).find(ch => ch.name === pName);
-    if (p) {
-      const pm = (p.merits || []).find(pm2 =>
-        pm2.category === 'domain' && pm2.name === m.name && domKey(pm2) === key
-      );
-      if (pm) partnerTotal += domMeritShareableSingle(pm);
+  if (own >= 1) {
+    for (const pName of partners) {
+      const p = (state.chars || []).find(ch => ch.name === pName);
+      if (p) {
+        const pm = (p.merits || []).find(pm2 =>
+          pm2.category === 'domain' && pm2.name === m.name && domKey(pm2) === key
+        );
+        if (pm) partnerTotal += domMeritShareableSingle(pm);
+      }
     }
-  }
-  if (partners.length > 0 && partnerTotal === 0 && m._partner_dots > 0) {
-    partnerTotal = m._partner_dots;
+    if (partners.length > 0 && partnerTotal === 0 && m._partner_dots > 0) {
+      partnerTotal = m._partner_dots;
+    }
   }
   return Math.min(5, own + partnerTotal);
 }
@@ -177,15 +179,17 @@ export function domMeritTotal(c, name) {
   const own = domMeritContribSingle(c, m);
   const partners = m.shared_with || [];
   let partnerTotal = 0;
-  for (const pName of partners) {
-    const p = (state.chars || []).find(ch => ch.name === pName);
-    if (p) partnerTotal += domMeritShareable(p, name);
-  }
-  // Fallback: if no partner chars were found in state.chars (player portal
-  // only has the player's own characters), use _partner_dots which the
-  // server pre-computed on the ?mine=1 fetch path.
-  if (partners.length > 0 && partnerTotal === 0 && m._partner_dots > 0) {
-    partnerTotal = m._partner_dots;
+  if (own >= 1) {
+    for (const pName of partners) {
+      const p = (state.chars || []).find(ch => ch.name === pName);
+      if (p) partnerTotal += domMeritShareable(p, name);
+    }
+    // Fallback: if no partner chars were found in state.chars (player portal
+    // only has the player's own characters), use _partner_dots which the
+    // server pre-computed on the ?mine=1 fetch path.
+    if (partners.length > 0 && partnerTotal === 0 && m._partner_dots > 0) {
+      partnerTotal = m._partner_dots;
+    }
   }
   const total = own + partnerTotal;
   // Herd can exceed 5 when Flock is present
@@ -298,6 +302,7 @@ export function meritEffectiveRating(c, m) {
 export function domMeritAccess(c, name) {
   const own = domMeritTotal(c, name);
   if (own > 0) return own;
+  if (domMeritContrib(c, name) < 1) return 0;
   for (const partner of (state.chars || [])) {
     const pm = (partner.merits || []).find(m =>
       m.category === 'domain' && m.name === name &&

--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -141,6 +141,15 @@ function shDotsMixed(purchased, bonus) {
   return '<span class="trait-dots">' + '\u25CF'.repeat(purchased) + '\u25CB'.repeat(bonus) + '</span>';
 }
 
+/** Three-tier domain merit dot rendering: inherent (\u25CF), bonus (\u25CB), shared/underlined (\u25CB). */
+function shDotsThreeTier(inherent, bonus, shared) {
+  let h = '';
+  for (let i = 0; i < inherent; i++) h += '\u25CF';
+  for (let i = 0; i < bonus; i++)    h += '\u25CB';
+  for (let i = 0; i < shared; i++)   h += '<span class="dot-shared">\u25CB</span>';
+  return '<span class="trait-dots">' + h + '</span>';
+}
+
 /** Derived dot source notes on a merit. Only emits lines where the field > 0. */
 function _derivedNotes(m) {
   const _n = (v, lbl, why) => v ? '<div class="derived-note">' + lbl + ': +' + v + ' dot' + (v !== 1 ? 's' : '') + ' (auto) \u2014 ' + why + '</div>' : '';
@@ -1066,11 +1075,12 @@ export function shRenderDomainMerits(c, editMode) {
       } else {
         dotHtml = '<span class="trait-dots">' + shDots(de) + '</span>';
       }
-      // Shared display: own dots filled + partner contribution hollow.
-      const _shPurch = (m.cp || 0) + (m.xp || 0);
-      const _shOwn = Math.min(de, _shPurch);
-      const _shPart = Math.max(0, de - _shOwn);
-      const _shHtml = '<div class="dom-total-view" title="\u25CF own, \u25CB partners">' + shDotsMixed(_shOwn, _shPart) + '</div>';
+      // Shared display: three tiers \u2014 filled \u25CF inherent (cp+xp), hollow \u25CB bonus (free_*), underlined \u25CB shared (partner).
+      const _sh3Inherent = Math.min(de, (m.cp || 0) + (m.xp || 0));
+      const _sh3OwnAll   = Math.min(de, (m.cp || 0) + (m.xp || 0) + meritFreeSum(m));
+      const _sh3Bonus    = _sh3OwnAll - _sh3Inherent;
+      const _sh3Shared   = Math.max(0, de - _sh3OwnAll);
+      const _shHtml      = '<div class="dom-total-view" title="\u25CF inherent, \u25CB bonus, \u25CB\u0332 shared">' + shDotsThreeTier(_sh3Inherent, _sh3Bonus, _sh3Shared) + '</div>';
       // Display name includes qualifier when present
       const _dispName = m.name + (m.qualifier ? ' <span class="trait-qual">(' + esc(m.qualifier) + ')</span>' : '');
       h += '<div class="merit-plain"><div class="trait-row"><div class="trait-main"><span class="trait-name">' + _dispName + '</span><div class="trait-right">' + (dp ? _shHtml : dotHtml) + '</div></div>' + (dp ? '<div class="trait-sub"><span class="trait-qual dom-shared-lbl">Shared \u00B7 ' + dp.map(n => { const p = chars.find(ch => ch.name === n), pd = p ? domMeritShareable(p, m.name) : 0; return esc(n) + (pd ? ' ' + shDots(pd) : ''); }).join(', ') + '</span></div>' : '') + '</div>';

--- a/public/js/game/tracker.js
+++ b/public/js/game/tracker.js
@@ -185,7 +185,7 @@ async function reconcileInfluenceDT() {
     const allCycles = await res.json();
     // Sort by game_number (not _id) to handle re-imported cycles — matches signin-tab.js pattern
     const lastClosed = (allCycles || [])
-      .filter(c => c.status && c.status !== 'open')
+      .filter(c => c.status === 'closed')
       .sort((a, b) => (b.game_number || 0) - (a.game_number || 0))[0] || null;
     if (!lastClosed) return;
 
@@ -193,7 +193,7 @@ async function reconcileInfluenceDT() {
     if (_reconciledCycles.has(cycleId)) return;   // already run this session
 
     const subRes = await fetch(`${API_BASE}/api/downtime_submissions?cycle_id=${cycleId}`, { headers: authHeaders() });
-    if (!subRes.ok) { _reconciledCycles.add(cycleId); return; }
+    if (!subRes.ok) { return; }   // transient failure — do not mark done; next initTracker retries
     const subs = await subRes.json();
 
     // Build per-character spend totals (mirrors signin-tab.js loadLastCycleData)
@@ -219,9 +219,6 @@ async function reconcileInfluenceDT() {
       if (infMax === 0) continue;
       const cs = _cache[charId];
       if (!cs) continue;
-      // Between-session guard: if already below max, reconciliation already ran
-      // (or ST manually adjusted) — do not overwrite
-      if (cs.inf < infMax) continue;
       cs.inf = Math.max(0, infMax - spent);
       saveToApi(charId, { influence: cs.inf });
     }

--- a/public/js/tabs/feeding-tab.js
+++ b/public/js/tabs/feeding-tab.js
@@ -16,7 +16,7 @@ import { FEED_METHODS, TERRITORY_DATA } from './downtime-data.js';
 import { SKILLS_MENTAL } from '../data/constants.js';
 import { isSTRole } from '../auth/discord.js';
 import { domMeritContrib, effectiveInvictusStatus, calcTotalInfluence } from '../editor/domain.js';
-import { trackerAdj, trackerRead } from '../game/tracker.js';
+import { trackerAdj, trackerRead, trackerReadRaw } from '../game/tracker.js';
 
 // Dice math (configurable again threshold: 10 = standard, 9 = 9-again, 8 = 8-again)
 function d10() { return Math.floor(Math.random() * 10) + 1; }
@@ -786,7 +786,8 @@ function render() {
         h += `<div class="feed-st-row-lbl">Influence Remaining</div>`;
         h += `<div class="feed-st-row-ctrl">`;
         h += `<button class="feed-adj" id="feed-inf-adj-down">\u2212</button>`;
-        h += `<span class="feed-inf-val" id="feed-inf-spent" data-inf-max="${infMax}">${infMax}</span>`;
+        const _curInf = trackerRead(String(currentChar._id))?.inf ?? infMax;
+        h += `<span class="feed-inf-val" id="feed-inf-spent" data-inf-max="${infMax}">${_curInf}</span>`;
         h += `<button class="feed-adj" id="feed-inf-adj-up">+</button>`;
         h += `</div>`;
         h += `<div class="feed-st-row-max">/ ${infMax}</div>`;
@@ -930,6 +931,9 @@ function wireEvents() {
     // Write vitae and influence to API — single source of truth for tracker state
     try {
       await apiPut('/api/tracker_state/' + charId, { vitae: n, influence: infAfter });
+      // Keep tracker.js in-memory cache in sync so the tracker card re-renders correctly
+      const _raw = trackerReadRaw(charId);
+      if (_raw) _raw.inf = infAfter;
       // vitae_confirmed used by trackerAdj to clear confirmed marker on manual ST override
       try {
         const key = 'tm_tracker_local_' + charId;

--- a/server/routes/characters.js
+++ b/server/routes/characters.js
@@ -175,14 +175,14 @@ async function _enrichCollectiveSharing(chars) {
   const sourceMerits = [...new Set(collectiveRules.map(r => r?.sharing_scope?.merit).filter(Boolean))];
   let searchContext = chars;
   if (sourceMerits.length) {
-    const haveNames = new Set(chars.map(c => c.name).filter(Boolean));
+    const haveIds = new Set(chars.map(c => String(c._id)).filter(Boolean));
     const extras = await col()
       .find(
         { 'merits.name': { $in: sourceMerits } },
         { projection: { name: 1, merits: 1 } }
       )
       .toArray();
-    const missing = extras.filter(e => e && e.name && !haveNames.has(e.name));
+    const missing = extras.filter(e => e && e._id && !haveIds.has(String(e._id)));
     if (missing.length) searchContext = chars.concat(missing);
   }
 

--- a/specs/stories/fix.685.shared-merit-min-dot-gate.story.md
+++ b/specs/stories/fix.685.shared-merit-min-dot-gate.story.md
@@ -1,0 +1,283 @@
+---
+id: fix.685
+title: Shared merit — gate partner bonus on own dot investment; render as third dot tier
+status: review
+issue: 685
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/685
+branch: ms/issue-685-shared-merit-min-dot-gate
+type: bug
+---
+
+## Story
+
+As an ST managing shared domain merits, I want the system to enforce the rule that
+a character must have at least 1 own dot (inherent OR bonus) before they can draw
+on partner-contributed dots, and I want partner-contributed dots to appear as a
+visually distinct third tier (underlined hollow) so they are distinguishable from
+both inherent (filled) and bonus (hollow) dots.
+
+## Acceptance criteria
+
+- [ ] A character with 0 own dots (no cp, no xp, no free_*) in a shared merit
+  receives 0 effective dots from the partner — the partner contribution is blocked
+- [ ] A character with ≥1 own dot (inherent OR bonus — any channel counts) receives
+  the full partner contribution as normal
+- [ ] Einar's own effective total is unchanged — 0-dot stubs on partners do not
+  affect the primary owner's calculation
+- [ ] Safe Place, Feeding Grounds, Herd, and all other shareable domain merit types
+  apply the same gate
+- [ ] In the read-only sheet view, a shared merit renders three tiers:
+  filled ● for inherent (cp+xp), hollow ○ for bonus (free_*), underlined hollow
+  for shared (partner-contributed) dots
+- [ ] In the edit-mode "My dots" label, shared dots are not shown (that label
+  shows own dots only — inherent + bonus)
+
+---
+
+## Dev notes
+
+### Concept: three dot tiers
+
+| Tier | Source | Display |
+|------|--------|---------|
+| Inherent | cp + xp | ● filled |
+| Bonus | free_* channels (MCI grants, ST free, fwb, attache, etc.) | ○ hollow |
+| Shared | partner contribution via `shared_with` | ○ hollow + underlined |
+
+Eligibility: shared tier is only non-zero if `domMeritContribSingle(c, m) >= 1`
+(inherent + bonus combined). A 0-dot stub has `domMeritContribSingle = 0` → shared = 0.
+
+Effective rating for display = inherent + bonus + shared.
+
+---
+
+### Part 1 — Calculation gate in `public/js/editor/domain.js`
+
+Three functions need the gate. The gate condition is the same in all three:
+**`domMeritContribSingle(c, m) >= 1`** (any own dot from any channel).
+
+---
+
+#### 1a — `domMeritTotalSingle` (line 73–91)
+
+Used by multi-instance types (Safe Place, Feeding Grounds) and the Haven/MG cap.
+
+```js
+// BEFORE:
+function domMeritTotalSingle(c, m) {
+  const own = domMeritContribSingle(c, m);
+  const partners = m.shared_with || [];
+  const key = domKey(m);
+  let partnerTotal = 0;
+  for (const pName of partners) { ... partnerTotal += domMeritShareableSingle(pm); }
+  if (partners.length > 0 && partnerTotal === 0 && m._partner_dots > 0) {
+    partnerTotal = m._partner_dots;
+  }
+  return Math.min(5, own + partnerTotal);
+}
+
+// AFTER — wrap the partner block in the gate:
+function domMeritTotalSingle(c, m) {
+  const own = domMeritContribSingle(c, m);
+  const partners = m.shared_with || [];
+  const key = domKey(m);
+  let partnerTotal = 0;
+  if (own >= 1) {
+    for (const pName of partners) {
+      const p = (state.chars || []).find(ch => ch.name === pName);
+      if (p) {
+        const pm = (p.merits || []).find(pm2 =>
+          pm2.category === 'domain' && pm2.name === m.name && domKey(pm2) === key
+        );
+        if (pm) partnerTotal += domMeritShareableSingle(pm);
+      }
+    }
+    if (partners.length > 0 && partnerTotal === 0 && m._partner_dots > 0) {
+      partnerTotal = m._partner_dots;
+    }
+  }
+  return Math.min(5, own + partnerTotal);
+}
+```
+
+---
+
+#### 1b — `domMeritTotal` singleton path (line 177–193)
+
+Used by Haven, Herd, and other singleton domain merits.
+
+```js
+// BEFORE:
+const own = domMeritContribSingle(c, m);
+const partners = m.shared_with || [];
+let partnerTotal = 0;
+for (const pName of partners) {
+  const p = (state.chars || []).find(ch => ch.name === pName);
+  if (p) partnerTotal += domMeritShareable(p, name);
+}
+if (partners.length > 0 && partnerTotal === 0 && m._partner_dots > 0) {
+  partnerTotal = m._partner_dots;
+}
+const total = own + partnerTotal;
+const cap = (name === 'Herd' && flockHerdBonus(c) > 0) ? Infinity : 5;
+return Math.min(cap, total);
+
+// AFTER — same gate:
+const own = domMeritContribSingle(c, m);
+const partners = m.shared_with || [];
+let partnerTotal = 0;
+if (own >= 1) {
+  for (const pName of partners) {
+    const p = (state.chars || []).find(ch => ch.name === pName);
+    if (p) partnerTotal += domMeritShareable(p, name);
+  }
+  if (partners.length > 0 && partnerTotal === 0 && m._partner_dots > 0) {
+    partnerTotal = m._partner_dots;
+  }
+}
+const total = own + partnerTotal;
+const cap = (name === 'Herd' && flockHerdBonus(c) > 0) ? Infinity : 5;
+return Math.min(cap, total);
+```
+
+---
+
+#### 1c — `domMeritAccess` partner-scan (line 298–309)
+
+After the above fixes, `domMeritTotal(c, name)` returns 0 for a 0-dot character.
+But the partner-scan fallback at lines 301–307 still fires and returns the
+partner's total. This scan must also be gated.
+
+`domMeritContrib(c, name)` is the exported multi-instance-safe version of
+`domMeritContribSingle` and is the right check here.
+
+```js
+// BEFORE:
+export function domMeritAccess(c, name) {
+  const own = domMeritTotal(c, name);
+  if (own > 0) return own;
+  for (const partner of (state.chars || [])) {
+    const pm = (partner.merits || []).find(m =>
+      m.category === 'domain' && m.name === name &&
+      (m.shared_with || []).includes(c.name)
+    );
+    if (pm) return domMeritTotal(partner, name);
+  }
+  return 0;
+}
+
+// AFTER — add own-dot gate before the partner scan:
+export function domMeritAccess(c, name) {
+  const own = domMeritTotal(c, name);
+  if (own > 0) return own;
+  if (domMeritContrib(c, name) < 1) return 0;
+  for (const partner of (state.chars || [])) {
+    const pm = (partner.merits || []).find(m =>
+      m.category === 'domain' && m.name === name &&
+      (m.shared_with || []).includes(c.name)
+    );
+    if (pm) return domMeritTotal(partner, name);
+  }
+  return 0;
+}
+```
+
+---
+
+### Part 2 — Three-tier dot rendering in `public/js/editor/sheet.js`
+
+#### 2a — New helper `shDotsThreeTier(inherent, bonus, shared)`
+
+Add alongside `shDotsMixed` (line 138). The underlined hollow dot wraps each
+character in a `<span class="dot-shared">` tag.
+
+```js
+// Add after shDotsMixed (~line 142):
+function shDotsThreeTier(inherent, bonus, shared) {
+  let h = '';
+  for (let i = 0; i < inherent; i++) h += '●';
+  for (let i = 0; i < bonus; i++)    h += '○';
+  for (let i = 0; i < shared; i++)   h += '<span class="dot-shared">○</span>';
+  return '<span class="trait-dots">' + h + '</span>';
+}
+```
+
+---
+
+#### 2b — Update the read-only shared merit display (lines 1069–1076)
+
+Currently the shared view uses `shDotsMixed(_shOwn, _shPart)` which collapses
+bonus and shared dots into a single "hollow" bucket. Replace it with the three-tier
+split using `shDotsThreeTier`.
+
+```js
+// BEFORE (lines 1069-1073):
+const _shPurch = (m.cp || 0) + (m.xp || 0);
+const _shOwn   = Math.min(de, _shPurch);
+const _shPart  = Math.max(0, de - _shOwn);
+const _shHtml  = '<div class="dom-total-view" title="● own, ○ partners">'
+  + shDotsMixed(_shOwn, _shPart) + '</div>';
+
+// AFTER — three-tier split:
+const _sh3Inherent = Math.min(de, (m.cp || 0) + (m.xp || 0));
+const _sh3OwnAll   = Math.min(de, (m.cp || 0) + (m.xp || 0) + meritFreeSum(m));
+const _sh3Bonus    = _sh3OwnAll - _sh3Inherent;
+const _sh3Shared   = Math.max(0, de - _sh3OwnAll);
+const _shHtml      = '<div class="dom-total-view" title="● inherent, ○ bonus, ○̲ shared">'
+  + shDotsThreeTier(_sh3Inherent, _sh3Bonus, _sh3Shared) + '</div>';
+```
+
+Note: `meritFreeSum` is already imported in sheet.js from domain.js.
+`domMeritContribSingle` does NOT need to be imported — we can compute
+`inherent + bonus` using `(cp+xp) + meritFreeSum(m)` which is the same subset
+used for display purposes (excludes SSJ/Flock/auto-bonuses which are Herd-only,
+and Herd is in `_noShare` so it never hits this code path).
+
+---
+
+### Part 3 — CSS for `.dot-shared`
+
+Add to `public/css/components.css` in the dot/trait-dots section:
+
+```css
+.dot-shared {
+  text-decoration: underline;
+}
+```
+
+---
+
+### What NOT to change
+
+- `domMeritShareableSingle` / `domMeritShareable` — these compute what a
+  character CONTRIBUTES. Einar's shareable dots are unaffected by this fix.
+- The edit-mode "My dots" label (line 1008) already shows only the character's
+  own dots (it reads from `dd` which excludes partner totals). No change needed.
+- The `shared_with` link data — do not alter. A 0-dot stub stays linked.
+- `_partner_dots` server-enrichment: this fallback feeds into `domMeritTotalSingle`
+  and `domMeritTotal`, which are now gated — no server-side change required.
+- `meritEffectiveRating` for CAP_DOMAIN (Haven, Mandragora Garden): that path
+  uses the character's own cp+xp+free_* directly; it already returns 0 for a
+  0-dot character without needing a change.
+
+### What to verify after the fix
+
+1. Open admin sheet for Rene M (0-dot Haven linked to Einar).
+   - Her Haven effective dots should show 0, not 1.
+2. Give Rene 1 cp dot in Haven → she should now show filled ● + Einar's
+   contribution as underlined hollow ○.
+3. Open Einar's sheet — his Haven total is unchanged.
+4. Verify a character with only a free_mci grant (1 bonus dot, 0 cp/xp) in a
+   shared merit CAN receive partner dots — the gate allows bonus dots.
+5. Prereq checker: Haven 1 prereq should NOT pass for Rene at 0 own dots.
+
+### Files to change
+
+| File | Change |
+|------|--------|
+| `public/js/editor/domain.js` | `domMeritTotalSingle`: wrap partner loop in `own >= 1` |
+| `public/js/editor/domain.js` | `domMeritTotal` singleton path: same gate |
+| `public/js/editor/domain.js` | `domMeritAccess`: add `domMeritContrib(c, name) < 1` early-return before partner scan |
+| `public/js/editor/sheet.js` | Add `shDotsThreeTier` helper after `shDotsMixed` |
+| `public/js/editor/sheet.js` | Replace `_shHtml` shared-view construction with three-tier split |
+| `public/css/components.css` | Add `.dot-shared { text-decoration: underline; }` |

--- a/tests/fix-685-shared-merit-min-dot-gate.spec.js
+++ b/tests/fix-685-shared-merit-min-dot-gate.spec.js
@@ -1,0 +1,228 @@
+/**
+ * Fix #685 — Shared domain merit min-dot gate + three-tier dot display
+ *
+ * A character must have ≥1 own dot (cp, xp, or any free_* channel)
+ * before receiving partner-contributed "shared" dots.
+ *
+ * Three-tier display in read-only sheet:
+ *   ● filled            — inherent (cp + xp)
+ *   ○ hollow            — bonus (free_* channels, e.g. free_mci)
+ *   ○ underlined        — shared (partner contribution, .dot-shared class)
+ *
+ * Fixtures use Safe Place (MULTI_INSTANCE_DOMAIN) because its effective rating
+ * is computed by domMeritTotalSingle — which includes partner contribution —
+ * making the gate and three-tier display directly observable in the sheet.
+ * Haven is CAP_DOMAIN (effective = min(stored, cap)), so its display was never
+ * wrong; the gate there matters for domMeritAccess / prereq checking only.
+ *
+ * AC coverage:
+ *   AC-1 — 0-dot stub (no cp, xp, free_*) → 0 effective dots, gate blocks partner
+ *   AC-2 — ≥1 own dot → full partner contribution added
+ *   AC-3 — Primary owner effective total unchanged by 0-dot partners
+ *   AC-4 — Partner dots render as .dot-shared (underlined hollow ○)
+ *   AC-4b — All three tiers distinct: ● inherent, ○ bonus, underlined ○ shared
+ *   AC-5 — Edit-mode domain block contains no .dot-shared elements
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const ST_USER = {
+  id: '777000685', username: 'test_st685', global_name: 'Test ST 685',
+  avatar: null, role: 'st', player_id: 'p-685',
+  character_ids: ['char-685-einar', 'char-685-rene'],
+  is_dual_role: false,
+};
+
+// Both characters must share the same SP qualifier so domKey() matches in the
+// partner lookup inside domMeritTotalSingle.
+const SP_QUALIFIER = 'The Lair';
+
+// ── Fixture builders ──────────────────────────────────────────────────────────
+
+function makeSP(opts = {}) {
+  return {
+    category: 'domain',
+    name: 'Safe Place',
+    qualifier: SP_QUALIFIER,
+    cp:            opts.cp       ?? 0,
+    xp:            opts.xp       ?? 0,
+    free:          0,
+    free_mci:      opts.free_mci ?? 0,
+    free_bloodline: 0,
+    free_pet:      0,
+    free_vm:       0,
+    free_lk:       0,
+    free_inv:      0,
+    rating:        opts.cp ?? 0,
+    shared_with:   opts.shared_with ?? [],
+  };
+}
+
+function baseAttrs() {
+  const a = {};
+  for (const n of ['Intelligence','Wits','Resolve','Strength','Dexterity','Stamina','Presence','Manipulation','Composure'])
+    a[n] = { dots: 2, bonus: 0 };
+  return a;
+}
+
+function buildChar(id, name, spOpts = {}) {
+  return {
+    _id: id,
+    name,
+    moniker: null, honorific: null,
+    clan: 'Mekhet', covenant: 'Ordo Dracul', player: 'Test Player',
+    blood_potency: 2, humanity: 7, humanity_base: 7,
+    court_title: null, retired: false,
+    status: { city: 0, clan: 0, covenant: {} },
+    attributes: baseAttrs(),
+    skills: {},
+    disciplines: {},
+    merits: Object.keys(spOpts).length ? [makeSP(spOpts)] : [],
+    powers: [], ordeals: [],
+    xp_log: { spent: 0 },
+  };
+}
+
+// ── Test harness ──────────────────────────────────────────────────────────────
+
+async function setupAdmin(page, chars) {
+  await page.addInitScript((u) => {
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 36000000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(u));
+  }, ST_USER);
+
+  // Catch-all first; specific routes registered after take priority (LIFO)
+  await page.route('**/api/**', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.route('**/api/auth/me', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(ST_USER) })
+  );
+  await page.route(/\/api\/characters$/, r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(chars) })
+  );
+  await page.route('**/api/characters/names', r =>
+    r.fulfill({ status: 200, contentType: 'application/json',
+      body: JSON.stringify(chars.map(c => ({ _id: c._id, name: c.name, moniker: null, honorific: null }))),
+    })
+  );
+  for (const c of chars) {
+    await page.route(new RegExp(`/api/characters/${c._id}$`), r =>
+      r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(c) })
+    );
+  }
+  await page.route('**/api/rules', r =>
+    r.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+}
+
+async function openCharReadOnly(page, char) {
+  await page.goto('/admin.html');
+  await page.waitForSelector('#admin-app:not([style*="display: none"])');
+  await page.waitForSelector(`[data-id="${char._id}"]`, { timeout: 5000 });
+  await page.click(`[data-id="${char._id}"]`);
+  await page.waitForSelector('#cd-edit-toggle', { timeout: 5000 });
+  await page.waitForTimeout(400);
+}
+
+async function openCharInEditMode(page, char) {
+  await openCharReadOnly(page, char);
+  await page.click('#cd-edit-toggle');
+  await page.waitForSelector('#cd-save-api:not([style*="display: none"])', { timeout: 5000 });
+  await page.waitForTimeout(300);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('fix-685: shared merit min-dot gate + three-tier display', () => {
+
+  test('AC-1: 0-dot stub receives 0 effective dots — gate blocks partner contribution', async ({ page }) => {
+    // Einar: 1 cp in SP, shared with Rene
+    // Rene:  0 cp/xp/free — gate must prevent her from inheriting Einar's dot
+    const einar = buildChar('char-685-einar', 'Einar',  { cp: 1, shared_with: ['Rene M'] });
+    const rene  = buildChar('char-685-rene',  'Rene M', { cp: 0, shared_with: ['Einar'] });
+    await setupAdmin(page, [einar, rene]);
+    await openCharReadOnly(page, rene);
+
+    // dp is set on Rene's SP (shared_with=['Einar']), so _shHtml renders.
+    // own=0 → gate blocks → partnerTotal=0 → de=0 → shDotsThreeTier(0,0,0) → empty trait-dots.
+    // The .dom-total-view container is in the DOM even though it has no content (empty span = 0px).
+    await expect(page.locator('.dom-total-view')).toBeAttached({ timeout: 5000 });
+    // No shared dots — the gate blocked all partner contribution
+    await expect(page.locator('.dom-total-view .dot-shared')).toHaveCount(0);
+    // Trait-dots span textContent is empty (0 effective dots)
+    const traitText = await page.locator('.dom-total-view .trait-dots').evaluate(el => el.textContent);
+    expect(traitText).toBe('');
+  });
+
+  test('AC-2: 1-own-dot character receives full partner contribution', async ({ page }) => {
+    // Rene has 1 cp — gate passes — Einar's 1 shareable dot is added: de=2
+    const einar = buildChar('char-685-einar', 'Einar',  { cp: 1, shared_with: ['Rene M'] });
+    const rene  = buildChar('char-685-rene',  'Rene M', { cp: 1, shared_with: ['Einar'] });
+    await setupAdmin(page, [einar, rene]);
+    await openCharReadOnly(page, rene);
+
+    // de=2: shDotsThreeTier(1, 0, 1) → '●' + '<span class="dot-shared">○</span>'
+    // textContent = '●○' — 2 characters
+    const domView = page.locator('.dom-total-view .trait-dots');
+    await expect(domView).toBeVisible({ timeout: 5000 });
+    const text = await domView.evaluate(el => el.textContent);
+    expect(text.length).toBe(2);
+  });
+
+  test('AC-3: primary owner effective total is unchanged by a 0-dot partner', async ({ page }) => {
+    // Einar owns 1 dot; Rene contributes 0 shareable → Einar stays at 1
+    const einar = buildChar('char-685-einar', 'Einar',  { cp: 1, shared_with: ['Rene M'] });
+    const rene  = buildChar('char-685-rene',  'Rene M', { cp: 0, shared_with: ['Einar'] });
+    await setupAdmin(page, [einar, rene]);
+    await openCharReadOnly(page, einar);
+
+    // own=1, Rene's shareable=0 → de=1; shDotsThreeTier(1,0,0) → '●'
+    const domView = page.locator('.dom-total-view .trait-dots');
+    await expect(domView).toBeVisible({ timeout: 5000 });
+    const text = await domView.evaluate(el => el.textContent);
+    expect(text).toBe('●');
+  });
+
+  test('AC-4: partner dots render as .dot-shared spans', async ({ page }) => {
+    // Rene 1 cp + Einar 1 shareable → 1 partner dot → exactly 1 .dot-shared in the view
+    const einar = buildChar('char-685-einar', 'Einar',  { cp: 1, shared_with: ['Rene M'] });
+    const rene  = buildChar('char-685-rene',  'Rene M', { cp: 1, shared_with: ['Einar'] });
+    await setupAdmin(page, [einar, rene]);
+    await openCharReadOnly(page, rene);
+
+    await expect(page.locator('.dom-total-view .dot-shared')).toHaveCount(1, { timeout: 5000 });
+  });
+
+  test('AC-4b: three tiers all distinct — inherent ●, bonus ○, shared underlined ○', async ({ page }) => {
+    // Rene: 1 inherent (cp=1) + 1 bonus (free_mci=1) + 1 shared (Einar cp=1) = de=3
+    // _sh3Inherent=1, _sh3Bonus=1, _sh3Shared=1
+    const einar = buildChar('char-685-einar', 'Einar',  { cp: 1, shared_with: ['Rene M'] });
+    const rene  = buildChar('char-685-rene',  'Rene M', { cp: 1, free_mci: 1, shared_with: ['Einar'] });
+    await setupAdmin(page, [einar, rene]);
+    await openCharReadOnly(page, rene);
+
+    const domView = page.locator('.dom-total-view .trait-dots');
+    await expect(domView).toBeVisible({ timeout: 5000 });
+    // textContent = '●○○' (inherent + bonus + shared — shared renders as ○ via .dot-shared span)
+    const text = await domView.evaluate(el => el.textContent);
+    expect(text.length).toBe(3);
+    // Exactly one .dot-shared span (the partner dot)
+    await expect(page.locator('.dom-total-view .dot-shared')).toHaveCount(1);
+  });
+
+  test('AC-5: edit-mode domain block contains no .dot-shared elements', async ({ page }) => {
+    // In edit mode the "My dots" stepper shows own dots only; partner dots must not appear
+    const einar = buildChar('char-685-einar', 'Einar',  { cp: 1, shared_with: ['Rene M'] });
+    const rene  = buildChar('char-685-rene',  'Rene M', { cp: 1, shared_with: ['Einar'] });
+    await setupAdmin(page, [einar, rene]);
+    await openCharInEditMode(page, rene);
+
+    await expect(page.locator('.dom-edit-block')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.dom-edit-block .dot-shared')).toHaveCount(0);
+  });
+
+});


### PR DESCRIPTION
## Summary

- Characters with 0 own dots (no cp, xp, or free_*) no longer receive partner-contributed dots — `domMeritTotalSingle`, `domMeritTotal`, and `domMeritAccess` all gate on `own >= 1`
- Partner-contributed dots render as a distinct third tier: underlined hollow ○ (`.dot-shared` class), separate from inherent ● (cp+xp) and bonus ○ (free_*)
- Also carries 7 adversarial code-review patches from the prior session covering tracker, feeding, characters, and rules-helpers

## Closes

- Closes #685

## Story

- specs/stories/fix.685.shared-merit-min-dot-gate.story.md

## Test plan

- [ ] `npx playwright test tests/fix-685-shared-merit-min-dot-gate.spec.js` — 6 tests, all pass
- [ ] CI green
- [ ] Manual: open admin sheet for Rene M — Haven shows 0 effective dots; give Rene 1 cp in Haven and confirm ● + underlined ○ appear; open Einar's sheet and confirm his total is unchanged

## Branch flow

- From: `ms/issue-685-shared-merit-min-dot-gate`
- Into: `dev`