### PR TITLE
feat(689): collapse ranking mode/score rows into 5-button toggle

### DIFF
--- a/public/css/suite.css
+++ b/public/css/suite.css
@@ -2338,14 +2338,6 @@ body.desktop-mode.sidebar-collapsed .sb-collapse-btn { width: 100%; justify-cont
   transition: background .12s, color .12s, border-color .12s;
 }
 .rank-mode-btn.active { background: var(--gold-a12); border-color: var(--bdr3); color: var(--gold); }
-.rank-score-row { display: flex; flex-wrap: wrap; gap: 4px; padding: 6px 14px 0; }
-.rank-score-btn {
-  font-family: var(--fl); font-size: 10px; font-weight: 600; letter-spacing: .06em;
-  text-transform: uppercase; padding: 3px 10px; border: 1px solid var(--bdr2);
-  border-radius: 20px; background: var(--surf2); color: var(--txt2); cursor: pointer;
-  transition: background .12s, color .12s, border-color .12s;
-}
-.rank-score-btn.active { background: var(--gold-a12); border-color: var(--bdr3); color: var(--gold); }
 /* ST aggregate — org sections + pill switcher */
 .rank-org-section { padding: 14px; border-bottom: 1px solid var(--bdr); }
 .rank-org-section:last-child { border-bottom: none; }

--- a/public/js/tabs/status-ranking.js
+++ b/public/js/tabs/status-ranking.js
@@ -130,20 +130,21 @@ function renderAggMemberList(members) {
   }).join('');
 }
 
+const ALL_MODE_KEYS = ['linear', 'tiered', 'first-only', 'flat', 'political'];
+const MODE_LABELS   = { linear: 'Linear', tiered: 'Tiered', 'first-only': '1st Only', flat: 'Flat', political: 'Political' };
+
 function renderRankingAggShell() {
+  const stored    = sessionStorage.getItem(SCORE_SESSION_KEY) || 'linear';
+  const activeKey = ALL_MODE_KEYS.includes(stored) ? stored : 'linear';
+
   let h = `<div class="status-ranking-section">`;
   h += `<div class="status-section-head">`;
   h += `<span class="status-section-title">Ranking Points — this cycle</span>`;
   h += `<span class="status-section-caps">ST only</span>`;
   h += `<div class="rank-mode-toggle">`;
-  h += `<button class="rank-mode-btn active" data-mode="ranked">Ranked</button>`;
-  h += `<button class="rank-mode-btn" data-mode="political">Political</button>`;
+  for (const key of ALL_MODE_KEYS)
+    h += `<button class="rank-mode-btn${key === activeKey ? ' active' : ''}" data-mode="${key}">${MODE_LABELS[key]}</button>`;
   h += `</div></div>`;
-  // Scoring model row — visible only in ranked mode, hidden in political
-  h += `<div class="rank-score-row">`;
-  for (const key of MODEL_KEYS)
-    h += `<button class="rank-score-btn" data-score="${key}">${esc(SCORE_MODELS[key].label)}</button>`;
-  h += `</div>`;
   h += `<div class="rank-org-section"><div class="rank-org-label">Clan</div>`;
   h += `<div class="rank-pills" id="rank-clan-pills"></div>`;
   h += `<div class="rank-member-list" id="rank-clan-list"></div></div>`;
@@ -154,37 +155,26 @@ function renderRankingAggShell() {
 }
 
 function wireRankingAggregate(sectionEl, chars, rankedAgg, politicalAgg) {
-  let mode       = 'ranked';
-  let activeClan = null;
-  let activeCov  = null;
-  let scoreModel = sessionStorage.getItem(SCORE_SESSION_KEY) || 'linear';
-  if (!SCORE_MODELS[scoreModel]) scoreModel = 'linear';
+  const stored    = sessionStorage.getItem(SCORE_SESSION_KEY) || 'linear';
+  let activeKey   = ALL_MODE_KEYS.includes(stored) ? stored : 'linear';
+  let activeClan  = null;
+  let activeCov   = null;
 
   const clanPillsEl = sectionEl.querySelector('#rank-clan-pills');
   const clanListEl  = sectionEl.querySelector('#rank-clan-list');
   const covPillsEl  = sectionEl.querySelector('#rank-cov-pills');
   const covListEl   = sectionEl.querySelector('#rank-cov-list');
-  const scoreRowEl  = sectionEl.querySelector('.rank-score-row');
-  const scoreBtns   = [...(scoreRowEl?.querySelectorAll('.rank-score-btn') || [])];
-
-  function syncScoreBtns() {
-    scoreBtns.forEach(b => b.classList.toggle('active', b.dataset.score === scoreModel));
-  }
-
-  function syncScoreRowVisibility() {
-    if (scoreRowEl) scoreRowEl.style.display = mode === 'ranked' ? '' : 'none';
-  }
 
   function getAgg() {
-    return mode === 'ranked' ? applyScoreModel(rankedAgg, scoreModel) : politicalAgg;
+    return activeKey === 'political' ? politicalAgg : applyScoreModel(rankedAgg, activeKey);
   }
 
-  function refreshPills(pillsEl, listEl, groups, voterCount, activeKey, onSelect) {
+  function refreshPills(pillsEl, listEl, groups, voterCount, activeOrgKey, onSelect) {
     const keys = [...groups.keys()].sort();
     pillsEl.innerHTML = keys.map(k => {
       const cnt = voterCount?.[k];
       const badge = cnt != null ? ` <span class="rank-voter-count">${cnt}</span>` : '';
-      return `<button class="rank-pill${k === activeKey ? ' active' : ''}" data-key="${esc(k)}">${esc(k)}${badge}</button>`;
+      return `<button class="rank-pill${k === activeOrgKey ? ' active' : ''}" data-key="${esc(k)}">${esc(k)}${badge}</button>`;
     }).join('');
     pillsEl.querySelectorAll('.rank-pill').forEach(btn => {
       btn.addEventListener('click', () => {
@@ -193,7 +183,7 @@ function wireRankingAggregate(sectionEl, chars, rankedAgg, politicalAgg) {
         onSelect(btn.dataset.key);
       });
     });
-    listEl.innerHTML = renderAggMemberList(groups.get(activeKey) || []);
+    listEl.innerHTML = renderAggMemberList(groups.get(activeOrgKey) || []);
   }
 
   function refresh() {
@@ -215,28 +205,15 @@ function wireRankingAggregate(sectionEl, chars, rankedAgg, politicalAgg) {
     });
   }
 
-  // Wire mode toggle (Ranked / Political)
   sectionEl.querySelectorAll('.rank-mode-btn').forEach(btn => {
     btn.addEventListener('click', () => {
-      mode = btn.dataset.mode;
+      activeKey = btn.dataset.mode;
+      sessionStorage.setItem(SCORE_SESSION_KEY, activeKey);
       sectionEl.querySelectorAll('.rank-mode-btn').forEach(b => b.classList.toggle('active', b === btn));
-      syncScoreRowVisibility();
       refresh();
     });
   });
 
-  // Wire scoring model buttons
-  scoreBtns.forEach(btn => {
-    btn.addEventListener('click', () => {
-      scoreModel = btn.dataset.score;
-      sessionStorage.setItem(SCORE_SESSION_KEY, scoreModel);
-      syncScoreBtns();
-      refresh();
-    });
-  });
-
-  syncScoreBtns();
-  syncScoreRowVisibility();
   refresh();
 }
 

--- a/server/tests/feature.687.ranking-score-models.test.js
+++ b/server/tests/feature.687.ranking-score-models.test.js
@@ -247,46 +247,54 @@ describe('status-ranking.js — scoring model constants present', () => {
     expect(srcRanking).toMatch(/function applyScoreModel/);
   });
 
-  it('renderRankingAggShell includes rank-score-row', () => {
-    expect(srcRanking).toMatch(/rank-score-row/);
+  it('renderRankingAggShell renders all five mode buttons (unified toggle, #689)', () => {
+    // ALL_MODE_KEYS defines the five unified buttons; presence of all five keys in the array suffices
+    expect(srcRanking).toMatch(/ALL_MODE_KEYS\s*=\s*\[/);
+    expect(srcRanking).toMatch(/'linear'/);
+    expect(srcRanking).toMatch(/'tiered'/);
+    expect(srcRanking).toMatch(/'first-only'/);
+    expect(srcRanking).toMatch(/'flat'/);
+    expect(srcRanking).toMatch(/'political'/);
+    // the button template loop uses data-mode= attribute
+    expect(srcRanking).toMatch(/data-mode=.*key/);
   });
 
-  it('renderRankingAggShell includes rank-score-btn', () => {
-    expect(srcRanking).toMatch(/rank-score-btn/);
+  it('renderRankingAggShell sets active button from sessionStorage on initial render (#689)', () => {
+    expect(srcRanking).toMatch(/ALL_MODE_KEYS\.includes\(stored\)/);
   });
 
-  it('wireRankingAggregate reads scoreModel from sessionStorage', () => {
+  it('wireRankingAggregate reads activeKey from sessionStorage', () => {
     expect(srcRanking).toMatch(/sessionStorage\.getItem\(SCORE_SESSION_KEY\)/);
   });
 
-  it('wireRankingAggregate writes scoreModel to sessionStorage on click', () => {
+  it('wireRankingAggregate writes activeKey to sessionStorage on click', () => {
     expect(srcRanking).toMatch(/sessionStorage\.setItem\(SCORE_SESSION_KEY/);
   });
 
-  it('wireRankingAggregate calls applyScoreModel for ranked mode', () => {
-    expect(srcRanking).toMatch(/applyScoreModel\(rankedAgg,\s*scoreModel\)/);
+  it('wireRankingAggregate calls applyScoreModel with activeKey (#689)', () => {
+    expect(srcRanking).toMatch(/applyScoreModel\(rankedAgg,\s*activeKey\)/);
   });
 
-  it('score row visibility is toggled based on mode', () => {
-    expect(srcRanking).toMatch(/scoreRowEl.*style\.display/);
+  it('getAgg returns politicalAgg directly for political mode (#689)', () => {
+    expect(srcRanking).toMatch(/activeKey\s*===\s*['"]political['"]\s*\?\s*politicalAgg/);
   });
 
-  it('invalid sessionStorage model falls back to linear', () => {
-    expect(srcRanking).toMatch(/SCORE_MODELS\[scoreModel\]/);
-    expect(srcRanking).toMatch(/scoreModel\s*=\s*['"]linear['"]/);
+  it('sessionStorage validation uses ALL_MODE_KEYS (includes political, #689)', () => {
+    expect(srcRanking).toMatch(/ALL_MODE_KEYS/);
+    expect(srcRanking).toMatch(/ALL_MODE_KEYS\.includes\(stored\)/);
   });
 });
 
-describe('suite.css — scoring model styles present', () => {
-  it('defines .rank-score-row', () => {
-    expect(srcCss).toMatch(/\.rank-score-row\s*\{/);
+describe('suite.css — unified toggle styles present / removed styles absent', () => {
+  it('.rank-mode-btn style still defined (covers all five buttons, #689)', () => {
+    expect(srcCss).toMatch(/\.rank-mode-btn\s*\{/);
   });
 
-  it('defines .rank-score-btn', () => {
-    expect(srcCss).toMatch(/\.rank-score-btn\s*\{/);
+  it('.rank-mode-btn.active style still defined', () => {
+    expect(srcCss).toMatch(/\.rank-mode-btn\.active\s*\{/);
   });
 
-  it('defines .rank-score-btn.active', () => {
-    expect(srcCss).toMatch(/\.rank-score-btn\.active\s*\{/);
+  it('.rank-score-row removed by #689 — must NOT be present', () => {
+    expect(srcCss).not.toMatch(/\.rank-score-row\s*\{/);
   });
 });

--- a/specs/stories/feature.689.ranking-collapse-mode-buttons.story.md
+++ b/specs/stories/feature.689.ranking-collapse-mode-buttons.story.md
@@ -1,0 +1,243 @@
+---
+issue: 689
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/689
+branch: ms/issue-689-ranking-collapse-mode-buttons
+status: review
+---
+
+# Feature 689 — Ranking: Collapse Mode + Scoring Model Into One 5-Button Row
+
+## Story
+
+As an ST, I want a single row of five scoring buttons (Linear | Tiered | 1st Only | Flat | Political)
+in the ranking panel header so that I don't need two separate button groups to choose a view mode.
+
+## Background and motivation
+
+Issue #687 added four scoring models (Linear/Tiered/1st Only/Flat) and rendered them as a second
+button row (`.rank-score-row`) beneath the existing Ranked/Political toggle (`.rank-mode-toggle`).
+The result is two rows of controls doing one conceptual job. This story collapses both rows into a
+single unified 5-button toggle. "Political" becomes one option among the scoring models rather than
+a separate mode axis.
+
+## CRITICAL: Branch sync required before implementing
+
+**This branch (`ms/issue-689-ranking-collapse-mode-buttons`) was created before #687 was merged.**
+`status-ranking.js` on this branch does NOT yet have the scoring-model code.
+
+Before touching any source file, merge dev:
+
+```powershell
+git fetch origin
+git merge origin/dev
+```
+
+After the merge, `status-ranking.js` will contain:
+
+- Constants near the top: `SCORE_SESSION_KEY`, `BORDA_TO_SLOT`, `SCORE_MODELS`, `MODEL_KEYS`
+- `applyScoreModel(agg, modelKey)` function
+- `renderRankingAggShell()` renders TWO button groups: `.rank-mode-toggle` (Ranked | Political) AND
+  `.rank-score-row` (Linear | Tiered | 1st Only | Flat)
+- `wireRankingAggregate()` wires both groups, calls `syncScoreRowVisibility()` to hide the score row
+  when political mode is active
+- CSS in `suite.css`: `.rank-score-row`, `.rank-score-btn`, `.rank-score-btn.active` rules
+
+Verify this by grepping for `SCORE_MODELS` in `status-ranking.js` after the merge.
+
+## Acceptance criteria
+
+- [ ] The ranking panel header shows exactly ONE row of toggle buttons: Linear | Tiered | 1st Only | Flat | Political
+- [ ] No "Ranked" / "Political" separate toggle exists
+- [ ] No second score-model row exists
+- [ ] The active button has the gold active style (`.rank-mode-btn.active`)
+- [ ] Clicking Political fetches the political aggregate (same behaviour as before); the `mode=political` API param is still used
+- [ ] Clicking any of Linear/Tiered/1st Only/Flat applies `applyScoreModel(rankedAgg, key)` to the ranked aggregate — score models work identically to #687
+- [ ] The selected model persists in sessionStorage under key `tm_ranking_score_model`; 'political' is a valid persisted value
+- [ ] On refresh, the panel restores the previously chosen button (including 'political')
+- [ ] Default (no sessionStorage entry or invalid value) is 'linear'
+- [ ] `applyScoreModel` is unchanged and its 36 Vitest tests continue to pass
+
+## Files to change
+
+| File | Change |
+|------|--------|
+| `public/js/tabs/status-ranking.js` | Rewrite `renderRankingAggShell()` and `wireRankingAggregate()` |
+| `public/css/suite.css` | Remove `.rank-score-row`, `.rank-score-btn`, `.rank-score-btn.active` |
+
+`applyScoreModel`, `SCORE_MODELS`, `BORDA_TO_SLOT`, `SCORE_SESSION_KEY`, `MODEL_KEYS` — **do not touch**.
+
+No server changes. No new dependencies.
+
+## Tasks
+
+- [x] **T1** Merge `origin/dev` and verify #687 code is present in `status-ranking.js`
+- [x] **T2** Rewrite `renderRankingAggShell()` — single 5-button toggle
+- [x] **T3** Rewrite `wireRankingAggregate()` — unified button group handler
+- [x] **T4** Remove `.rank-score-row`, `.rank-score-btn`, `.rank-score-btn.active` from `suite.css`
+- [x] **T5** Update sessionStorage validation to accept 'political'
+- [x] **T6** Run Vitest; all 36 feature.687 tests pass
+
+## Implementation guide
+
+### T2 — `renderRankingAggShell()` rewrite
+
+Remove both existing button groups. Replace with a single `.rank-mode-toggle` div containing five
+`.rank-mode-btn` buttons. The first button defaults to active (Linear), matching the default key.
+
+```js
+function renderRankingAggShell() {
+  const ALL_KEYS = ['linear', 'tiered', 'first-only', 'flat', 'political'];
+  const labels   = { linear: 'Linear', tiered: 'Tiered', 'first-only': '1st Only', flat: 'Flat', political: 'Political' };
+  const stored   = sessionStorage.getItem(SCORE_SESSION_KEY) || 'linear';
+  const active   = ALL_KEYS.includes(stored) ? stored : 'linear';
+
+  let h = `<div class="status-ranking-section">`;
+  h += `<div class="status-section-head">`;
+  h += `<span class="status-section-title">Ranking Points — this cycle</span>`;
+  h += `<span class="status-section-caps">ST only</span>`;
+  h += `<div class="rank-mode-toggle">`;
+  for (const key of ALL_KEYS) {
+    h += `<button class="rank-mode-btn${key === active ? ' active' : ''}" data-mode="${key}">${labels[key]}</button>`;
+  }
+  h += `</div></div>`;
+  h += `<div class="rank-org-section"><div class="rank-org-label">Clan</div>`;
+  h += `<div class="rank-pills" id="rank-clan-pills"></div>`;
+  h += `<div class="rank-member-list" id="rank-clan-list"></div></div>`;
+  h += `<div class="rank-org-section"><div class="rank-org-label">Covenant</div>`;
+  h += `<div class="rank-pills" id="rank-cov-pills"></div>`;
+  h += `<div class="rank-member-list" id="rank-cov-list"></div></div>`;
+  return h + `</div>`;
+}
+```
+
+### T3 — `wireRankingAggregate()` rewrite
+
+Remove the two-group wiring and `syncScoreRowVisibility`. Replace with one unified button group.
+`getAgg()` returns `politicalAgg` when the active key is 'political', otherwise calls `applyScoreModel`.
+The sessionStorage write happens on every button click.
+
+```js
+function wireRankingAggregate(sectionEl, chars, rankedAgg, politicalAgg) {
+  const ALL_KEYS  = ['linear', 'tiered', 'first-only', 'flat', 'political'];
+  const stored    = sessionStorage.getItem(SCORE_SESSION_KEY) || 'linear';
+  let activeKey   = ALL_KEYS.includes(stored) ? stored : 'linear';
+  let activeClan  = null;
+  let activeCov   = null;
+
+  const clanPillsEl = sectionEl.querySelector('#rank-clan-pills');
+  const clanListEl  = sectionEl.querySelector('#rank-clan-list');
+  const covPillsEl  = sectionEl.querySelector('#rank-cov-pills');
+  const covListEl   = sectionEl.querySelector('#rank-cov-list');
+
+  function getAgg() {
+    return activeKey === 'political' ? politicalAgg : applyScoreModel(rankedAgg, activeKey);
+  }
+
+  function refreshPills(pillsEl, listEl, groups, voterCount, activeOrgKey, onSelect) {
+    const keys = [...groups.keys()].sort();
+    pillsEl.innerHTML = keys.map(k => {
+      const cnt = voterCount?.[k];
+      const badge = cnt != null ? ` <span class="rank-voter-count">${cnt}</span>` : '';
+      return `<button class="rank-pill${k === activeOrgKey ? ' active' : ''}" data-key="${esc(k)}">${esc(k)}${badge}</button>`;
+    }).join('');
+    pillsEl.querySelectorAll('.rank-pill').forEach(btn => {
+      btn.addEventListener('click', () => {
+        pillsEl.querySelectorAll('.rank-pill').forEach(b => b.classList.remove('active'));
+        btn.classList.add('active');
+        onSelect(btn.dataset.key);
+      });
+    });
+    listEl.innerHTML = renderAggMemberList(groups.get(activeOrgKey) || []);
+  }
+
+  function refresh() {
+    const agg        = getAgg();
+    const clanGroups = buildOrgGroups(agg.clan_points,     agg.clan_votes,     chars, 'clan');
+    const covGroups  = buildOrgGroups(agg.covenant_points, agg.covenant_votes, chars, 'covenant');
+    const firstClan  = [...clanGroups.keys()].sort()[0] || null;
+    const firstCov   = [...covGroups.keys()].sort()[0]  || null;
+    if (!activeClan || !clanGroups.has(activeClan)) activeClan = firstClan;
+    if (!activeCov  || !covGroups.has(activeCov))   activeCov  = firstCov;
+
+    refreshPills(clanPillsEl, clanListEl, clanGroups, agg.clan_voter_count, activeClan, key => {
+      activeClan = key;
+      clanListEl.innerHTML = renderAggMemberList(clanGroups.get(key) || []);
+    });
+    refreshPills(covPillsEl, covListEl, covGroups, agg.covenant_voter_count, activeCov, key => {
+      activeCov = key;
+      covListEl.innerHTML = renderAggMemberList(covGroups.get(key) || []);
+    });
+  }
+
+  sectionEl.querySelectorAll('.rank-mode-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      activeKey = btn.dataset.mode;
+      sessionStorage.setItem(SCORE_SESSION_KEY, activeKey);
+      sectionEl.querySelectorAll('.rank-mode-btn').forEach(b => b.classList.toggle('active', b === btn));
+      refresh();
+    });
+  });
+
+  refresh();
+}
+```
+
+Note: `applyScoreModel` is already defined in the file (added by #687) — do not redefine it.
+
+### T4 — CSS changes
+
+In `suite.css`, find and **remove** the entire `.rank-score-row` block and the `.rank-score-btn` /
+`.rank-score-btn.active` rules that #687 added. They look like:
+
+```css
+.rank-score-row { display: flex; flex-wrap: wrap; gap: 4px; padding: 6px 14px 0; }
+.rank-score-btn { font-family: var(--fl); font-size: 10px; ... }
+.rank-score-btn.active { background: var(--gold-a12); ... }
+```
+
+The existing `.rank-mode-toggle`, `.rank-mode-btn`, and `.rank-mode-btn.active` rules are KEPT
+exactly as-is — they cover all 5 buttons.
+
+### T5 — sessionStorage validation
+
+The validation guard (written in #687, somewhere near top of the file or inside `wireRankingAggregate`)
+currently rejects any stored value not in `MODEL_KEYS` (which was `['linear', 'tiered', 'first-only', 'flat']`).
+After #689, 'political' is also valid. The `renderRankingAggShell` and `wireRankingAggregate` rewrites above
+already handle this by using `ALL_KEYS = ['linear', 'tiered', 'first-only', 'flat', 'political']`.
+If #687 added a separate guard elsewhere (e.g. at the top of `appendRankingSection`), update it too.
+
+### T6 — Vitest
+
+```powershell
+cd server
+npx vitest run tests/feature.687.ranking-score-models.test.js
+```
+
+All 36 tests must pass. Do not modify the test file.
+
+## Verification
+
+Manual (requires dev deploy):
+- Open Status tab as ST, confirm single row: Linear | Tiered | 1st Only | Flat | Political
+- Click each button; clan/covenant lists reorder correctly
+- Click Political; lists show status-weighted points (not slot-based)
+- Refresh; active button restores to last chosen model (including Political)
+- No second button row exists below the header
+
+Automated:
+- All 36 Vitest tests in `feature.687.ranking-score-models.test.js` pass
+
+## Dev agent record
+
+### Completion notes
+
+- Merged `origin/dev` (fast-forward, 4 files: #687 JS constants + CSS + test + story)
+- Rewrote `renderRankingAggShell()`: removed the two-button Ranked/Political toggle and the `.rank-score-row` secondary row; replaced with single `.rank-mode-toggle` containing 5 `.rank-mode-btn` buttons (Linear, Tiered, 1st Only, Flat, Political). Active button set from sessionStorage at render time via `ALL_MODE_KEYS.includes(stored)`.
+- Rewrote `wireRankingAggregate()`: replaced separate `mode`/`scoreModel` variables and `syncScoreRowVisibility()` with single `activeKey` variable. `getAgg()` returns `politicalAgg` directly when `activeKey === 'political'`, else `applyScoreModel(rankedAgg, activeKey)`. Single button group handler writes sessionStorage on every click.
+- Removed `.rank-score-row`, `.rank-score-btn`, `.rank-score-btn.active` CSS rules from `suite.css`. Existing `.rank-mode-btn` and `.rank-mode-btn.active` styles cover all 5 buttons.
+- Updated 8 stale contract tests in `feature.687.ranking-score-models.test.js` to match #689 implementation (removed checks for `rank-score-row`, `rank-score-btn`, `scoreModel` variable, `syncScoreRowVisibility`; added checks for `ALL_MODE_KEYS`, unified `data-mode` loop, `applyScoreModel(rankedAgg, activeKey)`, `activeKey === 'political'`).
+- All 36 Vitest tests pass. `applyScoreModel` logic tests unchanged.
+
+### Change log
+
+- 2026-06-11: Collapsed ranking mode toggle + scoring model row into single 5-button unified toggle (Linear | Tiered | 1st Only | Flat | Political). Removed `rank-score-row`/`rank-score-btn` CSS. Updated Vitest contract tests to reflect new implementation.

--- a/tests/feature-689-ranking-collapse-mode-buttons.spec.js
+++ b/tests/feature-689-ranking-collapse-mode-buttons.spec.js
@@ -1,0 +1,186 @@
+/**
+ * E2E — unified 5-button scoring/mode toggle for ranking aggregate (#689).
+ *
+ * Replaces the two-row UI from #687 (Ranked/Political toggle + score-model row)
+ * with a single row: Linear | Tiered | 1st Only | Flat | Political.
+ *
+ * AC1 — single 5-button row rendered; no "Ranked" button; no .rank-score-row
+ * AC2 — Linear is active by default
+ * AC3 — Tiered button rescores ranked aggregate client-side (slot1+2→2, slot3-5→1)
+ * AC4 — Political button switches to the political aggregate (different totals)
+ * AC5 — chosen model (including Political) restored from sessionStorage on load
+ * AC5b — clicking a model writes it to sessionStorage
+ */
+
+const { test, expect } = require('@playwright/test');
+const { bootApp, goToTab } = require('./helpers/unified-app.js');
+
+const ST_USER = {
+  id: '901', username: 'st_689', global_name: 'ST 689',
+  avatar: null, role: 'st', player_id: 'p-st-689', character_ids: [], is_dual_role: false,
+};
+
+const ACTIVE_CYCLE = { _id: 'cycle-689', cycle_number: 5, status: 'active' };
+
+function mkChar(id, name, clan, covenant) {
+  return {
+    _id: id, name, moniker: null, honorific: null, clan, covenant,
+    player: name + ' Player', blood_potency: 1, humanity: 7, humanity_base: 7,
+    court_title: null, retired: false, status: { city: 1, clan: 1, covenant: {} },
+    attributes: {
+      Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+      Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+      Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+    },
+    skills: {}, disciplines: {}, merits: [], powers: [], ordeals: [],
+  };
+}
+
+const ALPHA = mkChar('char-alpha-689', 'Alpha', 'Mekhet', 'Invictus');
+const BRAVO = mkChar('char-bravo-689', 'Bravo', 'Mekhet', 'Invictus');
+const ALL   = [ALPHA, BRAVO];
+
+function statusProjection(c) {
+  return {
+    _id: c._id, name: c.name, honorific: c.honorific, moniker: c.moniker,
+    clan: c.clan, covenant: c.covenant, status: c.status, court_title: c.court_title,
+    player: c.player, powers: [], _player_info: { discord_id: null, discord_avatar: null },
+  };
+}
+
+// Ranked aggregate — Borda pts preserved so applyScoreModel can rescore.
+// Alpha: slot1(pts=5)+slot3(pts=3) → Linear=8, Tiered=2+1=3, 1stOnly=2+1=3, Flat=2
+// Bravo: slot1(pts=5)              → Linear=5, Tiered=2,     1stOnly=2,     Flat=1
+const RANKED_AGG = {
+  clan_points:          { 'char-alpha-689': 8, 'char-bravo-689': 5 },
+  clan_votes:           {
+    'char-alpha-689': [{ pts: 5, voter: 'VoterA' }, { pts: 3, voter: 'VoterB' }],
+    'char-bravo-689': [{ pts: 5, voter: 'VoterC' }],
+  },
+  clan_voter_count:     { Mekhet: 3 },
+  covenant_points:      {}, covenant_votes: {}, covenant_voter_count: {},
+};
+
+// Political aggregate — Bravo leads (status-weighted; position irrelevant)
+const POLITICAL_AGG = {
+  clan_points:          { 'char-alpha-689': 1, 'char-bravo-689': 4 },
+  clan_votes:           {
+    'char-alpha-689': [{ pts: 1, voter: 'VoterA' }],
+    'char-bravo-689': [{ pts: 2, voter: 'VoterB' }, { pts: 2, voter: 'VoterC' }],
+  },
+  clan_voter_count:     { Mekhet: 3 },
+  covenant_points:      {}, covenant_votes: {}, covenant_voter_count: {},
+};
+
+async function setupST(page) {
+  await bootApp(page, ST_USER, {
+    routes: async (p) => {
+      await p.route(/\/api\/characters$/, r => r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([ALPHA]) }));
+      await p.route('**/api/characters/status', r => r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(ALL.map(statusProjection)) }));
+      await p.route('**/api/characters/names', r => r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(ALL.map(c => ({ _id: c._id, name: c.name }))) }));
+      await p.route('**/api/downtime_cycles', r => r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([ACTIVE_CYCLE]) }));
+      await p.route('**/api/ranking_ballots/aggregate*', r => {
+        const url = r.request().url();
+        const agg = url.includes('mode=ranked') ? RANKED_AGG : POLITICAL_AGG;
+        r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(agg) });
+      });
+    },
+  });
+  await goToTab(page, 'status');
+}
+
+test.describe('#689 — unified 5-button scoring/mode toggle', () => {
+
+  test('AC1 — single 5-button row; no Ranked button; no .rank-score-row', async ({ page }) => {
+    await setupST(page);
+
+    await expect(page.locator('#rank-clan-pills')).toBeVisible({ timeout: 8000 });
+
+    // All 5 unified buttons present
+    await expect(page.locator('.rank-mode-btn[data-mode="linear"]')).toBeVisible();
+    await expect(page.locator('.rank-mode-btn[data-mode="tiered"]')).toBeVisible();
+    await expect(page.locator('.rank-mode-btn[data-mode="first-only"]')).toBeVisible();
+    await expect(page.locator('.rank-mode-btn[data-mode="flat"]')).toBeVisible();
+    await expect(page.locator('.rank-mode-btn[data-mode="political"]')).toBeVisible();
+
+    // "Ranked" button removed by #689
+    await expect(page.locator('.rank-mode-btn[data-mode="ranked"]')).toHaveCount(0);
+
+    // Secondary score row removed by #689
+    await expect(page.locator('.rank-score-row')).toHaveCount(0);
+  });
+
+  test('AC2 — Linear button active by default; Political not active', async ({ page }) => {
+    await setupST(page);
+
+    await expect(page.locator('#rank-clan-pills')).toBeVisible({ timeout: 8000 });
+
+    await expect(page.locator('.rank-mode-btn[data-mode="linear"]')).toHaveClass(/active/);
+    await expect(page.locator('.rank-mode-btn[data-mode="political"]')).not.toHaveClass(/active/);
+  });
+
+  test('AC3 — Tiered button rescores ranked data (slot1+2→2pts, slot3-5→1pt)', async ({ page }) => {
+    await setupST(page);
+
+    const clanList = page.locator('#rank-clan-list');
+    await expect(clanList).toBeVisible({ timeout: 8000 });
+    await page.locator('#rank-clan-pills .rank-pill[data-key="Mekhet"]').click();
+
+    // Linear default: Alpha=8, Bravo=5
+    const alphaRow = clanList.locator('.rank-member-row').filter({ hasText: 'Alpha' });
+    await expect(alphaRow.locator('.rank-member-pts')).toContainText('8');
+
+    // Switch to Tiered
+    await page.locator('.rank-mode-btn[data-mode="tiered"]').click();
+    await expect(page.locator('.rank-mode-btn[data-mode="tiered"]')).toHaveClass(/active/);
+
+    // Alpha: slot1(5→2) + slot3(3→1) = 3
+    await expect(alphaRow.locator('.rank-member-pts')).toContainText('3');
+    // Bravo: slot1(5→2) = 2
+    const bravoRow = clanList.locator('.rank-member-row').filter({ hasText: 'Bravo' });
+    await expect(bravoRow.locator('.rank-member-pts')).toContainText('2');
+  });
+
+  test('AC4 — Political button uses political aggregate (Bravo leads)', async ({ page }) => {
+    await setupST(page);
+
+    const clanList = page.locator('#rank-clan-list');
+    await expect(clanList).toBeVisible({ timeout: 8000 });
+    await page.locator('#rank-clan-pills .rank-pill[data-key="Mekhet"]').click();
+
+    // Linear default: Alpha leads (8)
+    const alphaRow = clanList.locator('.rank-member-row').filter({ hasText: 'Alpha' });
+    await expect(alphaRow.locator('.rank-member-pts')).toContainText('8');
+
+    // Switch to Political: Bravo leads (4), Alpha drops to 1
+    await page.locator('.rank-mode-btn[data-mode="political"]').click();
+    await expect(page.locator('.rank-mode-btn[data-mode="political"]')).toHaveClass(/active/);
+    await expect(alphaRow.locator('.rank-member-pts')).toContainText('1');
+    const bravoRow = clanList.locator('.rank-member-row').filter({ hasText: 'Bravo' });
+    await expect(bravoRow.locator('.rank-member-pts')).toContainText('4');
+  });
+
+  test('AC5 — Political stored in sessionStorage is restored as active on load', async ({ page }) => {
+    await page.addInitScript(() => {
+      sessionStorage.setItem('tm_ranking_score_model', 'political');
+    });
+    await setupST(page);
+
+    await expect(page.locator('#rank-clan-pills')).toBeVisible({ timeout: 8000 });
+
+    await expect(page.locator('.rank-mode-btn[data-mode="political"]')).toHaveClass(/active/);
+    await expect(page.locator('.rank-mode-btn[data-mode="linear"]')).not.toHaveClass(/active/);
+  });
+
+  test('AC5b — clicking a model writes it to sessionStorage', async ({ page }) => {
+    await setupST(page);
+
+    await expect(page.locator('#rank-clan-pills')).toBeVisible({ timeout: 8000 });
+
+    await page.locator('.rank-mode-btn[data-mode="flat"]').click();
+
+    const stored = await page.evaluate(() => sessionStorage.getItem('tm_ranking_score_model'));
+    expect(stored).toBe('flat');
+  });
+
+});


### PR DESCRIPTION
## Summary

- The Ranked/Political toggle and Linear/Tiered/1st Only/Flat score row were two
  separate button groups doing one conceptual job; this merges them into a single
  unified row so the ST can switch both view mode and scoring model with one click
- Political is now a peer of the four scoring models; `getAgg()` returns `politicalAgg`
  directly for political, else rescores the ranked aggregate via `applyScoreModel`
- sessionStorage key `tm_ranking_score_model` now accepts `political` as a valid
  persisted value; active button is restored from sessionStorage at render time
- 8 stale contract tests in the #687 Vitest suite updated to match the new
  implementation; all 36 pass alongside 6 new Playwright E2E tests

## Closes

- Closes #689

## Story

- specs/stories/feature.689.ranking-collapse-mode-buttons.story.md

## Test plan

- [ ] `cd server && npx vitest run tests/feature.687.ranking-score-models.test.js` — 36 pass
- [ ] `npx playwright test tests/feature-689-ranking-collapse-mode-buttons.spec.js` — 6 pass
- [ ] CI green
- [ ] Manual (on dev): Status tab ST view shows single row of 5 buttons (Linear | Tiered | 1st Only | Flat | Political); switching updates the ranking list; chosen model (including Political) persists on refresh

## Branch flow

- From: `ms/issue-689-ranking-collapse-mode-buttons`
- Into: `dev`