### PR TITLE
N-3: Necropolis merit family seed + Collective Compound rule_grant + rating_of_source (#692)

### DIFF
--- a/public/js/editor/rule_engine/pool-evaluator.js
+++ b/public/js/editor/rule_engine/pool-evaluator.js
@@ -52,6 +52,13 @@ function _computeAmount(c, rule) {
         : (rule.partner_merit_name ? [rule.partner_merit_name] : []);
       return names.reduce((sum, n) => sum + _ratingOfPartner(c, n), 0);
     }
+    case 'rating_of_source':
+      // N-3 / MNEC (issue #692): pool size = the source merit's own purchased
+      // rating. Necropolis Sepulcher 3 → 3 free dots distributable across the
+      // Collective Compound's six target merits via `free_grants.necro`.
+      // Reads cp+xp directly (matches _ratingOfPartner semantics — pool basis
+      // is purchased dots only, not free grants — to avoid feedback loops).
+      return _ratingOfPartner(c, rule.source);
     case 'flat':
       return rule.amount ?? 0;
     default:

--- a/server/scripts/seed-rules-necropolis.js
+++ b/server/scripts/seed-rules-necropolis.js
@@ -1,0 +1,324 @@
+#!/usr/bin/env node
+
+/**
+ * N-3 / MNEC (issue #692, epic specs/epic-mnec-necropolis-merits.md) — atomic
+ * Necropolis merit family seeder.
+ *
+ * Two collections touched in one idempotent pass:
+ *
+ *   purchasable_powers — nine merit docs upserted by `key`:
+ *     true-worm, necropolis-sepulcher, catacombs, caldarium, garbage-pit,
+ *     labyrinth-guardians, dark-temple, white-ants, trap-door.
+ *
+ *   rule_grant — one Collective Compound source doc for Necropolis Sepulcher
+ *     (`source_slug: 'necro'`, `amount_basis: 'rating_of_source'`,
+ *     `sharing_scope: { type: 'collective_owners_of_merit', merit:
+ *     'Necropolis Sepulcher', min_dots: 1 }`, `partner_shareable: true`,
+ *     six pool_targets — the collectively-shared target merits).
+ *
+ * Verbatim rule text per the MNEC epic. Three typos preserved per Peter's
+ * 2026-06-10 ack — see the epic's Editorial Notes:
+ *   - White Ants:  'to detects' (intended 'to detect')
+ *   - Trap Door:   'above group' (intended 'above ground')
+ *   - Trap Door:   'a entrance'  (intended 'an entrance')
+ * DO NOT auto-correct these.
+ *
+ * Idempotent: uses `replaceOne(filter, doc, { upsert: true })` keyed on the
+ * stable `key` (merits) and `{source, grant_type}` (rule_grant). Re-running
+ * with no flag (dry-run) reports zero pending writes after the first apply.
+ *
+ * Usage:
+ *   node server/scripts/seed-rules-necropolis.js                # dry run (default)
+ *   node server/scripts/seed-rules-necropolis.js --apply        # write
+ *   MONGODB_DB=tm_suite_test node server/scripts/seed-rules-necropolis.js --apply
+ *
+ * Locally, run from `server/` so cwd-relative `dotenv/config` picks up
+ * `server/.env`. On Render env vars are pre-set (no-op).
+ * (See memory [[feedback_server_scripts_dotenv_path]].)
+ */
+
+import 'dotenv/config';
+import { MongoClient } from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+const DRY_RUN = !APPLY;
+const MONGODB_URI = process.env.MONGODB_URI;
+const DB_NAME = process.env.MONGODB_DB || 'tm_suite';
+
+if (!MONGODB_URI) {
+  console.error('MONGODB_URI not set. Ensure server/.env is present and the script is run from server/.');
+  process.exit(1);
+}
+
+// ── Prereq tree shorthands ──
+const PREREQ_CLAN = { type: 'clan', name: 'Nosferatu' };
+const PREREQ_FAMILY = {
+  all: [
+    PREREQ_CLAN,
+    { type: 'merit', name: 'Necropolis Sepulcher', dots: 1 },
+  ],
+};
+
+/** Common shape — implementation status flags + nullable fields the existing
+ *  merit docs all carry. Filled per-merit below. */
+function _baseDoc(overrides) {
+  return {
+    category: 'merit',
+    parent: 'Kindred',
+    rank: null,
+    rating_range: null,
+    description: null,
+    pool: null,
+    resistance: null,
+    cost: null,
+    action: null,
+    duration: null,
+    prereq: null,
+    exclusive: null,
+    xp_fixed: null,
+    special: null,
+    bloodline: null,
+    implemented: true,
+    selected: true,
+    sub_category: null,
+    cult: null,
+    offering: null,
+    ...overrides,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Nine merits — verbatim rule text per epic-mnec-necropolis-merits.md
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MERITS = [
+  // 1. Necropolis Sepulcher — the gate / Collective Compound source.
+  _baseDoc({
+    key: 'necropolis-sepulcher',
+    name: 'Necropolis Sepulcher',
+    rating_range: [1, 5],
+    prereq: PREREQ_CLAN,
+    description:
+      "Prerequisites: Nosferatu Status •\n\n" +
+      "One dot of this merit buys a Nosferatu small home within the Necropolis and gives them 1 point per dot to spend in other Necropolis Merits. " +
+      "Further expenditure on this merit provides a larger space for the Haunt's Haven and provides more dots to invest into the Necropolis. " +
+      "This acts as a personal, non-shareable, Safe Place in the Necropolis.",
+  }),
+
+  // 2. Catacombs — collective-shared.
+  _baseDoc({
+    key: 'catacombs',
+    name: 'Catacombs',
+    rating_range: [1, 5],
+    prereq: PREREQ_FAMILY,
+    description:
+      "Navigating the tunnels necessitates an extended Wits + Investigation roll, with ten successes required. " +
+      "Each roll is equivalent to one hour's worth of wandering. Those who do not have dots in Necropolis Sepulcher suffer a penalty to this roll equal to the total dots in this Catacombs. " +
+      "Those who do possess any dots in the Merit, however, may still have to succeed if distracted, or under time pressure or duress. " +
+      "Even the Haunts may find themselves periodically lost in the dark and distorted heart of their own Necropolis. " +
+      "In such a case, a resident can add Clan Status to these rolls, representing how familiar they are with the Catacombs and the Warren in general.\n\n" +
+      "This Merit is shared between all Haunts with dots in the Necropolis.",
+  }),
+
+  // 3. Caldarium — collective-shared.
+  _baseDoc({
+    key: 'caldarium',
+    name: 'Caldarium',
+    rating_range: [1, 3],
+    prereq: PREREQ_FAMILY,
+    description:
+      "The Caldaria is the one location in the Necropolis that strangers may be allowed to visit, it is, in a way, a Nosferatu Elysium: one shall not bring violence here.\n\n" +
+      "At one dot, the Caldarium provides a place of social power for the Nosferatu: all Haunts within the Caldarium gain +1 to City Status and rolls involving Expression, Persuasion, Socialize or Subterfuge.\n\n" +
+      "At two dots, this bonus increases to +2.\n\n" +
+      "At three dots, a dark serenity stays with the Haunt even after it leaves the bathhouse. For the rest of the night, Haunts may re-roll one Social or Mental action.\n\n" +
+      "This Merit is shared between all Haunts with dots in the Necropolis.",
+  }),
+
+  // 4. Garbage Pit — collective-shared.
+  _baseDoc({
+    key: 'garbage-pit',
+    name: 'Garbage Pit',
+    rating_range: [1, 3],
+    prereq: PREREQ_FAMILY,
+    description:
+      "The Garbage Pit provides 2 distinct benefits that Haunts have learnt not to look too closely at: " +
+      "Once per Chapter a Haunt willing to spend the time can find a trash version of basically anything in the depths of the pit. " +
+      "Anything above Availability equal to this merit will be trashed enough to reduce it to that level. " +
+      "Secondly, any object thrown into the Garbage Pit with intention is never, ever, seen again. No, torpored Kindred are not objects.\n\n" +
+      "This Merit is shared between all Haunts with dots in the Necropolis.",
+  }),
+
+  // 5. Labyrinth Guardians — collective-shared.
+  _baseDoc({
+    key: 'labyrinth-guardians',
+    name: 'Labyrinth Guardians',
+    rating_range: [1, 5],
+    prereq: PREREQ_FAMILY,
+    description:
+      "Guardian Swarms are packs or hordes of mutant animals that live in the Warren. " +
+      "These creatures are unnatural (flat-white eyes, stitched-together limbs, too human voices, etc.) and will attack any non-resident they come across. " +
+      "If the Guardians have their Health track filled with lethal damage, they'll disperse. However, they will return after a week to roam the Warren once again. " +
+      "Any resident who encounters the Labyrinth Guardians must feed them a point of Vitae, or suffer their attacks — their vigil has a price, after all.\n\n" +
+      "This Merit is shared between all Haunts with dots in the Necropolis.",
+  }),
+
+  // 6. Dark Temple — collective-shared; flat 2 dots, xp_fixed: 2.
+  _baseDoc({
+    key: 'dark-temple',
+    name: 'Dark Temple',
+    rating_range: [2, 2],
+    xp_fixed: 2,
+    prereq: PREREQ_FAMILY,
+    description:
+      "A Haunt spending time in the Dark Temple has their Beast quietened; they take the Sated Condition (+1 on Frenzy checks) and are considered to have meditated (+1 on Breakpoint checks). " +
+      "However, it is unquiet even for a Haunt, and they take the Spooked Condition, distracted by otherworldly whispers at the edges of perception.\n\n" +
+      "This Merit is shared between all Haunts with dots in the Necropolis.",
+  }),
+
+  // 7. White Ants — collective-shared, territory-linked. Typo PRESERVED: "to detects".
+  _baseDoc({
+    key: 'white-ants',
+    name: 'White Ants',
+    rating_range: [1, 5],
+    prereq: PREREQ_FAMILY,
+    description:
+      "The Necropolis sprawls and opens into Territories far beyond what is reasonable. " +
+      "For each dot in this merit select a Territory the Necropolis has infected. " +
+      // VERBATIM TYPO PRESERVED ("to detects" — intended "to detect") per Peter 2026-06-10 ack.
+      "Haunts taking clandestine actions in that area apply a -3 to all rolls to detects their personal actions against anyone who does not possess dots in Necropolis Sepulcher.\n\n" +
+      "This Merit is shared between all Haunts with dots in the Necropolis.",
+  }),
+
+  // 8. Trap Door — attached dual-anchor; flat 1 dot, xp_fixed: 1.
+  //    Typos PRESERVED: "a entrance", "above group".
+  _baseDoc({
+    key: 'trap-door',
+    name: 'Trap Door',
+    rating_range: [1, 1],
+    xp_fixed: 1,
+    prereq: PREREQ_FAMILY,
+    description:
+      // VERBATIM TYPOS PRESERVED ("a entrance" → "an entrance"; "above group" → "above ground") per Peter 2026-06-10 ack.
+      "The Haunt has put a entrance to the Necropolis in a purchased Safe Place above group in a Territory covered by White Ants. " +
+      "While they can do much to keep this entrance secret from other Haunts, nothing is ever guaranteed and any other Haunt using this entrance can bypass external Safe Place benefits. " +
+      "To find this other Haunts must navigate the Catacomb as if they do not possess dots in Necropolis Sepulcher.\n\n" +
+      "This merit is not shared and is linked to a specific Safe Place.",
+  }),
+
+  // 9. True Worm — standalone drawback; flat 2 dots, xp_fixed: 2.
+  _baseDoc({
+    key: 'true-worm',
+    name: 'True Worm',
+    rating_range: [2, 2],
+    xp_fixed: 2,
+    prereq: PREREQ_CLAN,
+    description:
+      "So used to the dark, the Nosferatu no longer feels the draw of day sleep when in the tunnels of the Necropolis that lay more than 10 meters below the earth where there is no possibility of sunlight. " +
+      "They still must spend 1 Vitae each day to 'wake'.\n\n" +
+      "Drawback: While active during the day, the Nosferatu is at half his normal Speed (round up). " +
+      "In addition, a Haunt possessing this Merit is especially harmed by sunlight. " +
+      "The Nosferatu suffers +1 Health point per time unit when exposed to any of the sun's rays.",
+  }),
+];
+
+// ─────────────────────────────────────────────────────────────────────────────
+// One Collective Compound source rule_grant doc for Necropolis Sepulcher.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const NECRO_RULE_GRANT = {
+  source: 'Necropolis Sepulcher',
+  source_slug: 'necro',
+  grant_type: 'pool',
+  condition: 'merit_present',
+  amount_basis: 'rating_of_source',
+  pool_targets: [
+    'Catacombs',
+    'Caldarium',
+    'Garbage Pit',
+    'Labyrinth Guardians',
+    'Dark Temple',
+    'White Ants',
+  ],
+  partner_shareable: true,
+  sharing_scope: {
+    type: 'collective_owners_of_merit',
+    merit: 'Necropolis Sepulcher',
+    min_dots: 1,
+  },
+  notes:
+    'MNEC Collective Compound source (issue #692). R dots in Necropolis Sepulcher grant R free dots into free_grants.necro, ' +
+    'distributable across the six collectively-shared target merits. Sharing is auto-synthesised at render time via ' +
+    'resolveSharingScope (no partner_explicit list to maintain). Per MNEC epic + ADR-005 Rev 2.',
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Driver
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log(`Mode: ${APPLY ? 'APPLY (will write)' : 'DRY RUN (read only; pass --apply to write)'}`);
+  console.log(`Target DB: ${DB_NAME}\n`);
+
+  const client = new MongoClient(MONGODB_URI, { serverSelectionTimeoutMS: 10000, tls: true });
+  try {
+    await client.connect();
+    const db = client.db(DB_NAME);
+    const merits = db.collection('purchasable_powers');
+    const grants = db.collection('rule_grant');
+
+    let touched = 0;
+
+    console.log('purchasable_powers:');
+    for (const doc of MERITS) {
+      // Compare against the existing doc (if any) to decide whether this run
+      // would actually change state. _id is preserved on existing docs and
+      // re-generated on inserts; excluded from comparison.
+      const existing = await merits.findOne({ key: doc.key });
+      const willChange = _docDiffers(existing, doc);
+      const verb = DRY_RUN ? '[DRY RUN] would' : '';
+      console.log(`  ${doc.key.padEnd(22)} ${existing ? 'exists' : 'new   '} ${willChange ? `${verb} write` : 'no change'}`);
+      if (!DRY_RUN && willChange) {
+        await merits.replaceOne({ key: doc.key }, doc, { upsert: true });
+        touched++;
+      } else if (DRY_RUN && willChange) {
+        touched++;
+      }
+    }
+
+    console.log('\nrule_grant:');
+    const existingRule = await grants.findOne({ source: NECRO_RULE_GRANT.source, grant_type: 'pool' });
+    const ruleChanges = _docDiffers(existingRule, NECRO_RULE_GRANT);
+    const verb = DRY_RUN ? '[DRY RUN] would' : '';
+    console.log(`  Necropolis Sepulcher pool ${existingRule ? 'exists' : 'new   '} ${ruleChanges ? `${verb} upsert` : 'no change'}`);
+    if (!DRY_RUN && ruleChanges) {
+      await grants.replaceOne({ source: NECRO_RULE_GRANT.source, grant_type: 'pool' }, NECRO_RULE_GRANT, { upsert: true });
+      touched++;
+    } else if (DRY_RUN && ruleChanges) {
+      touched++;
+    }
+
+    console.log('');
+    if (DRY_RUN) {
+      console.log(`[DRY RUN] Would touch ${touched} doc(s) across both collections.`);
+      console.log('Re-run with --apply to write.');
+    } else {
+      console.log(`Touched ${touched} doc(s) across both collections.`);
+      console.log('Idempotency check: re-run with no flag (dry-run) and confirm "no change" on every line.');
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+/** Shallow-then-deep comparison excluding _id. Returns true if the docs differ
+ *  in any field that the seed populates. New doc keys not in existing → diff. */
+function _docDiffers(existing, target) {
+  if (!existing) return true;
+  for (const k of Object.keys(target)) {
+    if (k === '_id') continue;
+    if (JSON.stringify(existing[k]) !== JSON.stringify(target[k])) return true;
+  }
+  return false;
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/server/tests/n3-necropolis.test.js
+++ b/server/tests/n3-necropolis.test.js
@@ -1,0 +1,299 @@
+/**
+ * N-3 (issue #692, MNEC epic) — Necropolis merit family seed + evaluator extension.
+ *
+ * Four acceptance gates from the dispatch:
+ *   1. MERITS_DB entry presence + shape — all 9 docs present in purchasable_powers
+ *      after --apply, with correct rating_range / xp_fixed / prereq.
+ *   2. rule_grant seed idempotency + shape — Necropolis Sepulcher pool doc has
+ *      partner_shareable + sharing_scope + amount_basis='rating_of_source';
+ *      re-running the seed touches zero docs.
+ *   3. pool-evaluator rating_of_source math — character with Necropolis
+ *      Sepulcher 3 → emits a `_grant_pools` entry of amount 3 across the six
+ *      target merits.
+ *   4. End-to-end Collective Compound (Necropolis-flavoured) — two chars with
+ *      Sepulcher dots + Catacombs allocations see each other in the synthesised
+ *      `_collective_shared_with` on Catacombs.
+ *
+ * Plus: verbatim-typo presence assertion (the three preserved typos).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { createTestApp, stUser } from './helpers/test-app.js';
+import { setupDb, teardownDb } from './helpers/db-setup.js';
+import { getCollection } from '../db.js';
+import { resolveSharingScope } from '../../public/js/data/rules-helpers.js';
+import { applyPoolRulesFromDb } from '../../public/js/editor/rule_engine/pool-evaluator.js';
+
+let app;
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SEED_PATH = resolve(__dirname, '..', 'scripts', 'seed-rules-necropolis.js');
+
+const MERIT_KEYS = [
+  'necropolis-sepulcher', 'catacombs', 'caldarium', 'garbage-pit',
+  'labyrinth-guardians', 'dark-temple', 'white-ants', 'trap-door', 'true-worm',
+];
+
+beforeAll(async () => {
+  await setupDb();
+  app = createTestApp();
+  // Clean any prior residue then apply the seed exactly once for this test
+  // suite. The script is keyed by `key` / `{source, grant_type}` so re-running
+  // it after this round mid-suite is also safe.
+  await getCollection('purchasable_powers').deleteMany({ key: { $in: MERIT_KEYS } });
+  await getCollection('rule_grant').deleteMany({ source: 'Necropolis Sepulcher' });
+  await getCollection('characters').deleteMany({ _test_n3: true });
+
+  const r = spawnSync('node', [SEED_PATH, '--apply'], {
+    env: { ...process.env, MONGODB_DB: process.env.MONGODB_DB || 'tm_suite_test' },
+    encoding: 'utf8',
+  });
+  if (r.status !== 0) {
+    throw new Error(`seed --apply failed: ${r.stdout}\n${r.stderr}`);
+  }
+});
+
+afterAll(async () => {
+  await getCollection('purchasable_powers').deleteMany({ key: { $in: MERIT_KEYS } });
+  await getCollection('rule_grant').deleteMany({ source: 'Necropolis Sepulcher' });
+  await getCollection('characters').deleteMany({ _test_n3: true });
+  await teardownDb();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gate 1 — all 9 MERITS_DB entries present with correct shape
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-3 — purchasable_powers seed (9 Necropolis merits)', () => {
+  it('all 9 merit docs exist with parent="Kindred" and category="merit"', async () => {
+    const docs = await getCollection('purchasable_powers').find({ key: { $in: MERIT_KEYS } }).toArray();
+    expect(docs).toHaveLength(9);
+    expect(docs.every(d => d.parent === 'Kindred')).toBe(true);
+    expect(docs.every(d => d.category === 'merit')).toBe(true);
+    expect(docs.every(d => typeof d.description === 'string' && d.description.length > 0)).toBe(true);
+  });
+
+  it('rating_range matches the MNEC epic table', async () => {
+    const m = Object.fromEntries(
+      (await getCollection('purchasable_powers').find({ key: { $in: MERIT_KEYS } }).toArray())
+        .map(d => [d.key, d])
+    );
+    expect(m['necropolis-sepulcher'].rating_range).toEqual([1, 5]);
+    expect(m['catacombs'].rating_range).toEqual([1, 5]);
+    expect(m['caldarium'].rating_range).toEqual([1, 3]);
+    expect(m['garbage-pit'].rating_range).toEqual([1, 3]);
+    expect(m['labyrinth-guardians'].rating_range).toEqual([1, 5]);
+    expect(m['white-ants'].rating_range).toEqual([1, 5]);
+    expect(m['dark-temple'].rating_range).toEqual([2, 2]);
+    expect(m['true-worm'].rating_range).toEqual([2, 2]);
+    expect(m['trap-door'].rating_range).toEqual([1, 1]);
+  });
+
+  it('xp_fixed set on the three flat-cost merits, null elsewhere', async () => {
+    const m = Object.fromEntries(
+      (await getCollection('purchasable_powers').find({ key: { $in: MERIT_KEYS } }).toArray())
+        .map(d => [d.key, d])
+    );
+    expect(m['true-worm'].xp_fixed).toBe(2);
+    expect(m['dark-temple'].xp_fixed).toBe(2);
+    expect(m['trap-door'].xp_fixed).toBe(1);
+    // The remaining six use the standard rated-merit formula.
+    for (const key of ['necropolis-sepulcher', 'catacombs', 'caldarium', 'garbage-pit', 'labyrinth-guardians', 'white-ants']) {
+      expect(m[key].xp_fixed).toBeNull();
+    }
+  });
+
+  it('prereqs match the MNEC family/standalone split', async () => {
+    const m = Object.fromEntries(
+      (await getCollection('purchasable_powers').find({ key: { $in: MERIT_KEYS } }).toArray())
+        .map(d => [d.key, d])
+    );
+    // Standalone clan-only: Sepulcher (the gate itself) and True Worm.
+    expect(m['necropolis-sepulcher'].prereq).toEqual({ type: 'clan', name: 'Nosferatu' });
+    expect(m['true-worm'].prereq).toEqual({ type: 'clan', name: 'Nosferatu' });
+    // The six family-bound + Trap Door: compound clan + Sepulcher ≥ 1.
+    const FAMILY = { all: [{ type: 'clan', name: 'Nosferatu' }, { type: 'merit', name: 'Necropolis Sepulcher', dots: 1 }] };
+    for (const key of ['catacombs', 'caldarium', 'garbage-pit', 'labyrinth-guardians', 'dark-temple', 'white-ants', 'trap-door']) {
+      expect(m[key].prereq).toEqual(FAMILY);
+    }
+  });
+
+  it('preserves the three CSV-verbatim typos per Peter 2026-06-10 ack', async () => {
+    const wa = await getCollection('purchasable_powers').findOne({ key: 'white-ants' });
+    const td = await getCollection('purchasable_powers').findOne({ key: 'trap-door' });
+    // White Ants: "to detects" — NOT "to detect".
+    expect(wa.description).toContain('to detects their personal actions');
+    // Trap Door: "a entrance" — NOT "an entrance".
+    expect(td.description).toContain('a entrance to the Necropolis');
+    // Trap Door: "above group" — NOT "above ground".
+    expect(td.description).toContain('above group in a Territory');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gate 2 — rule_grant shape + idempotency
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-3 — Necropolis Sepulcher rule_grant', () => {
+  it('exists with Collective Compound shape', async () => {
+    const rule = await getCollection('rule_grant').findOne({ source: 'Necropolis Sepulcher', grant_type: 'pool' });
+    expect(rule).toBeTruthy();
+    expect(rule.source_slug).toBe('necro');
+    expect(rule.amount_basis).toBe('rating_of_source');
+    expect(rule.partner_shareable).toBe(true);
+    expect(rule.sharing_scope).toEqual({
+      type: 'collective_owners_of_merit',
+      merit: 'Necropolis Sepulcher',
+      min_dots: 1,
+    });
+    expect(rule.pool_targets).toEqual([
+      'Catacombs', 'Caldarium', 'Garbage Pit',
+      'Labyrinth Guardians', 'Dark Temple', 'White Ants',
+    ]);
+  });
+
+  it('re-running the seed --apply is idempotent (zero further writes)', async () => {
+    const r = spawnSync('node', [SEED_PATH, '--apply'], {
+      env: { ...process.env, MONGODB_DB: process.env.MONGODB_DB || 'tm_suite_test' },
+      encoding: 'utf8',
+    });
+    expect(r.status).toBe(0);
+    // After the beforeAll apply, a second --apply finds every doc unchanged
+    // and reports "Touched 0 doc(s)".
+    expect(r.stdout).toMatch(/Touched 0 doc\(s\)/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gate 3 — pool-evaluator `rating_of_source` math
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-3 — pool-evaluator amount_basis=rating_of_source', () => {
+  it('emits _grant_pools entry of amount = source merit rating', () => {
+    const c = {
+      _grant_pools: [],
+      merits: [
+        // Necropolis Sepulcher 3 (cp=2, xp=1 → rating 3).
+        { name: 'Necropolis Sepulcher', cp: 2, xp: 1 },
+      ],
+    };
+    const rule = {
+      source: 'Necropolis Sepulcher',
+      source_slug: 'necro',
+      grant_type: 'pool',
+      condition: 'merit_present',
+      amount_basis: 'rating_of_source',
+      pool_targets: ['Catacombs', 'Caldarium', 'Garbage Pit', 'Labyrinth Guardians', 'Dark Temple', 'White Ants'],
+      category: 'necro',
+    };
+    applyPoolRulesFromDb(c, { grants: [rule] });
+    expect(c._grant_pools).toHaveLength(1);
+    expect(c._grant_pools[0]).toMatchObject({
+      source: 'Necropolis Sepulcher',
+      category: 'necro',
+      amount: 3,
+      names: ['Catacombs', 'Caldarium', 'Garbage Pit', 'Labyrinth Guardians', 'Dark Temple', 'White Ants'],
+    });
+  });
+
+  it('does NOT emit when the source merit is absent (condition: merit_present)', () => {
+    const c = { _grant_pools: [], merits: [{ name: 'Some Other Merit', cp: 5 }] };
+    const rule = {
+      source: 'Necropolis Sepulcher',
+      grant_type: 'pool',
+      condition: 'merit_present',
+      amount_basis: 'rating_of_source',
+      pool_targets: ['Catacombs'],
+      category: 'necro',
+    };
+    applyPoolRulesFromDb(c, { grants: [rule] });
+    expect(c._grant_pools).toHaveLength(0);
+  });
+
+  it('rating_of_source uses purchased dots only (cp+xp) — free grants don\'t feedback', () => {
+    // Anti-loop guard: if the engine counted free_<slug> dots, a Necropolis
+    // Sepulcher grant could amplify itself. Confirm purchased-only.
+    const c = {
+      _grant_pools: [],
+      merits: [
+        { name: 'Necropolis Sepulcher', cp: 1, xp: 0, free_grants: { necro: 99 }, free_mci: 99 },
+      ],
+    };
+    const rule = {
+      source: 'Necropolis Sepulcher',
+      grant_type: 'pool',
+      condition: 'merit_present',
+      amount_basis: 'rating_of_source',
+      pool_targets: ['Catacombs'],
+      category: 'necro',
+    };
+    applyPoolRulesFromDb(c, { grants: [rule] });
+    expect(c._grant_pools[0].amount).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Gate 4 — end-to-end Collective Compound (Necropolis-flavoured)
+//   Pins the general-case test from N-1 to the actual Necropolis instance.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-3 — end-to-end Collective Compound (Necropolis fixture)', () => {
+  let aliceId, bobId, carlId;
+
+  beforeAll(async () => {
+    const mk = (name, sepulcherDots, catacombsDots) => ({
+      _test_n3: true,
+      name,
+      merits: [
+        ...(sepulcherDots > 0
+          ? [{ name: 'Necropolis Sepulcher', category: 'general', cp: sepulcherDots, xp: 0 }]
+          : []),
+        ...(catacombsDots > 0
+          ? [{ name: 'Catacombs', category: 'domain', cp: catacombsDots, xp: 0 }]
+          : []),
+      ],
+    });
+    const ins = await getCollection('characters').insertMany([
+      mk('N3_Alice', 3, 2),
+      mk('N3_Bob',   2, 1),
+      mk('N3_Carl',  0, 0),
+    ]);
+    aliceId = ins.insertedIds[0];
+    bobId = ins.insertedIds[1];
+    carlId = ins.insertedIds[2];
+  });
+
+  it('GET /api/characters synthesises _collective_shared_with on Catacombs for both Sepulcher owners', async () => {
+    const res = await request(app).get('/api/characters').set('X-Test-User', stUser());
+    expect(res.status).toBe(200);
+    const find = (name) => res.body.find(c => c.name === name);
+
+    const alice = find('N3_Alice');
+    const bob = find('N3_Bob');
+    const carl = find('N3_Carl');
+
+    const aliceCatacombs = alice.merits.find(m => m.name === 'Catacombs');
+    const bobCatacombs = bob.merits.find(m => m.name === 'Catacombs');
+    expect(aliceCatacombs._collective_shared_with).toEqual(['N3_Bob']);
+    expect(bobCatacombs._collective_shared_with).toEqual(['N3_Alice']);
+
+    // Carl has no Catacombs merit at all (and no Sepulcher) — nothing to assert
+    // beyond the absence of the field on any of his merits.
+    expect((carl.merits || []).every(m => !('_collective_shared_with' in m))).toBe(true);
+  });
+
+  it('pure-function resolver matches the API behaviour for the same fixture', async () => {
+    // Sanity: the helper and the server enrichment must agree, otherwise the
+    // synthesis writeup vs the resolveSharingScope contract has drifted.
+    const chars = await getCollection('characters').find({ _test_n3: true }).toArray();
+    const scope = { type: 'collective_owners_of_merit', merit: 'Necropolis Sepulcher', min_dots: 1 };
+    const alice = chars.find(c => c.name === 'N3_Alice');
+    const carl = chars.find(c => c.name === 'N3_Carl');
+    expect(resolveSharingScope(scope, alice, chars)).toEqual(['N3_Bob']);
+    expect(resolveSharingScope(scope, carl, chars)).toBeNull();
+  });
+});

--- a/specs/epic-mnec-necropolis-merits.md
+++ b/specs/epic-mnec-necropolis-merits.md
@@ -1,0 +1,304 @@
+# Epic MNEC: Necropolis Merit Family (Collective Compound — first instance)
+
+## Status (2026-06-10)
+
+**FINAL.** All 9 merits carry canonical rule text from Peter's CSV (verbatim text forwarded by Khepri 2026-06-10). Structural shape, schema patterns, prereqs, xp_fixed, family clan constraint, and the four Khepri-resolved decisions are LOCKED. ADR-005 Rev 2 (PR #659) carries the dual-anchor `attached_to` shape that supports Trap Door (D7). N-3 dispatch unblocked.
+
+Three CSV-verbatim typos (White Ants: "to detects"; Trap Door: "a entrance" + "above group") preserved per the canonical-CSV principle — Peter explicitly acked preserve-as-is 2026-06-10. See **Editorial Notes** at the foot of this epic. The rules engine and player-facing display render the verbatim text.
+
+## Motivation
+
+Peter is introducing a family of nine merits centred on a shared underground site (the Necropolis). The structural shape of this family — a per-character **gate** merit that grants pool dots into a set of **collectively-shared** target merits, plus optional **attached** merits — is the first concrete instance of a recurring pattern: **Collective Compound**. Future covenant compounds (Lancea Sanctum crypt, Carthian commune), clan-specific group sites (Ventrue corporate, Mekhet archive), and bloodline shared rites are likely to follow the same shape.
+
+This epic specifies:
+1. The **Collective Compound** abstraction at the PRD level (shape, sharing semantics, schema patterns) so future instances can be scoped against a named pattern.
+2. The nine **Necropolis** merits as the first concrete instance, integrated into the existing merit-family structure.
+
+Architecture for the abstraction is owned by **ADR-005** (in design by Imhotep). This epic provides the product framing; ADR-005 chooses how the read-side resolver and schema slot into the rules engine.
+
+## Clan constraint
+
+**The entire MNEC family is Nosferatu-exclusive.** Every merit in this epic carries `{"type":"clan","name":"Nosferatu"}` as part of its `prereq_json`. Eight of the nine merits also require `{"type":"merit","name":"Necropolis Sepulcher","dots":1}` (everything except Necropolis Sepulcher itself and True Worm). The composite prereq for the family-bound merits is:
+
+```json
+{"all":[
+  {"type":"clan","name":"Nosferatu"},
+  {"type":"merit","name":"Necropolis Sepulcher","dots":1}
+]}
+```
+
+True Worm is Nosferatu-only but **not** Sepulcher-gated (it stands alone within the family). Necropolis Sepulcher itself is Nosferatu-only, no merit prereq.
+
+## Goals
+
+- Players can purchase Necropolis Sepulcher dots and receive free grants into a curated pool of Necropolis target merits.
+- Six collectively-shared merits in the family auto-share between all characters with Necropolis Sepulcher dots — no per-merit partner picker, no explicit ally list.
+- One attached merit (Trap Door) bridges a Safe Place to a Necropolis Sepulcher — dual-anchor.
+- One drawback merit (True Worm) lives in the family for thematic grouping but is mechanically standalone.
+- The schema and resolver shape are general enough that the next covenant or clan compound is a content addition, not a redesign.
+
+## Non-Goals
+
+- **No partner picker UI.** Collective sharing is implicit (gated on Sepulcher dots); there is no allies list to maintain.
+- **No retroactive audit-cleanup of existing pool-grant inconsistency in this epic.** Lorekeeper / Invested / VM / MCI use varying partner_shareable treatments that may be deliberate or accreted. That audit is a separate prerequisite story flagged below; do NOT bundle into MNEC scope.
+- **No global template library** of compound merits in v1 — this epic introduces one concrete instance plus the abstraction; cross-instance management UI is future work if it materialises.
+- **No second compound instance.** Covenant/clan/bloodline variants are out of scope here; this epic stands up the pattern only.
+
+## The Collective Compound abstraction
+
+A Collective Compound merit family has three roles:
+
+1. **Gate merit** — per-character, rated (1-5). Owning the gate is the entry condition for the compound. Dot rating drives pool grants into the target merit set. Per-character; **not** collectively-shared (each ST/player buys their own dots).
+2. **Target merits** — one or more merits whose mechanical benefit is **collectively-shared** between every character who owns Gate dots ≥ N. Per-character ownership of a target is a free grant funded by gate pool; benefit fires for any gate-owner.
+3. **Attached merits** (optional) — per-character merits whose effect anchors to one or more named compound roles. Examples include single-anchor (Haven-style `attached_to: Safe Place`) and **dual-anchor** (Trap Door: `attached_to: { origin: Necropolis Sepulcher, destination: Safe Place }`).
+
+The family can also include **standalone members** — merits that group thematically with the family but participate in no pool, no sharing, and no anchoring. True Worm is the example here.
+
+### Schema patterns introduced by this epic
+
+These are PRD-level requirements on the merit schema; ADR-005 specifies the canonical field names and resolver behaviour.
+
+- **`sharing_scope`** — discriminator-tagged sharing specification on each target merit. Source-bound for now, structured for extension:
+  ```js
+  sharing_scope: { type: "collective_owners_of_merit", merit: "Necropolis Sepulcher", min_dots: 1 }
+  ```
+  The `type` field is the gate discriminator. Future covenant or clan variants add new types (e.g. `"collective_members_of_covenant"`) rather than overloading the existing one.
+
+- **`partner_shareable`** — uniform default across pool-grants in this family; per-merit override permitted where deliberate. Default: TBD by ADR-005, consistent with Sepulcher pool semantics. Per-merit override path exists for the deferred audit of existing pool-grants.
+
+- **`attached_to`** — generalised to a **named-anchor map** to support dual-anchor merits per ADR-005 Rev 2 §D7. Existing single-anchor merits (Haven) remain expressible. Trap Door is the dual-anchor case:
+  ```js
+  attached_to: { origin: "Necropolis Sepulcher", destination: "Safe Place" }
+  ```
+
+- **Purchase prereq vs render-time anchor constraint** — distinguished. A `prereq_json` clause gates *purchase* (engine refuses to buy without it). An `attached_to` anchor constraint is evaluated at *render* (mod is purchased and persistent, but the merit goes *non-functional* if the anchor target fails its constraint). Trap Door is the worked example: Necropolis Sepulcher dots are a hard purchase prereq AND the `origin` anchor; a White-Ants-covered Territory is NOT a purchase prereq but IS a render-time constraint on the `destination` anchor's containing Territory. ADR-005 Rev 2 §D7 places the constraint evaluation in the named-anchor resolver.
+
+- **`pool_source`** — flag on the gate merit indicating that its dot rating funds free grants into the target set. R dots → R free grants. ADR-005 specifies the resolver shape.
+
+## The Nine Necropolis Merits
+
+Each entry below has the structural fields populated and the canonical mechanical rule text quoted verbatim from Peter's source CSV.
+
+---
+
+### 1. Necropolis Sepulcher (gate)
+
+- **Type:** Gate merit
+- **Rating:** 1-5
+- **Sharing:** Personal, non-shareable (per-character purchase)
+- **Pool:** `pool_source: true` — R dots grant R free Necropolis-family target merits
+- **Category:** Merit (sub_category: Kindred)
+- **Prereq JSON:** `{"type":"clan","name":"Nosferatu"}`
+- **XP cost:** standard rated-merit formula (xp_fixed blank)
+- **Role in family:** Funds free grants into the six collectively-shared target merits; gates collective sharing for the whole family
+
+**Rule text (canonical):**
+
+> Prerequisites: Nosferatu Status •
+>
+> One dot of this merit buys a Nosferatu small home within the Necropolis and gives them 1 point per dot to spend in other Necropolis Merits. Further expenditure on this merit provides a larger space for the Haunt's Haven and provides more dots to invest into the Necropolis. This acts as a personal, non-shareable, Safe Place in the Necropolis.
+
+---
+
+### 2. Catacombs (target, collectively-shared)
+
+- **Type:** Target merit
+- **Rating:** 1-5
+- **Sharing:** Collectively-shared — `sharing_scope: { type: "collective_owners_of_merit", merit: "Necropolis Sepulcher", min_dots: 1 }`
+- **Category:** Merit (sub_category: Kindred)
+- **Prereq JSON:** `{"all":[{"type":"clan","name":"Nosferatu"},{"type":"merit","name":"Necropolis Sepulcher","dots":1}]}`
+- **XP cost:** standard rated-merit formula (xp_fixed blank)
+- **Role in family:** Wits + Investigation extended roll mechanic; outsider penalty
+
+**Rule text (canonical):**
+
+> Navigating the tunnels necessitates an extended Wits + Investigation roll, with ten successes required. Each roll is equivalent to one hour's worth of wandering. Those who do not have dots in Necropolis Sepulcher suffer a penalty to this roll equal to the total dots in this Catacombs. Those who do possess any dots in the Merit, however, may still have to succeed if distracted, or under time pressure or duress. Even the Haunts may find themselves periodically lost in the dark and distorted heart of their own Necropolis. In such a case, a resident can add Clan Status to these rolls, representing how familiar they are with the Catacombs and the Warren in general.
+>
+> This Merit is shared between all Haunts with dots in the Necropolis.
+
+---
+
+### 3. Caldarium (target, collectively-shared)
+
+- **Type:** Target merit
+- **Rating:** 1-3
+- **Sharing:** Collectively-shared — `sharing_scope: { type: "collective_owners_of_merit", merit: "Necropolis Sepulcher", min_dots: 1 }`
+- **Category:** Merit (sub_category: Kindred)
+- **Prereq JSON:** `{"all":[{"type":"clan","name":"Nosferatu"},{"type":"merit","name":"Necropolis Sepulcher","dots":1}]}`
+- **XP cost:** standard rated-merit formula (xp_fixed blank)
+- **Role in family:** Social bonuses + re-roll mechanic at 3 dots
+
+**Rule text (canonical):**
+
+> The Caldaria is the one location in the Necropolis that strangers may be allowed to visit, it is, in a way, a Nosferatu Elysium: one shall not bring violence here.
+>
+> At one dot, the Caldarium provides a place of social power for the Nosferatu: all Haunts within the Caldarium gain +1 to City Status and rolls involving Expression, Persuasion, Socialize or Subterfuge.
+>
+> At two dots, this bonus increases to +2.
+>
+> At three dots, a dark serenity stays with the Haunt even after it leaves the bathhouse. For the rest of the night, Haunts may re-roll one Social or Mental action.
+>
+> This Merit is shared between all Haunts with dots in the Necropolis.
+
+---
+
+### 4. Garbage Pit (target, collectively-shared)
+
+- **Type:** Target merit
+- **Rating:** 1-3
+- **Sharing:** Collectively-shared — `sharing_scope: { type: "collective_owners_of_merit", merit: "Necropolis Sepulcher", min_dots: 1 }`
+- **Category:** Merit (sub_category: Kindred)
+- **Prereq JSON:** `{"all":[{"type":"clan","name":"Nosferatu"},{"type":"merit","name":"Necropolis Sepulcher","dots":1}]}`
+- **XP cost:** standard rated-merit formula (xp_fixed blank)
+- **Role in family:** Retrieval + disposal mechanic
+
+**Rule text (canonical):**
+
+> The Garbage Pit provides 2 distinct benefits that Haunts have learnt not to look too closely at: Once per Chapter a Haunt willing to spend the time can find a trash version of basically anything in the depths of the pit. Anything above Availability equal to this merit will be trashed enough to reduce it to that level. Secondly, any object thrown into the Garbage Pit with intention is never, ever, seen again. No, torpored Kindred are not objects.
+>
+> This Merit is shared between all Haunts with dots in the Necropolis.
+
+---
+
+### 5. Labyrinth Guardians (target, collectively-shared)
+
+- **Type:** Target merit
+- **Rating:** 1-5
+- **Sharing:** Collectively-shared — `sharing_scope: { type: "collective_owners_of_merit", merit: "Necropolis Sepulcher", min_dots: 1 }`
+- **Category:** Merit (sub_category: Kindred)
+- **Prereq JSON:** `{"all":[{"type":"clan","name":"Nosferatu"},{"type":"merit","name":"Necropolis Sepulcher","dots":1}]}`
+- **XP cost:** standard rated-merit formula (xp_fixed blank)
+- **Role in family:** Guardian swarms; resident Vitae cost
+
+**Rule text (canonical):**
+
+> Guardian Swarms are packs or hordes of mutant animals that live in the Warren. These creatures are unnatural (flat-white eyes, stitched-together limbs, too human voices, etc.) and will attack any non-resident they come across. If the Guardians have their Health track filled with lethal damage, they'll disperse. However, they will return after a week to roam the Warren once again. Any resident who encounters the Labyrinth Guardians must feed them a point of Vitae, or suffer their attacks — their vigil has a price, after all.
+>
+> This Merit is shared between all Haunts with dots in the Necropolis.
+
+---
+
+### 6. Dark Temple (target, collectively-shared)
+
+- **Type:** Target merit
+- **Rating:** Rank 2 (fixed, no per-dot scaling)
+- **Sharing:** Collectively-shared — `sharing_scope: { type: "collective_owners_of_merit", merit: "Necropolis Sepulcher", min_dots: 1 }`
+- **Category:** Merit (sub_category: Kindred)
+- **Prereq JSON:** `{"all":[{"type":"clan","name":"Nosferatu"},{"type":"merit","name":"Necropolis Sepulcher","dots":1}]}`
+- **XP cost:** `xp_fixed: 2`
+- **Role in family:** Sated + Spooked conditions
+
+**Rule text (canonical):**
+
+> A Haunt spending time in the Dark Temple has their Beast quietened; they take the Sated Condition (+1 on Frenzy checks) and are considered to have meditated (+1 on Breakpoint checks). However, it is unquiet even for a Haunt, and they take the Spooked Condition, distracted by otherworldly whispers at the edges of perception.
+>
+> This Merit is shared between all Haunts with dots in the Necropolis.
+
+---
+
+### 7. White Ants (target, collectively-shared, **territory-integrated**)
+
+- **Type:** Target merit
+- **Rating:** 1-5
+- **Sharing:** Collectively-shared — `sharing_scope: { type: "collective_owners_of_merit", merit: "Necropolis Sepulcher", min_dots: 1 }`
+- **Category:** Merit (sub_category: Kindred)
+- **Prereq JSON:** `{"all":[{"type":"clan","name":"Nosferatu"},{"type":"merit","name":"Necropolis Sepulcher","dots":1}]}`
+- **XP cost:** standard rated-merit formula (xp_fixed blank)
+- **Role in family:** Territory-linked penalty; player selects ONE real campaign territory per dot
+- **Integration note:** UI must surface the live territory list from the campaign territory system; player picks R territories from real options, not free text. ADR-005 Rev 2 specifies the read shape.
+
+**Rule text (canonical):**
+
+> The Necropolis sprawls and opens into Territories far beyond what is reasonable. For each dot in this merit select a Territory the Necropolis has infected. Haunts taking clandestine actions in that area apply a -3 to all rolls to detects¹ their personal actions against anyone who does not possess dots in Necropolis Sepulcher.
+>
+> This Merit is shared between all Haunts with dots in the Necropolis.
+
+¹ CSV-verbatim typo ("to detects") preserved per Khepri's canonical-preservation principle; flagged in Editorial Notes at the foot of this epic.
+
+---
+
+### 8. Trap Door (attached, dual-anchor)
+
+- **Type:** Attached merit (per-character, not collectively-shared)
+- **Rating:** Rank 1 (fixed, no rating)
+- **Sharing:** None (per-character purchase)
+- **Category:** Merit (sub_category: Kindred)
+- **Purchase prereq JSON:** `{"all":[{"type":"clan","name":"Nosferatu"},{"type":"merit","name":"Necropolis Sepulcher","dots":1}]}`
+- **XP cost:** `xp_fixed: 1`
+- **Anchors (dual):** `attached_to: { origin: "Necropolis Sepulcher", destination: "Safe Place" }` — engine requires both at render time
+- **Render-time anchor constraint:** the `destination` Safe Place must live in a Territory the character has White Ants coverage in. **NOT a hard purchase prereq** — the merit can be bought and persisted at any time, but the engine renders it as **non-functional** if the White-Ants-Territory constraint fails. Constraint evaluation lives in the named-anchor resolver per ADR-005 Rev 2 §D7.
+- **Role in family:** Entrance bypass mechanic — bridges a Safe Place to a Necropolis
+- **Architectural note:** First dual-anchor merit. Existing `attached_to` mechanism (Haven-style single-target) generalises to named-anchor map per ADR-005 Rev 2 §D7.
+
+**Rule text (canonical):**
+
+> The Haunt has put a entrance to the Necropolis in a purchased Safe Place above group² in a Territory covered by White Ants. While they can do much to keep this entrance secret from other Haunts, nothing is ever guaranteed and any other Haunt using this entrance can bypass external Safe Place benefits. To find this other Haunts must navigate the Catacomb as if they do not possess dots in Necropolis Sepulcher.
+>
+> This merit is not shared and is linked to a specific Safe Place.
+
+² CSV-verbatim typo ("above group" — likely intended "above ground") preserved per Khepri's canonical-preservation principle; flagged in Editorial Notes at the foot of this epic.
+
+---
+
+### 9. True Worm (standalone, drawback)
+
+- **Type:** Standalone (family member by theme only)
+- **Rating:** Rank 2 (fixed, no rating)
+- **Sharing:** None — per-character purchase
+- **Category:** Merit (sub_category: Kindred)
+- **Prereq JSON:** `{"type":"clan","name":"Nosferatu"}` — Nosferatu-only but NOT Sepulcher-gated; fully standalone within the family
+- **XP cost:** `xp_fixed: 2`
+- **Role in family:** Drawback merit; day-sleep relief in deep tunnels
+- **Engine note:** **No rules-engine logic.** Descriptive text only. STs apply sun damage manually via the ST Mods overlay (Epic STM) when adjudicating exposure scenes.
+
+**Rule text (canonical):**
+
+> So used to the dark, the Nosferatu no longer feels the draw of day sleep when in the tunnels of the Necropolis that lay more than 10 meters below the earth where there is no possibility of sunlight. They still must spend 1 Vitae each day to 'wake'.
+>
+> **Drawback:** While active during the day, the Nosferatu is at half his normal Speed (round up). In addition, a Haunt possessing this Merit is especially harmed by sunlight. The Nosferatu suffers +1 Health point per time unit when exposed to any of the sun's rays.
+
+---
+
+## Deferred prerequisite: pool-grant partner_shareable audit
+
+Existing pool-granting merits (Lorekeeper, Invested, Vinculum Master, Mater Consanguineus Inferior) use inconsistent partner_shareable treatments. Before ADR-005 finalises the uniform default for MNEC, an audit story should determine, per existing merit:
+
+- Was the current partner-shareable behaviour deliberate game-design or accreted inconsistency?
+- For deliberate cases, mark the merit with an explicit `partner_shareable` override on the new schema.
+- For accreted cases, fix to the uniform default during the consolidation.
+
+**Out of scope for MNEC implementation;** flagged for SM dispatch queue as a deferred prereq. ADR-005 should choose the uniform default for MNEC without waiting on this audit, and the override path supplies the migration on.
+
+## Dependencies
+
+- **Architecture:** ADR-005 — Collective Compound abstraction (shape, resolver, schema). Imhotep Rev 2 pushed in PR #659 covers dual-anchor `attached_to` (§D7) supporting Trap Door's render-time anchor constraint.
+- **Existing merit infrastructure:** `public/js/editor/merits.js`, the hardcoded MERITS_DB until Epic PP consolidates it to Mongo. MNEC describes rules; PP eventually owns storage.
+- **Territory integration:** White Ants requires read access to the live campaign territory list. ADR-005 specifies the read shape.
+- **Safe Place integration:** Trap Door's dual-anchor mechanism reuses the existing `attached_to` Safe Place pattern (Haven). The schema generalisation to named-anchor map is the architecturally novel piece.
+- **CLAUDE.md amendment:** when ADR-005 ships, CLAUDE.md needs a note naming the Collective Compound pattern. Pin to whichever story owns the schema introduction, same load-bearing pattern as STM-2.
+- **Epic STM (ST Mods overlay):** True Worm's day/sun adjudication uses the ST Mods overlay. No technical coupling beyond the existing overlay; noted for ST awareness.
+- **Open follow-up story (not blocking MNEC):** partner_shareable audit on Lorekeeper / Invested / VM / MCI.
+
+## Stories
+
+Story breakdown is owned by Khepri (SM) after ADR-005 ships and the rule text is finalised. PRD-level expectations:
+- Schema introduction (sharing_scope, partner_shareable, generalised attached_to, pool_source) — first story.
+- Necropolis Sepulcher gate + pool-grant resolver.
+- The six collectively-shared target merits (Catacombs, Caldarium, Garbage Pit, Labyrinth Guardians, Dark Temple, White Ants) — likely groupable by sharing scope and similar rule shape; one story per merit unless trivially identical.
+- Trap Door dual-anchor.
+- True Worm (descriptive-only, lowest effort).
+- Territory-list integration for White Ants.
+
+Story ordering and parallelism are SM's call once ADR-005 lands.
+
+## Editorial Notes
+
+Three minor typos identified in the source CSV during the 2026-06-10 fold-in. **Peter acked preserve-as-is 2026-06-10** per the canonical-CSV principle (rule text is source-of-truth). The rules engine and player-facing display render verbatim. Documented here for audit:
+
+| Merit | CSV reads | Alternative reading | Footnote |
+|---|---|---|---|
+| White Ants | "to detects their personal actions" | "to detect their personal actions" | ¹ |
+| Trap Door | "a entrance to the Necropolis" | "an entrance to the Necropolis" | ² |
+| Trap Door | "in a purchased Safe Place above group" | "above ground" | ² |
+
+If a later editorial pass overrides this preservation choice, update both this epic and the canonical CSV in one commit, and append a correction note here citing the date and authoriser.

--- a/specs/stories/issue-692-n3-necropolis-seed.story.md
+++ b/specs/stories/issue-692-n3-necropolis-seed.story.md
@@ -1,0 +1,77 @@
+# Issue #692: N-3 — Necropolis merit family seed + Collective Compound rule_grant + rating_of_source evaluator
+
+Status: Ready for Review
+
+issue: 692
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/692
+branch: piatra/issue-692-n3-necropolis-seed
+epic: MNEC (specs/epic-mnec-necropolis-merits.md — committed in this PR; was a Thoth session artefact uncommitted on dev)
+adr: ADR-005 Rev 2 (specs/architecture/adr-005-pool-grant-and-sharing-scope-generalisation.md)
+dispatch: PROCEED-WITH-NOTICE; HALT-DAR raised + resolved 2026-06-11 (canonical MNEC file copied in from main workdir; Khepri confirmed contents match Thoth's session output).
+
+## Story
+
+As an N-1-merged campaign,
+I want the nine Necropolis merits + the Necropolis Sepulcher Collective Compound rule_grant + the pool-evaluator `amount_basis: 'rating_of_source'` handler all in production,
+so that Nosferatu characters can buy Sepulcher and have its dot rating fund free grants into the six collectively-shared target merits — auto-shared across all qualifying owners via the N-1 synthesis path — and N-4 / N-5 can land their UI work on top of the data.
+
+## What ships
+
+- **MNEC epic file** committed at `specs/epic-mnec-necropolis-merits.md` (was an uncommitted Thoth session artefact on the main workdir; this PR makes it canonical on `dev`).
+- **9 `purchasable_powers` docs** seeded via `server/scripts/seed-rules-necropolis.js` — verbatim rule text per the MNEC epic, including the three preserved CSV typos per Peter's 2026-06-10 ack (no auto-correct):
+  - White Ants: "to **detects** their personal actions" (intended "to detect")
+  - Trap Door: "**a** entrance to the Necropolis" (intended "an entrance")
+  - Trap Door: "above **group** in a Territory" (intended "above ground")
+- **One `rule_grant` doc** for Necropolis Sepulcher with `source_slug: 'necro'`, `amount_basis: 'rating_of_source'`, `partner_shareable: true`, `sharing_scope: { type: 'collective_owners_of_merit', merit: 'Necropolis Sepulcher', min_dots: 1 }`, and the six target merit names in `pool_targets`.
+- **Pool-evaluator extension** — `_computeAmount` now handles `amount_basis: 'rating_of_source'` by delegating to the existing `_ratingOfPartner` helper against `rule.source`. Reads purchased dots only (cp+xp) — anti-loop guard ensures the source's own free grants don't amplify the pool.
+- **Trap Door dual-anchor data shape only** — Trap Door's prereq + xp_fixed + flat rating are seeded. The actual `attached_to: { origin, destination }` value is set at purchase-time by the player; the schema accepts it (N-1 D7). UI picker is N-5.
+
+## Acceptance gates
+
+1. ✅ MERITS_DB shape — all 9 docs exist with `parent: 'Kindred'`, `category: 'merit'`, correct `rating_range`, `xp_fixed` set on the three flat-cost merits (True Worm, Dark Temple, Trap Door), and the prereq trees matching the MNEC family/standalone split.
+2. ✅ rule_grant Collective Compound shape — pool doc carries `partner_shareable: true`, `sharing_scope.type === 'collective_owners_of_merit'`, and the six pool_targets.
+3. ✅ Idempotency — running the seeder a second time touches zero docs (regression test runs `--apply` twice and asserts "Touched 0 doc(s)" on the second).
+4. ✅ Pool-evaluator `rating_of_source` math — Necropolis Sepulcher 3 → `_grant_pools` entry of amount 3 across the six targets. Source-absent skips the grant. Purchased-only guard verified.
+5. ✅ End-to-end Collective Compound (Necropolis fixture) — Alice (Sepulcher 3, Catacombs 2) and Bob (Sepulcher 2, Catacombs 1) see each other in `_collective_shared_with` on Catacombs; Carl (no Sepulcher, no Catacombs) sees no synthesised field on any merit. Resolver helper agrees with the API behaviour for the same fixture (sanity).
+6. ✅ Verbatim-typo presence — explicit assertions on `description` for the three CSV typos.
+
+## Tasks / Subtasks
+
+- [x] MNEC epic file (`specs/epic-mnec-necropolis-merits.md`) — canonical from Thoth's session; committed.
+- [x] Pool-evaluator `_computeAmount` — add `case 'rating_of_source': return _ratingOfPartner(c, rule.source);`.
+- [x] Atomic seeder (`server/scripts/seed-rules-necropolis.js`) — idempotent, `--dry-run` default, `--apply` to write; 9 merit upserts + 1 rule_grant upsert.
+- [x] Test file (`server/tests/n3-necropolis.test.js`) — 12 vitest cases across the 4 dispatch ACs + typo-preservation.
+- [x] Story file (this one).
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-7 (Ptah / DEV)
+
+### Completion Notes List
+
+- **HALT-DAR raised + resolved (2026-06-11).** The MNEC epic referenced as the source of truth wasn't committed on `dev` — Thoth had written it in his session but never `git add`-ed. Khepri confirmed the canonical file lived in the main workdir at `/Volumes/EXT.2T.1/Git/Misc/TerraMortis/specs/epic-mnec-necropolis-merits.md` (304 lines, 21867 bytes) and matched his session transmission. Copied into the worktree and committed as part of N-3 so the canonical source-of-truth lives on `dev` going forward.
+- **The "MERITS_DB" naming in the dispatch is a slight misframing** — there is no JS `MERITS_DB` constant in the current codebase; merits live in the `purchasable_powers` MongoDB collection (loaded via `getRuleByKey(slug)` from the rules cache). The seeder writes there. The dispatch's structural intent is satisfied.
+- **"rank" field stays null on all 9 entries** — across all existing merits in the live DB, none populate `rank` (rank is used by disciplines, where it indicates the discipline-power tier). Flat-rated merits (True Worm, Dark Temple, Trap Door) encode as `rating_range: [N, N]` plus `xp_fixed: N`. The dispatch's "rank 2" framing for these maps to the existing flat-range convention.
+- **`sub_category: null` on all 9** — existing merit docs use sub_category to drive rendering placement (general / domain / influence). Necropolis Sepulcher is described in the epic as a "personal non-shareable Safe Place" so could plausibly be `'domain'`, but the rest of the family doesn't cleanly fit any existing bucket. Defaulted to null for all 9 to match the conservative existing pattern (~80% of merits are sub_category=null); STs can adjust if a rendering preference emerges.
+- **`pool-evaluator rating_of_source` reuses `_ratingOfPartner`** rather than introducing a new helper. The semantics are identical: read cp + xp on every merit named `rule.source`. Avoiding a new helper keeps the evaluator-purity convention (no external imports) intact.
+- **`amount_basis: 'rating_of_source'` was already in the schema enum** (`rule-grant.schema.js`) — the evaluator just didn't have the handler. This is the "small addition" the dispatch flagged; no schema change needed.
+- **Three pre-existing test-file failures** (archive-import) carry forward from the N-1 PR — not caused by N-3. All 1271 individual tests pass.
+- **Worktree pattern continued** (`/tmp/tm-ptah/n3-necropolis`, node_modules + server/.env symlinked from main).
+
+### File List
+
+**New**
+- `specs/epic-mnec-necropolis-merits.md` — canonical Thoth-authored epic, committed to dev for the first time
+- `server/scripts/seed-rules-necropolis.js` — atomic, idempotent seeder (9 purchasable_powers + 1 rule_grant)
+- `server/tests/n3-necropolis.test.js` — 12 vitest cases
+- `specs/stories/issue-692-n3-necropolis-seed.story.md` — this file
+
+**Modified**
+- `public/js/editor/rule_engine/pool-evaluator.js` — `_computeAmount` gains the `rating_of_source` case
+
+### Change Log
+
+- 2026-06-11 (Ptah): HALT-DAR — MNEC epic missing on dev; Khepri pointed at canonical file in main workdir; copied + committed.
+- 2026-06-11 (Ptah): N-3 shipped — 9 merits + 1 rule_grant seeded; pool-evaluator extended; 12 tests passing.


### PR DESCRIPTION
## Summary

MNEC epic (Collective Compound first instance) lands as a complete seed on top of N-1's foundation. Nine new Necropolis merits, one Collective Compound `rule_grant` for Necropolis Sepulcher, and the small `pool-evaluator` extension for `amount_basis: 'rating_of_source'` that the schema enum already allowed but the evaluator didn't handle.

## HALT-DAR raised + resolved (2026-06-11)

The MNEC epic at `specs/epic-mnec-necropolis-merits.md` was an uncommitted Thoth session artefact on the main workdir — not on `dev`. Khepri pointed at the canonical file (304 lines, 21867 bytes, verified to match his session transmission); copied into the worktree and committed as part of N-3 so the canonical source-of-truth lives on `dev` going forward.

## What ships

- **MNEC epic file** at `specs/epic-mnec-necropolis-merits.md` — Thoth-authored, canonical from his session.
- **`server/scripts/seed-rules-necropolis.js`** — atomic, idempotent (`--dry-run` default, `--apply` to write):
  - **9 `purchasable_powers` upserts** keyed by `key`. Verbatim rule text per the MNEC epic. Three CSV typos PRESERVED per Peter's 2026-06-10 ack:
    - White Ants: `"to detects their personal actions"` (intended *"to detect"*)
    - Trap Door:  `"a entrance to the Necropolis"` (intended *"an entrance"*)
    - Trap Door:  `"above group in a Territory"` (intended *"above ground"*)
  - **1 `rule_grant` upsert** for Necropolis Sepulcher as the Collective Compound source: `source_slug: 'necro'`, `amount_basis: 'rating_of_source'`, `partner_shareable: true`, `sharing_scope: { type: 'collective_owners_of_merit', merit: 'Necropolis Sepulcher', min_dots: 1 }`, six `pool_targets` (Catacombs / Caldarium / Garbage Pit / Labyrinth Guardians / Dark Temple / White Ants).
- **`public/js/editor/rule_engine/pool-evaluator.js`** — `_computeAmount` gains the `'rating_of_source'` case. Delegates to the existing `_ratingOfPartner` helper (cp+xp only — anti-loop guard so the source's own free grants don't amplify the pool).

## Design notes worth flagging

- **"MERITS_DB" in the dispatch is a slight misframing.** There's no JS `MERITS_DB` constant — merits live in the `purchasable_powers` Mongo collection. The seeder writes there. The dispatch's structural intent is satisfied.
- **`rank` stays null on all 9.** Across existing live merits, none populate `rank` (it's used by disciplines). Flat-cost merits (True Worm, Dark Temple, Trap Door) encode as `rating_range: [N, N]` + `xp_fixed: N`. The dispatch's "rank 2" framing maps to this existing convention.
- **`sub_category: null` on all 9.** ~80% of existing merits are null; conservative match. STs can adjust if a rendering preference emerges.
- **`amount_basis: 'rating_of_source'` was already in the schema enum.** The evaluator just didn't have the handler. No schema change.
- **Trap Door dual-anchor:** N-3 ships the data shape only (prereq + xp_fixed + flat rating). The actual `attached_to: { origin: 'Necropolis Sepulcher', destination: '<Safe Place>' }` value is set at purchase-time; the schema accepts it (N-1 D7). UI picker is N-5.

## Tests

**12 vitest cases** in `server/tests/n3-necropolis.test.js`:

- All 9 merit docs present with `parent: 'Kindred'` / `category: 'merit'`, correct `rating_range`, `xp_fixed` on the three flat-cost merits, prereqs matching the MNEC family/standalone split.
- `rule_grant` Collective Compound shape (source_slug, amount_basis, partner_shareable, sharing_scope, pool_targets).
- **Seed idempotency** — runs `--apply` a second time and asserts `"Touched 0 doc(s)"`.
- **Pool-evaluator `rating_of_source` math** — Necropolis Sepulcher 3 → `_grant_pools` entry amount 3; source-absent skips; purchased-only anti-loop guard.
- **End-to-end Necropolis Collective** — two chars with Sepulcher see each other in synthesised `_collective_shared_with` on Catacombs; non-member's merits don't get the field. Pure-function resolver agrees with the API behaviour for the same fixture.
- **Verbatim-typo presence** — three explicit assertions for the preserved CSV typos.

**Full regression: 1271/1271 individual tests pass.** The same three test-FILE failures (archive-path imports) carry forward from N-1; not caused by N-3.

## Test plan

- [ ] Apply seed against `tm_suite_test` then `tm_suite` once N-3 merges to `dev`:
  ```
  cd server && node scripts/seed-rules-necropolis.js              # dry-run preview
  cd server && node scripts/seed-rules-necropolis.js --apply       # write
  cd server && node scripts/seed-rules-necropolis.js               # idempotency: every line "no change"
  ```
- [ ] Roll a Nosferatu character with Necropolis Sepulcher 3 in the admin editor → `free_grants.necro` pool of 3 dots is offered across the six target merits.
- [ ] Two characters with Sepulcher dots: each sees the other in `_collective_shared_with` on a shared Catacombs / Caldarium / etc. (foundation pinned in N-1; this is the Necropolis-flavoured smoke).
- [ ] Verbatim text rendering — the three preserved typos appear unaltered on the player-facing description for White Ants and Trap Door.

Closes #692