### PR TITLE
N-4: White Ants Territory linkage — picker UI + render union helper + server validation (#696)

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -425,6 +425,17 @@ html:not([data-theme="dark"]) .edit-icon {
 .dom-attach-lbl{font-size:10px;font-family:var(--ft);color:var(--txt3);white-space:nowrap;}
 .dom-attach-sel{flex:1;background:var(--surf2);border:1px solid var(--bdr2);color:var(--txt);font-size:11px;padding:2px 4px;outline:none;}
 .dom-attach-sel:focus{border-color:var(--gold);}
+/* N-4 (MNEC #696): White Ants Territory picker — one row per dot. */
+.wa-picker-block{padding:4px 8px 2px;display:flex;flex-direction:column;gap:3px;}
+.wa-picker-lbl{font-size:10px;font-family:var(--ft);color:var(--txt3);white-space:nowrap;}
+.wa-picker-row{display:flex;align-items:center;gap:6px;}
+.wa-picker-dot{font-size:10px;color:var(--txt3);min-width:14px;text-align:right;font-family:var(--ft);}
+.wa-picker-sel{flex:1;background:var(--surf2);border:1px solid var(--bdr2);color:var(--txt);font-size:11px;padding:2px 4px;outline:none;}
+.wa-picker-sel:focus{border-color:var(--gold);}
+.wa-picker-row--empty .wa-picker-sel,
+.wa-picker-row--dup .wa-picker-sel{border-color:var(--warn-dk);}
+.wa-picker-warn{font-size:10px;color:var(--warn-dk);font-family:var(--ft);}
+.wa-picker-empty{font-size:10px;color:var(--txt3);font-style:italic;margin:0;padding:0 0 0 8px;}
 .dom-cap-warn{font-size:10px;color:var(--warn-dk);font-family:var(--ft);padding:1px 8px 2px;}
 .dom-cap-info{font-size:9px;color:var(--txt3);padding:0 8px 2px;}
 

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -63,6 +63,7 @@ import {
   shAddRite, shRemoveRite, shToggleRiteFree, shRefreshRiteDropdown,
   shAddPact, shRemovePact, shEditPact,
   shEditMeritPt, shStepMeritRating, shEditXP, shAdjAttrBonus, shAdjMeritBonus, shAdjSkillBonus,
+  shSetWhiteAntsTerritory,
   registerCallbacks as registerEditCallbacks,
   getDirtyPartners, clearDirtyPartners
 } from './editor/edit.js';
@@ -1324,6 +1325,7 @@ Object.assign(window, {
   shAddRite, shRemoveRite, shToggleRiteFree, shRefreshRiteDropdown,
   shAddPact, shRemovePact, shEditPact,
   shEditMeritPt, shStepMeritRating, shEditXP, shAdjAttrBonus, shAdjMeritBonus, shAdjSkillBonus,
+  shSetWhiteAntsTerritory,
   clickAttrDot, adjAttrBonus, clickSkillDot, toggleNineAgain, adjSkillBonus, updSkillSpec,
   updField, updStatus,
   renderIdentityTab, renderAttrsTab,

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -35,6 +35,7 @@ import {
   shEditGenMerit, shRemoveGenMerit, shAddGenMerit,
   shEditStandMerit, shEditStandAssetSkill,
   shToggleMCI, shTogglePT, shEditMCIDot, shRemoveStandMerit, shAddStandMCI, shAddStandPT,
+  shSetWhiteAntsTerritory,
   shEditMeritPt, shStepMeritRating, shEditXP, shAdjAttrBonus, shAdjMeritBonus, shAdjSkillBonus,
   shAddEquip, shRemoveEquip, shEquipBucketFilter, shAddAsset, shRemoveAsset,
   registerCallbacks as registerEditCallbacks
@@ -1129,6 +1130,7 @@ Object.assign(window, {
   shEditDomMerit,
   shRemoveDomMerit,
   shAddDomMerit,
+  shSetWhiteAntsTerritory,
   shAddDomainPartner,
   shRemoveDomainPartner,
   shEditGenMerit,

--- a/public/js/data/accessors.js
+++ b/public/js/data/accessors.js
@@ -315,6 +315,17 @@ export function getRegentTerritoryFor(c) {
   return findRegentTerritory(_currentTerritories, c);
 }
 
+/**
+ * Read the module-level territories store. Returns the live list (loaded by
+ * the app at boot via `setStatusTerritories`) or an empty array if not yet
+ * populated. Single source of truth for any consumer that needs the full
+ * territory list (N-4 White Ants picker, etc.) — avoids each call site
+ * re-fetching `/api/territories`.
+ */
+export function getStoredTerritories() {
+  return _currentTerritories;
+}
+
 // Lieutenants intentionally receive no ambience bonus (issue #13 Q-A, 2026-05-05).
 // Bonus is regent-only by design; do not extend to lieutenant_id without an
 // explicit game-rules decision.

--- a/public/js/data/rules-helpers.js
+++ b/public/js/data/rules-helpers.js
@@ -201,6 +201,49 @@ export function resolveSharingScope(scope, c, chars, rule) {
 }
 
 /**
+ * N-4 (MNEC, issue #696) — render-side union of Territories the Necropolis
+ * has infected. Walks `chars`, finds every Necropolis Sepulcher owner
+ * (cp+xp ≥ 1), then for each owner aggregates the `territories[]` arrays on
+ * their White Ants merits, deduplicated.
+ *
+ * Used at render time:
+ *   - N-5 Trap Door anchor validation (destination Safe Place must be in a
+ *     Territory in this union).
+ *   - Any UI consumer that wants to display "the Necropolis touches X" maps.
+ *
+ * Pure function — no DB access, no module-level state. Caller passes the
+ * full chars array; on the client that's `editorState.chars` /
+ * `suiteState.chars`; on the server it's a fresh `characters.find().toArray()`.
+ *
+ * @param {object[]} chars
+ * @returns {string[]} deduplicated territory slugs, insertion order preserved
+ */
+export function getNecropolisInfectedTerritories(chars) {
+  if (!Array.isArray(chars)) return [];
+  const out = [];
+  const seen = new Set();
+  for (const c of chars) {
+    if (!c || !Array.isArray(c.merits)) continue;
+    // Membership gate: owner has Sepulcher ≥ 1 purchased (cp+xp).
+    const isOwner = c.merits.some(m =>
+      m && m.name === 'Necropolis Sepulcher' && ((m.cp || 0) + (m.xp || 0)) >= 1
+    );
+    if (!isOwner) continue;
+    for (const m of c.merits) {
+      if (!m || m.name !== 'White Ants') continue;
+      if (!Array.isArray(m.territories)) continue;
+      for (const slug of m.territories) {
+        if (typeof slug !== 'string' || !slug) continue;
+        if (seen.has(slug)) continue;
+        seen.add(slug);
+        out.push(slug);
+      }
+    }
+  }
+  return out;
+}
+
+/**
  * Pure synthesis for `{ type: 'collective_owners_of_merit', merit, min_dots }`.
  *
  *  - Walks `chars` for every character that owns `scope.merit` at >=

--- a/public/js/editor/edit-domain.js
+++ b/public/js/editor/edit-domain.js
@@ -315,6 +315,58 @@ export function shEditDomMerit(idx, field, val) {
   _renderSheet(c);
 }
 
+/**
+ * N-4 (MNEC, issue #696) — White Ants Territory picker handler.
+ *
+ * Bound to `<select>` `onchange` for each per-dot picker on a White Ants merit.
+ * Writes the picked Territory slug into `m.territories[dotIdx]`, trims any
+ * tail beyond the merit's current effective rating (covers the case where the
+ * player dropped a Sepulcher dot and the rating shrank), and re-renders.
+ *
+ * Duplicate detection lives in the renderer (`sheet.js#_whiteAntsTerritoriesBlock`):
+ * a duplicate slug renders the row with a warning + disables Save via the
+ * existing dirty-state path. Save backstop is the server middleware
+ * `validateWhiteAntsTerritoriesMiddleware`.
+ *
+ * @param {number} realIdx - index into c.merits
+ * @param {number} dotIdx  - which dot's picker fired (0-indexed)
+ * @param {string} value   - selected Territory slug, or '' for the placeholder
+ */
+export function shSetWhiteAntsTerritory(realIdx, dotIdx, value) {
+  if (state.editIdx < 0) return;
+  const c = state.chars[state.editIdx];
+  const m = (c.merits || [])[realIdx];
+  if (!m || m.name !== 'White Ants') return;
+
+  if (!Array.isArray(m.territories)) m.territories = [];
+  // Grow the array to dotIdx with empty slots if the picker is for a slot we
+  // haven't created yet (just added a dot, etc.).
+  while (m.territories.length <= dotIdx) m.territories.push('');
+  m.territories[dotIdx] = value || '';
+
+  // Trim trailing slots if rating shrank (e.g. Sepulcher dropped) — keeps the
+  // territories length aligned with rating without losing user picks.
+  const rating = (m.cp || 0) + (m.xp || 0) + _whiteAntsFreeSum(m);
+  if (m.territories.length > rating) m.territories.length = rating;
+
+  _markDirty();
+  _renderSheet(c);
+}
+
+// Inline sum mirroring `meritFreeSum` (rules-helpers.js) — kept here to avoid
+// a cross-import dance just for one merit's rating calc. Union of new map
+// + 14 legacy flat fields per N-1.
+function _whiteAntsFreeSum(m) {
+  const fromMap = m.free_grants && typeof m.free_grants === 'object'
+    ? Object.values(m.free_grants).reduce((s, n) => s + (n || 0), 0)
+    : 0;
+  const legacy = (m.free_attache || 0) + (m.free_bloodline || 0) + (m.free_carthian || 0)
+    + (m.free_fwb || 0) + (m.free_inv || 0) + (m.free_lk || 0) + (m.free_mci || 0)
+    + (m.free_mdb || 0) + (m.free_ohm || 0) + (m.free_pet || 0) + (m.free_pt || 0)
+    + (m.free_retainer || 0) + (m.free_sw || 0) + (m.free_vm || 0);
+  return fromMap + legacy;
+}
+
 export function shRemoveDomMerit(idx) {
   if (state.editIdx < 0) return;
   const c = state.chars[state.editIdx];

--- a/public/js/editor/edit.js
+++ b/public/js/editor/edit.js
@@ -22,6 +22,7 @@ import {
   shEditDomMerit, shRemoveDomMerit, shAddDomMerit,
   shAddDomainPartner, shRemoveDomainPartner,
   shAddStyle, shRemoveStyle, shEditStyle, shAddPick, shRemovePick,
+  shSetWhiteAntsTerritory,
   registerCallbacks as registerDomainCallbacks,
   getDirtyPartners, clearDirtyPartners
 } from './edit-domain.js';
@@ -34,6 +35,7 @@ export {
   shEditDomMerit, shRemoveDomMerit, shAddDomMerit,
   shAddDomainPartner, shRemoveDomainPartner,
   shAddStyle, shRemoveStyle, shEditStyle, shAddPick, shRemovePick,
+  shSetWhiteAntsTerritory,
   getDirtyPartners, clearDirtyPartners
 };
 

--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -12,6 +12,8 @@ import { xpToDots, xpEarned, xpSpent, xpLeft, xpStarting, xpHumanityDrop, xpOrde
 import { meritBase, meritDotCount, meritLookup, meritFixedRating, buildMeritOptions, buildSubCategoryMeritOptions, buildMCIGrantOptions, buildFThiefOptions, ensureMeritSync, meetsDevPrereqs, devPrereqStr, meetsPrereq, prereqLabel } from './merits.js';
 // N-1 (Concern #11): every read of m.attached_to goes through this normaliser.
 import { normaliseAttachedTo } from '../data/rules-helpers.js';
+// N-4 (MNEC, issue #696): White Ants Territory picker reads the live list.
+import { getStoredTerritories } from '../data/accessors.js';
 import { getRulesByCategory, getRuleByKey } from '../data/loader.js';
 import { applyDerivedMerits, getPoolTotal, getPoolUsed, getPoolsForCategory, mciPoolTotal, getMCIPoolUsed } from './mci.js';
 import { domMeritTotal, domMeritAccess, domMeritContrib, domMeritShareable, calcTotalInfluence, influenceBreakdown, calcContactsInfluence, calcMeritInfluence, hasHoneyWithVinegar, hasViralMythology, vmUsed, ssjHerdBonus, flockHerdBonus, hasLorekeeper, lorekeeperUsed, hasOHM, ohmUsed, hasInvested, investedPool, investedUsed, effectiveInvictusStatus, attacheBonusDots, meritFreeSum, syncMeritRating, meritEffectiveRating, domKey } from './domain.js';
@@ -1309,6 +1311,8 @@ export function shRenderGeneralMerits(c, editMode) {
         h += '<span class="infl-dots-derived">' + '\u25CF'.repeat(_gPurch) + '\u25CB'.repeat(Math.max(0, dd + _mBonus - _gPurch)) + '</span>'
           + '<button class="dev-rm-btn" onclick="shRemoveGenMerit(' + gi + ')" title="Remove">&times;</button></div>';
         h += meritBdRow(rIdx, m, meritFixedRating(m.name), { showMCI: _genMciPool > 0 });
+        // N-4 (MNEC #696): White Ants Territory picker — one select per dot.
+        h += _whiteAntsTerritoriesBlock(m, rIdx);
         h += _derivedNotes(m);
         h += _prereqWarn(c, m.name, m);
       }
@@ -1887,6 +1891,70 @@ export function shRenderMeritRow(m, idPrefix, i, dotHtml, chipHtml) {
     return '<div class="exp-row" id="exp-row-' + id2 + '" onclick="toggleExp(\'' + id2 + '\')">' + _inner(true) + '</div><div class="exp-body" id="exp-body-' + id2 + '">' + body + '</div>';
   }
   return '<div class="merit-plain">' + _inner(false) + '</div>';
+}
+
+/**
+ * N-4 (MNEC, issue #696) — White Ants Territory picker block.
+ *
+ * Renders one `<select>` per dot of effective rating, each populated from the
+ * live territories store (`getStoredTerritories()`). Empty slots show a
+ * "Pick a Territory" warning; duplicate selections within the same merit show
+ * a duplicate warning. Returns '' for any non-White-Ants merit.
+ *
+ * The handler `shSetWhiteAntsTerritory(realIdx, dotIdx, value)` lives in
+ * edit-domain.js and is exposed on `window` by admin.js / app.js — see N-1's
+ * delegated-routing memory for why these inline-onchange handlers are safe
+ * when the global is reliably bound at module-load time.
+ */
+function _whiteAntsTerritoriesBlock(m, realIdx) {
+  if (!m || m.name !== 'White Ants') return '';
+  // Effective rating mirrors the meritFreeSum sum: cp + xp + sum(free_grants) + sum(legacy free_<slug>).
+  const fg = m.free_grants || {};
+  const fromMap = Object.values(fg).reduce((s, n) => s + (n || 0), 0);
+  const legacy = (m.free_attache || 0) + (m.free_bloodline || 0) + (m.free_carthian || 0)
+    + (m.free_fwb || 0) + (m.free_inv || 0) + (m.free_lk || 0) + (m.free_mci || 0)
+    + (m.free_mdb || 0) + (m.free_ohm || 0) + (m.free_pet || 0) + (m.free_pt || 0)
+    + (m.free_retainer || 0) + (m.free_sw || 0) + (m.free_vm || 0);
+  const rating = (m.cp || 0) + (m.xp || 0) + fromMap + legacy;
+  if (rating <= 0) return '';
+
+  const territories = getStoredTerritories();
+  const picked = Array.isArray(m.territories) ? m.territories : [];
+
+  // Empty store → placeholder only. The admin/suite apps load territories at
+  // boot via setStatusTerritories, so this branch is mostly a defensive
+  // fallback for a render that fires before the boot fetch resolves.
+  if (!territories || territories.length === 0) {
+    return '<div class="wa-picker-block"><label class="wa-picker-lbl">White Ants &mdash; Territories:</label><p class="wa-picker-empty">Loading territories…</p></div>';
+  }
+
+  // Pre-build option markup once; per-row mark which one is "selected".
+  const optsBare = '<option value="">(pick a Territory)</option>'
+    + territories.map(t => {
+      const slug = (t && t.slug) || '';
+      if (!slug) return '';
+      return `<option value="${esc(slug)}">${esc(t.name || slug)}</option>`;
+    }).join('');
+
+  let h = '<div class="wa-picker-block"><label class="wa-picker-lbl">White Ants &mdash; Territories the Necropolis has infected:</label>';
+  for (let i = 0; i < rating; i++) {
+    const current = picked[i] || '';
+    // Duplicate detection: this slug also appears at some other index in the same array.
+    const isDup = !!current && picked.some((s, j) => s === current && j !== i);
+    // Re-emit options with `selected` on the current pick.
+    const opts = current
+      ? optsBare.replace(`<option value="${esc(current)}">`, `<option value="${esc(current)}" selected>`)
+      : optsBare.replace('<option value="">', '<option value="" selected>');
+    const rowCls = !current ? 'wa-picker-row wa-picker-row--empty' : (isDup ? 'wa-picker-row wa-picker-row--dup' : 'wa-picker-row');
+    h += `<div class="${rowCls}">`
+      + `<span class="wa-picker-dot">${i + 1}.</span>`
+      + `<select class="wa-picker-sel" onchange="shSetWhiteAntsTerritory(${realIdx}, ${i}, this.value)">${opts}</select>`;
+    if (!current) h += '<span class="wa-picker-warn">Pick a Territory</span>';
+    else if (isDup) h += '<span class="wa-picker-warn">Duplicate</span>';
+    h += '</div>';
+  }
+  h += '</div>';
+  return h;
 }
 
 /* ── renderSheet orchestrator ── */

--- a/server/lib/normalize-character.js
+++ b/server/lib/normalize-character.js
@@ -134,3 +134,69 @@ export function normalizeMeritsMiddleware(req, _res, next) {
   }
   next();
 }
+
+/**
+ * N-4 (MNEC, issue #696) — cross-field validation for White Ants.
+ *
+ * JSON-Schema can't express "the array's length must equal a sibling field's
+ * computed value" so the rule lives here. Two invariants per White Ants merit:
+ *
+ *   1. `territories.length === effectiveRating` — every dot picks a Territory.
+ *   2. No duplicates within a single merit's territories array.
+ *
+ * Effective rating uses the same union-of-channels math as `meritFreeSum`:
+ *   cp + xp + sum(free_grants.*) + sum(free_<slug>)
+ * which mirrors the client-side `syncMeritRating` formula (domain.js). We
+ * recompute here rather than trusting `m.rating` because the API accepts
+ * partial bodies that may omit `m.rating` even when bumping the dot fields.
+ *
+ * Partial-save tolerance: if `req.body.merits` is absent, this middleware is a
+ * no-op (PATCH-style saves that only touch e.g. status are allowed).
+ */
+export function validateWhiteAntsTerritoriesMiddleware(req, res, next) {
+  const merits = req.body && Array.isArray(req.body.merits) ? req.body.merits : null;
+  if (!merits) return next();
+
+  for (let i = 0; i < merits.length; i++) {
+    const m = merits[i];
+    if (!m || m.name !== 'White Ants') continue;
+
+    const rating = _effectiveMeritRating(m);
+    const territories = Array.isArray(m.territories) ? m.territories : [];
+
+    if (territories.length !== rating) {
+      return res.status(400).json({
+        error: 'VALIDATION_ERROR',
+        message: `White Ants territories length (${territories.length}) must equal merit rating (${rating}). One Territory must be picked per dot.`,
+        detail: { merit_index: i, merit: 'White Ants', rating, territories_length: territories.length },
+      });
+    }
+    const seen = new Set();
+    for (const slug of territories) {
+      if (seen.has(slug)) {
+        return res.status(400).json({
+          error: 'VALIDATION_ERROR',
+          message: `White Ants territories must be distinct — '${slug}' appears more than once.`,
+          detail: { merit_index: i, merit: 'White Ants', duplicate: slug },
+        });
+      }
+      seen.add(slug);
+    }
+  }
+  return next();
+}
+
+function _effectiveMeritRating(m) {
+  const cp = m.cp || 0;
+  const xp = m.xp || 0;
+  const fromMap = m.free_grants && typeof m.free_grants === 'object'
+    ? Object.values(m.free_grants).reduce((s, n) => s + (n || 0), 0)
+    : 0;
+  // 14 legacy free_<slug> fields, summed verbatim (same shape as the
+  // LEGACY_FREE_SLUGS constant in public/js/data/rules-helpers.js).
+  const legacy = (m.free_attache || 0) + (m.free_bloodline || 0) + (m.free_carthian || 0)
+    + (m.free_fwb || 0) + (m.free_inv || 0) + (m.free_lk || 0) + (m.free_mci || 0)
+    + (m.free_mdb || 0) + (m.free_ohm || 0) + (m.free_pet || 0) + (m.free_pt || 0)
+    + (m.free_retainer || 0) + (m.free_sw || 0) + (m.free_vm || 0);
+  return cp + xp + fromMap + legacy;
+}

--- a/server/routes/characters.js
+++ b/server/routes/characters.js
@@ -3,7 +3,7 @@ import { ObjectId } from 'mongodb';
 import { getCollection } from '../db.js';
 import { requireRole, isStRole } from '../middleware/auth.js';
 import { validateCharacter, validateCharacterPartial } from '../middleware/validateCharacter.js';
-import { normalizeMeritsMiddleware, normalizeCharacterMerits } from '../lib/normalize-character.js';
+import { normalizeMeritsMiddleware, normalizeCharacterMerits, validateWhiteAntsTerritoriesMiddleware } from '../lib/normalize-character.js';
 // N-1 (ADR-005 Rev 2): map-fallback shape for per-slug reads. Used in the
 // partner-dots enrichment below so the server's hardcoded subset survives
 // the N-2 backfill from `m.free_<slug>` to `m.free_grants.<slug>`. The
@@ -405,7 +405,7 @@ router.get('/:id', async (req, res) => {
 });
 
 // POST /api/characters/wizard — player creates their own character
-router.post('/wizard', requireRole('player'), stripEphemeral, validateCharacter, normalizeMeritsMiddleware, async (req, res) => {
+router.post('/wizard', requireRole('player'), stripEphemeral, validateCharacter, normalizeMeritsMiddleware, validateWhiteAntsTerritoriesMiddleware, async (req, res) => {
   const players = getCollection('players');
   const player = await players.findOne({ _id: req.user.player_id });
   const existingIds = player?.character_ids || [];
@@ -432,7 +432,7 @@ router.post('/wizard', requireRole('player'), stripEphemeral, validateCharacter,
 });
 
 // POST /api/characters — ST only
-router.post('/', requireRole('st'), stripEphemeral, validateCharacter, normalizeMeritsMiddleware, async (req, res) => {
+router.post('/', requireRole('st'), stripEphemeral, validateCharacter, normalizeMeritsMiddleware, validateWhiteAntsTerritoriesMiddleware, async (req, res) => {
   const doc = req.body;
   if (!doc || !doc.name) return res.status(400).json({ error: 'VALIDATION_ERROR', message: "Field 'name' is required" });
 
@@ -444,7 +444,7 @@ router.post('/', requireRole('st'), stripEphemeral, validateCharacter, normalize
 // PUT /api/characters/:id — ST only
 // Uses partial schema validation: types/shapes checked but no field is required,
 // so both full document saves and partial updates (e.g. regent assignment) are valid.
-router.put('/:id', requireRole('st'), stripEphemeral, validateCharacterPartial, normalizeMeritsMiddleware, async (req, res) => {
+router.put('/:id', requireRole('st'), stripEphemeral, validateCharacterPartial, normalizeMeritsMiddleware, validateWhiteAntsTerritoriesMiddleware, async (req, res) => {
   const oid = parseId(req.params.id);
   if (!oid) return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid character ID format' });
 

--- a/server/schemas/character.schema.js
+++ b/server/schemas/character.schema.js
@@ -414,6 +414,11 @@ export const characterSchema = {
         asset_skills:  { type: 'array', items: { type: 'string' } },
         shared_with:   { type: 'array', items: { type: 'string' } },
         spheres:       { type: 'array', items: { type: 'string' } },
+        // N-4 (MNEC, issue #696): White Ants — Territory slugs picked per dot.
+        // Length-must-equal-rating is enforced at the route level (route can
+        // pull the merit's rating from cp+xp+free); JSON schema only enforces
+        // string-array shape since cross-field validation isn't representable here.
+        territories:   { type: 'array', items: { type: 'string' } },
         granted_by:    { type: 'string' },
         active:        { type: 'boolean' },
         location:      { type: ['string', 'null'] }, // #506: street+suburb for Safe Place instances; carries across DT cycles

--- a/server/tests/n4-white-ants-territory.test.js
+++ b/server/tests/n4-white-ants-territory.test.js
@@ -1,0 +1,199 @@
+/**
+ * N-4 (issue #696, MNEC White Ants Territory linkage).
+ *
+ * Three+ acceptance gates from the dispatch:
+ *   1. `territories.length === rating` enforced on save — PUT /api/characters/:id
+ *      rejects White Ants merits where the array's length doesn't match the
+ *      effective rating (cp + xp + sum(free_grants.*) + sum(legacy free_<slug>)).
+ *   2. Duplicate Territory selections within the same merit rejected on save.
+ *   3. `getNecropolisInfectedTerritories(allChars)` union math — Alice's picks
+ *      ∪ Bob's picks (both Sepulcher owners), with deduplication. Non-owners
+ *      (Carl, no Sepulcher) contribute zero even with `territories[]` populated.
+ *   4. Partial-save tolerance — a PATCH-style body that omits `merits` skips
+ *      the validator entirely (no false-positive on touchstone-only saves).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { ObjectId } from 'mongodb';
+import { createTestApp, stUser } from './helpers/test-app.js';
+import { setupDb, teardownDb } from './helpers/db-setup.js';
+import { getCollection } from '../db.js';
+import { getNecropolisInfectedTerritories } from '../../public/js/data/rules-helpers.js';
+
+let app;
+const TEST_FLAG = { _test_n4: true };
+
+beforeAll(async () => {
+  await setupDb();
+  app = createTestApp();
+  await getCollection('characters').deleteMany(TEST_FLAG);
+});
+
+afterAll(async () => {
+  await getCollection('characters').deleteMany(TEST_FLAG);
+  await teardownDb();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure-function: getNecropolisInfectedTerritories union math
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-4 — getNecropolisInfectedTerritories', () => {
+  const mkChar = (name, sepulcher, waDots, waTerritories) => ({
+    name,
+    merits: [
+      ...(sepulcher > 0 ? [{ name: 'Necropolis Sepulcher', cp: sepulcher, xp: 0 }] : []),
+      ...(waDots > 0 ? [{ name: 'White Ants', cp: waDots, xp: 0, territories: waTerritories }] : []),
+    ],
+  });
+
+  it('returns deduplicated union across all Sepulcher owners', () => {
+    const chars = [
+      mkChar('Alice', 3, 2, ['terr-a', 'terr-b']),
+      mkChar('Bob',   2, 3, ['terr-b', 'terr-c', 'terr-d']),
+    ];
+    expect(getNecropolisInfectedTerritories(chars)).toEqual(['terr-a', 'terr-b', 'terr-c', 'terr-d']);
+  });
+
+  it('non-owners (no Sepulcher) contribute zero even with territories[] populated', () => {
+    // Carl has White Ants 5 with picks but no Sepulcher → not a member, ignored.
+    const chars = [
+      mkChar('Alice', 1, 1, ['terr-a']),
+      mkChar('Carl',  0, 5, ['terr-x', 'terr-y', 'terr-z', 'terr-w', 'terr-v']),
+    ];
+    expect(getNecropolisInfectedTerritories(chars)).toEqual(['terr-a']);
+  });
+
+  it('insertion order preserved within the dedup', () => {
+    const chars = [
+      mkChar('Alice', 1, 3, ['terr-c', 'terr-a', 'terr-b']),
+      mkChar('Bob',   1, 2, ['terr-a', 'terr-d']),
+    ];
+    expect(getNecropolisInfectedTerritories(chars)).toEqual(['terr-c', 'terr-a', 'terr-b', 'terr-d']);
+  });
+
+  it('handles missing/empty chars + missing territories gracefully', () => {
+    expect(getNecropolisInfectedTerritories(null)).toEqual([]);
+    expect(getNecropolisInfectedTerritories([])).toEqual([]);
+    expect(getNecropolisInfectedTerritories([{ name: 'X' }])).toEqual([]);
+    expect(getNecropolisInfectedTerritories([{ name: 'X', merits: null }])).toEqual([]);
+    // Sepulcher owner with White Ants but no territories[] field.
+    expect(getNecropolisInfectedTerritories([{
+      name: 'X', merits: [
+        { name: 'Necropolis Sepulcher', cp: 1 },
+        { name: 'White Ants', cp: 2 },
+      ],
+    }])).toEqual([]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Server middleware: length === rating, no duplicates, partial-body tolerance
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-4 — PUT /api/characters/:id White Ants validation', () => {
+  let charId;
+
+  beforeAll(async () => {
+    const ins = await getCollection('characters').insertOne({
+      ...TEST_FLAG,
+      name: 'N4_Validator_Char',
+      merits: [
+        { name: 'Necropolis Sepulcher', category: 'general', cp: 2, xp: 0 },
+      ],
+    });
+    charId = ins.insertedId;
+  });
+
+  it('accepts a White Ants save where territories.length === rating', async () => {
+    const res = await request(app)
+      .put(`/api/characters/${charId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        merits: [
+          { name: 'Necropolis Sepulcher', category: 'general', cp: 2, xp: 0 },
+          { name: 'White Ants', category: 'general', cp: 2, xp: 0, territories: ['ter-a', 'ter-b'] },
+        ],
+      });
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects when territories.length < rating', async () => {
+    const res = await request(app)
+      .put(`/api/characters/${charId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        merits: [
+          { name: 'Necropolis Sepulcher', category: 'general', cp: 2, xp: 0 },
+          { name: 'White Ants', category: 'general', cp: 3, xp: 0, territories: ['ter-a', 'ter-b'] }, // rating 3, 2 picks
+        ],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('VALIDATION_ERROR');
+    expect(res.body.message).toContain('White Ants territories length');
+    expect(res.body.detail).toMatchObject({ rating: 3, territories_length: 2 });
+  });
+
+  it('rejects when territories.length > rating', async () => {
+    const res = await request(app)
+      .put(`/api/characters/${charId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        merits: [
+          { name: 'White Ants', category: 'general', cp: 1, xp: 0, territories: ['ter-a', 'ter-b'] }, // rating 1, 2 picks
+        ],
+      });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects duplicate territory slugs within the same merit', async () => {
+    const res = await request(app)
+      .put(`/api/characters/${charId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        merits: [
+          { name: 'White Ants', category: 'general', cp: 3, xp: 0, territories: ['ter-a', 'ter-b', 'ter-a'] },
+        ],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toContain('distinct');
+    expect(res.body.detail).toMatchObject({ duplicate: 'ter-a' });
+  });
+
+  it('includes free_grants in the rating calc (N-1 union)', async () => {
+    // Sepulcher 2 (cp) + free_grants.necro 1 → effective rating 3; needs 3 picks.
+    const res = await request(app)
+      .put(`/api/characters/${charId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        merits: [
+          { name: 'White Ants', category: 'general', cp: 2, xp: 0, free_grants: { necro: 1 }, territories: ['ter-a', 'ter-b', 'ter-c'] },
+        ],
+      });
+    expect(res.status).toBe(200);
+  });
+
+  it('partial body that omits merits skips the validator (touchstone-style PATCH)', async () => {
+    // Even with a broken White Ants persisted, a body that doesn't carry the
+    // merits array shouldn't trigger validation — only the fields you send
+    // are checked.
+    const res = await request(app)
+      .put(`/api/characters/${charId}`)
+      .set('X-Test-User', stUser())
+      .send({ humanity: 6 });
+    expect(res.status).toBe(200);
+  });
+
+  it('rating-zero White Ants accepts an empty territories[] (degenerate-but-legal)', async () => {
+    const res = await request(app)
+      .put(`/api/characters/${charId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        merits: [
+          { name: 'White Ants', category: 'general', cp: 0, xp: 0, territories: [] },
+        ],
+      });
+    expect(res.status).toBe(200);
+  });
+});

--- a/specs/stories/issue-696-n4-white-ants-territory.story.md
+++ b/specs/stories/issue-696-n4-white-ants-territory.story.md
@@ -1,0 +1,91 @@
+# Issue #696: N-4 — White Ants Territory linkage (picker UI + render union helper)
+
+Status: Ready for Review
+
+issue: 696
+issue_url: https://github.com/angelusvmorningstar/issues/696
+branch: piatra/issue-696-n4-white-ants-territory
+epic: MNEC (specs/epic-mnec-necropolis-merits.md)
+adr: ADR-005 Rev 2 (specs/architecture/adr-005-pool-grant-and-sharing-scope-generalisation.md)
+dispatch: PROCEED-WITH-NOTICE.
+
+## Story
+
+As a player whose Nosferatu character has White Ants dots,
+I want to pick which Territories the Necropolis has infected — one Territory per dot, from the live campaign Territory list — and have that selection persist and surface as the Necropolis-infected union for any render-time consumer (N-5 Trap Door anchor validation; ST-side maps),
+so that the rule text's "for each dot in this merit select a Territory" lands as actual character state, with N-5 unblocked to consume the union helper.
+
+## What ships
+
+- **Data shape** — White Ants merit entries gain a `territories: string[]` field holding the picked Territory slugs.
+- **Sheet editor UI** — one `<select>` per dot of effective White Ants rating, populated from the live `getStoredTerritories()` store (same source the admin app loads at boot via `setStatusTerritories`). Empty pickers show "Pick a Territory"; duplicate selections within the same merit show "Duplicate" warnings with a coloured row border.
+- **Server-side cross-field validation** — new `validateWhiteAntsTerritoriesMiddleware` runs after `normalizeMeritsMiddleware` on POST + PUT + POST `/wizard`. Rejects saves where `territories.length !== effective_rating` (effective rating = `cp + xp + sum(free_grants.*) + sum(legacy free_<slug>)`) and saves with duplicate slugs within a single merit. Partial bodies that omit `merits` skip the validator (touchstone-style PATCH stays unaffected).
+- **Render-side helper** — `getNecropolisInfectedTerritories(chars)` in `public/js/data/rules-helpers.js`. Walks `chars`, filters to Sepulcher owners (cp+xp >= 1), aggregates `territories[]` from each owner's White Ants merits, dedupes preserving insertion order. Pure ES module — importable client/server/vitest. N-5 consumes this.
+- **`getStoredTerritories()` exported** from `accessors.js` — module-level store (populated at app boot via the existing `setStatusTerritories` path) now has a public reader so the sheet picker doesn't have to re-fetch `/api/territories`.
+
+## Acceptance gates
+
+1. ✅ `territories: string[]` accepted on every merit shape per the schema; cross-field length check at the route level via middleware.
+2. ✅ Save fails (400) when `territories.length !== rating` — short, long, and mixed-source-rating (free_grants.necro contributes) cases asserted.
+3. ✅ Save fails (400) on duplicate slugs within a merit.
+4. ✅ Sheet renders one `<select>` per effective dot, options from the live territories store; empty rows + duplicate rows surface warning indicators; rating-zero shows no picker.
+5. ✅ `getNecropolisInfectedTerritories` union math: Alice ∪ Bob → deduplicated; insertion order preserved; non-Sepulcher owners contribute zero even if their White Ants merit has `territories[]` populated; missing/empty input handled defensively.
+6. ✅ Partial-body tolerance — a PUT body that omits `merits` (e.g. a touchstone-only save) is not blocked by White Ants validation.
+7. ✅ No regression — 1282/1282 individual tests pass; same 3 pre-existing archive-import test-file failures carry forward from N-1.
+
+## Out of scope
+
+- **-3 penalty enforcement** — the rule text's "-3 to all rolls to detects their personal actions" is roll-engine adjudication. ST Mods overlay (Epic STM) applies it manually per ST adjudication, consistent with True Worm's sun damage handling. A future story can integrate it natively when the roll engine grows the relevant hook.
+- Cross-character coalition / Coterie-level Territory awareness (out of MNEC scope).
+- N-5 Trap Door anchor picker — separate story; consumes the union helper this story ships.
+
+## Tasks / Subtasks
+
+- [x] `getNecropolisInfectedTerritories(chars)` in `rules-helpers.js` — pure helper.
+- [x] `getStoredTerritories()` reader in `accessors.js` — exposes the existing module-level store.
+- [x] `m.territories: { type: 'array', items: { type: 'string' } }` in `character.schema.js` merit shape.
+- [x] `validateWhiteAntsTerritoriesMiddleware` in `normalize-character.js` — wired into POST + PUT + POST /wizard.
+- [x] `_whiteAntsTerritoriesBlock(m, realIdx)` renderer in `sheet.js` — called after `meritBdRow` in the general-merits branch.
+- [x] `shSetWhiteAntsTerritory(realIdx, dotIdx, value)` handler in `edit-domain.js` — re-exported through `edit.js`, threaded through `admin.js` + `app.js` window assignment.
+- [x] CSS for `.wa-picker-block` + row variants in `components.css`.
+- [x] 11 vitest cases in `n4-white-ants-territory.test.js` (helper + route validation + partial-body tolerance + rating-zero edge).
+- [x] Story file (this one).
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-7 (Ptah / DEV)
+
+### Completion Notes List
+
+- **JSON-Schema cannot express the cross-field length check.** `territories.length === rating` requires reading a sibling-field-derived value (effective rating), which isn't representable inside Ajv's per-property schema. The middleware handles it, and the schema's `array of string` shape is the upstream guard.
+- **Effective rating math mirrors `meritFreeSum`** (sum of new `free_grants.*` map + the 14 legacy flat `free_<slug>` fields, per N-1's transition shape) plus `cp + xp`. Inlined in the middleware to avoid importing the client helper on the server hot path — the calc is small enough that the duplication is preferable to the cross-module dependency.
+- **Picker injected in the general-merits branch only.** White Ants is most naturally a `category: 'general'` merit (no influence/domain/standing semantics); the seed has `sub_category: null`. If the merit ends up assigned to a different category by some user flow, the picker won't render — easy follow-up to add the call site if it ever surfaces.
+- **The `getStoredTerritories` getter completes the existing `setStatusTerritories` pair** that was previously read-internal (the `getRegentTerritoryFor` accessor used it). Single source of truth for the live Territory list; the sheet picker doesn't re-fetch `/api/territories`.
+- **Inline-onchange handler is the established sheet.js pattern** (`shEditDomMerit`, `shEditGenMerit`, etc.). `shSetWhiteAntsTerritory` follows it exactly. This is NOT the listener-routing blind spot from the memory — there's no `change` listener routing click events; the `onchange` attribute binds directly to the global handler exposed by `admin.js`/`app.js`.
+- **Three pre-existing test-file failures** (archive-import) carry forward from N-1. Not caused by N-4.
+- **Worktree pattern continued** (`/tmp/tm-ptah/n4-whiteants`, node_modules + server/.env symlinked from main).
+
+### File List
+
+**New**
+- `server/tests/n4-white-ants-territory.test.js` — 11 vitest cases
+- `specs/stories/issue-696-n4-white-ants-territory.story.md` — this file
+
+**Modified**
+- `public/js/data/rules-helpers.js` — added `getNecropolisInfectedTerritories`
+- `public/js/data/accessors.js` — added `getStoredTerritories` reader
+- `public/js/editor/sheet.js` — picker renderer + import wiring
+- `public/js/editor/edit-domain.js` — `shSetWhiteAntsTerritory` handler
+- `public/js/editor/edit.js` — re-exports `shSetWhiteAntsTerritory`
+- `public/js/admin.js` — imports + window-assigns `shSetWhiteAntsTerritory`
+- `public/js/app.js` — imports + window-assigns `shSetWhiteAntsTerritory`
+- `public/css/components.css` — `.wa-picker-block` and row variants
+- `server/schemas/character.schema.js` — `territories: string[]` on merit shape
+- `server/lib/normalize-character.js` — `validateWhiteAntsTerritoriesMiddleware`
+- `server/routes/characters.js` — wires the middleware into POST / PUT / POST /wizard
+
+### Change Log
+
+- 2026-06-11 (Ptah): N-4 White Ants Territory linkage shipped.


### PR DESCRIPTION
## Summary

MNEC White Ants merit gets the per-dot Territory selection it was specced for, plus the render union helper that N-5 (Trap Door anchor validation) consumes.

## What ships

- **Data shape:** `m.territories: string[]` on White Ants entries — Territory slugs.
- **Sheet editor UI:** one `<select>` per dot of effective rating, options from the live `getStoredTerritories()` store (populated by the app at boot via the existing `setStatusTerritories` path). Empty rows show "Pick a Territory"; duplicate slugs within a merit show "Duplicate" with a coloured row border.
- **Server validation** (`validateWhiteAntsTerritoriesMiddleware`, wired into POST + PUT + POST `/wizard`):
  - Rejects (400) when `territories.length !== effective_rating`. Effective rating uses the same union as `meritFreeSum`: `cp + xp + sum(free_grants.*) + sum(legacy free_<slug>)`.
  - Rejects duplicate slugs within a single merit.
  - **Partial-body tolerance:** PUT bodies that omit `merits` skip the validator entirely (touchstone-only / status-only saves stay unaffected).
- **Render-side helper** `getNecropolisInfectedTerritories(chars)` in `public/js/data/rules-helpers.js`. Walks chars, filters to Sepulcher owners (cp+xp ≥ 1), aggregates `territories[]` from each owner's White Ants, dedupes preserving insertion order. Pure ES module — importable client/server/vitest. **N-5 consumes this.**
- **`getStoredTerritories()` reader** in `accessors.js` — completes the existing `setStatusTerritories` pair so the sheet picker doesn't have to re-fetch `/api/territories`.

## Out of scope (per issue)

- **-3 penalty enforcement** — rule text's "-3 to all rolls to detects their personal actions" is roll-engine adjudication. **ST Mods overlay applies manually until future roll-engine integration**, consistent with True Worm's sun damage handling.
- Coalition / Coterie-level Territory awareness.
- N-5 Trap Door anchor picker — separate story; consumes the union helper.

## Design notes worth flagging

- **JSON-Schema cannot express the cross-field length check** (`territories.length === rating` needs a sibling-derived value). The middleware handles it; the schema's `array of string` shape is the upstream guard.
- **Effective rating math mirrors `meritFreeSum`** (N-1 union) — inlined in the middleware to avoid a cross-module dep on the server hot path. Small enough that the duplication is preferable.
- **Picker injected in the general-merits branch only.** White Ants is most naturally `category: 'general'` (no influence/domain/standing semantics; seed has `sub_category: null`). Easy follow-up to add elsewhere if a flow surfaces.
- **Inline-onchange handler is the established sheet.js pattern** (`shEditDomMerit`, `shEditGenMerit`, etc.). `shSetWhiteAntsTerritory` follows it exactly. **NOT** the listener-routing blind spot from memory — no `change` listener routing click events; `onchange` binds directly to the global handler.

## Tests

**11 vitest cases** in `server/tests/n4-white-ants-territory.test.js`:
- Helper union math: dedup, insertion order, non-owner ignored, defensive null/empty.
- Middleware: accepts `length === rating`; rejects short / long / duplicate / free_grants-aware-rating cases.
- Partial-body tolerance + rating-zero degenerate-but-legal edge.

**Full regression: 1282/1282 individual tests pass.** Same three pre-existing archive-import test-FILE failures carry forward from N-1.

## Test plan

- [ ] Roll a Nosferatu character with Necropolis Sepulcher 3 + White Ants 3 in the admin editor → three Territory pickers appear under White Ants. Pick three distinct Territories → Save works.
- [ ] Pick two identical Territories → row shows "Duplicate" warning + coloured border; Save fails 400 from the server.
- [ ] Add a fourth White Ants dot before picking → an empty fourth picker appears with "Pick a Territory" warning; Save fails 400.
- [ ] Drop a Sepulcher dot so White Ants's `free_grants.necro` shrinks → trailing pickers retire and the territories array trims.
- [ ] Two characters with White Ants picks → `getNecropolisInfectedTerritories(allChars)` returns the deduplicated union (sanity for N-5).

Closes #696