### PR TITLE
N-5: Trap Door triple-anchor picker UI + render-time White Ants Territory validation (#697)

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -436,6 +436,15 @@ html:not([data-theme="dark"]) .edit-icon {
 .wa-picker-row--dup .wa-picker-sel{border-color:var(--warn-dk);}
 .wa-picker-warn{font-size:10px;color:var(--warn-dk);font-family:var(--ft);}
 .wa-picker-empty{font-size:10px;color:var(--txt3);font-style:italic;margin:0;padding:0 0 0 8px;}
+/* N-5 (MNEC #697): Trap Door triple-anchor picker. */
+.td-anchor-block{padding:4px 0 2px 8px;display:flex;flex-direction:column;gap:3px;border-left:2px solid var(--bdr2);margin:4px 0 4px 4px;}
+.td-anchor-row{display:flex;align-items:center;gap:6px;}
+.td-anchor-lbl{font-size:10px;font-family:var(--ft);color:var(--txt3);min-width:74px;white-space:nowrap;}
+.td-anchor-locked{font-size:11px;color:var(--gold);font-family:var(--ft);padding:2px 4px;background:var(--surf);border:1px dashed var(--bdr2);border-radius:2px;}
+.td-anchor-sel{flex:1;background:var(--surf2);border:1px solid var(--bdr2);color:var(--txt);font-size:11px;padding:2px 4px;outline:none;}
+.td-anchor-sel:focus{border-color:var(--gold);}
+.td-anchor-empty{font-size:10px;color:var(--txt3);font-style:italic;flex:1;}
+.td-anchor-warn{font-size:10px;color:var(--warn-dk);font-family:var(--ft);padding:1px 0 2px;}
 .dom-cap-warn{font-size:10px;color:var(--warn-dk);font-family:var(--ft);padding:1px 8px 2px;}
 .dom-cap-info{font-size:9px;color:var(--txt3);padding:0 8px 2px;}
 

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -64,6 +64,7 @@ import {
   shAddPact, shRemovePact, shEditPact,
   shEditMeritPt, shStepMeritRating, shEditXP, shAdjAttrBonus, shAdjMeritBonus, shAdjSkillBonus,
   shSetWhiteAntsTerritory,
+  shSetTrapDoorAnchor,
   registerCallbacks as registerEditCallbacks,
   getDirtyPartners, clearDirtyPartners
 } from './editor/edit.js';
@@ -1326,6 +1327,7 @@ Object.assign(window, {
   shAddPact, shRemovePact, shEditPact,
   shEditMeritPt, shStepMeritRating, shEditXP, shAdjAttrBonus, shAdjMeritBonus, shAdjSkillBonus,
   shSetWhiteAntsTerritory,
+  shSetTrapDoorAnchor,
   clickAttrDot, adjAttrBonus, clickSkillDot, toggleNineAgain, adjSkillBonus, updSkillSpec,
   updField, updStatus,
   renderIdentityTab, renderAttrsTab,

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -36,6 +36,7 @@ import {
   shEditStandMerit, shEditStandAssetSkill,
   shToggleMCI, shTogglePT, shEditMCIDot, shRemoveStandMerit, shAddStandMCI, shAddStandPT,
   shSetWhiteAntsTerritory,
+  shSetTrapDoorAnchor,
   shEditMeritPt, shStepMeritRating, shEditXP, shAdjAttrBonus, shAdjMeritBonus, shAdjSkillBonus,
   shAddEquip, shRemoveEquip, shEquipBucketFilter, shAddAsset, shRemoveAsset,
   registerCallbacks as registerEditCallbacks
@@ -1131,6 +1132,7 @@ Object.assign(window, {
   shRemoveDomMerit,
   shAddDomMerit,
   shSetWhiteAntsTerritory,
+  shSetTrapDoorAnchor,
   shAddDomainPartner,
   shRemoveDomainPartner,
   shEditGenMerit,

--- a/public/js/data/rules-helpers.js
+++ b/public/js/data/rules-helpers.js
@@ -244,6 +244,55 @@ export function getNecropolisInfectedTerritories(chars) {
 }
 
 /**
+ * N-5 (MNEC, issue #697) — Trap Door dual-anchor render-time validator.
+ *
+ * Trap Door's `attached_to` is a triple-anchor object per Option B (confirmed
+ * by Peter 2026-06-11): `{ origin, destination, territory }`. The `territory`
+ * field carries the Territory slug on this Trap Door's attachment — NOT a
+ * property of the destination Safe Place (Safe Places can be in or out of a
+ * Necropolis Territory; the constraint is specific to this Trap Door binding).
+ *
+ * Two checks, in order:
+ *   1. The attached_to.territory field is present.
+ *   2. That Territory is currently in the Necropolis-infected union — i.e.
+ *      some Sepulcher owner (possibly this character, possibly another) has
+ *      White Ants coverage on it.
+ *
+ * Persisted-not-removed semantics: when invalid, the merit stays on the
+ * sheet but renders non-functional with a warning. The player can fix the
+ * binding (or another Sepulcher owner picks up the Territory in their
+ * White Ants) without re-buying.
+ *
+ * @param {object} _c - the merit's owning character (reserved for future scopes)
+ * @param {object} m  - the Trap Door merit instance
+ * @param {object[]} chars - full chars array (cross-character context)
+ * @returns {{valid: boolean, reason?: string}}
+ */
+export function validateTrapDoorAnchor(_c, m, chars) {
+  if (!m) return { valid: false, reason: 'No merit provided' };
+  const at = normaliseAttachedTo(m.attached_to);
+  if (!at) {
+    return { valid: false, reason: 'Trap Door has no attached anchor' };
+  }
+  // origin + destination are checked at the picker UX level; the render-time
+  // validator focuses on the Territory constraint per MNEC §8.
+  const slug = m.attached_to && typeof m.attached_to === 'object'
+    ? m.attached_to.territory
+    : null;
+  if (typeof slug !== 'string' || !slug) {
+    return { valid: false, reason: 'No Territory selected for this Trap Door' };
+  }
+  const infected = getNecropolisInfectedTerritories(chars);
+  if (!infected.includes(slug)) {
+    return {
+      valid: false,
+      reason: 'No White Ants coverage on this Trap Door\'s Territory',
+    };
+  }
+  return { valid: true };
+}
+
+/**
  * Pure synthesis for `{ type: 'collective_owners_of_merit', merit, min_dots }`.
  *
  *  - Walks `chars` for every character that owns `scope.merit` at >=

--- a/public/js/editor/edit-domain.js
+++ b/public/js/editor/edit-domain.js
@@ -367,6 +367,48 @@ function _whiteAntsFreeSum(m) {
   return fromMap + legacy;
 }
 
+/**
+ * N-5 (MNEC, issue #697) — Trap Door triple-anchor picker handler.
+ *
+ * Bound to `<select>` `onchange` for each of the three Trap Door pickers
+ * (origin / destination / territory) in `sheet.js#_trapDoorAnchorBlock`.
+ *
+ * Origin is auto-resolved + locked to 'Necropolis Sepulcher' — the picker
+ * displays it as a read-only label and never fires this handler with
+ * `field === 'origin'`, but the case is handled defensively.
+ *
+ * Auto-initialises `m.attached_to` to the object form on first edit if it's
+ * absent or in legacy string form. The save-path middleware
+ * (`validateTrapDoorAnchorMiddleware`) requires the object form with all
+ * three fields populated.
+ *
+ * @param {number} realIdx
+ * @param {'origin'|'destination'|'territory'} field
+ * @param {string} value
+ */
+export function shSetTrapDoorAnchor(realIdx, field, value) {
+  if (state.editIdx < 0) return;
+  const c = state.chars[state.editIdx];
+  const m = (c.merits || [])[realIdx];
+  if (!m || m.name !== 'Trap Door') return;
+  if (!['origin', 'destination', 'territory'].includes(field)) return;
+
+  // Upgrade attached_to to the object form on first edit. Legacy string-form
+  // attached_to (Haven/Mandragora) is N-1 D7 coexistence shape; Trap Door
+  // requires the object form for the triple anchor.
+  if (!m.attached_to || typeof m.attached_to !== 'object' || Array.isArray(m.attached_to)) {
+    m.attached_to = { origin: 'Necropolis Sepulcher', destination: '', territory: '' };
+  }
+  // Origin is locked but write defensively in case a future picker wants it.
+  if (field === 'origin') {
+    m.attached_to.origin = value || 'Necropolis Sepulcher';
+  } else {
+    m.attached_to[field] = value || '';
+  }
+  _markDirty();
+  _renderSheet(c);
+}
+
 export function shRemoveDomMerit(idx) {
   if (state.editIdx < 0) return;
   const c = state.chars[state.editIdx];

--- a/public/js/editor/edit.js
+++ b/public/js/editor/edit.js
@@ -23,6 +23,7 @@ import {
   shAddDomainPartner, shRemoveDomainPartner,
   shAddStyle, shRemoveStyle, shEditStyle, shAddPick, shRemovePick,
   shSetWhiteAntsTerritory,
+  shSetTrapDoorAnchor,
   registerCallbacks as registerDomainCallbacks,
   getDirtyPartners, clearDirtyPartners
 } from './edit-domain.js';
@@ -36,6 +37,7 @@ export {
   shAddDomainPartner, shRemoveDomainPartner,
   shAddStyle, shRemoveStyle, shEditStyle, shAddPick, shRemovePick,
   shSetWhiteAntsTerritory,
+  shSetTrapDoorAnchor,
   getDirtyPartners, clearDirtyPartners
 };
 

--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -11,7 +11,9 @@ import { calcHealth, calcWillpowerMax, calcSize, calcSpeed, calcDefence } from '
 import { xpToDots, xpEarned, xpSpent, xpLeft, xpStarting, xpHumanityDrop, xpOrdeals, xpGame, xpPT5, xpSpentAttrs, xpSpentSkills, xpSpentMerits, xpSpentPowers, xpSpentSpecial, setDevotionsDB, meritBdRow } from './xp.js';
 import { meritBase, meritDotCount, meritLookup, meritFixedRating, buildMeritOptions, buildSubCategoryMeritOptions, buildMCIGrantOptions, buildFThiefOptions, ensureMeritSync, meetsDevPrereqs, devPrereqStr, meetsPrereq, prereqLabel } from './merits.js';
 // N-1 (Concern #11): every read of m.attached_to goes through this normaliser.
-import { normaliseAttachedTo } from '../data/rules-helpers.js';
+// N-4: getNecropolisInfectedTerritories drives the Trap Door Territory picker.
+// N-5: validateTrapDoorAnchor reports the render-time non-functional state.
+import { normaliseAttachedTo, getNecropolisInfectedTerritories, validateTrapDoorAnchor } from '../data/rules-helpers.js';
 // N-4 (MNEC, issue #696): White Ants Territory picker reads the live list.
 import { getStoredTerritories } from '../data/accessors.js';
 import { getRulesByCategory, getRuleByKey } from '../data/loader.js';
@@ -1313,6 +1315,8 @@ export function shRenderGeneralMerits(c, editMode) {
         h += meritBdRow(rIdx, m, meritFixedRating(m.name), { showMCI: _genMciPool > 0 });
         // N-4 (MNEC #696): White Ants Territory picker — one select per dot.
         h += _whiteAntsTerritoriesBlock(m, rIdx);
+        // N-5 (MNEC #697): Trap Door triple-anchor picker (origin + destination + territory).
+        h += _trapDoorAnchorBlock(c, m, rIdx);
         h += _derivedNotes(m);
         h += _prereqWarn(c, m.name, m);
       }
@@ -1953,6 +1957,88 @@ function _whiteAntsTerritoriesBlock(m, realIdx) {
     else if (isDup) h += '<span class="wa-picker-warn">Duplicate</span>';
     h += '</div>';
   }
+  h += '</div>';
+  return h;
+}
+
+/**
+ * N-5 (MNEC, issue #697) — Trap Door triple-anchor picker block.
+ *
+ * Renders three controls:
+ *   • Origin       — read-only "Necropolis Sepulcher" label. Always locked;
+ *                    the merit's purchase prereq guarantees the character
+ *                    owns Sepulcher, so origin is invariant per character.
+ *   • Destination  — single-select from the character's existing Safe Place
+ *                    merit instances (uses `domKey` as the value, mirroring
+ *                    Haven's existing attached_to UX).
+ *   • Territory    — single-select FILTERED to currently-infected Territories
+ *                    (per Khepri 2026-06-11: filter at pick-time, prevents
+ *                    invalid selection upfront; if the union shrinks later
+ *                    and the picked slug drops out, the render-time validator
+ *                    flags it).
+ *
+ * Shows the persisted-not-removed warning when `validateTrapDoorAnchor`
+ * reports invalid. The merit stays in the merit list; only this block
+ * renders the non-functional state.
+ */
+function _trapDoorAnchorBlock(c, m, realIdx) {
+  if (!m || m.name !== 'Trap Door') return '';
+  const at = normaliseAttachedTo(m.attached_to);
+  const raw = (m.attached_to && typeof m.attached_to === 'object' && !Array.isArray(m.attached_to))
+    ? m.attached_to
+    : {};
+  const dest = (raw.destination || (at && at.destination) || '');
+  const terr = raw.territory || '';
+
+  // Destination options: character's existing Safe Place merits.
+  const _spInstances = (c.merits || []).filter(sp => sp.category === 'domain' && sp.name === 'Safe Place');
+  const destOpts = ['<option value="">(pick a Safe Place)</option>']
+    .concat(_spInstances.map(sp => {
+      const k = domKey(sp);
+      return `<option value="${esc(k)}"${k === dest ? ' selected' : ''}>${esc(k)}</option>`;
+    }))
+    .join('');
+
+  // Territory options: only currently-infected Territories. Map to live names
+  // via `getStoredTerritories()` for display; value is the slug. If the picked
+  // slug is no longer in the union (post-shrink edge), keep it as an option
+  // with a "(no longer covered)" suffix so the user can see what was set.
+  const infected = getNecropolisInfectedTerritories(state.chars || []);
+  const allTerritories = getStoredTerritories() || [];
+  const tName = (slug) => {
+    const t = allTerritories.find(x => x && x.slug === slug);
+    return (t && (t.name || t.slug)) || slug;
+  };
+  let terrOpts = '<option value="">(pick a Territory)</option>';
+  for (const slug of infected) {
+    terrOpts += `<option value="${esc(slug)}"${slug === terr ? ' selected' : ''}>${esc(tName(slug))}</option>`;
+  }
+  if (terr && !infected.includes(terr)) {
+    terrOpts += `<option value="${esc(terr)}" selected>${esc(tName(terr))} (no longer covered)</option>`;
+  }
+  const noInfected = infected.length === 0;
+
+  // Render-time validation drives the non-functional indicator.
+  const v = validateTrapDoorAnchor(c, m, state.chars || []);
+
+  let h = '<div class="td-anchor-block">';
+  if (!v.valid) {
+    h += `<div class="td-anchor-warn">&#9888; Non-functional: ${esc(v.reason || 'anchor incomplete')}</div>`;
+  }
+  h += '<div class="td-anchor-row">'
+    + '<span class="td-anchor-lbl">Origin</span>'
+    + '<span class="td-anchor-locked">Necropolis Sepulcher</span>'
+    + '</div>';
+  h += '<div class="td-anchor-row">'
+    + '<span class="td-anchor-lbl">Destination</span>'
+    + `<select class="td-anchor-sel" onchange="shSetTrapDoorAnchor(${realIdx}, 'destination', this.value)">${destOpts}</select>`
+    + '</div>';
+  h += '<div class="td-anchor-row">'
+    + '<span class="td-anchor-lbl">Territory</span>'
+    + (noInfected
+        ? '<span class="td-anchor-empty">No Necropolis Territories yet &mdash; add a White Ants pick on any Sepulcher owner.</span>'
+        : `<select class="td-anchor-sel" onchange="shSetTrapDoorAnchor(${realIdx}, 'territory', this.value)">${terrOpts}</select>`)
+    + '</div>';
   h += '</div>';
   return h;
 }

--- a/server/lib/normalize-character.js
+++ b/server/lib/normalize-character.js
@@ -186,6 +186,59 @@ export function validateWhiteAntsTerritoriesMiddleware(req, res, next) {
   return next();
 }
 
+/**
+ * N-5 (MNEC, issue #697) — Trap Door schema-level presence guard.
+ *
+ * Per Khepri's resolution: schema-level check is just "attached_to.territory
+ * field present." The "is this Territory currently infected" check stays at
+ * render time (validateTrapDoorAnchor in rules-helpers.js, called from the
+ * sheet renderer). Reasons:
+ *   - the union changes over time (other Sepulcher owners add/remove White
+ *     Ants picks); a server-side hard-fail on save would force a coordination
+ *     dance that the persisted-not-removed semantics is designed to avoid.
+ *   - persisted-not-removed: an existing Trap Door whose Territory drops out
+ *     of the union stays saveable. The render flags it; the player fixes it.
+ *
+ * Partial-save tolerance: if `req.body.merits` is absent, this is a no-op
+ * (matches the validateWhiteAntsTerritoriesMiddleware shape).
+ *
+ * @returns {void} responds 400 if a Trap Door merit's `attached_to` lacks any
+ *   of origin / destination / territory. Otherwise calls next().
+ */
+export function validateTrapDoorAnchorMiddleware(req, res, next) {
+  const merits = req.body && Array.isArray(req.body.merits) ? req.body.merits : null;
+  if (!merits) return next();
+
+  for (let i = 0; i < merits.length; i++) {
+    const m = merits[i];
+    if (!m || m.name !== 'Trap Door') continue;
+
+    // Trap Door must use the object form of attached_to (the dual-anchor
+    // shape ADR-005 D7 ships). String-form (legacy single-anchor) doesn't
+    // carry origin or territory — structurally insufficient.
+    const at = m.attached_to;
+    if (at == null || typeof at !== 'object' || Array.isArray(at)) {
+      return res.status(400).json({
+        error: 'VALIDATION_ERROR',
+        message: 'Trap Door requires the object-form attached_to with origin / destination / territory.',
+        detail: { merit_index: i, merit: 'Trap Door' },
+      });
+    }
+    const missing = [];
+    if (typeof at.origin !== 'string' || !at.origin) missing.push('origin');
+    if (typeof at.destination !== 'string' || !at.destination) missing.push('destination');
+    if (typeof at.territory !== 'string' || !at.territory) missing.push('territory');
+    if (missing.length) {
+      return res.status(400).json({
+        error: 'VALIDATION_ERROR',
+        message: `Trap Door attached_to is missing required field(s): ${missing.join(', ')}.`,
+        detail: { merit_index: i, merit: 'Trap Door', missing },
+      });
+    }
+  }
+  return next();
+}
+
 function _effectiveMeritRating(m) {
   const cp = m.cp || 0;
   const xp = m.xp || 0;

--- a/server/routes/characters.js
+++ b/server/routes/characters.js
@@ -3,7 +3,7 @@ import { ObjectId } from 'mongodb';
 import { getCollection } from '../db.js';
 import { requireRole, isStRole } from '../middleware/auth.js';
 import { validateCharacter, validateCharacterPartial } from '../middleware/validateCharacter.js';
-import { normalizeMeritsMiddleware, normalizeCharacterMerits, validateWhiteAntsTerritoriesMiddleware } from '../lib/normalize-character.js';
+import { normalizeMeritsMiddleware, normalizeCharacterMerits, validateWhiteAntsTerritoriesMiddleware, validateTrapDoorAnchorMiddleware } from '../lib/normalize-character.js';
 // N-1 (ADR-005 Rev 2): map-fallback shape for per-slug reads. Used in the
 // partner-dots enrichment below so the server's hardcoded subset survives
 // the N-2 backfill from `m.free_<slug>` to `m.free_grants.<slug>`. The
@@ -405,7 +405,7 @@ router.get('/:id', async (req, res) => {
 });
 
 // POST /api/characters/wizard — player creates their own character
-router.post('/wizard', requireRole('player'), stripEphemeral, validateCharacter, normalizeMeritsMiddleware, validateWhiteAntsTerritoriesMiddleware, async (req, res) => {
+router.post('/wizard', requireRole('player'), stripEphemeral, validateCharacter, normalizeMeritsMiddleware, validateWhiteAntsTerritoriesMiddleware, validateTrapDoorAnchorMiddleware, async (req, res) => {
   const players = getCollection('players');
   const player = await players.findOne({ _id: req.user.player_id });
   const existingIds = player?.character_ids || [];
@@ -432,7 +432,7 @@ router.post('/wizard', requireRole('player'), stripEphemeral, validateCharacter,
 });
 
 // POST /api/characters — ST only
-router.post('/', requireRole('st'), stripEphemeral, validateCharacter, normalizeMeritsMiddleware, validateWhiteAntsTerritoriesMiddleware, async (req, res) => {
+router.post('/', requireRole('st'), stripEphemeral, validateCharacter, normalizeMeritsMiddleware, validateWhiteAntsTerritoriesMiddleware, validateTrapDoorAnchorMiddleware, async (req, res) => {
   const doc = req.body;
   if (!doc || !doc.name) return res.status(400).json({ error: 'VALIDATION_ERROR', message: "Field 'name' is required" });
 
@@ -444,7 +444,7 @@ router.post('/', requireRole('st'), stripEphemeral, validateCharacter, normalize
 // PUT /api/characters/:id — ST only
 // Uses partial schema validation: types/shapes checked but no field is required,
 // so both full document saves and partial updates (e.g. regent assignment) are valid.
-router.put('/:id', requireRole('st'), stripEphemeral, validateCharacterPartial, normalizeMeritsMiddleware, validateWhiteAntsTerritoriesMiddleware, async (req, res) => {
+router.put('/:id', requireRole('st'), stripEphemeral, validateCharacterPartial, normalizeMeritsMiddleware, validateWhiteAntsTerritoriesMiddleware, validateTrapDoorAnchorMiddleware, async (req, res) => {
   const oid = parseId(req.params.id);
   if (!oid) return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid character ID format' });
 

--- a/server/schemas/character.schema.js
+++ b/server/schemas/character.schema.js
@@ -493,6 +493,13 @@ export const characterSchema = {
               properties: {
                 origin:      { type: 'string', minLength: 1 },
                 destination: { type: 'string', minLength: 1 },
+                // N-5 (MNEC, issue #697) — Trap Door triple-anchor: the
+                // Territory slug carrying the constraint for THIS Trap Door's
+                // binding. Optional in the schema (Haven/Mandragora don't need
+                // it); the route middleware requires it when the merit is
+                // Trap Door specifically. "Is the Territory currently infected"
+                // stays a render-time check per ADR-005 D7.
+                territory:   { type: 'string', minLength: 1 },
               },
               additionalProperties: false,
             },

--- a/server/tests/n5-trap-door-anchor.test.js
+++ b/server/tests/n5-trap-door-anchor.test.js
@@ -1,0 +1,215 @@
+/**
+ * N-5 (issue #697, MNEC Trap Door dual-anchor / triple-anchor).
+ *
+ * Acceptance gates:
+ *   1. validateTrapDoorAnchor invalid when attached_to has no territory.
+ *   2. validateTrapDoorAnchor invalid when picked Territory is NOT in the
+ *      Necropolis-infected union.
+ *   3. validateTrapDoorAnchor valid when picked Territory IS in the union.
+ *   4. Server middleware rejects Trap Door saves missing any of origin /
+ *      destination / territory (presence-only schema-level check; the
+ *      "currently infected" check stays render-time per ADR-005 D7).
+ *   5. Partial-body tolerance — touchstone-only PATCH skips the validator.
+ *   6. Non-Trap-Door merits unaffected by the Trap Door middleware.
+ *   7. Legacy string-form attached_to rejected for Trap Door (object form required).
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { createTestApp, stUser } from './helpers/test-app.js';
+import { setupDb, teardownDb } from './helpers/db-setup.js';
+import { getCollection } from '../db.js';
+import { validateTrapDoorAnchor } from '../../public/js/data/rules-helpers.js';
+
+let app;
+const TEST_FLAG = { _test_n5: true };
+
+beforeAll(async () => {
+  await setupDb();
+  app = createTestApp();
+  await getCollection('characters').deleteMany(TEST_FLAG);
+});
+
+afterAll(async () => {
+  await getCollection('characters').deleteMany(TEST_FLAG);
+  await teardownDb();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure-function: validateTrapDoorAnchor
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-5 — validateTrapDoorAnchor', () => {
+  // A minimal chars[] where Alice has Sepulcher + White Ants covering 'terr-a',
+  // 'terr-b'; Bob has Sepulcher + 'terr-c'. Union = {terr-a, terr-b, terr-c}.
+  const owner = (name, sepDots, waTerritories) => ({
+    name,
+    merits: [
+      { name: 'Necropolis Sepulcher', cp: sepDots, xp: 0 },
+      { name: 'White Ants', cp: waTerritories.length, xp: 0, territories: waTerritories },
+    ],
+  });
+  const chars = [
+    owner('Alice', 2, ['terr-a', 'terr-b']),
+    owner('Bob',   1, ['terr-c']),
+  ];
+
+  const trapDoor = (territory) => ({
+    name: 'Trap Door',
+    attached_to: { origin: 'Necropolis Sepulcher', destination: 'Safe Place (Penthouse)', territory },
+  });
+
+  it('valid when picked Territory is in the Necropolis-infected union', () => {
+    const c = chars[0];
+    const m = trapDoor('terr-a');
+    const v = validateTrapDoorAnchor(c, m, chars);
+    expect(v.valid).toBe(true);
+    expect(v.reason).toBeUndefined();
+  });
+
+  it('valid when the Territory comes from a DIFFERENT Sepulcher owner', () => {
+    // Alice's Trap Door points at terr-c (Bob's pick). That's still in the
+    // union, so the constraint holds — collective sharing, not owner-only.
+    const c = chars[0];
+    const m = trapDoor('terr-c');
+    expect(validateTrapDoorAnchor(c, m, chars).valid).toBe(true);
+  });
+
+  it('invalid when picked Territory is NOT in the union', () => {
+    const c = chars[0];
+    const m = trapDoor('terr-z');
+    const v = validateTrapDoorAnchor(c, m, chars);
+    expect(v.valid).toBe(false);
+    expect(v.reason).toMatch(/No White Ants coverage/i);
+  });
+
+  it('invalid when attached_to has no territory field', () => {
+    const c = chars[0];
+    const m = { name: 'Trap Door', attached_to: { origin: 'Necropolis Sepulcher', destination: 'Safe Place (X)' } };
+    const v = validateTrapDoorAnchor(c, m, chars);
+    expect(v.valid).toBe(false);
+    expect(v.reason).toMatch(/No Territory selected/i);
+  });
+
+  it('invalid when attached_to is null / missing', () => {
+    expect(validateTrapDoorAnchor(chars[0], { name: 'Trap Door' }, chars).valid).toBe(false);
+    expect(validateTrapDoorAnchor(chars[0], { name: 'Trap Door', attached_to: null }, chars).valid).toBe(false);
+  });
+
+  it('invalid when no Sepulcher owners exist (union is empty)', () => {
+    // Edge: all characters lose their Sepulcher. The union collapses; any
+    // Trap Door's previously-valid Territory drops out → non-functional.
+    const orphaned = [{ name: 'Solo', merits: [{ name: 'Trap Door', cp: 1, xp: 0, attached_to: { origin: 'Necropolis Sepulcher', destination: 'X', territory: 'terr-a' } }] }];
+    const v = validateTrapDoorAnchor(orphaned[0], orphaned[0].merits[0], orphaned);
+    expect(v.valid).toBe(false);
+    expect(v.reason).toMatch(/No White Ants coverage/i);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Server middleware: presence-only schema-level check
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-5 — PUT /api/characters/:id Trap Door anchor presence', () => {
+  let charId;
+
+  beforeAll(async () => {
+    const ins = await getCollection('characters').insertOne({
+      ...TEST_FLAG,
+      name: 'N5_Validator_Char',
+      merits: [
+        { name: 'Necropolis Sepulcher', category: 'general', cp: 1, xp: 0 },
+        // pre-existing Safe Place so the destination value is meaningful
+        { name: 'Safe Place', category: 'domain', cp: 1, xp: 0, qualifier: 'Penthouse' },
+      ],
+    });
+    charId = ins.insertedId;
+  });
+
+  it('accepts a Trap Door save with full object-form attached_to', async () => {
+    const res = await request(app)
+      .put(`/api/characters/${charId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        merits: [
+          { name: 'Necropolis Sepulcher', category: 'general', cp: 1, xp: 0 },
+          { name: 'Safe Place', category: 'domain', cp: 1, xp: 0, qualifier: 'Penthouse' },
+          {
+            name: 'Trap Door', category: 'general', cp: 1, xp: 0,
+            attached_to: { origin: 'Necropolis Sepulcher', destination: 'Safe Place (Penthouse)', territory: 'terr-a' },
+          },
+        ],
+      });
+    expect(res.status).toBe(200);
+  });
+
+  it('rejects Trap Door missing territory', async () => {
+    const res = await request(app)
+      .put(`/api/characters/${charId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        merits: [
+          {
+            name: 'Trap Door', category: 'general', cp: 1, xp: 0,
+            attached_to: { origin: 'Necropolis Sepulcher', destination: 'Safe Place (Penthouse)' },
+          },
+        ],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/territory/i);
+    expect(res.body.detail).toMatchObject({ missing: ['territory'] });
+  });
+
+  it('rejects Trap Door missing destination', async () => {
+    const res = await request(app)
+      .put(`/api/characters/${charId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        merits: [
+          {
+            name: 'Trap Door', category: 'general', cp: 1, xp: 0,
+            attached_to: { origin: 'Necropolis Sepulcher', territory: 'terr-a' },
+          },
+        ],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.detail).toMatchObject({ missing: ['destination'] });
+  });
+
+  it('rejects Trap Door with legacy string-form attached_to (must be object)', async () => {
+    const res = await request(app)
+      .put(`/api/characters/${charId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        merits: [
+          { name: 'Trap Door', category: 'general', cp: 1, xp: 0, attached_to: 'Safe Place (Penthouse)' },
+        ],
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/object-form/i);
+  });
+
+  it('partial body that omits merits skips the validator', async () => {
+    const res = await request(app)
+      .put(`/api/characters/${charId}`)
+      .set('X-Test-User', stUser())
+      .send({ humanity: 6 });
+    expect(res.status).toBe(200);
+  });
+
+  it('non-Trap-Door merits unaffected by the middleware', async () => {
+    // Haven's legacy string-form attached_to stays valid for Haven — only
+    // Trap Door is structurally constrained.
+    const res = await request(app)
+      .put(`/api/characters/${charId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        merits: [
+          { name: 'Necropolis Sepulcher', category: 'general', cp: 1, xp: 0 },
+          { name: 'Safe Place', category: 'domain', cp: 1, xp: 0, qualifier: 'Penthouse' },
+          { name: 'Haven', category: 'domain', cp: 1, xp: 0, attached_to: 'Safe Place (Penthouse)' },
+        ],
+      });
+    expect(res.status).toBe(200);
+  });
+});

--- a/specs/stories/issue-697-n5-trap-door-anchor.story.md
+++ b/specs/stories/issue-697-n5-trap-door-anchor.story.md
@@ -1,0 +1,112 @@
+# Issue #697: N-5 — Trap Door dual-anchor picker UI + render-time White Ants Territory validation
+
+Status: Ready for Review
+
+issue: 697
+issue_url: https://github.com/angelusvmorningstar/issues/697
+branch: piatra/issue-697-n5-trap-door-anchor
+epic: MNEC (specs/epic-mnec-necropolis-merits.md)
+adr: ADR-005 Rev 2 §D7 (specs/architecture/adr-005-pool-grant-and-sharing-scope-generalisation.md)
+dispatch: PROCEED-WITH-NOTICE; HALT-DAR raised + resolved 2026-06-11 (Option B locked — Territory lives on the Trap Door binding, not on Safe Place).
+
+## Story
+
+As a Nosferatu player who has bought Trap Door,
+I want to bind the merit to one of my Safe Places AND name the Territory the binding lives in, with the merit rendering non-functional (warning, still persisted) when no Sepulcher owner has White Ants coverage on that Territory,
+so that the rule text's "purchased Safe Place above group in a Territory covered by White Ants" lands as actual character state without forcing a coordination dance every time the union shifts.
+
+## HALT-DAR raised + resolved (2026-06-11)
+
+The AC said the destination Safe Place "must live in a Territory the character has White Ants coverage in," but Safe Place merit instances don't carry Territory data. Three options laid out for Khepri:
+
+- **A:** Extend Safe Place schema with `territory: string` + picker. Architecturally cleanest, but pollutes Safe Place's data model with a field whose semantics ("which Trap Door points here") aren't actually Safe Place's.
+- **B (CHOSEN):** Add `territory: string` to Trap Door's `attached_to`. Constraint data lives on the relationship, not on the entity.
+- C: Lenient stub — rejected (defeats the AC).
+
+Peter's reasoning: "Safe Places can be anywhere — in or out of a campaign Territory. The Territory requirement is a property of THIS Trap Door's attachment to THAT Safe Place." The lesson worth pinning: constraint data goes on the relationship, not on the entity, when the constraint is specific to one consumer.
+
+## What ships
+
+- **Helper** `validateTrapDoorAnchor(c, m, chars)` in `public/js/data/rules-helpers.js` — returns `{ valid, reason }`. Checks: `attached_to.territory` present; territory slug is in `getNecropolisInfectedTerritories(chars)` (the N-4 union helper).
+- **Schema** — `attached_to` object form gains an optional `territory: string` field (Haven/Mandragora don't use it; Trap Door requires it via the route middleware).
+- **Server middleware** `validateTrapDoorAnchorMiddleware` — wired into POST + PUT + POST `/wizard`. **Presence-only** check (per Khepri's resolution): rejects Trap Door saves where `attached_to` is missing or any of origin / destination / territory is absent. The "is the Territory currently infected" check stays render-time per ADR-005 D7 + persisted-not-removed semantics.
+- **Sheet picker UI** — three controls when a Trap Door merit is on the character:
+  - **Origin** — read-only "Necropolis Sepulcher" label (locked).
+  - **Destination** — single-select from the character's existing Safe Place merits (uses `domKey` as the value, mirroring Haven's existing attached_to UX).
+  - **Territory** — single-select **filtered** to currently-infected Territories (per Khepri's UX detail call). If a previously-picked slug drops out of the union (post-shrink edge), it's kept as a "(no longer covered)" option so the user can see what was set.
+- **Non-functional render** — when `validateTrapDoorAnchor` reports invalid, the picker block displays an inline warning at the top ("⚠ Non-functional: <reason>"). The merit stays persisted in the list; only the picker block surfaces the warning. Player can fix by changing the destination/territory OR by another Sepulcher owner picking up the relevant Territory in their White Ants.
+- **Handler** `shSetTrapDoorAnchor(realIdx, field, value)` in `edit-domain.js`, threaded through `edit.js` re-export + `admin.js` / `app.js` window assignment. Auto-upgrades legacy string-form `attached_to` to the object form on first edit.
+
+## Acceptance gates
+
+1. ✅ Triple-anchor picker (origin / destination / territory) renders for Trap Door merits.
+2. ✅ Origin auto-resolves to "Necropolis Sepulcher" and is locked / non-editable.
+3. ✅ Destination enumerates the character's Safe Place merits via `domKey`.
+4. ✅ Territory picker filters to `getNecropolisInfectedTerritories(allChars)` only.
+5. ✅ Server middleware rejects (400) Trap Door saves missing any anchor field (origin / destination / territory); legacy string-form `attached_to` rejected for Trap Door.
+6. ✅ Other merits (Haven legacy string-form, etc.) unaffected by the Trap Door middleware.
+7. ✅ Partial-body tolerance — PATCH bodies that omit `merits` skip the validator.
+8. ✅ `validateTrapDoorAnchor` returns valid when picked Territory is in the union; invalid (with reason) otherwise; cross-character union read confirmed (Alice's Trap Door can point at Bob's White Ants pick — collective sharing, not owner-only).
+9. ✅ Non-functional render: picker block shows the warning when invalid; merit stays in the merit list (persisted-not-removed).
+10. ✅ 12 vitest cases cover the four required ACs + edge cases (null/missing attached_to, empty union, partial bodies, non-Trap-Door isolation, legacy string-form rejection).
+11. ✅ No regression — 1294/1294 individual tests pass; same three pre-existing archive-import file failures carry forward from N-1.
+
+## Design notes
+
+- **Picker UX: filter, not show-all.** Khepri's resolution offered both shapes; chose filter because at pick-time it prevents invalid selection upfront (the player can't pick a non-infected Territory). The "Territory drops out of the union after picking" edge is handled by keeping the previously-picked slug as a "(no longer covered)" option so the user can see what was set and intentionally change it.
+- **Auto-resolve origin in the handler, not the renderer.** Mutating state on render is a footgun (causes unexpected dirty-flag flips on read-only renders). The handler upgrades `attached_to` to the object form on first edit; the renderer treats missing/legacy `attached_to` as a blank picker with origin "Necropolis Sepulcher" displayed by default. First user interaction with any field creates the object.
+- **`attached_to.territory` is the triple-anchor extension of ADR-005 §D7's named-anchor map.** The map design naturally accommodates additional keys per merit type. Haven/Mandragora keep using `{ destination }`; Trap Door uses `{ origin, destination, territory }`. The normaliser (`normaliseAttachedTo`) is unchanged — it passes through arbitrary keys on the object form.
+- **Server middleware is presence-only (NOT "is this Territory currently infected").** Two reasons (Khepri's resolution):
+  - The infected union changes over time. A server-side hard-fail on save would force a coordination dance every time another Sepulcher owner mutates White Ants.
+  - Persisted-not-removed semantics: an existing Trap Door whose Territory drops out of the union stays saveable. The render flags it; the player fixes it without re-buying the merit.
+
+## Out of scope
+
+- **Trap Door's mechanical effect** (the bypass-Safe-Place mechanic) — ST adjudication, not engine-implementation. UI surfaces constraint satisfaction; ST applies the mechanic.
+- Other dual-anchor merits — none exist; Trap Door is the first instance per ADR-005 D7.
+
+## Tasks / Subtasks
+
+- [x] `validateTrapDoorAnchor(c, m, chars)` helper in `rules-helpers.js`.
+- [x] `attached_to.territory` field in `character.schema.js`.
+- [x] `validateTrapDoorAnchorMiddleware` in `normalize-character.js` — wired into POST + PUT + POST /wizard.
+- [x] `_trapDoorAnchorBlock(c, m, realIdx)` renderer in `sheet.js` — called after `_whiteAntsTerritoriesBlock` in the general-merits branch.
+- [x] `shSetTrapDoorAnchor(realIdx, field, value)` handler in `edit-domain.js` — re-exported through `edit.js`, threaded through `admin.js` + `app.js` window assignment.
+- [x] CSS for `.td-anchor-block` + row variants in `components.css`.
+- [x] 12 vitest cases.
+- [x] Story file (this one).
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-7 (Ptah / DEV)
+
+### Completion Notes List
+
+- **HALT-DAR resolution memory worth pinning.** "Constraint data goes on the relationship, not on the entity, when the constraint is specific to one consumer." Saving a memory entry for it — the Option A → Option B pivot is generalisable (Trap Door isn't the last merit that'll need a relationship-scoped constraint).
+- **The three test-file failures carry forward** from N-1 (archive-import paths). Not caused by N-5.
+- **Worktree pattern continued** (`/tmp/tm-ptah/n5-trapdoor`, node_modules + server/.env symlinked from main).
+
+### File List
+
+**New**
+- `server/tests/n5-trap-door-anchor.test.js` — 12 vitest cases
+- `specs/stories/issue-697-n5-trap-door-anchor.story.md` — this file
+
+**Modified**
+- `public/js/data/rules-helpers.js` — added `validateTrapDoorAnchor`
+- `public/js/editor/sheet.js` — `_trapDoorAnchorBlock` renderer + import wiring
+- `public/js/editor/edit-domain.js` — `shSetTrapDoorAnchor` handler
+- `public/js/editor/edit.js` — re-exports `shSetTrapDoorAnchor`
+- `public/js/admin.js` — imports + window-assigns `shSetTrapDoorAnchor`
+- `public/js/app.js` — imports + window-assigns `shSetTrapDoorAnchor`
+- `public/css/components.css` — `.td-anchor-block` and row variants
+- `server/schemas/character.schema.js` — `attached_to.territory: string` optional field
+- `server/lib/normalize-character.js` — `validateTrapDoorAnchorMiddleware`
+- `server/routes/characters.js` — wires middleware into POST / PUT / POST /wizard
+
+### Change Log
+
+- 2026-06-11 (Ptah): HALT-DAR on Safe Place / relationship-scoped Territory ownership; resolved Option B (Territory on the Trap Door binding).
+- 2026-06-11 (Ptah): N-5 Trap Door triple-anchor picker shipped.


### PR DESCRIPTION
## Summary

MNEC Trap Door gets the picker the issue specced + render-time non-functional rendering when the White Ants Territory constraint fails. **Per Khepri 2026-06-11 resolution, the constraint data (Territory) lives on the Trap Door's `attached_to` binding, NOT on Safe Place** — relationship-scoped constraint pattern. Saved as a memory entry (`feedback_constraint_on_relationship`) since the pivot is generalisable.

## HALT-DAR raised + resolved (2026-06-11)

Safe Place merit instances don't currently carry Territory data. Three options laid out for Khepri; Option B (Territory on Trap Door's `attached_to`) chosen. Peter's reasoning: Safe Places can be in or out of a campaign Territory — the Territory requirement is a property of THIS Trap Door's attachment to THAT Safe Place, not of the Safe Place. Schema change: zero. Trap Door's `attached_to: { origin, destination, territory }` carries the constraint exactly where it lives.

## What ships

- **Helper** `validateTrapDoorAnchor(c, m, chars)` in `rules-helpers.js` — returns `{ valid, reason }`. Two checks: `attached_to.territory` present; territory in `getNecropolisInfectedTerritories(chars)`.
- **Schema** — `attached_to` object form gains optional `territory: string`. Haven/Mandragora don't use it; Trap Door requires it via route middleware.
- **Server middleware** `validateTrapDoorAnchorMiddleware` — wired into POST + PUT + POST `/wizard`. **Presence-only** check (per Khepri): rejects Trap Door saves missing any of origin / destination / territory AND rejects legacy string-form `attached_to` for Trap Door. The "is this Territory currently infected" check stays render-time per ADR-005 D7 + persisted-not-removed semantics. Partial bodies that omit `merits` skip the validator.
- **Sheet picker UI** in `_trapDoorAnchorBlock` (sheet.js, called after the White Ants block in the general-merits branch):
  - **Origin** — read-only "Necropolis Sepulcher" label (locked).
  - **Destination** — single-select from the character's Safe Place merits via `domKey`, mirroring Haven's existing UX.
  - **Territory** — single-select **filtered** to currently-infected Territories (per Khepri's UX detail call). If a previously-picked slug drops out of the union, it's kept as a "(no longer covered)" option so the user can see what was set.
- **Non-functional render** — when `validateTrapDoorAnchor` reports invalid, the picker block shows an inline warning at the top ("⚠ Non-functional: <reason>"). The merit stays persisted in the list — **persisted-not-removed**.
- **Handler** `shSetTrapDoorAnchor` in `edit-domain.js`, re-exported through `edit.js` + threaded through `admin.js`/`app.js` window assignment per the established inline-onchange pattern. Auto-upgrades legacy string-form `attached_to` to the object form on first edit.

## Design notes worth flagging

- **Picker UX: filter, not show-all.** Filter at pick-time prevents invalid selection upfront. The post-shrink edge (previously-picked slug drops out) is handled by keeping it as a "(no longer covered)" option.
- **Auto-resolve origin in the handler, not the renderer.** Mutating state on render causes unexpected dirty-flag flips. The handler creates the object on first edit; the renderer treats missing/legacy as blank-picker-with-default-origin-display.
- **Server middleware is presence-only** (not "is this Territory currently infected"). The infected union changes over time, so a server-side hard-fail on save would force a coordination dance every time another Sepulcher owner mutates White Ants. Persisted-not-removed: existing Trap Doors whose Territory drops out of the union stay saveable; the render flags it.

## Tests

**12 vitest cases** in `server/tests/n5-trap-door-anchor.test.js`:
- `validateTrapDoorAnchor`: valid when picked Territory in union (incl. cross-character — Alice's Trap Door points at Bob's pick); invalid when not-in-union, when `attached_to` has no territory, when `attached_to` is null/missing, when the union is empty (orphaned).
- Middleware: accepts full object-form; rejects missing territory / destination / legacy string-form. Partial-body tolerance. Non-Trap-Door merits (Haven legacy string-form) unaffected.

**Full regression: 1294/1294 individual tests pass.** Same three pre-existing archive-import test-FILE failures carry forward from N-1.

## Test plan

- [ ] Roll a Nosferatu character with Necropolis Sepulcher + Trap Door + a Safe Place. Verify the three-control picker appears under Trap Door: origin locked to "Necropolis Sepulcher", destination select with the Safe Place options, territory select filtered to currently-infected Territories.
- [ ] Pick a Territory that another Sepulcher owner has White Ants coverage on → no warning; Save works.
- [ ] Pick a Territory that becomes uncovered (have an ST drop someone's White Ants pick in another tab) → on next render the picker shows the "(no longer covered)" option and the "Non-functional" warning; merit stays in the list.
- [ ] Try to save a Trap Door with empty territory → server returns 400 with `missing: ['territory']`.
- [ ] Save Haven with the legacy string-form `attached_to: 'Safe Place (X)'` → still works (Trap Door middleware doesn't touch other merits).

## Memory pin

Saved `feedback_constraint_on_relationship`: when a constraint is specific to one consumer, put the constraint data on the relationship, not on the entity it points at. The Option A → Option B pivot is generalisable to any future merit that needs a relationship-scoped constraint.

Closes #697