### PR TITLE
fix(691): show budget capacity even when no active game session found

### DIFF
--- a/public/js/tabs/office-tab.js
+++ b/public/js/tabs/office-tab.js
@@ -97,7 +97,8 @@ async function _wireHosActions(el, char, chars) {
 
   function renderBudget() {
     if (!sessionId) {
-      budgetLine.textContent = 'No active game session found.';
+      budgetLine.textContent = `${budget} actions available per session — no active game session found`;
+      budgetLine.className = 'office-budget-line';
       return;
     }
     const remaining = Math.max(0, budget - paidUsed());


### PR DESCRIPTION
## Summary

- Budget ribbon previously showed \`No active game session found.\` with no useful info on dev, because dev's frontend proxies to prod Render where the new \`/api/office_actions\` routes don't exist yet
- \`renderBudget()\` now always shows the budget capacity (\`N actions available per session\`) alongside the no-session note, so the player knows their budget even before the server routes reach prod
- Display degrades gracefully: once a real session is found, it switches to the normal \`N of M remaining\` counter

## Closes

_None_ (follow-up fix for #691)

## Story

- \`specs/stories/feature.691.hos-city-status-power.story.md\`

## Test plan

- [ ] Budget line on Office tab shows e.g. \`4 actions available per session — no active game session found\` on dev (before prod deploy)
- [ ] Once server routes are on prod, budget line shows \`N of M remaining this session\` with a live session
- [ ] CI green

## Branch flow

- From: \`ms/issue-691-hos-city-status-power\`
- Into: \`dev\`