### PR TITLE
N-2: character-data backfill — legacy free_<slug> → free_grants map (#695)

### DIFF
--- a/server/scripts/backfill-free-grants.js
+++ b/server/scripts/backfill-free-grants.js
@@ -1,0 +1,239 @@
+#!/usr/bin/env node
+
+/**
+ * N-2 / ADR-005 Rev 2 D6 (issue #695) — character-data backfill.
+ *
+ * Moves persisted legacy `m.free_<slug>` flat fields into the new
+ * `m.free_grants[<slug>]` slug-keyed map (introduced by N-1 PR #672, merged
+ * 2026-06-10). Mirrors STM-13's backfill pattern: idempotent, --dry-run
+ * default, dotenv-first per [[feedback_server_scripts_dotenv_path]].
+ *
+ * Correctness is migration-independent because `meritFreeSum` runtime-guards
+ * by summing BOTH the map AND the 14 legacy fields (N-1's union-sum). So a
+ * partial backfill state is safe — no character renders wrong while this
+ * runs. After this script completes against a database, the legacy fields
+ * are gone on every character; a future cleanup story can remove the
+ * union-sum fallback from `meritFreeSum`.
+ *
+ * ──────────────────────────────────────────────────────────────────────────
+ *   Conflict handling — merit-scoped skip
+ * ──────────────────────────────────────────────────────────────────────────
+ *
+ *   For each legacy slug on a merit, compare against `m.free_grants[slug]`:
+ *
+ *     EITHER absent / 0 in the map  →  copy legacy → map, unset legacy
+ *     BOTH non-zero, values EQUAL   →  unset legacy (map already correct)
+ *     BOTH non-zero, values DIFFER  →  CONFLICT. Skip the ENTIRE MERIT (not
+ *                                      just this slug) so a human can decide
+ *                                      which value is canonical before any
+ *                                      slug on that merit is touched. The
+ *                                      summary lists every conflict by
+ *                                      character + merit + slug values.
+ *
+ *   The whole-merit skip is the load-bearing safety: a conflict on one slug
+ *   suggests the merit has data drift somewhere, and migrating its other
+ *   slugs in isolation could compound the drift.
+ *
+ * Idempotency: re-running matches zero docs the second time (every legacy
+ * field gets unset on the first apply pass).
+ *
+ * Usage:
+ *   # preview (default — no writes):
+ *   node server/scripts/backfill-free-grants.js
+ *
+ *   # apply:
+ *   node server/scripts/backfill-free-grants.js --apply
+ *
+ *   # scope to a single character (debugging convenience):
+ *   node server/scripts/backfill-free-grants.js --character-id 64ab... --apply
+ *
+ *   # target the test DB:
+ *   MONGODB_DB=tm_suite_test node server/scripts/backfill-free-grants.js --apply
+ *
+ * Locally, run from `server/` so cwd-relative `dotenv/config` picks up
+ * `server/.env`. On Render env vars are pre-set (no-op).
+ */
+
+import 'dotenv/config';
+import { pathToFileURL } from 'url';
+import { ObjectId } from 'mongodb';
+import { connectDb, getCollection, closeDb } from '../db.js';
+
+/**
+ * The 14 legacy `m.free_<slug>` channels from ADR-005's survey. Mirrors the
+ * LEGACY_FREE_SLUGS constant in `public/js/data/rules-helpers.js`. Order is
+ * irrelevant — alphabetical for diff-stability.
+ */
+export const LEGACY_FREE_SLUGS = [
+  'attache', 'bloodline', 'carthian', 'fwb', 'inv', 'lk', 'mci', 'mdb',
+  'ohm', 'pet', 'pt', 'retainer', 'sw', 'vm',
+];
+
+/**
+ * Backfill a single character's merits in-memory. Returns a summary plus the
+ * mutated merits array. Pure compute — no DB access, no module-level state.
+ *
+ * @param {object} c         - character doc
+ * @param {object} [opts]    - { dryRun?: boolean }
+ * @returns {{ touched: boolean, meritsTouched: number, fieldsMigrated: number, conflicts: Array, perSlug: object, merits: object[] }}
+ */
+export function backfillCharacterMerits(c, opts = {}) {
+  const dryRun = !!opts.dryRun;
+  const result = {
+    touched: false,
+    meritsTouched: 0,
+    fieldsMigrated: 0,
+    conflicts: [],
+    perSlug: Object.create(null),
+    merits: c.merits,
+  };
+  if (!Array.isArray(c.merits) || !c.merits.length) return result;
+
+  // Shallow-clone merits so the in-memory dryRun pass doesn't mutate the input
+  // (caller may want to re-read). On apply we still produce a new array; the
+  // caller writes it back as the canonical merits.
+  const next = c.merits.map(m => ({ ...m, ...(m && m.free_grants ? { free_grants: { ...m.free_grants } } : {}) }));
+
+  for (let i = 0; i < next.length; i++) {
+    const m = next[i];
+    if (!m || typeof m !== 'object') continue;
+
+    // Per-merit pass: collect legacy slugs to migrate + detect conflicts.
+    const planned = [];
+    const conflicts = [];
+    for (const slug of LEGACY_FREE_SLUGS) {
+      const flatKey = 'free_' + slug;
+      const flatVal = m[flatKey];
+      // Skip if absent or zero — nothing to migrate, no map entry to create.
+      if (typeof flatVal !== 'number' || flatVal <= 0) continue;
+
+      const mapVal = (m.free_grants && typeof m.free_grants === 'object') ? m.free_grants[slug] : undefined;
+      const mapPopulated = typeof mapVal === 'number' && mapVal > 0;
+
+      if (mapPopulated && mapVal !== flatVal) {
+        // Differ → real conflict. Whole-merit skip.
+        conflicts.push({ slug, mapVal, legacyVal: flatVal });
+      } else {
+        // Equal-or-empty → safe to migrate. Map gets the value; legacy gets unset.
+        planned.push({ slug, value: flatVal });
+      }
+    }
+
+    if (conflicts.length > 0) {
+      result.conflicts.push({
+        char_id: c._id ? String(c._id) : null,
+        char_name: c.name || '(unnamed)',
+        merit_index: i,
+        merit_name: m.name || '(unnamed)',
+        conflicts,
+      });
+      continue; // SKIP MERIT entirely — safety guard.
+    }
+
+    if (!planned.length) continue;
+
+    if (!dryRun) {
+      if (!m.free_grants || typeof m.free_grants !== 'object') m.free_grants = {};
+      for (const { slug, value } of planned) {
+        m.free_grants[slug] = value;
+        delete m['free_' + slug];
+      }
+    }
+    result.meritsTouched += 1;
+    result.fieldsMigrated += planned.length;
+    for (const { slug } of planned) {
+      result.perSlug[slug] = (result.perSlug[slug] || 0) + 1;
+    }
+    result.touched = true;
+  }
+
+  if (result.touched) result.merits = next;
+  return result;
+}
+
+/**
+ * Drive the backfill against MongoDB. Returns the aggregate summary.
+ *
+ * @param {object} [opts]
+ * @param {boolean} [opts.dryRun]
+ * @param {string}  [opts.characterId]
+ * @param {boolean} [opts.log]
+ */
+export async function backfill(opts = {}) {
+  const { dryRun = true, characterId, log = true } = opts;
+  const col = getCollection('characters');
+  const filter = characterId ? { _id: new ObjectId(characterId) } : {};
+  const chars = await col.find(filter).toArray();
+
+  const totals = {
+    charsScanned: chars.length,
+    charsTouched: 0,
+    meritsTouched: 0,
+    fieldsMigrated: 0,
+    perSlug: Object.create(null),
+    conflicts: [],
+  };
+
+  for (const c of chars) {
+    const r = backfillCharacterMerits(c, { dryRun });
+    if (r.conflicts.length) totals.conflicts.push(...r.conflicts);
+    if (!r.touched) continue;
+    totals.charsTouched += 1;
+    totals.meritsTouched += r.meritsTouched;
+    totals.fieldsMigrated += r.fieldsMigrated;
+    for (const [slug, n] of Object.entries(r.perSlug)) {
+      totals.perSlug[slug] = (totals.perSlug[slug] || 0) + n;
+    }
+    if (!dryRun) {
+      await col.updateOne({ _id: c._id }, { $set: { merits: r.merits } });
+    }
+  }
+
+  if (log) {
+    const verb = dryRun ? '[DRY RUN] would touch' : 'touched';
+    console.log(`Scanned ${totals.charsScanned} character(s); ${verb} ${totals.charsTouched} char(s), ${totals.meritsTouched} merit(s), ${totals.fieldsMigrated} field(s).`);
+    if (Object.keys(totals.perSlug).length) {
+      console.log('Per-slug:');
+      for (const slug of LEGACY_FREE_SLUGS) {
+        const n = totals.perSlug[slug] || 0;
+        if (n > 0) console.log(`  ${slug.padEnd(10)} ${n}`);
+      }
+    }
+    if (totals.conflicts.length) {
+      console.log(`\nCONFLICTS (${totals.conflicts.length}) — these merits were SKIPPED for human review:`);
+      for (const c of totals.conflicts) {
+        const lines = c.conflicts.map(x =>
+          `      ${x.slug}: map=${x.mapVal}, legacy=${x.legacyVal}`,
+        );
+        console.log(`  ${c.char_name} (${c.char_id || '?'}) → merit[${c.merit_index}] "${c.merit_name}":`);
+        for (const l of lines) console.log(l);
+      }
+    }
+  }
+  return totals;
+}
+
+export async function main(argv = process.argv) {
+  const dryRun = !argv.includes('--apply');
+  const cidIdx = argv.indexOf('--character-id');
+  const characterId = cidIdx >= 0 ? argv[cidIdx + 1] : null;
+
+  console.log(`Mode: ${dryRun ? 'DRY RUN (read only; pass --apply to write)' : 'APPLY (will write)'}`);
+  console.log(`Target DB: ${process.env.MONGODB_DB || 'tm_suite'}`);
+  if (characterId) console.log(`Scoped to character: ${characterId}`);
+  console.log('');
+
+  await connectDb();
+  try {
+    await backfill({ dryRun, characterId });
+  } finally {
+    await closeDb();
+  }
+
+  console.log('\nIdempotency check (after --apply): re-run with no flag and confirm "touched 0 char(s)".');
+}
+
+// Auto-run only when invoked directly (not when imported by a test).
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch(err => { console.error(err); process.exit(1); });
+}

--- a/server/tests/n2-backfill-free-grants.test.js
+++ b/server/tests/n2-backfill-free-grants.test.js
@@ -1,0 +1,237 @@
+/**
+ * N-2 (issue #695, ADR-005 Rev 2 D6) — character-data backfill of legacy
+ * `m.free_<slug>` flat fields → `m.free_grants[<slug>]` map.
+ *
+ * Four+ acceptance gates from the dispatch:
+ *   1. Basic copy + unset — legacy value > 0 with no map entry: map gains
+ *      the value, legacy field is unset.
+ *   2. Conflict skip — when map AND legacy are both non-zero with DIFFERENT
+ *      values, the WHOLE merit is skipped (other slugs on the same merit are
+ *      NOT touched even if they'd otherwise migrate cleanly).
+ *   3. Idempotency — a second --apply pass touches zero docs (every legacy
+ *      field was unset on the first pass).
+ *   4. Zero-value skip — legacy `free_<slug>: 0` is NOT migrated (creating
+ *      an empty map entry would be noise).
+ *
+ * Plus: equal-values are NOT a conflict (no-op for the slug, but the merit
+ * proceeds normally — legacy gets unset, map keeps its value).
+ * Plus: --character-id scoping touches only the named character.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { ObjectId } from 'mongodb';
+import { setupDb, teardownDb } from './helpers/db-setup.js';
+import { getCollection } from '../db.js';
+import { backfill, backfillCharacterMerits, LEGACY_FREE_SLUGS } from '../scripts/backfill-free-grants.js';
+
+const TEST_FLAG = { _test_n2: true };
+
+beforeAll(async () => {
+  await setupDb();
+  await getCollection('characters').deleteMany(TEST_FLAG);
+});
+
+afterAll(async () => {
+  await getCollection('characters').deleteMany(TEST_FLAG);
+  await teardownDb();
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure-function: backfillCharacterMerits
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-2 — backfillCharacterMerits (pure)', () => {
+  it('copies legacy non-zero free_<slug> to free_grants and unsets legacy', () => {
+    const c = {
+      merits: [
+        { name: 'Herd', cp: 1, free_lk: 2, free_vm: 1 },
+      ],
+    };
+    const r = backfillCharacterMerits(c);
+    expect(r.touched).toBe(true);
+    expect(r.fieldsMigrated).toBe(2);
+    expect(r.merits[0].free_grants).toEqual({ lk: 2, vm: 1 });
+    expect(r.merits[0]).not.toHaveProperty('free_lk');
+    expect(r.merits[0]).not.toHaveProperty('free_vm');
+    // Input is preserved (non-destructive — dryRun-mode is also non-destructive
+    // because the input is shallow-cloned). The returned merits are the canonical
+    // post-migration shape.
+  });
+
+  it('SKIPS the whole merit when map and legacy disagree on any slug', () => {
+    // free_mci=3 conflicts with free_grants.mci=5. Even though free_lk=1
+    // would migrate cleanly, the whole merit is skipped — safety guard.
+    const c = {
+      name: 'Conflicted',
+      merits: [
+        { name: 'Herd', free_mci: 3, free_lk: 1, free_grants: { mci: 5 } },
+      ],
+    };
+    const r = backfillCharacterMerits(c);
+    expect(r.touched).toBe(false);
+    expect(r.fieldsMigrated).toBe(0);
+    expect(r.conflicts).toHaveLength(1);
+    expect(r.conflicts[0]).toMatchObject({
+      merit_name: 'Herd',
+      conflicts: [{ slug: 'mci', mapVal: 5, legacyVal: 3 }],
+    });
+    // Crucially, free_lk is preserved — the safety guard means the unrelated
+    // clean slug is NOT half-migrated.
+    expect(r.merits[0].free_lk).toBe(1);
+  });
+
+  it('equal map and legacy values are NOT a conflict — legacy is unset, map kept', () => {
+    const c = {
+      merits: [
+        { name: 'Herd', free_lk: 3, free_grants: { lk: 3 } },
+      ],
+    };
+    const r = backfillCharacterMerits(c);
+    expect(r.touched).toBe(true);
+    expect(r.fieldsMigrated).toBe(1);
+    expect(r.merits[0].free_grants).toEqual({ lk: 3 });
+    expect(r.merits[0]).not.toHaveProperty('free_lk');
+    expect(r.conflicts).toHaveLength(0);
+  });
+
+  it('zero legacy values are not migrated (no empty map entry created)', () => {
+    const c = {
+      merits: [
+        { name: 'Herd', free_lk: 0, free_vm: 2 },
+      ],
+    };
+    const r = backfillCharacterMerits(c);
+    expect(r.merits[0].free_grants).toEqual({ vm: 2 });
+    expect(r.merits[0].free_grants.lk).toBeUndefined();
+    expect(r.fieldsMigrated).toBe(1);
+    expect(r.perSlug).toEqual({ vm: 1 });
+  });
+
+  it('dry-run does NOT mutate the merits array; field counts still report correctly', () => {
+    const c = {
+      merits: [
+        { name: 'Herd', free_lk: 2 },
+      ],
+    };
+    const r = backfillCharacterMerits(c, { dryRun: true });
+    expect(r.touched).toBe(true);
+    expect(r.fieldsMigrated).toBe(1);
+    // Dry-run preserves the in-memory shape exactly. Caller uses the totals
+    // for the preview; the mutated array is only written when dryRun is false.
+    expect(c.merits[0].free_lk).toBe(2);
+    expect(c.merits[0].free_grants).toBeUndefined();
+  });
+
+  it('covers all 14 legacy slugs without enumeration drift', () => {
+    // Sanity: building a merit with every legacy slug populated should
+    // migrate exactly 14 fields and the perSlug counts match the slug set.
+    const m = { name: 'Stuffed' };
+    for (const slug of LEGACY_FREE_SLUGS) m['free_' + slug] = 1;
+    const c = { merits: [m] };
+    const r = backfillCharacterMerits(c);
+    expect(r.fieldsMigrated).toBe(LEGACY_FREE_SLUGS.length);
+    expect(Object.keys(r.perSlug).sort()).toEqual([...LEGACY_FREE_SLUGS].sort());
+    expect(Object.keys(r.merits[0].free_grants).sort()).toEqual([...LEGACY_FREE_SLUGS].sort());
+    for (const slug of LEGACY_FREE_SLUGS) {
+      expect(r.merits[0]).not.toHaveProperty('free_' + slug);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DB-driven: backfill() against a live test DB
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-2 — backfill (DB-driven)', () => {
+  let cleanId, conflictId, otherId;
+
+  beforeAll(async () => {
+    // Reset the test surface.
+    await getCollection('characters').deleteMany(TEST_FLAG);
+
+    // cleanChar: 3 legacy fields ready to migrate; no map entries.
+    const ins1 = await getCollection('characters').insertOne({
+      ...TEST_FLAG,
+      name: 'N2_Clean',
+      merits: [
+        { name: 'Herd', category: 'general', cp: 1, xp: 0, free_lk: 2, free_vm: 1, free_mci: 3 },
+      ],
+    });
+    cleanId = ins1.insertedId;
+
+    // conflictChar: one merit with map/legacy disagreement; another merit with
+    // a clean migration. After backfill: conflict merit untouched; clean merit
+    // migrated.
+    const ins2 = await getCollection('characters').insertOne({
+      ...TEST_FLAG,
+      name: 'N2_Conflict',
+      merits: [
+        { name: 'Herd', category: 'general', free_mci: 3, free_lk: 1, free_grants: { mci: 5 } },
+        { name: 'Mentor', category: 'general', free_pt: 2 },
+      ],
+    });
+    conflictId = ins2.insertedId;
+
+    // otherChar: no legacy fields — should remain untouched.
+    const ins3 = await getCollection('characters').insertOne({
+      ...TEST_FLAG,
+      name: 'N2_Other',
+      merits: [
+        { name: 'Resources', category: 'influence', cp: 2, xp: 1 },
+      ],
+    });
+    otherId = ins3.insertedId;
+  });
+
+  it('--apply migrates clean characters and skips conflicted merits', async () => {
+    const totals = await backfill({ dryRun: false, log: false });
+    expect(totals.charsScanned).toBeGreaterThanOrEqual(3); // shared test DB may have other docs
+    expect(totals.conflicts.length).toBeGreaterThanOrEqual(1);
+    expect(totals.conflicts.some(c => c.char_name === 'N2_Conflict' && c.merit_name === 'Herd')).toBe(true);
+
+    const clean = await getCollection('characters').findOne({ _id: cleanId });
+    expect(clean.merits[0].free_grants).toEqual({ lk: 2, vm: 1, mci: 3 });
+    expect(clean.merits[0]).not.toHaveProperty('free_lk');
+    expect(clean.merits[0]).not.toHaveProperty('free_vm');
+    expect(clean.merits[0]).not.toHaveProperty('free_mci');
+
+    const conflict = await getCollection('characters').findOne({ _id: conflictId });
+    // The Herd merit (conflict) is untouched — both legacy fields still present.
+    expect(conflict.merits[0].free_mci).toBe(3);
+    expect(conflict.merits[0].free_lk).toBe(1);
+    expect(conflict.merits[0].free_grants).toEqual({ mci: 5 });
+    // The Mentor merit (no conflict) migrated cleanly.
+    expect(conflict.merits[1].free_grants).toEqual({ pt: 2 });
+    expect(conflict.merits[1]).not.toHaveProperty('free_pt');
+  });
+
+  it('second --apply pass is idempotent (touches zero docs)', async () => {
+    const totals = await backfill({ dryRun: false, log: false });
+    // The previously-conflicted merit is the only doc still carrying legacy
+    // fields; the run reports it as a conflict but doesn't write — so the
+    // touched-count is zero.
+    expect(totals.charsTouched).toBe(0);
+    expect(totals.fieldsMigrated).toBe(0);
+    // The Herd merit on N2_Conflict still shows as a conflict on every run
+    // until a human resolves it.
+    expect(totals.conflicts.some(c => c.char_name === 'N2_Conflict')).toBe(true);
+  });
+
+  it('--character-id scoping touches only the named character', async () => {
+    // Inject a fresh legacy field on otherChar (which the previous pass left
+    // untouched) and scope the backfill to its ID. cleanChar and conflictChar
+    // remain unchanged because they're outside the scope filter.
+    await getCollection('characters').updateOne(
+      { _id: otherId },
+      { $set: { merits: [{ name: 'Resources', category: 'influence', free_inv: 1 }] } },
+    );
+    const totals = await backfill({ dryRun: false, characterId: String(otherId), log: false });
+    expect(totals.charsScanned).toBe(1);
+    expect(totals.charsTouched).toBe(1);
+    expect(totals.fieldsMigrated).toBe(1);
+
+    const other = await getCollection('characters').findOne({ _id: otherId });
+    expect(other.merits[0].free_grants).toEqual({ inv: 1 });
+    expect(other.merits[0]).not.toHaveProperty('free_inv');
+  });
+});

--- a/specs/stories/issue-695-n2-character-backfill.story.md
+++ b/specs/stories/issue-695-n2-character-backfill.story.md
@@ -1,0 +1,94 @@
+# Issue #695: N-2 — character-data backfill (legacy `free_<slug>` flat → `free_grants[<slug>]` map)
+
+Status: Ready for Review
+
+issue: 695
+issue_url: https://github.com/angelusvmorningstar/issues/695
+branch: piatra/issue-695-n2-character-backfill
+epic: MNEC (specs/epic-mnec-necropolis-merits.md)
+adr: ADR-005 Rev 2 D1 + D6 (specs/architecture/adr-005-pool-grant-and-sharing-scope-generalisation.md)
+dispatch: PROCEED-WITH-NOTICE.
+
+## Story
+
+As an operator who has N-1's foundation in production,
+I want an idempotent backfill script that moves persisted legacy `m.free_<slug>` flat fields into the new `m.free_grants[<slug>]` map per ADR-005 Rev 2 D1 (introduced by PR #672),
+so that a future cleanup story can remove the union-sum fallback from `meritFreeSum` without stranding any character whose free-grant data still lives in the legacy fields.
+
+## What ships
+
+- **`server/scripts/backfill-free-grants.js`** — atomic, idempotent (`--dry-run` default, `--apply` to write). Optional `--character-id <id>` flag scopes to a single character (debugging convenience).
+- Mirrors the established `server/scripts` pattern (per memory `feedback_server_scripts_dotenv_path`):
+  - `import 'dotenv/config'` first.
+  - `connectDb` / `getCollection` / `closeDb` from `db.js`.
+  - Exports `backfill()` + `backfillCharacterMerits()` + `LEGACY_FREE_SLUGS`; `main()` is guarded by `import.meta.url === pathToFileURL(process.argv[1]).href` so importing the module in a test doesn't auto-connect or call `process.exit`.
+- **Conflict handling — merit-scoped skip.** For each legacy slug on a merit:
+  - Map absent / 0 → migrate (copy legacy → map, unset legacy).
+  - Map present and EQUAL → no conflict; unset legacy (map already correct).
+  - Map present and DIFFER → **whole-merit skip**. Other slugs on the same merit are NOT touched, even if they'd otherwise migrate cleanly. The summary lists every conflict by char + merit + slug values for human review.
+- **Per-slug summary** — alphabetical counts of fields migrated per slug, plus a CONFLICTS section listing every skipped merit with its differing values.
+
+## Why the whole-merit skip rather than per-slug skip
+
+A conflict on one slug suggests the merit has data drift somewhere (otherwise the map and legacy values would never have diverged). Migrating the merit's OTHER slugs in isolation could compound the drift — the human resolving the one conflict might also want to investigate the others before any are mutated. Atomically skipping the merit keeps the resolution surface small.
+
+## Acceptance gates
+
+1. ✅ Script exists at `server/scripts/backfill-free-grants.js`. Runs against MongoDB Atlas via the established `db.js` pattern + `dotenv/config`-first.
+2. ✅ Default = dry-run; `--apply` writes.
+3. ✅ Per character, for each merit's `free_<slug>` (value > 0), value copies into `m.free_grants[<slug>]` and legacy field is unset.
+4. ✅ Conflict (map AND legacy non-zero AND differ) → whole merit skipped, summary records the conflict.
+5. ✅ Idempotent — second `--apply` reports `touched 0 char(s), 0 merit(s), 0 field(s)` (any merit-level conflict still surfaces in the summary on every run until resolved).
+6. ✅ Zero legacy values not migrated (avoids creating empty map entries).
+7. ✅ Equal map/legacy values not treated as conflict — legacy unset, map kept.
+8. ✅ `--character-id <id>` scopes to a single character; other characters untouched.
+9. ✅ Render-invocable from a Render one-off shell without code modification (env from process; `dotenv/config` no-ops when env is pre-set).
+10. ✅ 9 vitest cases — pure-function (6) + DB-driven (3). Covers basic copy + unset, conflict skip, idempotency, zero-skip, equal-no-conflict, all-14-slugs coverage, --character-id scoping.
+11. ✅ No regression — 1303/1303 individual tests pass.
+
+## Pre-existing test-FILE failures carried forward
+
+Four test files fail at import / read time on `dev`. **None are caused by N-2.**
+
+- `tests/migrate-submission-cycle-id-to-oid.test.js` — references `../scripts/migrate-submission-cycle-id-to-oid.js` (archived in commit `f07887fc`).
+- `tests/migrate-submission-territory-keys.test.js` — same archive-move trap.
+- `tests/stm-13-backfill.test.js` — same archive-move trap.
+- `tests/feature.691.hos-city-status-power.test.js` — new: uses a relative path `fs.readFileSync('server/routes/office-actions.js', ...)` that fails when vitest's cwd is `server/`. Introduced by PR #700 (HoS city status power), merged before N-2. The route + schema files DO exist; the test's path is wrong.
+
+All four are noted but stay out of scope per N-2's brief.
+
+## Out of scope
+
+- **Removing the union-sum fallback from `meritFreeSum`.** N-1's runtime guard sums both the map AND the legacy fields; after this script runs everywhere the legacy fields are gone, but the fallback can stay in place safely. Future cleanup story removes it.
+- The production run itself — Peter-triggered post-merge.
+
+## Tasks / Subtasks
+
+- [x] `server/scripts/backfill-free-grants.js` — script with `backfill()` + `backfillCharacterMerits()` + `LEGACY_FREE_SLUGS` exports; entry-point-guarded `main()`.
+- [x] `server/tests/n2-backfill-free-grants.test.js` — 9 vitest cases (6 pure + 3 DB-driven).
+- [x] Story file (this one).
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-7 (Ptah / DEV)
+
+### Completion Notes List
+
+- **Exports both `backfill` (DB-driven) and `backfillCharacterMerits` (pure).** The pure function takes a character doc and returns the migration plan + mutated merits without touching Mongo. Lets the test suite cover the migration logic without spinning up the test DB for every case, and gives future callers (e.g., a one-off cleanup invoked inside a route) a way to migrate in-memory without re-implementing the rules.
+- **Equal map/legacy values are NOT a conflict** (interpreted leniently). Strictly the AC said "both non-zero values"; equal is unambiguous and unsetting legacy is correct. Different values is where human review is genuinely needed. Documented this in the script header.
+- **Dry-run preserves the in-memory shape exactly** (input shallow-cloned). Caller uses the totals for preview; the mutated array is only written when `dryRun === false`. Verified by a test.
+- **Verified live (read-only)** — ran `--dry-run` against `tm_suite_test` end-to-end (connect → scan → report → close). 0 fields to migrate in the test DB; test fixtures cover the actual migration paths.
+- **Worktree pattern continued** (`/tmp/tm-ptah/n2-backfill`, node_modules + server/.env symlinked from main).
+
+### File List
+
+**New**
+- `server/scripts/backfill-free-grants.js` — backfill script
+- `server/tests/n2-backfill-free-grants.test.js` — 9 vitest cases
+- `specs/stories/issue-695-n2-character-backfill.story.md` — this file
+
+### Change Log
+
+- 2026-06-11 (Ptah): N-2 character-data backfill shipped.


### PR DESCRIPTION
## Summary

ADR-005 Rev 2 D1 + D6 backfill — moves persisted legacy `m.free_<slug>` flat fields into the new `m.free_grants[<slug>]` slug-keyed map (introduced by N-1 PR #672). After this script runs against a database, legacy fields are gone on every character; a future cleanup story can then remove the union-sum fallback from `meritFreeSum`.

**Last remaining MNEC story.** Mirrors STM-13's idempotent shape; pure-backend, no client surface.

## What ships

- **`server/scripts/backfill-free-grants.js`** — idempotent, `--dry-run` default, `--apply` to write, optional `--character-id <id>` flag for single-char scoping.
- Mirrors the established `server/scripts` pattern (`feedback_server_scripts_dotenv_path` memory):
  - `import 'dotenv/config'` first.
  - `connectDb` / `getCollection` / `closeDb` from `db.js`.
  - Exports `backfill()` (DB-driven) + `backfillCharacterMerits()` (pure) + `LEGACY_FREE_SLUGS`; `main()` is guarded by `import.meta.url` so tests can import without auto-connecting.
- **Conflict handling — merit-scoped skip.** Per legacy slug on a merit:
  - Map absent / 0 → migrate (copy legacy → map, unset legacy).
  - Map present + EQUAL → no conflict (unset legacy, map already correct).
  - Map present + DIFFER → **whole merit skipped**. Other slugs on the same merit are NOT touched, even if they'd otherwise migrate cleanly.
- **Per-slug summary** (alphabetical) + **CONFLICTS section** listing every skipped merit with its differing values for human review.

## Why whole-merit skip rather than per-slug skip

A conflict on one slug suggests the merit has data drift somewhere. Migrating the merit's OTHER slugs in isolation could compound the drift — the human resolving the one conflict might also want to investigate the others before any are mutated. Atomically skipping the merit keeps the resolution surface small.

## Tests

**9 vitest cases** in `server/tests/n2-backfill-free-grants.test.js`:

**Pure `backfillCharacterMerits` (6):**
- basic copy + unset
- conflict skips the whole merit even when other slugs are clean (safety-guard load-bearing)
- equal map/legacy values aren't a conflict (no-op + unset)
- zero legacy values not migrated (avoids empty map entries)
- dry-run preserves the in-memory shape exactly
- all 14 slugs covered without enumeration drift

**DB-driven `backfill()` (3):**
- `--apply` migrates clean chars + skips conflicted merits (clean merit on the same conflict char DOES migrate)
- second `--apply` pass is idempotent (touched 0; conflict still surfaces in summary every run until resolved)
- `--character-id` scopes to the named character without touching others

**Verified live (read-only):** ran `--dry-run` against `tm_suite_test` end-to-end (connect → scan → report → close).

**Full regression: 1303/1303 individual tests pass.**

## Four test-FILE failures carried forward — none caused by N-2

- `tests/migrate-submission-cycle-id-to-oid.test.js` — archive-import (since N-1; commit `f07887fc`).
- `tests/migrate-submission-territory-keys.test.js` — same.
- `tests/stm-13-backfill.test.js` — same.
- `tests/feature.691.hos-city-status-power.test.js` — NEW. Uses `fs.readFileSync('server/routes/office-actions.js', ...)` (relative path) which fails when vitest's cwd is `server/`. Introduced by PR #700 (HoS city status power), merged before N-2. The route + schema files DO exist; the test's path is wrong.

## Out of scope

- **Removing the union-sum fallback from `meritFreeSum`.** N-1's runtime guard sums both the map AND the legacy fields; after this script runs everywhere the legacy fields are gone, but the fallback can stay safely. Future cleanup story removes it.
- The production run itself — Peter-triggered post-merge.

## Test plan

- [ ] Apply seed against `tm_suite_test` then `tm_suite` once N-2 merges to `dev`:
  ```
  cd server && node scripts/backfill-free-grants.js                    # dry-run preview
  cd server && node scripts/backfill-free-grants.js --apply             # write
  cd server && node scripts/backfill-free-grants.js                     # idempotency: "touched 0 char(s)"
  ```
- [ ] Inspect any CONFLICTS in the summary; investigate each merit manually and decide which value (map vs legacy) is canonical before unsetting the loser by hand.
- [ ] If a conflict was investigated and resolved, re-run `--apply` to migrate the now-clean merit.

Closes #695