### PR TITLE
chore(#695): flip N-2 status to Done — Epic MNEC complete

### DIFF
--- a/specs/stories/issue-695-n2-character-backfill.story.md
+++ b/specs/stories/issue-695-n2-character-backfill.story.md
@@ -1,6 +1,6 @@
 # Issue #695: N-2 — character-data backfill (legacy `free_<slug>` flat → `free_grants[<slug>]` map)
 
-Status: Ready for Review
+Status: Done
 
 issue: 695
 issue_url: https://github.com/angelusvmorningstar/issues/695


### PR DESCRIPTION
Final bookkeeping flip after PR #704 (character-data backfill). Closes Epic MNEC on dev — all six stories (N-1 through N-5 + bonus #693 N-3 merit family) shipped.