### PR TITLE
feat(708.1): CYCLE epic story 1 — schema + API foundations

### DIFF
--- a/public/js/downtime/db.js
+++ b/public/js/downtime/db.js
@@ -65,6 +65,11 @@ export async function openGamePhase(id) {
 export const DTUX_PHASES = ['prep', 'city', 'projects', 'story', 'ready'];
 
 export function deriveCycleStatus(cycle) {
+  // CYCLE epic (#708): manual game_phase overrides legacy derivation when set.
+  if (cycle?.game_phase === 'game')        return 'game';
+  if (cycle?.game_phase === 'downtime')    return 'active';
+  if (cycle?.game_phase === 'processing')  return 'closed';
+  // Legacy derivation — covers cycles predating #708.
   const ps = cycle?.phase_signoff || {};
   // Closed wins regardless of override (issue #231 AC-4): once projects
   // are signed off the ST is processing; no late submissions.

--- a/server/index.js
+++ b/server/index.js
@@ -37,6 +37,7 @@ import stModsRouter, { auditRouter as stModAuditRouter } from './routes/st_mods.
 import appSettingsRouter from './routes/app-settings.js';
 import devlogRouter from './routes/devlog.js';
 import equipmentRouter from './routes/equipment.js';
+import chaptersRouter from './routes/chapters.js';
 import { attachWS } from './ws.js';
 // NOTE: The old /api/pdf route was removed. Character sheet PDFs are now
 // rendered client-side via public/js/print/. See
@@ -172,6 +173,7 @@ app.use('/api/st_mod_audit', requireAuth, noCache(), stModAuditRouter);
 // stale-cache lag.
 app.use('/api/settings', requireAuth, noCache(), appSettingsRouter);
 app.use('/api/devlog',   requireAuth, noCache(), devlogRouter);
+app.use('/api/chapters', requireAuth, noCache(), chaptersRouter);
 
 // Start server first, then attempt DB connection
 // Server must be reachable even if MongoDB is unavailable

--- a/server/routes/chapters.js
+++ b/server/routes/chapters.js
@@ -1,0 +1,95 @@
+import { Router } from 'express';
+import { ObjectId } from 'mongodb';
+import { getCollection } from '../db.js';
+import { requireRole } from '../middleware/auth.js';
+
+const col = () => getCollection('chapters');
+const cycles = () => getCollection('downtime_cycles');
+
+function parseId(id) {
+  try { return new ObjectId(id); } catch { return null; }
+}
+
+export const chaptersRouter = Router();
+
+// GET /api/chapters — list all chapters sorted by number asc (public read)
+chaptersRouter.get('/', async (req, res) => {
+  const docs = await col().find().sort({ number: 1 }).toArray();
+  res.json(docs);
+});
+
+// GET /api/chapters/:id — single chapter (public read)
+chaptersRouter.get('/:id', async (req, res) => {
+  const oid = parseId(req.params.id);
+  if (!oid) return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid chapter ID format' });
+  const doc = await col().findOne({ _id: oid });
+  if (!doc) return res.status(404).json({ error: 'NOT_FOUND', message: 'Chapter not found' });
+  res.json(doc);
+});
+
+// POST /api/chapters — create chapter (ST only)
+chaptersRouter.post('/', requireRole('st'), async (req, res) => {
+  const { number, label } = req.body;
+  if (typeof number !== 'number' || !Number.isInteger(number) || number < 1) {
+    return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'number must be a positive integer' });
+  }
+  if (typeof label !== 'string' || !label.trim()) {
+    return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'label must be a non-empty string' });
+  }
+  const doc = { number, label: label.trim(), created_at: new Date().toISOString() };
+  const result = await col().insertOne(doc);
+  const created = await col().findOne({ _id: result.insertedId });
+  res.status(201).json(created);
+});
+
+// PATCH /api/chapters/:id — update number and/or label (ST only)
+chaptersRouter.patch('/:id', requireRole('st'), async (req, res) => {
+  const oid = parseId(req.params.id);
+  if (!oid) return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid chapter ID format' });
+
+  const updates = {};
+  if (req.body.number !== undefined) {
+    const n = req.body.number;
+    if (typeof n !== 'number' || !Number.isInteger(n) || n < 1) {
+      return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'number must be a positive integer' });
+    }
+    updates.number = n;
+  }
+  if (req.body.label !== undefined) {
+    if (typeof req.body.label !== 'string' || !req.body.label.trim()) {
+      return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'label must be a non-empty string' });
+    }
+    updates.label = req.body.label.trim();
+  }
+  if (!Object.keys(updates).length) {
+    return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'At least one of number or label is required' });
+  }
+
+  const result = await col().findOneAndUpdate(
+    { _id: oid },
+    { $set: updates },
+    { returnDocument: 'after' },
+  );
+  if (!result) return res.status(404).json({ error: 'NOT_FOUND', message: 'Chapter not found' });
+  res.json(result);
+});
+
+// DELETE /api/chapters/:id — delete chapter (ST only); 409 if any cycles reference it
+chaptersRouter.delete('/:id', requireRole('st'), async (req, res) => {
+  const oid = parseId(req.params.id);
+  if (!oid) return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid chapter ID format' });
+
+  const idStr = req.params.id;
+  const linkedCount = await cycles().countDocuments({ chapter_id: idStr });
+  if (linkedCount > 0) {
+    return res.status(409).json({
+      error: 'CHAPTER_IN_USE',
+      message: `Chapter is linked to ${linkedCount} downtime cycle(s) and cannot be deleted`,
+      linked_cycles: linkedCount,
+    });
+  }
+
+  const result = await col().findOneAndDelete({ _id: oid });
+  if (!result) return res.status(404).json({ error: 'NOT_FOUND', message: 'Chapter not found' });
+  res.json({ deleted: true, _id: req.params.id });
+});

--- a/server/schemas/downtime_submission.schema.js
+++ b/server/schemas/downtime_submission.schema.js
@@ -568,6 +568,11 @@ export const downtimeCycleSchema = {
     out_of_window_player_ids: { type: 'array', items: { type: 'string' } },
     feeding_rights_confirmed: { type: 'boolean' },
 
+    // CYCLE epic (#708) — manual game phase control. Replaces auto-derive when set.
+    // null = derive from phase_signoff (legacy cycles). See deriveCycleStatus.
+    game_phase: { type: ['string', 'null'], enum: ['game', 'downtime', 'processing', null] },
+    chapter_id: { type: ['string', 'null'] },  // ref to chapters collection _id as string
+
     // Issue #231 — Manual "open downtimes" override (DT Prep tab).
     // Latched flag that forces effective status to 'active' regardless of
     // phase_signoff state (closed gate still wins). See public/js/downtime/db.js

--- a/server/tests/api-chapters.test.js
+++ b/server/tests/api-chapters.test.js
@@ -1,0 +1,291 @@
+/**
+ * Integration tests — /api/chapters (CYCLE epic #708 story 1).
+ * Covers CRUD, role gating, and the in-use cycle deletion guard.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import request from 'supertest';
+import 'dotenv/config';
+import { ObjectId } from 'mongodb';
+import { createTestApp, stUser, playerUser } from './helpers/test-app.js';
+import { setupDb, teardownDb } from './helpers/db-setup.js';
+import { getCollection } from '../db.js';
+
+let app;
+const cleanupIds = { chapters: [], downtime_cycles: [] };
+
+beforeAll(async () => {
+  await setupDb();
+  app = createTestApp();
+});
+
+afterEach(async () => {
+  for (const [colName, ids] of Object.entries(cleanupIds)) {
+    const col = getCollection(colName);
+    for (const id of ids) await col.deleteOne({ _id: id });
+    cleanupIds[colName] = [];
+  }
+});
+
+afterAll(async () => {
+  await teardownDb();
+});
+
+// ── GET /api/chapters ──────────────────────────────────────────────────────
+
+describe('GET /api/chapters', () => {
+  it('returns 200 and an array for authenticated users', async () => {
+    const res = await request(app)
+      .get('/api/chapters')
+      .set('X-Test-User', stUser());
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('returns 200 for player role (public read)', async () => {
+    const res = await request(app)
+      .get('/api/chapters')
+      .set('X-Test-User', playerUser([]));
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it('returns 401 with no auth header', async () => {
+    const res = await request(app).get('/api/chapters');
+    expect(res.status).toBe(401);
+  });
+
+  it('sorts chapters by number ascending', async () => {
+    const col = getCollection('chapters');
+    const [a, b] = await Promise.all([
+      col.insertOne({ number: 3, label: 'Chapter Three', created_at: new Date().toISOString() }),
+      col.insertOne({ number: 1, label: 'Chapter One',   created_at: new Date().toISOString() }),
+    ]);
+    cleanupIds.chapters.push(a.insertedId, b.insertedId);
+
+    const res = await request(app)
+      .get('/api/chapters')
+      .set('X-Test-User', stUser());
+    expect(res.status).toBe(200);
+
+    const returned = res.body.filter(c =>
+      [String(a.insertedId), String(b.insertedId)].includes(String(c._id))
+    );
+    expect(returned.length).toBe(2);
+    expect(returned[0].number).toBeLessThan(returned[1].number);
+  });
+});
+
+// ── GET /api/chapters/:id ──────────────────────────────────────────────────
+
+describe('GET /api/chapters/:id', () => {
+  it('returns the chapter by id', async () => {
+    const col = getCollection('chapters');
+    const ins = await col.insertOne({ number: 2, label: 'Chapter Two', created_at: new Date().toISOString() });
+    cleanupIds.chapters.push(ins.insertedId);
+
+    const res = await request(app)
+      .get(`/api/chapters/${ins.insertedId}`)
+      .set('X-Test-User', stUser());
+    expect(res.status).toBe(200);
+    expect(res.body.label).toBe('Chapter Two');
+  });
+
+  it('returns 404 for unknown id', async () => {
+    const res = await request(app)
+      .get(`/api/chapters/${new ObjectId()}`)
+      .set('X-Test-User', stUser());
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 for malformed id', async () => {
+    const res = await request(app)
+      .get('/api/chapters/not-an-id')
+      .set('X-Test-User', stUser());
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── POST /api/chapters ─────────────────────────────────────────────────────
+
+describe('POST /api/chapters', () => {
+  it('ST can create a chapter and receives 201', async () => {
+    const res = await request(app)
+      .post('/api/chapters')
+      .set('X-Test-User', stUser())
+      .send({ number: 2, label: 'Chapter Two: The Price of Power' });
+    expect(res.status).toBe(201);
+    expect(res.body.number).toBe(2);
+    expect(res.body.label).toBe('Chapter Two: The Price of Power');
+    expect(res.body._id).toBeTruthy();
+    cleanupIds.chapters.push(new ObjectId(res.body._id));
+  });
+
+  it('player cannot create a chapter (403)', async () => {
+    const res = await request(app)
+      .post('/api/chapters')
+      .set('X-Test-User', playerUser([]))
+      .send({ number: 1, label: 'Chapter One' });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects missing number (400)', async () => {
+    const res = await request(app)
+      .post('/api/chapters')
+      .set('X-Test-User', stUser())
+      .send({ label: 'No Number' });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects missing label (400)', async () => {
+    const res = await request(app)
+      .post('/api/chapters')
+      .set('X-Test-User', stUser())
+      .send({ number: 1 });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects non-integer number (400)', async () => {
+    const res = await request(app)
+      .post('/api/chapters')
+      .set('X-Test-User', stUser())
+      .send({ number: 1.5, label: 'Bad Number' });
+    expect(res.status).toBe(400);
+  });
+
+  it('trims whitespace from label', async () => {
+    const res = await request(app)
+      .post('/api/chapters')
+      .set('X-Test-User', stUser())
+      .send({ number: 99, label: '  Trimmed  ' });
+    expect(res.status).toBe(201);
+    expect(res.body.label).toBe('Trimmed');
+    cleanupIds.chapters.push(new ObjectId(res.body._id));
+  });
+});
+
+// ── PATCH /api/chapters/:id ────────────────────────────────────────────────
+
+describe('PATCH /api/chapters/:id', () => {
+  it('ST can update label', async () => {
+    const create = await request(app)
+      .post('/api/chapters')
+      .set('X-Test-User', stUser())
+      .send({ number: 3, label: 'Original Label' });
+    cleanupIds.chapters.push(new ObjectId(create.body._id));
+
+    const res = await request(app)
+      .patch(`/api/chapters/${create.body._id}`)
+      .set('X-Test-User', stUser())
+      .send({ label: 'Updated Label' });
+    expect(res.status).toBe(200);
+    expect(res.body.label).toBe('Updated Label');
+  });
+
+  it('ST can update number', async () => {
+    const create = await request(app)
+      .post('/api/chapters')
+      .set('X-Test-User', stUser())
+      .send({ number: 5, label: 'Will Change Number' });
+    cleanupIds.chapters.push(new ObjectId(create.body._id));
+
+    const res = await request(app)
+      .patch(`/api/chapters/${create.body._id}`)
+      .set('X-Test-User', stUser())
+      .send({ number: 6 });
+    expect(res.status).toBe(200);
+    expect(res.body.number).toBe(6);
+  });
+
+  it('player cannot patch (403)', async () => {
+    const col = getCollection('chapters');
+    const ins = await col.insertOne({ number: 1, label: 'Read Only', created_at: new Date().toISOString() });
+    cleanupIds.chapters.push(ins.insertedId);
+
+    const res = await request(app)
+      .patch(`/api/chapters/${ins.insertedId}`)
+      .set('X-Test-User', playerUser([]))
+      .send({ label: 'Hacked' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 for unknown id', async () => {
+    const res = await request(app)
+      .patch(`/api/chapters/${new ObjectId()}`)
+      .set('X-Test-User', stUser())
+      .send({ label: 'Ghost' });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 with empty body', async () => {
+    const col = getCollection('chapters');
+    const ins = await col.insertOne({ number: 1, label: 'Empty Patch', created_at: new Date().toISOString() });
+    cleanupIds.chapters.push(ins.insertedId);
+
+    const res = await request(app)
+      .patch(`/api/chapters/${ins.insertedId}`)
+      .set('X-Test-User', stUser())
+      .send({});
+    expect(res.status).toBe(400);
+  });
+});
+
+// ── DELETE /api/chapters/:id ───────────────────────────────────────────────
+
+describe('DELETE /api/chapters/:id', () => {
+  it('ST can delete an unlinked chapter', async () => {
+    const create = await request(app)
+      .post('/api/chapters')
+      .set('X-Test-User', stUser())
+      .send({ number: 10, label: 'To Be Deleted' });
+    const id = create.body._id;
+
+    const res = await request(app)
+      .delete(`/api/chapters/${id}`)
+      .set('X-Test-User', stUser());
+    expect(res.status).toBe(200);
+    expect(res.body.deleted).toBe(true);
+  });
+
+  it('player cannot delete (403)', async () => {
+    const col = getCollection('chapters');
+    const ins = await col.insertOne({ number: 1, label: 'No Delete', created_at: new Date().toISOString() });
+    cleanupIds.chapters.push(ins.insertedId);
+
+    const res = await request(app)
+      .delete(`/api/chapters/${ins.insertedId}`)
+      .set('X-Test-User', playerUser([]));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 409 CHAPTER_IN_USE when a cycle is linked', async () => {
+    const create = await request(app)
+      .post('/api/chapters')
+      .set('X-Test-User', stUser())
+      .send({ number: 11, label: 'In Use' });
+    const chapterId = create.body._id;
+    cleanupIds.chapters.push(new ObjectId(chapterId));
+
+    // Insert a cycle referencing this chapter
+    const cycleCol = getCollection('downtime_cycles');
+    const cycleIns = await cycleCol.insertOne({
+      label: 'DT 5', game_number: 5, status: 'prep',
+      chapter_id: chapterId, created_at: new Date().toISOString(),
+    });
+    cleanupIds.downtime_cycles.push(cycleIns.insertedId);
+
+    const res = await request(app)
+      .delete(`/api/chapters/${chapterId}`)
+      .set('X-Test-User', stUser());
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('CHAPTER_IN_USE');
+    expect(res.body.linked_cycles).toBe(1);
+  });
+
+  it('returns 404 for unknown id', async () => {
+    const res = await request(app)
+      .delete(`/api/chapters/${new ObjectId()}`)
+      .set('X-Test-User', stUser());
+    expect(res.status).toBe(404);
+  });
+});

--- a/server/tests/epic.708.1-cycle-schema-api.test.js
+++ b/server/tests/epic.708.1-cycle-schema-api.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+
+const SCHEMA   = fs.readFileSync('../server/schemas/downtime_submission.schema.js', 'utf8');
+const CHAPTERS = fs.readFileSync('../server/routes/chapters.js', 'utf8');
+const INDEX    = fs.readFileSync('../server/index.js', 'utf8');
+const DB       = fs.readFileSync('../public/js/downtime/db.js', 'utf8');
+
+// ── Schema ─────────────────────────────────────────────────────────────────
+
+describe('epic.708.1 — downtimeCycleSchema', () => {
+  it('declares game_phase field', () =>
+    expect(SCHEMA).toContain('game_phase'));
+
+  it('game_phase enum includes processing', () =>
+    expect(SCHEMA).toContain("'processing'"));
+
+  it('game_phase is nullable', () =>
+    expect(SCHEMA).toMatch(/game_phase.*\['string',\s*'null'\]/));
+
+  it('declares chapter_id field', () =>
+    expect(SCHEMA).toContain('chapter_id'));
+
+  it('chapter_id is nullable', () =>
+    expect(SCHEMA).toMatch(/chapter_id.*\['string',\s*'null'\]/));
+});
+
+// ── deriveCycleStatus ──────────────────────────────────────────────────────
+
+describe('epic.708.1 — deriveCycleStatus game_phase guard', () => {
+  it("returns 'game' when game_phase is 'game'", () =>
+    expect(DB).toContain("game_phase === 'game'"));
+
+  it("returns 'active' when game_phase is 'downtime'", () =>
+    expect(DB).toContain("game_phase === 'downtime'"));
+
+  it("returns 'closed' when game_phase is 'processing'", () =>
+    expect(DB).toContain("game_phase === 'processing'"));
+
+  it('guard block precedes the legacy ps.projects check', () => {
+    const gamePhaseIdx = DB.indexOf("game_phase === 'game'");
+    const projectsIdx  = DB.indexOf('if (ps.projects)');
+    expect(gamePhaseIdx).toBeGreaterThan(-1);
+    expect(gamePhaseIdx).toBeLessThan(projectsIdx);
+  });
+});
+
+// ── Chapters route ─────────────────────────────────────────────────────────
+
+describe('epic.708.1 — chapters route handlers', () => {
+  it('has GET / handler', () =>
+    expect(CHAPTERS).toContain("chaptersRouter.get('/',"));
+
+  it('has GET /:id handler', () =>
+    expect(CHAPTERS).toContain("chaptersRouter.get('/:id',"));
+
+  it('POST / requires ST role', () =>
+    expect(CHAPTERS).toMatch(/chaptersRouter\.post\s*\(\s*'\/'\s*,\s*requireRole\s*\(\s*'st'\s*\)/));
+
+  it('PATCH /:id requires ST role', () =>
+    expect(CHAPTERS).toMatch(/chaptersRouter\.patch\s*\(\s*'\/:id'\s*,\s*requireRole\s*\(\s*'st'\s*\)/));
+
+  it('DELETE /:id requires ST role', () =>
+    expect(CHAPTERS).toMatch(/chaptersRouter\.delete\s*\(\s*'\/:id'\s*,\s*requireRole\s*\(\s*'st'\s*\)/));
+
+  it('DELETE checks for in-use cycles and returns 409', () => {
+    expect(CHAPTERS).toContain('CHAPTER_IN_USE');
+    expect(CHAPTERS).toContain('409');
+    expect(CHAPTERS).toContain('linked_cycles');
+  });
+
+  it('GET / sorts by number asc', () =>
+    expect(CHAPTERS).toContain('number: 1'));
+
+  it('POST / returns 201', () =>
+    expect(CHAPTERS).toContain('201'));
+});
+
+// ── server/index.js mount ──────────────────────────────────────────────────
+
+describe('epic.708.1 — server/index.js', () => {
+  it('imports chaptersRouter', () =>
+    expect(INDEX).toContain("from './routes/chapters.js'"));
+
+  it("mounts chaptersRouter at '/api/chapters'", () =>
+    expect(INDEX).toContain("'/api/chapters'"));
+
+  it('mounts chapters with requireAuth', () =>
+    expect(INDEX).toMatch(/\/api\/chapters.*requireAuth|requireAuth.*\/api\/chapters/));
+});

--- a/server/tests/helpers/test-app.js
+++ b/server/tests/helpers/test-app.js
@@ -30,6 +30,7 @@ import stModsRouter, { auditRouter as stModAuditRouter } from '../../routes/st_m
 import appSettingsRouter from '../../routes/app-settings.js';
 import devlogRouter from '../../routes/devlog.js';
 import equipmentRouter from '../../routes/equipment.js';
+import { chaptersRouter } from '../../routes/chapters.js';
 
 /**
  * Create a test app with a mock user injected via header.
@@ -105,6 +106,8 @@ export function createTestApp() {
   app.use('/api/settings', mockAuth, noCache(), appSettingsRouter);
   // Issue #502: devlog entries (player read, ST write)
   app.use('/api/devlog', mockAuth, noCache(), devlogRouter);
+  // CYCLE epic (#708): chapter management
+  app.use('/api/chapters', mockAuth, noCache(), chaptersRouter);
 
   return app;
 }

--- a/specs/stories/epic.708.1-cycle-schema-api.story.md
+++ b/specs/stories/epic.708.1-cycle-schema-api.story.md
@@ -1,0 +1,243 @@
+---
+issue: 708
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/708
+branch: ms/issue-708-cycle-tab-game-phase
+epic: CYCLE — Game Cycle Management Tab
+story: 1 of 6
+status: review
+---
+
+# Epic CYCLE — Story 1: Schema & API Foundations
+
+## Story
+
+**As an** ST,
+**I want** the server to support a manual `game_phase` field on downtime cycles and a `chapters` collection,
+**so that** the cycle management tab (stories 2–6) has a clean, authoritative API to read and write game phase state without relying on auto-derived logic.
+
+---
+
+## Epic Context
+
+This is story 1 of 6 in the CYCLE epic (#708). The full epic replaces all auto-derived `cycle.status` logic with a single manual control surface in the admin app.
+
+**Epic story breakdown (do not implement beyond story 1 in this story):**
+- **Story 1 (this):** Schema + API — `game_phase` field, `chapters` collection, backward-compat `deriveCycleStatus` update
+- **Story 2:** Cycle tab shell — new admin sidebar entry, chapter list/create, cycle list
+- **Story 3:** Phase control panel — game/downtime/processing buttons with side effects (tracker reset, DT open/close)
+- **Story 4:** DT prep access controls — move `out_of_window_player_ids` management into cycle tab
+- **Story 5:** Publish pipeline — publish DT stories to Story tab, publish individual reports
+- **Story 6:** Attendance + XP absorption — cycle-scoped attendance view within cycle tab
+
+---
+
+## Acceptance Criteria
+
+- [ ] AC-1: `downtimeCycleSchema` in `server/schemas/downtime_submission.schema.js` accepts `game_phase` (enum: `'game'|'downtime'|'processing'`, nullable) and `chapter_id` (string, nullable)
+- [ ] AC-2: `PUT /api/downtime_cycles/:id` persists `game_phase` and `chapter_id` when included in the request body (existing `additionalProperties: true` means schema is sufficient)
+- [ ] AC-3: `deriveCycleStatus(cycle)` in `public/js/downtime/db.js` returns the appropriate legacy status when `game_phase` is set: `'game'` → `'game'`, `'downtime'` → `'active'`, `'processing'` → `'closed'`. When `game_phase` is null/absent, existing logic is unchanged.
+- [ ] AC-4: `GET /api/chapters` returns all chapters sorted by `number` asc (no auth required — public read, consistent with territories)
+- [ ] AC-5: `POST /api/chapters` creates a chapter (ST role required). Body: `{ number: int, label: string }`. Returns 201 with the created doc.
+- [ ] AC-6: `PATCH /api/chapters/:id` updates `number` and/or `label` (ST role required). Returns 200 with the updated doc.
+- [ ] AC-7: `DELETE /api/chapters/:id` deletes a chapter (ST role required). If any `downtime_cycles` document has `chapter_id` matching this chapter, returns 409 CONFLICT. Otherwise deletes and returns 200.
+- [ ] AC-8: `GET /api/chapters/:id` returns a single chapter (no auth required). Returns 404 if not found.
+- [ ] AC-9: `chaptersRouter` is mounted at `/api/chapters` in `server/index.js` with `requireAuth` (public reads inside the router; writes use `requireRole('st')`)
+- [ ] AC-10: Vitest contract tests pass (≥12 tests)
+
+---
+
+## Dev Notes
+
+### Design Decision: Extend `downtime_cycles`, not a new collection
+
+**Do NOT create a new `game_cycles` collection.** Add `game_phase` directly to `downtime_cycles`.
+
+Rationale:
+- `downtime_cycles` is already the unit of "one game event" — every piece of game-cycle state lives there already (`phase_signoff`, `manual_open`, `out_of_window_player_ids`, `regent_confirmations`, etc.)
+- ~14 reads of `cycle.status` exist across the codebase; all will transparently pick up the new field via the updated `deriveCycleStatus` without touching any call sites
+- A new collection would require cross-collection joins everywhere or a mass migration; the extension is additive and non-breaking
+
+### `game_phase` field semantics
+
+```
+game_phase: 'game'      → cycle is in game session (feeding, tracker, office powers active)
+game_phase: 'downtime'  → submissions open, regent confirmations active
+game_phase: 'processing'→ submissions closed, ST-only processing
+game_phase: null        → legacy mode — derive from phase_signoff (backwards compat)
+```
+
+When `game_phase` is set (non-null), it is the authoritative source of truth. The legacy `deriveCycleStatus` derivation is the fallback for cycles that predate this story.
+
+### `deriveCycleStatus` change (backwards-compatible wrapper)
+
+Current logic in `public/js/downtime/db.js:67-79`:
+```js
+export function deriveCycleStatus(cycle) {
+  const ps = cycle?.phase_signoff || {};
+  if (ps.projects) return 'closed';
+  if (cycle?.manual_open === true) return 'active';
+  if (!ps.prep) return 'prep';
+  if (!ps.city) return 'game';
+  return 'active';
+}
+```
+
+New logic — add a guard at the top before the existing body:
+```js
+export function deriveCycleStatus(cycle) {
+  // Manual game_phase overrides legacy derivation when set (CYCLE epic #708)
+  if (cycle?.game_phase === 'game')        return 'game';
+  if (cycle?.game_phase === 'downtime')    return 'active';
+  if (cycle?.game_phase === 'processing')  return 'closed';
+  // Legacy derivation (unchanged) — covers cycles predating #708
+  const ps = cycle?.phase_signoff || {};
+  if (ps.projects) return 'closed';
+  if (cycle?.manual_open === true) return 'active';
+  if (!ps.prep) return 'prep';
+  if (!ps.city) return 'game';
+  return 'active';
+}
+```
+
+**DO NOT change any other call sites.** All consumers of `deriveCycleStatus` and `cycle.status` will automatically pick up the correct value.
+
+### `chapters` collection schema
+
+Each document:
+```json
+{
+  "_id": ObjectId,
+  "number": 2,
+  "label": "Chapter Two: The Price of Power",
+  "created_at": "2026-06-11T00:00:00.000Z"
+}
+```
+
+`number` is a positive integer used for sort order. `label` is the display name. Neither needs to be unique (ST may have draft chapters), but practically they will be.
+
+### New file: `server/routes/chapters.js`
+
+Follow the exact same pattern as `server/routes/game-sessions.js` — that file is the closest structural match (coordinator-role writes, open reads).
+
+Key structure:
+```js
+import { Router } from 'express';
+import { ObjectId } from 'mongodb';
+import { getCollection } from '../db.js';
+import { requireRole } from '../middleware/auth.js';
+
+const col = () => getCollection('chapters');
+
+function parseId(id) {
+  try { return new ObjectId(id); } catch { return null; }
+}
+
+export const chaptersRouter = Router();
+
+chaptersRouter.get('/', async (req, res) => { ... });       // public read
+chaptersRouter.get('/:id', async (req, res) => { ... });    // public read
+chaptersRouter.post('/', requireRole('st'), async (req, res) => { ... });
+chaptersRouter.patch('/:id', requireRole('st'), async (req, res) => { ... });
+chaptersRouter.delete('/:id', requireRole('st'), async (req, res) => { ... });
+```
+
+For `DELETE`: query `downtime_cycles` for any doc with `chapter_id: req.params.id` (string match — `chapter_id` is stored as a string). If found, return `409 CONFLICT` with `{ error: 'CHAPTER_IN_USE', linked_cycles: N }`.
+
+### `server/index.js` mount pattern
+
+Follow the exact pattern of existing router mounts. Add near the other admin/data routes:
+```js
+import chaptersRouter from './routes/chapters.js';
+// ...
+app.use('/api/chapters', requireAuth, noCache(), chaptersRouter);
+```
+
+`requireAuth` at the mount level ensures the session is valid; the router's public endpoints don't add further role checks, and write endpoints use `requireRole('st')` internally. This matches the `territories` pattern.
+
+### `downtimeCycleSchema` additions
+
+In `server/schemas/downtime_submission.schema.js`, within the `downtimeCycleSchema.properties` object, add after the existing `feeding_rights_confirmed` property:
+
+```js
+// CYCLE epic (#708): manual game phase control. Replaces auto-derive when set.
+// null means derive from phase_signoff (legacy cycles). See deriveCycleStatus.
+game_phase: { type: ['string', 'null'], enum: ['game', 'downtime', 'processing', null] },
+chapter_id: { type: ['string', 'null'] },  // ref to chapters collection _id as string
+```
+
+**Important:** The schema has `additionalProperties: true`, so the PUT handler already passes unknown fields through. The schema addition is documentation + validation only — the PUT handler doesn't need to change.
+
+### Existing code to preserve (do not touch)
+
+- `cyclesRouter.post('/:id/confirm-feeding', ...)` — feeding confirmation, unrelated
+- `setManualOpen()` and `signoffPhase()` — legacy controls, still used by DT Prep tab until Story 4 absorbs them
+- `openGamePhase()` in `public/js/downtime/db.js:50-52` — sets `status: 'game'` directly; after this story, callers should migrate to setting `game_phase: 'game'` instead, but that migration is Story 3's job, NOT this story
+- All existing `cycle.status` reads across the codebase — untouched; `deriveCycleStatus` change handles them transparently
+
+### Auth pattern for chapters
+
+Read endpoints (`GET /`, `GET /:id`) — `requireAuth` at the router mount level is sufficient. No additional role check inside the handler.
+
+Write endpoints — `requireRole('st')` inside the handler, matching the pattern used in `downtime.js` cyclesRouter and `game-sessions.js`.
+
+### Vitest test file
+
+Create `server/tests/epic.708.1-cycle-schema-api.test.js`.
+
+Tests must be static-grep Vitest contracts (read files with `fs.readFileSync`, assert `toContain` / `toMatch`), matching the project's established testing pattern (see `server/tests/feature.691.hos-city-status-power.test.js` as the canonical example).
+
+Required assertions (≥12):
+- `SCHEMA` contains `'game_phase'`
+- `SCHEMA` contains `'chapter_id'`
+- `SCHEMA` game_phase enum contains `'processing'`
+- `CHAPTERS` route contains `'/chapters'` endpoint handlers
+- `CHAPTERS` route enforces ST role on POST
+- `CHAPTERS` route enforces ST role on PATCH
+- `CHAPTERS` route enforces ST role on DELETE
+- `CHAPTERS` route checks for in-use cycles before delete (409)
+- `INDEX` imports `chaptersRouter`
+- `INDEX` mounts at `'/api/chapters'`
+- `DB` (downtime/db.js) contains guard for `game_phase === 'game'`
+- `DB` contains guard for `game_phase === 'downtime'`
+- `DB` contains guard for `game_phase === 'processing'`
+
+---
+
+## Tasks
+
+- [x] **Task 1** — Update `server/schemas/downtime_submission.schema.js`: add `game_phase` and `chapter_id` to `downtimeCycleSchema.properties`
+- [x] **Task 2** — Update `public/js/downtime/db.js`: add `game_phase` guard block at the top of `deriveCycleStatus` (3 lines, before existing body)
+- [x] **Task 3** — Create `server/routes/chapters.js`: CRUD router with GET /, GET /:id, POST /, PATCH /:id, DELETE /:id (with in-use cycle check)
+- [x] **Task 4** — Update `server/index.js`: import `chaptersRouter` and mount at `/api/chapters` with `requireAuth, noCache()`
+- [x] **Task 5** — Create `server/tests/epic.708.1-cycle-schema-api.test.js`: ≥12 static-grep Vitest contract tests
+- [x] **Task 6** — Run `npx vitest run server/tests/epic.708.1-cycle-schema-api.test.js` and confirm all pass
+
+---
+
+## File List
+
+**New:**
+- `server/routes/chapters.js`
+- `server/tests/epic.708.1-cycle-schema-api.test.js`
+
+**Modified:**
+- `server/schemas/downtime_submission.schema.js` (add `game_phase`, `chapter_id` to `downtimeCycleSchema`)
+- `server/index.js` (import + mount chaptersRouter)
+- `public/js/downtime/db.js` (guard block in `deriveCycleStatus`)
+
+---
+
+## Dev Agent Record
+
+### Debug Log
+_Empty_
+
+### Completion Notes
+- Added `game_phase` (nullable enum: game/downtime/processing) and `chapter_id` (nullable string) to `downtimeCycleSchema`
+- Updated `deriveCycleStatus` with a 3-line guard block before the legacy `phase_signoff` logic — fully backwards-compatible; null `game_phase` falls through to existing behaviour unchanged
+- Created `server/routes/chapters.js`: GET /, GET /:id (public); POST /, PATCH /:id, DELETE /:id (ST-only). DELETE returns 409 CHAPTER_IN_USE if any cycle references the chapter
+- Mounted `chaptersRouter` at `/api/chapters` with `requireAuth, noCache()` in `server/index.js`
+- 20 Vitest contract tests — all pass
+
+### Change Log
+- 2026-06-11: Story implemented — schema fields, deriveCycleStatus guard, chapters CRUD API, 20 passing tests


### PR DESCRIPTION
## Summary

- Replaces scattered auto-derived cycle status logic with a manual `game_phase` field on `downtime_cycles`, giving STs direct authoritative control over the game/downtime/processing state
- Adds a `chapters` collection + full CRUD API so STs can manage story chapters independently of game cycles, and link cycles to chapters
- Adds a dedicated Cycle sidebar tab in the admin app with a chapters management panel (create, list, delete with in-use guard) and a read-only game cycles list showing phase and chapter association
- Backwards-compatible: existing cycles with no `game_phase` continue to derive status from `phase_signoff` via the updated `deriveCycleStatus` guard

## Closes

_None_ — partial epic (#708); stories 3–6 to follow on this branch

## Story

- specs/stories/epic.708.1-cycle-schema-api.story.md
- specs/stories/epic.708.2-cycle-tab-shell.story.md

## Test plan

- [x] 20 Vitest static-grep contract tests (story 1) — all pass
- [x] 22 Vitest supertest integration tests for `/api/chapters` CRUD — all pass
- [x] 15 Vitest static-grep contract tests (story 2) — all pass
- [x] 18 Playwright E2E tests — Cycle tab navigation, chapters panel (CRUD, 409 guard, validation), cycles panel (phase labels, chapter association, error state) — all pass
- [ ] CI green
- [ ] Manual: navigate to admin Cycle tab on dev, verify chapters list renders, create/delete a chapter, confirm cycles list shows phase labels

## Branch flow

- From: `ms/issue-708-cycle-tab-game-phase`
- Into: `dev`