### PR TITLE
feat(708.4): move out-of-window DT prep access controls into Cycle tab

### DIFF
--- a/public/js/admin/cycle-views.js
+++ b/public/js/admin/cycle-views.js
@@ -23,7 +23,7 @@ export async function initCycleView(charList) {
 
   el.innerHTML = '';
   el.appendChild(buildChaptersPanel(chapters));
-  el.appendChild(buildCyclesPanel(cycles, chapters));
+  el.appendChild(buildCyclesPanel(cycles, chapters, charList));
 }
 
 // ── Chapters panel ──────────────────────────────────────────────────────────
@@ -199,9 +199,59 @@ function buildPhaseCell(cy) {
   return td;
 }
 
+// ── Prep Access section ──────────────────────────────────────────────────────
+
+function buildAccessSection(cy, charList) {
+  const wrap = document.createElement('div');
+  wrap.style.cssText = 'padding:8px 0 4px;max-height:220px;overflow-y:auto';
+
+  const activeChars = charList
+    .filter(c => !c.retired)
+    .sort((a, b) => (a.moniker || a.name || '').localeCompare(b.moniker || b.name || ''));
+
+  if (!activeChars.length) {
+    wrap.textContent = 'No active characters.';
+    wrap.style.color = 'var(--txt2)';
+    return wrap;
+  }
+
+  const oowIds = new Set((cy.out_of_window_player_ids || []).map(String));
+
+  activeChars.forEach(c => {
+    const id = String(c._id);
+    const label = document.createElement('label');
+    label.style.cssText = 'display:flex;align-items:center;gap:8px;padding:3px 0;cursor:pointer;font-size:13px';
+
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.checked = oowIds.has(id);
+
+    const span = document.createElement('span');
+    span.textContent = c.moniker || c.name || String(c._id);
+
+    label.appendChild(cb);
+    label.appendChild(span);
+    wrap.appendChild(label);
+
+    cb.addEventListener('change', async () => {
+      const current = new Set((cy.out_of_window_player_ids || []).map(String));
+      if (cb.checked) current.add(id); else current.delete(id);
+      const updated = [...current];
+      try {
+        await apiPut('/api/downtime_cycles/' + cy._id, { out_of_window_player_ids: updated });
+        cy.out_of_window_player_ids = updated;
+      } catch (_err) {
+        cb.checked = !cb.checked;
+      }
+    });
+  });
+
+  return wrap;
+}
+
 // ── Game Cycles panel ───────────────────────────────────────────────────────
 
-function buildCyclesPanel(cycles, chapters) {
+function buildCyclesPanel(cycles, chapters, charList = []) {
   const sorted = [...cycles].sort((a, b) => (a.game_number ?? 0) - (b.game_number ?? 0));
   const chapterMap = Object.fromEntries(chapters.map(c => [String(c._id), c]));
 
@@ -227,6 +277,7 @@ function buildCyclesPanel(cycles, chapters) {
     <th>Label</th>
     <th style="width:270px">Phase</th>
     <th style="width:200px">Chapter</th>
+    <th style="width:110px">Prep Access</th>
   </tr></thead>`;
   const tbody = document.createElement('tbody');
 
@@ -247,7 +298,32 @@ function buildCyclesPanel(cycles, chapters) {
     tdChapter.textContent = chapterLabel;
     tr.appendChild(tdChapter);
 
+    // Prep Access toggle
+    const tdAccess = document.createElement('td');
+    const accessBtn = document.createElement('button');
+    accessBtn.className = 'btn-sm';
+    accessBtn.textContent = 'Prep Access';
+    tdAccess.appendChild(accessBtn);
+    tr.appendChild(tdAccess);
+
+    // Detail row (hidden by default)
+    const detailTr = document.createElement('tr');
+    detailTr.style.display = 'none';
+    const detailTd = document.createElement('td');
+    detailTd.colSpan = 4;
+    detailTd.style.cssText = 'padding:4px 12px 12px;background:var(--surf2)';
+    detailTd.appendChild(buildAccessSection(cy, charList));
+    detailTr.appendChild(detailTd);
+
+    accessBtn.addEventListener('click', () => {
+      const open = detailTr.style.display !== 'none';
+      detailTr.style.display = open ? 'none' : '';
+      accessBtn.style.borderColor = open ? '' : 'var(--gold2)';
+      accessBtn.style.color = open ? '' : 'var(--gold2)';
+    });
+
     tbody.appendChild(tr);
+    tbody.appendChild(detailTr);
   });
 
   table.appendChild(tbody);

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -2597,25 +2597,6 @@ function renderPrepPanel(cycle) {
   const deadlineVal = cycle.deadline_at ? isoToLocalInput(cycle.deadline_at) : '';
   const finaleChecked = cycle.is_chapter_finale ? ' checked' : '';
 
-  const oowIds = new Set((cycle.out_of_window_player_ids || []).map(String));
-
-  // Active (non-retired) characters, sorted by display name
-  const activeChars = (characters || [])
-    .filter(c => !c.retired)
-    .sort((a, b) => (a.name || '').localeCompare(b.name || ''));
-
-  const toggleHtml = activeChars.map(c => {
-    const id = String(c._id);
-    const checked = oowIds.has(id) ? ' checked' : '';
-    return `<label class="dt-early-toggle-row" data-player-id="${esc(id)}">
-      <span class="dt-early-name">${esc(dropdownName(c))}</span>
-      <input type="checkbox" class="dt-early-toggle"${checked}>
-    </label>`;
-  }).join('');
-
-  const earlyContent = activeChars.length
-    ? toggleHtml
-    : `<p class="placeholder">No active characters.</p>`;
 
   panel.innerHTML =
     renderManualOpenBanner(cycle) +
@@ -2626,10 +2607,6 @@ function renderPrepPanel(cycle) {
     `<input type="datetime-local" id="dt-prep-deadline-input" class="dt-deadline-input" value="${esc(deadlineVal)}"></div>` +
     `<div class="dt-prep-field"><label class="dt-lbl" style="display:flex;align-items:center;gap:.5rem;cursor:pointer;">` +
     `<input type="checkbox" id="dt-chapter-finale-input"${finaleChecked}><span>Chapter Finale</span></label></div>` +
-    `</div>` +
-    `<div class="dt-prep-early">` +
-    `<div class="dt-prep-early-title">Out-of-Window Access</div>` +
-    `<div class="dt-early-list">${earlyContent}</div>` +
     `</div>` +
     `<div class="dt-prep-actions">` +
     renderSignoffButton('prep', cycle) +
@@ -2675,21 +2652,6 @@ function renderPrepPanel(cycle) {
       const key = cb.dataset.key;
       if (!charId || !key) return;
       await setMaintenanceAudit(cycle, charId, key, e.target.checked);
-    });
-  });
-
-  panel.querySelectorAll('.dt-early-toggle').forEach(cb => {
-    cb.addEventListener('change', async () => {
-      const row = cb.closest('.dt-early-toggle-row');
-      const pid = row?.dataset.playerId;
-      if (!pid) return;
-      const current = new Set((cycle.out_of_window_player_ids || []).map(String));
-      if (cb.checked) current.add(pid); else current.delete(pid);
-      const updated = [...current];
-      await updateCycle(cycle._id, { out_of_window_player_ids: updated });
-      const idx = allCycles.findIndex(c => c._id === cycle._id);
-      if (idx >= 0) allCycles[idx].out_of_window_player_ids = updated;
-      cycle.out_of_window_player_ids = updated;
     });
   });
 

--- a/server/tests/epic.708.4-dt-prep-access-controls.test.js
+++ b/server/tests/epic.708.4-dt-prep-access-controls.test.js
@@ -1,0 +1,56 @@
+/**
+ * Contract tests — CYCLE epic #708, story 4: DT Prep Access Controls
+ * Static-grep assertions over public/js/admin/cycle-views.js and
+ * public/js/admin/downtime-views.js.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+
+const CYCLE_VIEWS = fs.readFileSync('../public/js/admin/cycle-views.js', 'utf8');
+const DT_VIEWS    = fs.readFileSync('../public/js/admin/downtime-views.js', 'utf8');
+
+describe('epic.708.4 — cycle-views.js: Prep Access section', () => {
+  it('defines buildAccessSection function', () => {
+    expect(CYCLE_VIEWS).toContain('buildAccessSection');
+  });
+
+  it('reads out_of_window_player_ids from cycle', () => {
+    expect(CYCLE_VIEWS).toContain('out_of_window_player_ids');
+  });
+
+  it('writes out_of_window_player_ids via apiPut', () => {
+    expect(CYCLE_VIEWS).toContain('apiPut');
+    expect(CYCLE_VIEWS).toContain('out_of_window_player_ids');
+  });
+
+  it('renders a Prep Access button per cycle row', () => {
+    expect(CYCLE_VIEWS).toContain('Prep Access');
+  });
+
+  it('accepts charList parameter in buildCyclesPanel', () => {
+    expect(CYCLE_VIEWS).toContain('charList');
+  });
+
+  it('renders expandable detail row (detailTr)', () => {
+    expect(CYCLE_VIEWS).toContain('detailTr');
+  });
+
+  it('reverts checkbox on API failure', () => {
+    expect(CYCLE_VIEWS).toContain('cb.checked = !cb.checked');
+  });
+
+  it('filters out retired characters', () => {
+    expect(CYCLE_VIEWS).toContain('retired');
+  });
+});
+
+describe('epic.708.4 — downtime-views.js: Out-of-Window section removed', () => {
+  it('does not contain dt-prep-early class', () => {
+    expect(DT_VIEWS).not.toContain('dt-prep-early');
+  });
+
+  it('does not contain dt-early-toggle event handler', () => {
+    expect(DT_VIEWS).not.toContain('dt-early-toggle');
+  });
+});

--- a/specs/stories/epic.708.4-dt-prep-access-controls.story.md
+++ b/specs/stories/epic.708.4-dt-prep-access-controls.story.md
@@ -1,0 +1,254 @@
+---
+issue: 708
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/708
+branch: ms/issue-708-cycle-tab-game-phase
+epic: CYCLE — Game Cycle Management Tab
+story: 4 of 6
+status: review
+---
+
+# Epic CYCLE — Story 4: DT Prep Access Controls
+
+## Story
+
+**As an** ST,
+**I want** to grant individual characters out-of-window downtime access from the Cycle tab,
+**so that** all cycle-level controls live in one place rather than being split across Cycle and DT Prep tabs.
+
+---
+
+## Epic Context
+
+Story 4 of 6 in the CYCLE epic (#708). Stories 1–3 (schema/API, tab shell, phase controls) are complete and on `main`.
+
+This story moves the "Out-of-Window Access" character checkbox list from the DT Prep tab (`renderPrepPanel` in `downtime-views.js`) into the Cycle tab (`cycle-views.js`). The server endpoint, server-side gate, and all client-side access gates are **unchanged**.
+
+Stories 5–6 will add the publish pipeline and attendance/XP absorption.
+
+---
+
+## Acceptance Criteria
+
+- [x] AC-1: Each cycle row in the Game Cycles panel has a "Prep Access" toggle button. Clicking it expands an inline detail section below that row showing a checkbox list of all non-retired characters.
+- [x] AC-2: Characters already in `out_of_window_player_ids` for that cycle are pre-checked. Characters not in the list are unchecked.
+- [x] AC-3: Toggling a checkbox calls `PUT /api/downtime_cycles/:id` with the updated `out_of_window_player_ids` array and updates the in-memory cycle object without re-rendering the panel.
+- [x] AC-4: The "Out-of-Window Access" section (the `<div class="dt-prep-early">` block and its checkbox event handler) is removed from `renderPrepPanel` in `downtime-views.js`. The rest of the DT Prep panel is unchanged.
+- [x] AC-5: All existing server-side and client-side access gates are preserved with no changes: `requireOpenCycle` middleware in `downtime.js`, `_hasWindowAccess` in `downtime-form.js`, `hasWindowAccess` in `downtime-tab.js`.
+- [x] AC-6: Contract tests pass (≥8 assertions in `server/tests/epic.708.4-dt-prep-access-controls.test.js`).
+
+---
+
+## Dev Notes
+
+### Files to change
+
+**Modified:**
+- `public/js/admin/cycle-views.js` — add `buildAccessSection(cy, charList)` helper; add Prep Access toggle to each cycle row; update `buildCyclesPanel()` signature to accept `charList`; update call in `initCycleView`
+- `public/js/admin/downtime-views.js` — remove the `dt-prep-early` block and its `.dt-early-toggle` event handler from `renderPrepPanel`
+
+**New:**
+- `server/tests/epic.708.4-dt-prep-access-controls.test.js` — static-grep contract tests
+
+### cycle-views.js — API import
+
+`apiPut` is already imported. No import changes needed.
+
+### cycle-views.js — charList through to buildCyclesPanel
+
+`initCycleView(charList)` already receives `charList`. Pass it through to `buildCyclesPanel`:
+
+```js
+el.appendChild(buildCyclesPanel(cycles, chapters, charList));
+```
+
+Update `buildCyclesPanel` signature:
+```js
+function buildCyclesPanel(cycles, chapters, charList = []) {
+```
+
+The active (non-retired) list is derived inside `buildAccessSection`:
+```js
+const activeChars = charList.filter(c => !c.retired)
+  .sort((a, b) => sortName(c) vs sortName(c) — see below);
+```
+
+For sort, use `(a.moniker || a.name || '')` vs `(b.moniker || b.name || '')` — same pattern used throughout the admin.
+
+### cycle-views.js — buildAccessSection
+
+Add as a module-level function alongside `buildPhaseCell`:
+
+```js
+function buildAccessSection(cy, charList) {
+  const wrap = document.createElement('div');
+  wrap.style.cssText = 'padding:8px 0 4px;max-height:220px;overflow-y:auto';
+
+  const activeChars = charList
+    .filter(c => !c.retired)
+    .sort((a, b) => (a.moniker || a.name || '').localeCompare(b.moniker || b.name || ''));
+
+  if (!activeChars.length) {
+    wrap.textContent = 'No active characters.';
+    wrap.style.color = 'var(--txt2)';
+    return wrap;
+  }
+
+  const oowIds = new Set((cy.out_of_window_player_ids || []).map(String));
+
+  activeChars.forEach(c => {
+    const id = String(c._id);
+    const label = document.createElement('label');
+    label.style.cssText = 'display:flex;align-items:center;gap:8px;padding:3px 0;cursor:pointer;font-size:13px';
+
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.checked = oowIds.has(id);
+
+    const span = document.createElement('span');
+    span.textContent = c.moniker || c.name || c._id;
+
+    label.appendChild(cb);
+    label.appendChild(span);
+    wrap.appendChild(label);
+
+    cb.addEventListener('change', async () => {
+      const current = new Set((cy.out_of_window_player_ids || []).map(String));
+      if (cb.checked) current.add(id); else current.delete(id);
+      const updated = [...current];
+      try {
+        await apiPut('/api/downtime_cycles/' + cy._id, { out_of_window_player_ids: updated });
+        cy.out_of_window_player_ids = updated;
+      } catch (err) {
+        cb.checked = !cb.checked; // revert on failure
+      }
+    });
+  });
+
+  return wrap;
+}
+```
+
+### cycle-views.js — Prep Access toggle in buildCyclesPanel
+
+Each cycle row in the table gets a 4th column with a small toggle button. Clicking it shows/hides a detail `<tr>` spanning all columns.
+
+Update the `<thead>` to add a 4th column:
+```html
+<thead><tr>
+  <th>Label</th>
+  <th style="width:270px">Phase</th>
+  <th style="width:200px">Chapter</th>
+  <th style="width:110px">Prep Access</th>
+</tr></thead>
+```
+
+In the `sorted.forEach` loop, after appending `tdChapter`, add:
+
+```js
+// Prep Access toggle button
+const tdAccess = document.createElement('td');
+const accessBtn = document.createElement('button');
+accessBtn.className = 'btn-sm';
+accessBtn.textContent = 'Prep Access';
+tdAccess.appendChild(accessBtn);
+tr.appendChild(tdAccess);
+
+// Detail row (hidden by default)
+const detailTr = document.createElement('tr');
+detailTr.style.display = 'none';
+const detailTd = document.createElement('td');
+detailTd.colSpan = 4;
+detailTd.style.cssText = 'padding:4px 12px 12px;background:var(--surf2)';
+
+const accessSection = buildAccessSection(cy, charList);
+detailTd.appendChild(accessSection);
+detailTr.appendChild(detailTd);
+
+accessBtn.addEventListener('click', () => {
+  const open = detailTr.style.display !== 'none';
+  detailTr.style.display = open ? 'none' : '';
+  accessBtn.style.borderColor = open ? '' : 'var(--gold2)';
+  accessBtn.style.color = open ? '' : 'var(--gold2)';
+});
+
+tbody.appendChild(tr);
+tbody.appendChild(detailTr);
+```
+
+Note: the existing `tbody.appendChild(tr)` at the bottom of the forEach is **replaced** by the block above (which appends both `tr` and `detailTr`).
+
+### downtime-views.js — removal from renderPrepPanel
+
+Remove lines 2630–2633 (the `dt-prep-early` div):
+```js
+// REMOVE THIS BLOCK:
+`<div class="dt-prep-early">` +
+`<div class="dt-prep-early-title">Out-of-Window Access</div>` +
+`<div class="dt-early-list">${earlyContent}</div>` +
+`</div>` +
+```
+
+Also remove the `oowIds`, `activeChars`, `toggleHtml`, `earlyContent` variable declarations (lines 2600–2618) and the `.dt-early-toggle` event handler block (lines 2681–2694). Leave all other `renderPrepPanel` content intact.
+
+### No server changes
+
+The `PUT /api/downtime_cycles/:id` endpoint already accepts `out_of_window_player_ids`. No server-side changes required. Verify by grepping `downtime.js` — the PUT handler uses `$set: updates` and imposes no field-level restrictions.
+
+### Character naming
+
+Use `c.moniker || c.name || c._id` for display. This is consistent with the rest of the admin app's character name rendering in non-ST-identity contexts.
+
+### Test file
+
+Same static-grep pattern as stories 1–3.
+
+```js
+import fs from 'fs';
+const CYCLE_VIEWS = fs.readFileSync('../public/js/admin/cycle-views.js', 'utf8');
+const DT_VIEWS    = fs.readFileSync('../public/js/admin/downtime-views.js', 'utf8');
+```
+
+Required assertions (≥8):
+- `CYCLE_VIEWS` contains `buildAccessSection`
+- `CYCLE_VIEWS` contains `out_of_window_player_ids`
+- `CYCLE_VIEWS` contains `apiPut` (already present from Story 3)
+- `CYCLE_VIEWS` contains `Prep Access`
+- `CYCLE_VIEWS` contains `charList`
+- `CYCLE_VIEWS` contains `detailTr`
+- `DT_VIEWS` does NOT contain `dt-prep-early` (removed)
+- `DT_VIEWS` does NOT contain `dt-early-toggle` (removed)
+
+---
+
+## Tasks
+
+- [x] **Task 1** — Add `buildAccessSection(cy, charList)` to `cycle-views.js`; thread `charList` through `buildCyclesPanel`; add Prep Access toggle + detail row to each cycle row
+- [x] **Task 2** — Remove `dt-prep-early` block, variable declarations, and `.dt-early-toggle` handler from `renderPrepPanel` in `downtime-views.js`
+- [x] **Task 3** — Create `server/tests/epic.708.4-dt-prep-access-controls.test.js` with ≥8 static-grep assertions; run and confirm all pass
+
+---
+
+## File List
+
+**New:**
+- `server/tests/epic.708.4-dt-prep-access-controls.test.js`
+
+**Modified:**
+- `public/js/admin/cycle-views.js`
+- `public/js/admin/downtime-views.js`
+
+---
+
+## Dev Agent Record
+
+### Debug Log
+_Empty_
+
+### Completion Notes
+- Added `buildAccessSection(cy, charList)` to `cycle-views.js`; renders sorted non-retired character checkboxes; pre-checks `out_of_window_player_ids`; toggles via `PUT /api/downtime_cycles/:id`; reverts checkbox on failure
+- Threaded `charList` through `buildCyclesPanel(cycles, chapters, charList = [])`; added "Prep Access" toggle button + expandable `detailTr` per cycle row (gold highlight when open); `buildCyclesPanel` call in `initCycleView` updated to pass `charList`
+- Removed `dt-prep-early` block, `oowIds`/`activeChars`/`toggleHtml`/`earlyContent` declarations, and `.dt-early-toggle` event handler from `renderPrepPanel` in `downtime-views.js`; remainder of DT Prep panel unchanged
+- 10 static-grep contract tests pass; Stories 1–3 (49 tests) unaffected
+
+### Change Log
+- 2026-06-11: Story implemented — Prep Access controls moved from DT Prep tab into Cycle tab; 10 passing contract tests

--- a/tests/cycle-prep-access.spec.js
+++ b/tests/cycle-prep-access.spec.js
@@ -1,0 +1,285 @@
+/**
+ * E2E tests — Admin Cycle tab: Prep Access controls (CYCLE epic #708, story 4)
+ * Covers: Prep Access button rendered, toggle expand/collapse, character list
+ * pre-checked, PUT on toggle, revert on failure, button highlight state.
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Test data ────────────────────────────────────────────────────────────────
+
+const ST_USER = {
+  id: '123456789', username: 'test_st', global_name: 'Test ST',
+  avatar: null, role: 'st', player_id: 'p-001',
+  character_ids: [], is_dual_role: false,
+};
+
+const TEST_CHAPTERS = [
+  { _id: 'ch-001', number: 1, label: 'Chapter One', created_at: '2026-01-01T00:00:00.000Z' },
+];
+
+// char-001: has out-of-window access on cyc-001
+// char-002: does NOT have access
+// char-003: retired (should not appear)
+const TEST_CHARACTERS = [
+  { _id: 'char-001', name: 'Alice Vane',  moniker: null, retired: false },
+  { _id: 'char-002', name: 'Bob Crane',   moniker: null, retired: false },
+  { _id: 'char-003', name: 'Charlie Daw', moniker: null, retired: true  },
+];
+
+const TEST_CYCLES = [
+  {
+    _id: 'cyc-001', label: 'DT 1', game_number: 1, game_phase: 'processing',
+    chapter_id: 'ch-001', status: 'closed',
+    out_of_window_player_ids: ['char-001'],
+  },
+  {
+    _id: 'cyc-002', label: 'DT 2', game_number: 2, game_phase: null,
+    chapter_id: null, status: 'active',
+    out_of_window_player_ids: [],
+  },
+];
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+async function loginAsST(page) {
+  await page.route('**/api/**', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.route('**/api/auth/me', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(ST_USER) })
+  );
+  await page.route(/\/api\/characters$/, route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(TEST_CHARACTERS) })
+  );
+  await page.route('**/api/characters/names', route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+  );
+  await page.addInitScript((user) => {
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, ST_USER);
+}
+
+async function mockCycleApis(page, { cycles = TEST_CYCLES, putStatus = 200 } = {}) {
+  let currentCycles = cycles.map(c => ({ ...c }));
+
+  await page.route(/\/api\/chapters$/, route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(TEST_CHAPTERS) })
+  );
+  await page.route(/\/api\/chapters\//, route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+  );
+  await page.route(/\/api\/downtime_cycles$/, route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(currentCycles) })
+  );
+  await page.route(/\/api\/downtime_cycles\/[^/]+$/, route => {
+    if (route.request().method() === 'PUT') {
+      const id = route.request().url().split('/').pop();
+      if (putStatus !== 200) {
+        return route.fulfill({ status: putStatus, contentType: 'application/json',
+          body: JSON.stringify({ error: 'SERVER_ERROR' }) });
+      }
+      const body = JSON.parse(route.request().postData() || '{}');
+      const cycle = currentCycles.find(c => c._id === id) || { _id: id };
+      const updated = { ...cycle, ...body };
+      const idx = currentCycles.findIndex(c => c._id === id);
+      if (idx >= 0) currentCycles[idx] = updated;
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(updated) });
+    }
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+  });
+}
+
+async function navigateToCycleTab(page) {
+  await page.goto('/admin.html');
+  await page.waitForSelector('#admin-app:not([style*="display: none"])');
+  await page.click('.sidebar-btn[data-domain="cycle"]');
+  await expect(page.locator('#d-cycle')).toHaveClass(/active/);
+  await page.waitForFunction(() => {
+    const el = document.getElementById('cycle-content');
+    return el && !el.textContent.includes('Loading');
+  }, { timeout: 5000 });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('Cycle tab — Prep Access: rendering', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsST(page);
+    await mockCycleApis(page);
+    await navigateToCycleTab(page);
+  });
+
+  test('each cycle row renders a Prep Access button', async ({ page }) => {
+    const rows = page.locator('#cycle-content table').last().locator('tbody tr:not([style*="display"])');
+    // 2 cycles → 2 visible rows (detail rows are hidden)
+    const prepBtns = page.locator('#cycle-content button', { hasText: 'Prep Access' });
+    await expect(prepBtns).toHaveCount(2);
+  });
+
+  test('Prep Access button is visible and enabled', async ({ page }) => {
+    const btn = page.locator('#cycle-content button', { hasText: 'Prep Access' }).first();
+    await expect(btn).toBeVisible();
+    await expect(btn).not.toBeDisabled();
+  });
+});
+
+test.describe('Cycle tab — Prep Access: expand/collapse', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsST(page);
+    await mockCycleApis(page);
+    await navigateToCycleTab(page);
+  });
+
+  test('clicking Prep Access expands the character list', async ({ page }) => {
+    const btn = page.locator('#cycle-content button', { hasText: 'Prep Access' }).first();
+    await btn.click();
+    // The detail row becomes visible — look for a checkbox inside the cycle table
+    await expect(page.locator('#cycle-content table').last().locator('input[type="checkbox"]').first()).toBeVisible();
+  });
+
+  test('clicking Prep Access again collapses the list', async ({ page }) => {
+    const btn = page.locator('#cycle-content button', { hasText: 'Prep Access' }).first();
+    await btn.click();
+    await expect(page.locator('#cycle-content table').last().locator('input[type="checkbox"]').first()).toBeVisible();
+    await btn.click();
+    await expect(page.locator('#cycle-content table').last().locator('input[type="checkbox"]').first()).not.toBeVisible();
+  });
+
+  test('Prep Access button is gold-highlighted when open', async ({ page }) => {
+    const btn = page.locator('#cycle-content button', { hasText: 'Prep Access' }).first();
+    await btn.click();
+    const color = await btn.evaluate(el => el.style.color);
+    expect(color).toMatch(/gold|rgb\(224, 196, 122\)/i);
+  });
+
+  test('retired characters are not shown in the list', async ({ page }) => {
+    const btn = page.locator('#cycle-content button', { hasText: 'Prep Access' }).first();
+    await btn.click();
+    // Charlie Daw is retired — should not appear
+    const labels = page.locator('#cycle-content table').last().locator('label');
+    await expect(labels.filter({ hasText: 'Charlie Daw' })).toHaveCount(0);
+  });
+});
+
+test.describe('Cycle tab — Prep Access: pre-checked state', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAsST(page);
+    await mockCycleApis(page);
+    await navigateToCycleTab(page);
+  });
+
+  test('char-001 is pre-checked for cyc-001 (has access)', async ({ page }) => {
+    // cyc-001 row is first; open its Prep Access
+    const btn = page.locator('#cycle-content button', { hasText: 'Prep Access' }).first();
+    await btn.click();
+    // Find the label for Alice Vane and check its checkbox
+    const aliceLabel = page.locator('#cycle-content table').last().locator('label', { hasText: 'Alice Vane' }).first();
+    const cb = aliceLabel.locator('input[type="checkbox"]');
+    await expect(cb).toBeChecked();
+  });
+
+  test('char-002 is unchecked for cyc-001 (no access)', async ({ page }) => {
+    const btn = page.locator('#cycle-content button', { hasText: 'Prep Access' }).first();
+    await btn.click();
+    const bobLabel = page.locator('#cycle-content table').last().locator('label', { hasText: 'Bob Crane' }).first();
+    const cb = bobLabel.locator('input[type="checkbox"]');
+    await expect(cb).not.toBeChecked();
+  });
+
+  test('all characters unchecked for cyc-002 (empty access list)', async ({ page }) => {
+    // cyc-002 is second row
+    const btn = page.locator('#cycle-content button', { hasText: 'Prep Access' }).nth(1);
+    await btn.click();
+    const checkboxes = page.locator('#cycle-content table').last()
+      .locator('tr:nth-child(4)').locator('input[type="checkbox"]');
+    // All should be unchecked
+    const count = await checkboxes.count();
+    for (let i = 0; i < count; i++) {
+      await expect(checkboxes.nth(i)).not.toBeChecked();
+    }
+  });
+});
+
+test.describe('Cycle tab — Prep Access: toggle behaviour', () => {
+  test('checking a character calls PUT with updated out_of_window_player_ids', async ({ page }) => {
+    await loginAsST(page);
+    await mockCycleApis(page);
+    await navigateToCycleTab(page);
+
+    let putBody = null;
+    await page.route(/\/api\/downtime_cycles\/cyc-001/, route => {
+      if (route.request().method() === 'PUT') {
+        putBody = JSON.parse(route.request().postData() || '{}');
+        return route.fulfill({ status: 200, contentType: 'application/json',
+          body: JSON.stringify({ _id: 'cyc-001', out_of_window_player_ids: putBody.out_of_window_player_ids }) });
+      }
+      route.continue();
+    });
+
+    const btn = page.locator('#cycle-content button', { hasText: 'Prep Access' }).first();
+    await btn.click();
+
+    // Uncheck Alice (char-001) — currently checked
+    const aliceLabel = page.locator('#cycle-content table').last().locator('label', { hasText: 'Alice Vane' }).first();
+    await aliceLabel.locator('input[type="checkbox"]').uncheck();
+    await page.waitForTimeout(300);
+
+    expect(putBody).not.toBeNull();
+    expect(Array.isArray(putBody.out_of_window_player_ids)).toBe(true);
+    expect(putBody.out_of_window_player_ids).not.toContain('char-001');
+  });
+
+  test('unchecking then re-checking adds the character back', async ({ page }) => {
+    await loginAsST(page);
+    await mockCycleApis(page);
+    await navigateToCycleTab(page);
+
+    const puts = [];
+    await page.route(/\/api\/downtime_cycles\/cyc-002/, route => {
+      if (route.request().method() === 'PUT') {
+        const body = JSON.parse(route.request().postData() || '{}');
+        puts.push(body.out_of_window_player_ids);
+        return route.fulfill({ status: 200, contentType: 'application/json',
+          body: JSON.stringify({ _id: 'cyc-002', out_of_window_player_ids: body.out_of_window_player_ids }) });
+      }
+      route.continue();
+    });
+
+    const btn = page.locator('#cycle-content button', { hasText: 'Prep Access' }).nth(1);
+    await btn.click();
+
+    // Scope to the cyc-002 detail row (4th <tr> in tbody: main1, detail1, main2, detail2)
+    const cyc002Detail = page.locator('#cycle-content table').last().locator('tbody tr').nth(3);
+    const bobLabel = cyc002Detail.locator('label', { hasText: 'Bob Crane' });
+    const cb = bobLabel.locator('input[type="checkbox"]');
+    await expect(cb).toBeVisible({ timeout: 3000 });
+    await cb.check();
+    await page.waitForTimeout(300);
+    expect(puts[0]).toContain('char-002');
+
+    await cb.uncheck();
+    await page.waitForTimeout(300);
+    expect(puts[1]).not.toContain('char-002');
+  });
+
+  test('checkbox reverts on API failure', async ({ page }) => {
+    await loginAsST(page);
+    await mockCycleApis(page, { putStatus: 500 });
+    await navigateToCycleTab(page);
+
+    const btn = page.locator('#cycle-content button', { hasText: 'Prep Access' }).first();
+    await btn.click();
+
+    // Alice is checked; try to uncheck — should revert after 500
+    const aliceLabel = page.locator('#cycle-content table').last().locator('label', { hasText: 'Alice Vane' }).first();
+    const cb = aliceLabel.locator('input[type="checkbox"]');
+    await cb.uncheck();
+    await page.waitForTimeout(400);
+
+    // Checkbox should be checked again (reverted)
+    await expect(cb).toBeChecked();
+  });
+});


### PR DESCRIPTION
## Summary

- Removes the `dt-prep-early` Out-of-Window Access section from the DT Prep tab so all cycle-level access controls live in one place
- Adds a `Prep Access` toggle button to each cycle row in the Cycle tab; clicking expands an inline character list with `out_of_window_player_ids` pre-checked
- Toggling a checkbox writes the updated array via `PUT /api/downtime_cycles/:id`; reverts on API failure — all existing server-side and client-side access gates (`requireOpenCycle`, `_hasWindowAccess`, `hasWindowAccess`) are unchanged

## Closes

_None_ — part of epic #708

## Story

- specs/stories/epic.708.4-dt-prep-access-controls.story.md

## Test plan

- [ ] \`npx vitest run server/tests/epic.708.4-dt-prep-access-controls.test.js\` — 10 contract tests pass
- [ ] \`npx playwright test tests/cycle-prep-access.spec.js\` — 12 E2E tests pass
- [ ] CI green
- [ ] Manual: open admin Cycle tab, click Prep Access on a cycle — list expands; tick a character, confirm PUT fires; verify DT Prep tab no longer shows Out-of-Window Access section

## Branch flow

- From: \`ms/issue-708-cycle-tab-game-phase\`
- Into: \`dev\`