### PR TITLE
feat(708): CYCLE epic — publish pipeline + attendance XP absorption

### DIFF
--- a/public/js/admin/cycle-views.js
+++ b/public/js/admin/cycle-views.js
@@ -278,6 +278,7 @@ function buildCyclesPanel(cycles, chapters, charList = []) {
     <th style="width:270px">Phase</th>
     <th style="width:200px">Chapter</th>
     <th style="width:110px">Prep Access</th>
+    <th style="width:130px">Publish</th>
   </tr></thead>`;
   const tbody = document.createElement('tbody');
 
@@ -310,7 +311,7 @@ function buildCyclesPanel(cycles, chapters, charList = []) {
     const detailTr = document.createElement('tr');
     detailTr.style.display = 'none';
     const detailTd = document.createElement('td');
-    detailTd.colSpan = 4;
+    detailTd.colSpan = 5;
     detailTd.style.cssText = 'padding:4px 12px 12px;background:var(--surf2)';
     detailTd.appendChild(buildAccessSection(cy, charList));
     detailTr.appendChild(detailTd);
@@ -320,6 +321,37 @@ function buildCyclesPanel(cycles, chapters, charList = []) {
       detailTr.style.display = open ? 'none' : '';
       accessBtn.style.borderColor = open ? '' : 'var(--gold2)';
       accessBtn.style.color = open ? '' : 'var(--gold2)';
+    });
+
+    // Publish Reports button
+    const tdPublish = document.createElement('td');
+    const publishBtn = document.createElement('button');
+    publishBtn.className = 'btn-sm';
+    publishBtn.textContent = 'Publish Reports';
+    const publishResult = document.createElement('span');
+    publishResult.style.cssText = 'display:block;font-size:11px;margin-top:3px;color:var(--txt2)';
+    tdPublish.appendChild(publishBtn);
+    tdPublish.appendChild(publishResult);
+    tr.appendChild(tdPublish);
+
+    publishBtn.addEventListener('click', async () => {
+      publishBtn.disabled = true;
+      publishResult.style.color = 'var(--txt2)';
+      publishResult.textContent = 'Publishing…';
+      try {
+        const result = await apiPost('/api/downtime_cycles/' + cy._id + '/publish', {});
+        if (result.published === 0) {
+          publishResult.textContent = 'No compiled reports found.';
+        } else {
+          publishResult.style.color = 'var(--gold2)';
+          publishResult.textContent = result.published + ' report' + (result.published === 1 ? '' : 's') + ' published.';
+        }
+      } catch (err) {
+        publishResult.style.color = 'var(--crim)';
+        publishResult.textContent = 'Publish failed: ' + err.message;
+      } finally {
+        publishBtn.disabled = false;
+      }
     });
 
     tbody.appendChild(tr);

--- a/public/js/admin/cycle-views.js
+++ b/public/js/admin/cycle-views.js
@@ -10,11 +10,12 @@ export async function initCycleView(charList) {
   const el = document.getElementById('cycle-content');
   el.innerHTML = '<p style="padding:16px;color:var(--txt2)">Loading…</p>';
 
-  let chapters, cycles;
+  let chapters, cycles, sessions;
   try {
-    [chapters, cycles] = await Promise.all([
+    [chapters, cycles, sessions] = await Promise.all([
       apiGet('/api/chapters'),
       apiGet('/api/downtime_cycles'),
+      apiGet('/api/game_sessions'),
     ]);
   } catch (err) {
     el.innerHTML = `<p style="padding:16px;color:var(--crim)">Failed to load cycle data: ${err.message}</p>`;
@@ -23,7 +24,7 @@ export async function initCycleView(charList) {
 
   el.innerHTML = '';
   el.appendChild(buildChaptersPanel(chapters));
-  el.appendChild(buildCyclesPanel(cycles, chapters, charList));
+  el.appendChild(buildCyclesPanel(cycles, chapters, charList, sessions));
 }
 
 // ── Chapters panel ──────────────────────────────────────────────────────────
@@ -249,9 +250,142 @@ function buildAccessSection(cy, charList) {
   return wrap;
 }
 
+// ── Attendance section ───────────────────────────────────────────────────────
+
+function buildAttendanceSection(cy, sessions) {
+  const wrap = document.createElement('div');
+  wrap.style.cssText = 'padding:8px 0 4px';
+
+  const selectWrap = document.createElement('div');
+  selectWrap.style.cssText = 'display:flex;align-items:center;gap:8px;margin-bottom:10px';
+
+  const lbl = document.createElement('label');
+  lbl.style.cssText = 'font-size:13px;color:var(--txt2)';
+  lbl.textContent = 'Linked Session:';
+
+  const sel = document.createElement('select');
+  sel.style.cssText = 'background:var(--surf);border:1px solid var(--bdr);color:var(--txt);border-radius:4px;padding:3px 6px;font-size:13px';
+
+  const blank = document.createElement('option');
+  blank.value = '';
+  blank.textContent = '— not linked —';
+  sel.appendChild(blank);
+
+  const sorted = [...sessions].sort((a, b) => (a.game_number ?? 999) - (b.game_number ?? 999));
+  sorted.forEach(s => {
+    const opt = document.createElement('option');
+    opt.value = String(s._id);
+    let label = s.game_number ? 'Game ' + s.game_number : '';
+    if (s.title) label += (label ? ' — ' : '') + s.title;
+    if (!label) label = s.session_date || String(s._id);
+    opt.textContent = label;
+    sel.appendChild(opt);
+  });
+
+  sel.value = cy.session_id || '';
+
+  const errEl = document.createElement('span');
+  errEl.style.cssText = 'color:var(--crim);font-size:11px;display:none';
+
+  selectWrap.appendChild(lbl);
+  selectWrap.appendChild(sel);
+  selectWrap.appendChild(errEl);
+  wrap.appendChild(selectWrap);
+
+  const tableWrap = document.createElement('div');
+  wrap.appendChild(tableWrap);
+
+  function renderTable() {
+    tableWrap.innerHTML = '';
+    const session = sessions.find(s => String(s._id) === sel.value);
+    if (!session) return;
+    const att = session.attendance || [];
+    if (!att.length) {
+      const msg = document.createElement('p');
+      msg.style.cssText = 'font-size:13px;color:var(--txt2);margin:4px 0';
+      msg.textContent = 'No attendance recorded for this session.';
+      tableWrap.appendChild(msg);
+      return;
+    }
+
+    const rows = [...att].sort((a, b) => {
+      const na = (a.character_display || a.character_name || '').toLowerCase();
+      const nb = (b.character_display || b.character_name || '').toLowerCase();
+      return na < nb ? -1 : na > nb ? 1 : 0;
+    });
+
+    const table = document.createElement('table');
+    table.className = 'infl-table';
+    table.style.cssText = 'width:100%;font-size:13px';
+    table.innerHTML = `<thead><tr>
+      <th>Character</th>
+      <th style="width:70px;text-align:center">Attend</th>
+      <th style="width:80px;text-align:center">Costuming</th>
+      <th style="width:50px;text-align:center">DT</th>
+      <th style="width:50px;text-align:center">Extra</th>
+      <th style="width:60px;text-align:center">XP</th>
+    </tr></thead>`;
+
+    const tbody = document.createElement('tbody');
+    let totAtt = 0, totCos = 0, totDT = 0, totExtra = 0, totXP = 0;
+
+    rows.forEach(a => {
+      const xp = (a.attended ? 1 : 0) + (a.costuming ? 1 : 0) + (a.downtime ? 1 : 0) + (a.extra || 0);
+      totAtt   += a.attended  ? 1 : 0;
+      totCos   += a.costuming ? 1 : 0;
+      totDT    += a.downtime  ? 1 : 0;
+      totExtra += (a.extra || 0);
+      totXP    += xp;
+
+      const name = a.character_display || a.character_name || a.character_id || '?';
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${name}</td>
+        <td style="text-align:center">${a.attended  ? '●' : '○'}</td>
+        <td style="text-align:center">${a.costuming ? '●' : '○'}</td>
+        <td style="text-align:center">${a.downtime  ? '●' : '○'}</td>
+        <td style="text-align:center">${a.extra || 0}</td>
+        <td style="text-align:center;font-weight:600">${xp}</td>`;
+      tbody.appendChild(tr);
+    });
+
+    const totTr = document.createElement('tr');
+    totTr.style.cssText = 'font-weight:700;border-top:1px solid var(--bdr)';
+    totTr.innerHTML = `
+      <td style="color:var(--txt2)">Total (${rows.length})</td>
+      <td style="text-align:center">${totAtt}</td>
+      <td style="text-align:center">${totCos}</td>
+      <td style="text-align:center">${totDT}</td>
+      <td style="text-align:center">${totExtra}</td>
+      <td style="text-align:center">${totXP}</td>`;
+    tbody.appendChild(totTr);
+
+    table.appendChild(tbody);
+    tableWrap.appendChild(table);
+  }
+
+  renderTable();
+
+  sel.addEventListener('change', async () => {
+    errEl.style.display = 'none';
+    const newId = sel.value || null;
+    try {
+      await apiPut('/api/downtime_cycles/' + cy._id, { session_id: newId });
+      cy.session_id = newId;
+      renderTable();
+    } catch (err) {
+      sel.value = cy.session_id || '';
+      errEl.textContent = 'Link failed: ' + err.message;
+      errEl.style.display = 'inline';
+    }
+  });
+
+  return wrap;
+}
+
 // ── Game Cycles panel ───────────────────────────────────────────────────────
 
-function buildCyclesPanel(cycles, chapters, charList = []) {
+function buildCyclesPanel(cycles, chapters, charList = [], sessions = []) {
   const sorted = [...cycles].sort((a, b) => (a.game_number ?? 0) - (b.game_number ?? 0));
   const chapterMap = Object.fromEntries(chapters.map(c => [String(c._id), c]));
 
@@ -279,6 +413,7 @@ function buildCyclesPanel(cycles, chapters, charList = []) {
     <th style="width:200px">Chapter</th>
     <th style="width:110px">Prep Access</th>
     <th style="width:130px">Publish</th>
+    <th style="width:110px">Attendance</th>
   </tr></thead>`;
   const tbody = document.createElement('tbody');
 
@@ -311,7 +446,7 @@ function buildCyclesPanel(cycles, chapters, charList = []) {
     const detailTr = document.createElement('tr');
     detailTr.style.display = 'none';
     const detailTd = document.createElement('td');
-    detailTd.colSpan = 5;
+    detailTd.colSpan = 6;
     detailTd.style.cssText = 'padding:4px 12px 12px;background:var(--surf2)';
     detailTd.appendChild(buildAccessSection(cy, charList));
     detailTr.appendChild(detailTd);
@@ -354,8 +489,32 @@ function buildCyclesPanel(cycles, chapters, charList = []) {
       }
     });
 
+    // Attendance toggle
+    const tdAtt = document.createElement('td');
+    const attBtn = document.createElement('button');
+    attBtn.className = 'btn-sm';
+    attBtn.textContent = 'Attendance';
+    tdAtt.appendChild(attBtn);
+    tr.appendChild(tdAtt);
+
+    const attendTr = document.createElement('tr');
+    attendTr.style.display = 'none';
+    const attendTd = document.createElement('td');
+    attendTd.colSpan = 6;
+    attendTd.style.cssText = 'padding:4px 12px 12px;background:var(--surf2)';
+    attendTd.appendChild(buildAttendanceSection(cy, sessions));
+    attendTr.appendChild(attendTd);
+
+    attBtn.addEventListener('click', () => {
+      const open = attendTr.style.display !== 'none';
+      attendTr.style.display = open ? 'none' : '';
+      attBtn.style.borderColor = open ? '' : 'var(--gold2)';
+      attBtn.style.color     = open ? '' : 'var(--gold2)';
+    });
+
     tbody.appendChild(tr);
     tbody.appendChild(detailTr);
+    tbody.appendChild(attendTr);
   });
 
   table.appendChild(tbody);

--- a/server/routes/downtime.js
+++ b/server/routes/downtime.js
@@ -554,6 +554,39 @@ cyclesRouter.put('/:id', requireRole('st'), async (req, res) => {
   res.json(result);
 });
 
+// POST /api/downtime_cycles/:id/publish — ST only; bulk-promote compiled DT reports
+cyclesRouter.post('/:id/publish', requireRole('st'), async (req, res) => {
+  const cycleOid = parseId(req.params.id);
+  if (!cycleOid) return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid cycle ID format' });
+
+  const subs = getCollection('downtime_submissions');
+  const all = await subs.find({ cycle_id: cycleOid }).toArray();
+
+  let published = 0;
+  let skipped = 0;
+  const now = new Date().toISOString();
+
+  for (const sub of all) {
+    const text = sub.st_review?.outcome_text;
+    if (!text) { skipped++; continue; }
+    if (sub.st_review?.outcome_visibility === 'published' && sub.published_outcome) {
+      skipped++;
+      continue;
+    }
+    await subs.updateOne(
+      { _id: sub._id },
+      { $set: {
+          published_outcome: text,
+          'st_review.outcome_visibility': 'published',
+          'st_review.published_at': now,
+      }}
+    );
+    published++;
+  }
+
+  res.json({ published, skipped });
+});
+
 // --- Submissions: /api/downtime_submissions ---
 
 export const submissionsRouter = Router();

--- a/server/schemas/downtime_submission.schema.js
+++ b/server/schemas/downtime_submission.schema.js
@@ -572,6 +572,7 @@ export const downtimeCycleSchema = {
     // null = derive from phase_signoff (legacy cycles). See deriveCycleStatus.
     game_phase: { type: ['string', 'null'], enum: ['game', 'downtime', 'processing', null] },
     chapter_id: { type: ['string', 'null'] },  // ref to chapters collection _id as string
+    session_id: { type: ['string', 'null'] },  // ref to game_sessions _id as string
 
     // Issue #231 — Manual "open downtimes" override (DT Prep tab).
     // Latched flag that forces effective status to 'active' regardless of

--- a/server/tests/epic.708.5-publish-pipeline.test.js
+++ b/server/tests/epic.708.5-publish-pipeline.test.js
@@ -1,0 +1,69 @@
+/**
+ * Contract tests — CYCLE epic #708, story 5: Publish Pipeline
+ * Static-grep assertions over server/routes/downtime.js and
+ * public/js/admin/cycle-views.js.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+
+const DOWNTIME    = fs.readFileSync('../server/routes/downtime.js', 'utf8');
+const CYCLE_VIEWS = fs.readFileSync('../public/js/admin/cycle-views.js', 'utf8');
+
+describe('epic.708.5 — downtime.js: POST /:id/publish endpoint', () => {
+  it('registers a POST handler on cyclesRouter', () => {
+    expect(DOWNTIME).toContain('cyclesRouter.post');
+  });
+
+  it('routes to /publish path', () => {
+    expect(DOWNTIME).toContain("'/:id/publish'");
+  });
+
+  it('is ST-only via requireRole', () => {
+    const publishBlock = DOWNTIME.slice(DOWNTIME.indexOf("'/:id/publish'"));
+    expect(publishBlock.slice(0, 60)).toContain('requireRole');
+  });
+
+  it('sets published_outcome from outcome_text', () => {
+    expect(DOWNTIME).toContain('published_outcome');
+  });
+
+  it('sets outcome_visibility to published', () => {
+    expect(DOWNTIME).toContain('outcome_visibility');
+    expect(DOWNTIME).toContain("'published'");
+  });
+
+  it('sets published_at timestamp', () => {
+    expect(DOWNTIME).toContain('published_at');
+  });
+
+  it('returns published and skipped counts', () => {
+    expect(DOWNTIME).toContain('{ published, skipped }');
+  });
+
+  it('skips already-published submissions', () => {
+    expect(DOWNTIME).toContain('skipped++');
+  });
+});
+
+describe('epic.708.5 — cycle-views.js: Publish Reports button', () => {
+  it('renders a Publish Reports button per cycle row', () => {
+    expect(CYCLE_VIEWS).toContain('Publish Reports');
+  });
+
+  it('calls the /publish endpoint', () => {
+    expect(CYCLE_VIEWS).toContain('/publish');
+  });
+
+  it('displays pluralised publish count feedback', () => {
+    expect(CYCLE_VIEWS).toContain("'s') + ' published.'");
+  });
+
+  it('shows fallback message when no reports found', () => {
+    expect(CYCLE_VIEWS).toContain('No compiled reports found.');
+  });
+
+  it('disables button during in-flight request', () => {
+    expect(CYCLE_VIEWS).toContain('publishBtn.disabled = true');
+  });
+});

--- a/server/tests/epic.708.6-attendance-xp-absorption.test.js
+++ b/server/tests/epic.708.6-attendance-xp-absorption.test.js
@@ -1,0 +1,63 @@
+/**
+ * Contract tests — CYCLE epic #708, story 6: Attendance & XP Absorption
+ * Static-grep assertions over cycle-views.js, downtime_submission.schema.js,
+ * and the Story 4 Playwright spec (row index fix).
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+
+const CYCLE_VIEWS = fs.readFileSync('../public/js/admin/cycle-views.js', 'utf8');
+const SCHEMA      = fs.readFileSync('../server/schemas/downtime_submission.schema.js', 'utf8');
+const SPEC        = fs.readFileSync('../tests/cycle-prep-access.spec.js', 'utf8');
+
+describe('epic.708.6 — cycle-views.js: buildAttendanceSection', () => {
+  it('defines buildAttendanceSection function', () => {
+    expect(CYCLE_VIEWS).toContain('buildAttendanceSection');
+  });
+
+  it('reads and writes session_id on the cycle', () => {
+    expect(CYCLE_VIEWS).toContain('session_id');
+  });
+
+  it('renders an Attendance button per cycle row', () => {
+    expect(CYCLE_VIEWS).toContain('Attendance');
+  });
+
+  it('fetches game_sessions in initCycleView', () => {
+    expect(CYCLE_VIEWS).toContain('game_sessions');
+  });
+
+  it('uses character_display for name lookup', () => {
+    expect(CYCLE_VIEWS).toContain('character_display');
+  });
+
+  it('renders a totals row', () => {
+    expect(CYCLE_VIEWS).toContain('Total (');
+  });
+
+  it('shows fallback message when no attendance recorded', () => {
+    expect(CYCLE_VIEWS).toContain('No attendance recorded for this session.');
+  });
+
+  it('appends attendTr alongside detailTr in forEach', () => {
+    expect(CYCLE_VIEWS).toContain('attendTr');
+  });
+});
+
+describe('epic.708.6 — downtime_submission.schema.js: session_id field', () => {
+  it('declares session_id in the cycle schema', () => {
+    expect(SCHEMA).toContain('session_id');
+  });
+});
+
+describe('epic.708.6 — cycle-prep-access.spec.js: updated row index', () => {
+  it('uses nth(4) for cyc-002 prep access detail (row index updated for attendance rows)', () => {
+    expect(SPEC).toContain('nth(4)');
+  });
+
+  it('does not use the old nth(3) locator for the cyc-002 detail row', () => {
+    // nth(3) should not appear as a locator in the test body anymore
+    expect(SPEC).not.toMatch(/\.nth\(3\)/);
+  });
+});

--- a/specs/stories/epic.708.5-publish-pipeline.story.md
+++ b/specs/stories/epic.708.5-publish-pipeline.story.md
@@ -1,0 +1,221 @@
+---
+issue: 708
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/708
+branch: ms/issue-708-cycle-tab-game-phase
+epic: CYCLE — Game Cycle Management Tab
+story: 5 of 6
+status: review
+---
+
+# Epic CYCLE — Story 5: Publish Pipeline
+
+## Story
+
+**As an** ST,
+**I want** to publish all DT reports for a cycle from the Cycle tab,
+**so that** I can finalise a downtime cycle in one click without navigating the per-character DT processing view.
+
+---
+
+## Epic Context
+
+Story 5 of 6 in the CYCLE epic (#708). Stories 1–4 are complete and on `dev`.
+
+This story adds a "Publish Reports" button to each cycle row in the Cycle tab. Clicking it promotes all submissions for that cycle that have compiled outcome text (`st_review.outcome_text` non-empty) to published state — setting `published_outcome`, `st_review.outcome_visibility = 'published'`, and `st_review.published_at`. A new server endpoint handles the bulk operation.
+
+Story 6 will add attendance/XP absorption.
+
+---
+
+## Background: Existing Publish Mechanism
+
+The ST writes per-character narratives in the DT processing view (`downtime-story.js`). Each submission has:
+
+- `st_narrative` — sections written by the ST (`story_moment`, `home_report`, `project_responses`, etc.)
+- `st_review.outcome_text` — compiled markdown built from `st_narrative` via `compilePushOutcome()` (run when ST clicks "Push" per character)
+- `st_review.outcome_visibility` — `'draft'|'ready'|'published'`
+- `published_outcome` — top-level string; once set, makes the report visible in Story tab, DT tab, Archive tab, and Feeding tab
+
+The existing per-character publish path:
+1. ST writes narrative in DT story tab
+2. ST clicks "Push" — `compilePushOutcome()` builds markdown, patches `st_review.outcome_text` + `outcome_visibility='published'` + copies to `published_outcome` via `PUT /api/downtime_submissions/:id`
+
+Story 5 adds a cycle-level "Publish Reports" button that promotes ALL ready submissions in a cycle at once. It does **not** re-compile from `st_narrative` — it works on submissions where `st_review.outcome_text` is already set (the ST has already done the per-character compilation in the DT tab).
+
+---
+
+## Acceptance Criteria
+
+- [x] AC-1: Each cycle row in the Game Cycles panel has a "Publish Reports" button.
+- [x] AC-2: Clicking "Publish Reports" calls `POST /api/downtime_cycles/:id/publish` and shows an inline confirmation with the count of reports published (e.g., "4 reports published") or a message if none were ready ("No compiled reports found for this cycle").
+- [x] AC-3: `POST /api/downtime_cycles/:id/publish` (ST-only) finds all submissions for the cycle where `st_review.outcome_text` is non-empty. For each, it sets: `published_outcome = st_review.outcome_text`, `st_review.outcome_visibility = 'published'`, `st_review.published_at = <now ISO>`. Returns `{ published: N, skipped: N }`.
+- [x] AC-4: Submissions already published (`st_review.outcome_visibility === 'published'` AND `published_outcome` set) are counted as `skipped` and not re-written.
+- [x] AC-5: API errors are caught and shown inline; no unhandled rejections.
+- [x] AC-6: Contract tests pass (≥8 assertions in `server/tests/epic.708.5-publish-pipeline.test.js`).
+
+---
+
+## Dev Notes
+
+### Files to change
+
+**Modified:**
+- `server/routes/downtime.js` — add `POST /:id/publish` to `cyclesRouter`
+- `public/js/admin/cycle-views.js` — add "Publish Reports" button + inline result span to each cycle row
+
+**New:**
+- `server/tests/epic.708.5-publish-pipeline.test.js` — static-grep contract tests
+
+### server/routes/downtime.js — POST /:id/publish
+
+Add after the existing `cyclesRouter.put('/:id', ...)` block. The `cyclesRouter` is already declared in `downtime.js` and mounted with `requireAuth` in `index.js`.
+
+```js
+// POST /api/downtime_cycles/:id/publish — ST only; bulk-promote compiled DT reports
+cyclesRouter.post('/:id/publish', requireRole('st'), async (req, res) => {
+  const cycleId = req.params.id;
+  const subs = getCollection('downtime_submissions');
+
+  // Find all submissions for this cycle (cycle_id may be string or ObjectId)
+  const all = await subs.find({ cycle_id: cycleId }).toArray();
+
+  let published = 0;
+  let skipped = 0;
+  const now = new Date().toISOString();
+
+  for (const sub of all) {
+    const text = sub.st_review?.outcome_text;
+    if (!text) { skipped++; continue; }
+    if (sub.st_review?.outcome_visibility === 'published' && sub.published_outcome) {
+      skipped++;
+      continue;
+    }
+    await subs.updateOne(
+      { _id: sub._id },
+      { $set: {
+          published_outcome: text,
+          'st_review.outcome_visibility': 'published',
+          'st_review.published_at': now,
+      }}
+    );
+    published++;
+  }
+
+  res.json({ published, skipped });
+});
+```
+
+**Note on cycle_id matching**: submissions store `cycle_id` as a plain string (the `_id` string of the cycle). Verify by checking a live submission if uncertain — but the string match is the standard pattern used throughout `downtime.js`.
+
+### cycle-views.js — Publish Reports button
+
+Add a 5th column "Publish" to the cycle table. Update the `<thead>`:
+
+```html
+<thead><tr>
+  <th>Label</th>
+  <th style="width:270px">Phase</th>
+  <th style="width:200px">Chapter</th>
+  <th style="width:110px">Prep Access</th>
+  <th style="width:130px">Publish</th>
+</tr></thead>
+```
+
+In the `sorted.forEach` loop, after the Prep Access `tdAccess` cell, add:
+
+```js
+const tdPublish = document.createElement('td');
+const publishBtn = document.createElement('button');
+publishBtn.className = 'btn-sm';
+publishBtn.textContent = 'Publish Reports';
+const publishResult = document.createElement('span');
+publishResult.style.cssText = 'display:block;font-size:11px;margin-top:3px;color:var(--txt2)';
+tdPublish.appendChild(publishBtn);
+tdPublish.appendChild(publishResult);
+tr.appendChild(tdPublish);
+
+publishBtn.addEventListener('click', async () => {
+  publishBtn.disabled = true;
+  publishResult.style.color = 'var(--txt2)';
+  publishResult.textContent = 'Publishing…';
+  try {
+    const result = await apiPost('/api/downtime_cycles/' + cy._id + '/publish', {});
+    if (result.published === 0) {
+      publishResult.textContent = 'No compiled reports found.';
+    } else {
+      publishResult.style.color = 'var(--gold2)';
+      publishResult.textContent = result.published + ' report' + (result.published === 1 ? '' : 's') + ' published.';
+    }
+  } catch (err) {
+    publishResult.style.color = 'var(--crim)';
+    publishResult.textContent = 'Publish failed: ' + err.message;
+  } finally {
+    publishBtn.disabled = false;
+  }
+});
+```
+
+`apiPost` is already imported in `cycle-views.js`.
+
+### No schema changes
+
+`published_outcome`, `st_review.outcome_text`, `st_review.outcome_visibility`, and `st_review.published_at` are all existing fields in `downtime_submission.schema.js`. No schema migration needed.
+
+### cycle_id string matching
+
+Submissions use `cycle_id` as the string form of the cycle's `_id`. The `POST /:id/publish` endpoint queries `{ cycle_id: req.params.id }` — this matches how submissions are created. If the cycle `_id` is a MongoDB ObjectId, `req.params.id` is the string representation; submissions store it as that same string.
+
+### Test file pattern
+
+Same static-grep pattern as stories 1–4.
+
+```js
+import fs from 'fs';
+const DOWNTIME  = fs.readFileSync('../server/routes/downtime.js', 'utf8');
+const CYCLE_VIEWS = fs.readFileSync('../public/js/admin/cycle-views.js', 'utf8');
+```
+
+Required assertions (≥8):
+- `DOWNTIME` contains `cyclesRouter.post` (the new endpoint)
+- `DOWNTIME` contains `'/publish'` or `'/:id/publish'`
+- `DOWNTIME` contains `requireRole`
+- `DOWNTIME` contains `published_outcome`
+- `DOWNTIME` contains `outcome_visibility`
+- `DOWNTIME` contains `published_at`
+- `CYCLE_VIEWS` contains `Publish Reports`
+- `CYCLE_VIEWS` contains `/publish`
+- `CYCLE_VIEWS` contains `published`  (result display)
+
+---
+
+## Tasks
+
+- [x] **Task 1** — Add `POST /:id/publish` to `cyclesRouter` in `server/routes/downtime.js` (ST-only, bulk promote compiled reports)
+- [x] **Task 2** — Add "Publish Reports" button + result span to each cycle row in `public/js/admin/cycle-views.js`; update `<thead>` to add 5th column
+- [x] **Task 3** — Create `server/tests/epic.708.5-publish-pipeline.test.js` with ≥8 static-grep assertions; run and confirm all pass
+
+---
+
+## File List
+
+**New:**
+- `server/tests/epic.708.5-publish-pipeline.test.js`
+
+**Modified:**
+- `server/routes/downtime.js`
+- `public/js/admin/cycle-views.js`
+
+---
+
+## Dev Agent Record
+
+### Debug Log
+_Empty_
+
+### Completion Notes
+- Added `POST /:id/publish` to `cyclesRouter` in `downtime.js`; queries submissions by `cycle_id` ObjectId; skips already-published and empty-text subs; returns `{ published, skipped }`
+- Added "Publish Reports" button + inline result span to each cycle row in `cycle-views.js`; `<thead>` updated to 5 columns; `detailTd.colSpan` updated to 5; button disabled during request, re-enabled in `finally`
+- 13 static-grep contract tests pass; Story 4 (10 tests) unaffected
+
+### Change Log
+- 2026-06-11: Story implemented — publish pipeline endpoint + Cycle tab button; 13 passing contract tests

--- a/specs/stories/epic.708.6-attendance-xp-absorption.story.md
+++ b/specs/stories/epic.708.6-attendance-xp-absorption.story.md
@@ -1,0 +1,385 @@
+---
+issue: 708
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/708
+branch: ms/issue-708-cycle-tab-game-phase
+epic: CYCLE — Game Cycle Management Tab
+story: 6 of 6
+status: review
+---
+
+# Epic CYCLE — Story 6: Attendance & XP Absorption
+
+## Story
+
+**As an** ST,
+**I want** to link a game session to each cycle and view the attendance XP summary in the Cycle tab,
+**so that** I can see who attended and how much XP they earned without switching to the Attendance tab.
+
+---
+
+## Epic Context
+
+Story 6 of 6 — the final CYCLE epic story. Stories 1–5 are complete on `dev`.
+
+This story adds an "Attendance" expandable section to each cycle row in the Cycle tab. The ST links a game session to the cycle via a dropdown, then sees a read-only XP summary table (Character | Attend | Costuming | DT | Extra | Total XP). Attendance editing stays in the Attendance tab — this is a focused view only.
+
+---
+
+## Background: Current Attendance System
+
+- **`game_sessions`** collection — each document has an `attendance` array of per-character records with `attended`, `costuming`, `downtime`, `extra` booleans/number.
+- **`downtime_cycles`** — entirely separate from `game_sessions`; no link between them currently.
+- **`GET /api/game_sessions`** — returns all sessions including full attendance arrays; no auth required.
+- **XP formula** (per character per session): `(attended?1:0) + (costuming?1:0) + (downtime?1:0) + (extra||0)`
+- Editing attendance stays in `public/js/admin/attendance.js` (the Attendance tab). Story 6 is **read-only** in the Cycle tab.
+
+---
+
+## Acceptance Criteria
+
+- [x] AC-1: Each cycle row in the Game Cycles panel has an "Attendance" toggle button. Clicking it expands an inline section below that row.
+- [x] AC-2: The expanded section shows a session dropdown populated with all `game_sessions` (label: `Game N — Title` if `game_number` and title set; fallback to `session_date`). The dropdown pre-selects the session linked to the cycle (`cy.session_id`), or shows a blank placeholder if unlinked.
+- [x] AC-3: Selecting a session from the dropdown calls `PUT /api/downtime_cycles/:id` with `{ session_id: <string> }` and updates `cy.session_id` in memory without re-rendering the panel. Selecting the blank option clears the link (`session_id: null`).
+- [x] AC-4: When a session is linked, a read-only XP summary table is shown immediately below the dropdown. Columns: Character | Attend | Costuming | DT | Extra | XP. One row per entry in `session.attendance`, sorted by character name. XP total = `(attended?1:0) + (costuming?1:0) + (downtime?1:0) + (extra||0)`.
+- [x] AC-5: The table shows a totals row (bold) at the bottom: sum of each column, and sum of XP.
+- [x] AC-6: If the linked session has no attendance records, the section shows "No attendance recorded for this session."
+- [x] AC-7: API errors on the PUT are caught and shown inline (same pattern as Prep Access).
+- [x] AC-8: `session_id` field is added to the `downtimeCycleSchema` in `server/schemas/downtime_submission.schema.js`.
+- [x] AC-9: The Story 4 Playwright test `cycle-prep-access.spec.js` is updated: the `nth(3)` locator for cyc-002's prep access detail row is changed to `nth(4)` (because Story 6 inserts one attendance detail row between the two main rows and their prep-access detail rows, shifting the index).
+- [x] AC-10: Contract tests pass (≥8 assertions in `server/tests/epic.708.6-attendance-xp-absorption.test.js`).
+
+---
+
+## Dev Notes
+
+### Files to change
+
+**Modified:**
+- `server/schemas/downtime_submission.schema.js` — add `session_id` to cycle schema
+- `public/js/admin/cycle-views.js` — add `buildAttendanceSection`, update `initCycleView` + `buildCyclesPanel` signature, update `detailTd.colSpan` to 6, add Attendance column to thead
+- `tests/cycle-prep-access.spec.js` — fix `nth(3)` → `nth(4)` in one test
+
+**New:**
+- `server/tests/epic.708.6-attendance-xp-absorption.test.js` — static-grep contract tests
+
+### downtime_submission.schema.js — add session_id
+
+In the `properties` block of `downtimeCycleSchema` (after `chapter_id`):
+
+```js
+session_id: { type: ['string', 'null'] },  // ref to game_sessions _id as string
+```
+
+### cycle-views.js — initCycleView
+
+Add `game_sessions` to the parallel fetch:
+
+```js
+[chapters, cycles, sessions] = await Promise.all([
+  apiGet('/api/chapters'),
+  apiGet('/api/downtime_cycles'),
+  apiGet('/api/game_sessions'),
+]);
+```
+
+Update `buildCyclesPanel` call:
+
+```js
+el.appendChild(buildCyclesPanel(cycles, chapters, charList, sessions));
+```
+
+### cycle-views.js — buildCyclesPanel signature
+
+```js
+function buildCyclesPanel(cycles, chapters, charList = [], sessions = []) {
+```
+
+### cycle-views.js — thead (6th column)
+
+```html
+<thead><tr>
+  <th>Label</th>
+  <th style="width:270px">Phase</th>
+  <th style="width:200px">Chapter</th>
+  <th style="width:110px">Prep Access</th>
+  <th style="width:130px">Publish</th>
+  <th style="width:110px">Attendance</th>
+</tr></thead>
+```
+
+### cycle-views.js — detailTd.colSpan
+
+Update the existing Prep Access `detailTd.colSpan` from 5 to **6**.
+
+### cycle-views.js — buildAttendanceSection(cy, sessions)
+
+Add as a module-level function alongside `buildAccessSection` and `buildPhaseCell`:
+
+```js
+function buildAttendanceSection(cy, sessions) {
+  const wrap = document.createElement('div');
+  wrap.style.cssText = 'padding:8px 0 4px';
+
+  // Session dropdown
+  const selectWrap = document.createElement('div');
+  selectWrap.style.cssText = 'display:flex;align-items:center;gap:8px;margin-bottom:10px';
+
+  const label = document.createElement('label');
+  label.style.cssText = 'font-size:13px;color:var(--txt2)';
+  label.textContent = 'Linked Session:';
+
+  const sel = document.createElement('select');
+  sel.style.cssText = 'background:var(--surf);border:1px solid var(--bdr);color:var(--txt);border-radius:4px;padding:3px 6px;font-size:13px';
+
+  const blank = document.createElement('option');
+  blank.value = '';
+  blank.textContent = '— not linked —';
+  sel.appendChild(blank);
+
+  const sorted = [...sessions].sort((a, b) => {
+    const na = a.game_number ?? 999;
+    const nb = b.game_number ?? 999;
+    return na - nb;
+  });
+
+  sorted.forEach(s => {
+    const opt = document.createElement('option');
+    opt.value = String(s._id);
+    let lbl = s.game_number ? 'Game ' + s.game_number : '';
+    if (s.title) lbl += (lbl ? ' — ' : '') + s.title;
+    if (!lbl) lbl = s.session_date || String(s._id);
+    opt.textContent = lbl;
+    sel.appendChild(opt);
+  });
+
+  sel.value = cy.session_id || '';
+
+  const errEl = document.createElement('span');
+  errEl.style.cssText = 'color:var(--crim);font-size:11px;display:none';
+
+  selectWrap.appendChild(label);
+  selectWrap.appendChild(sel);
+  selectWrap.appendChild(errEl);
+  wrap.appendChild(selectWrap);
+
+  // XP table container
+  const tableWrap = document.createElement('div');
+  wrap.appendChild(tableWrap);
+
+  function renderTable() {
+    tableWrap.innerHTML = '';
+    const session = sessions.find(s => String(s._id) === sel.value);
+    if (!session) return;
+    const att = session.attendance || [];
+    if (!att.length) {
+      const msg = document.createElement('p');
+      msg.style.cssText = 'font-size:13px;color:var(--txt2);margin:4px 0';
+      msg.textContent = 'No attendance recorded for this session.';
+      tableWrap.appendChild(msg);
+      return;
+    }
+
+    const rows = [...att].sort((a, b) => {
+      const na = (a.character_display || a.character_name || '').toLowerCase();
+      const nb = (b.character_display || b.character_name || '').toLowerCase();
+      return na < nb ? -1 : na > nb ? 1 : 0;
+    });
+
+    const table = document.createElement('table');
+    table.className = 'infl-table';
+    table.style.cssText = 'width:100%;font-size:13px';
+    table.innerHTML = `<thead><tr>
+      <th>Character</th>
+      <th style="width:70px;text-align:center">Attend</th>
+      <th style="width:80px;text-align:center">Costuming</th>
+      <th style="width:50px;text-align:center">DT</th>
+      <th style="width:50px;text-align:center">Extra</th>
+      <th style="width:60px;text-align:center">XP</th>
+    </tr></thead>`;
+
+    const tbody = document.createElement('tbody');
+    let totAtt = 0, totCos = 0, totDT = 0, totExtra = 0, totXP = 0;
+
+    rows.forEach(a => {
+      const xp = (a.attended ? 1 : 0) + (a.costuming ? 1 : 0) + (a.downtime ? 1 : 0) + (a.extra || 0);
+      totAtt   += a.attended  ? 1 : 0;
+      totCos   += a.costuming ? 1 : 0;
+      totDT    += a.downtime  ? 1 : 0;
+      totExtra += (a.extra || 0);
+      totXP    += xp;
+
+      const name = a.character_display || a.character_name || a.character_id || '?';
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${name}</td>
+        <td style="text-align:center">${a.attended  ? '●' : '○'}</td>
+        <td style="text-align:center">${a.costuming ? '●' : '○'}</td>
+        <td style="text-align:center">${a.downtime  ? '●' : '○'}</td>
+        <td style="text-align:center">${a.extra || 0}</td>
+        <td style="text-align:center;font-weight:600">${xp}</td>`;
+      tbody.appendChild(tr);
+    });
+
+    // Totals row
+    const totTr = document.createElement('tr');
+    totTr.style.cssText = 'font-weight:700;border-top:1px solid var(--bdr)';
+    totTr.innerHTML = `
+      <td style="color:var(--txt2)">Total (${rows.length})</td>
+      <td style="text-align:center">${totAtt}</td>
+      <td style="text-align:center">${totCos}</td>
+      <td style="text-align:center">${totDT}</td>
+      <td style="text-align:center">${totExtra}</td>
+      <td style="text-align:center">${totXP}</td>`;
+    tbody.appendChild(totTr);
+
+    table.appendChild(tbody);
+    tableWrap.appendChild(table);
+  }
+
+  renderTable();
+
+  sel.addEventListener('change', async () => {
+    errEl.style.display = 'none';
+    const newId = sel.value || null;
+    try {
+      await apiPut('/api/downtime_cycles/' + cy._id, { session_id: newId });
+      cy.session_id = newId;
+      renderTable();
+    } catch (err) {
+      sel.value = cy.session_id || '';
+      errEl.textContent = 'Link failed: ' + err.message;
+      errEl.style.display = 'inline';
+    }
+  });
+
+  return wrap;
+}
+```
+
+### cycle-views.js — Attendance toggle in buildCyclesPanel
+
+In the `sorted.forEach` loop, after the Publish button block and before `tbody.appendChild(tr)`, add:
+
+```js
+// Attendance toggle
+const tdAtt = document.createElement('td');
+const attBtn = document.createElement('button');
+attBtn.className = 'btn-sm';
+attBtn.textContent = 'Attendance';
+tdAtt.appendChild(attBtn);
+tr.appendChild(tdAtt);
+
+const attendTr = document.createElement('tr');
+attendTr.style.display = 'none';
+const attendTd = document.createElement('td');
+attendTd.colSpan = 6;
+attendTd.style.cssText = 'padding:4px 12px 12px;background:var(--surf2)';
+attendTd.appendChild(buildAttendanceSection(cy, sessions));
+attendTr.appendChild(attendTd);
+
+attBtn.addEventListener('click', () => {
+  const open = attendTr.style.display !== 'none';
+  attendTr.style.display = open ? 'none' : '';
+  attBtn.style.borderColor = open ? '' : 'var(--gold2)';
+  attBtn.style.color     = open ? '' : 'var(--gold2)';
+});
+```
+
+The `tbody.appendChild(tr)` and `tbody.appendChild(detailTr)` that end the loop become:
+
+```js
+tbody.appendChild(tr);
+tbody.appendChild(detailTr);   // Prep Access detail
+tbody.appendChild(attendTr);   // Attendance detail
+```
+
+### Row index change — Story 4 Playwright test fix
+
+With attendance rows appended **after** prep-access detail rows, the per-cycle row order in tbody becomes:
+
+```
+index 0: main row (cyc-001)
+index 1: detailTr (cyc-001 prep access)
+index 2: attendTr (cyc-001 attendance)
+index 3: main row (cyc-002)
+index 4: detailTr (cyc-002 prep access)  ← was nth(3), now nth(4)
+index 5: attendTr (cyc-002 attendance)
+```
+
+In `tests/cycle-prep-access.spec.js`, the test "unchecking then re-checking adds the character back" (line 255) has:
+
+```js
+const cyc002Detail = page.locator('#cycle-content table').last().locator('tbody tr').nth(3);
+```
+
+Update to:
+
+```js
+const cyc002Detail = page.locator('#cycle-content table').last().locator('tbody tr').nth(4);
+```
+
+### No new API routes
+
+The `PUT /api/downtime_cycles/:id` endpoint already accepts any field via `$set: updates` and `additionalProperties: true` in the schema. `GET /api/game_sessions` is already available. No new server routes required.
+
+### Test file pattern
+
+Same static-grep pattern as stories 1–5.
+
+```js
+import fs from 'fs';
+const CYCLE_VIEWS = fs.readFileSync('../public/js/admin/cycle-views.js', 'utf8');
+const SCHEMA      = fs.readFileSync('../server/schemas/downtime_submission.schema.js', 'utf8');
+const SPEC        = fs.readFileSync('../tests/cycle-prep-access.spec.js', 'utf8');
+```
+
+Required assertions (≥8):
+- `CYCLE_VIEWS` contains `buildAttendanceSection`
+- `CYCLE_VIEWS` contains `session_id`
+- `CYCLE_VIEWS` contains `Attendance`
+- `CYCLE_VIEWS` contains `game_sessions` (the apiGet call)
+- `CYCLE_VIEWS` contains `character_display`
+- `CYCLE_VIEWS` contains `totals` or `Total` (totals row)
+- `SCHEMA` contains `session_id`
+- `SPEC` contains `nth(4)` (updated locator)
+- `SPEC` does NOT contain `nth(3)` (old broken locator gone)
+
+---
+
+## Tasks
+
+- [x] **Task 1** — Add `session_id: { type: ['string', 'null'] }` to the cycle properties block in `server/schemas/downtime_submission.schema.js`
+- [x] **Task 2** — Update `initCycleView` in `cycle-views.js` to fetch `game_sessions`; update `buildCyclesPanel` signature to accept `sessions`; update `<thead>` to 6 columns; update `detailTd.colSpan` to 6
+- [x] **Task 3** — Add `buildAttendanceSection(cy, sessions)` to `cycle-views.js`; add Attendance toggle + `attendTr` to the `sorted.forEach` loop; append `attendTr` after `detailTr`
+- [x] **Task 4** — Fix `tests/cycle-prep-access.spec.js`: change `nth(3)` → `nth(4)` for the cyc-002 prep access detail locator
+- [x] **Task 5** — Create `server/tests/epic.708.6-attendance-xp-absorption.test.js` with ≥8 static-grep assertions; run and confirm all pass. Also confirm the existing Story 4 contract tests still pass.
+
+---
+
+## File List
+
+**New:**
+- `server/tests/epic.708.6-attendance-xp-absorption.test.js`
+
+**Modified:**
+- `server/schemas/downtime_submission.schema.js`
+- `public/js/admin/cycle-views.js`
+- `tests/cycle-prep-access.spec.js`
+
+---
+
+## Dev Agent Record
+
+### Debug Log
+_Empty_
+
+### Completion Notes
+- Added `session_id` to `downtimeCycleSchema` in `downtime_submission.schema.js`
+- `initCycleView` now fetches `GET /api/game_sessions` in parallel; passes `sessions` to `buildCyclesPanel`
+- `buildAttendanceSection(cy, sessions)` added: session dropdown pre-linked from `cy.session_id`; on change PUTs new session_id; renders read-only XP table (sorted by name, totals row) or "No attendance recorded" fallback
+- Attendance toggle + `attendTr` appended after `detailTr` per cycle row; thead updated to 6 columns; `detailTd.colSpan` updated to 6
+- Story 4 Playwright spec: `nth(3)` updated to `nth(4)` for cyc-002 prep access detail row
+- 11 contract tests pass (Story 6); Stories 4 (10) and 5 (13) unaffected — 34 total
+
+### Change Log
+- 2026-06-11: Story implemented — attendance session-link + read-only XP summary in Cycle tab; 11 passing contract tests

--- a/tests/cycle-prep-access.spec.js
+++ b/tests/cycle-prep-access.spec.js
@@ -251,8 +251,9 @@ test.describe('Cycle tab — Prep Access: toggle behaviour', () => {
     const btn = page.locator('#cycle-content button', { hasText: 'Prep Access' }).nth(1);
     await btn.click();
 
-    // Scope to the cyc-002 detail row (4th <tr> in tbody: main1, detail1, main2, detail2)
-    const cyc002Detail = page.locator('#cycle-content table').last().locator('tbody tr').nth(3);
+    // Scope to the cyc-002 prep-access detail row.
+    // tbody order: main1(0), prep1(1), attend1(2), main2(3), prep2(4), attend2(5)
+    const cyc002Detail = page.locator('#cycle-content table').last().locator('tbody tr').nth(4);
     const bobLabel = cyc002Detail.locator('label', { hasText: 'Bob Crane' });
     const cb = bobLabel.locator('input[type="checkbox"]');
     await expect(cb).toBeVisible({ timeout: 3000 });


### PR DESCRIPTION
## Summary

- Adds `POST /api/downtime_cycles/:id/publish` — bulk-promotes all compiled DT reports for a cycle to published state in one ST action, so STs can finalise a downtime cycle without visiting each character's processing view
- Adds "Publish Reports" button to each Cycle tab row with inline result feedback (N reports published / no compiled reports found / error)
- Adds "Attendance" toggle to each Cycle tab row — links a game session to a cycle via a dropdown and renders a read-only XP summary table (Attend/Costuming/DT/Extra/Total per character + totals row)
- Adds `session_id` to the downtime cycle schema; fixes Story 4 Playwright row-index locator shifted by the new attendance detail rows

## Closes

- Closes #708

## Story

- specs/stories/epic.708.5-publish-pipeline.story.md
- specs/stories/epic.708.6-attendance-xp-absorption.story.md

## Test plan

- [ ] `npx vitest run server/tests/epic.708.5-publish-pipeline.test.js server/tests/epic.708.6-attendance-xp-absorption.test.js` — 24 contract tests pass
- [ ] `npx vitest run server/tests/epic.708.4-dt-prep-access-controls.test.js` — Story 4 contract tests still pass (10 tests)
- [ ] CI green
- [ ] Manual: admin > Cycle tab — "Publish Reports" button per cycle calls the publish endpoint and shows inline feedback
- [ ] Manual: admin > Cycle tab — "Attendance" toggle expands session dropdown and XP table; linking a session PUTs session_id to the cycle

## Branch flow

- From: `ms/issue-708-cycle-tab-game-phase`
- Into: `dev`