### PR TITLE
fix(#713): allies sphere actions absent from DT processing queue

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -3188,12 +3188,25 @@ function buildProcessingQueue(subs) {
     let spheres  = raw.sphere_actions || [];
     if (!spheres.length) {
       // App-form submissions store sphere actions as flat response keys (sphere_N_merit etc.)
-      // Guard: require both merit label AND a non-empty action so existing submissions
-      // with phantom labels (player never toggled gate) are retroactively suppressed.
+      // Guard: require a non-empty action. Merit label may be absent for submissions
+      // made with the tabbed sphere UI (issue #713 — gate removed); derive from
+      // character data in that case so existing DT4 submissions surface correctly.
       for (let n = 1; n <= 5; n++) {
-        const meritType = resp[`sphere_${n}_merit`];
+        let meritType = resp[`sphere_${n}_merit`];
         const actionVal = resp[`sphere_${n}_action`];
-        if (!meritType || !actionVal) continue;
+        if (!actionVal) continue;
+        if (!meritType) {
+          const sphereChar = _subChar || charMap.get((sub.character_name || '').toLowerCase().trim());
+          const alliesMerits = (sphereChar?.merits || [])
+            .filter(m => m.category === 'influence' && m.name === 'Allies');
+          const am = alliesMerits[n - 1];
+          if (am) {
+            const dots = (am.rating || am.dots || 0) + (am.bonus || 0);
+            const area = am.area || am.qualifier || '';
+            meritType = area ? `Allies ${'●'.repeat(dots)} (${area})` : `Allies ${'●'.repeat(dots)}`;
+          }
+        }
+        if (!meritType) continue;
         spheres = [...spheres, {
           merit_type:      meritType,
           action_type:     resp[`sphere_${n}_action`]      || 'misc',

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -842,10 +842,12 @@ function collectResponses() {
       const el = document.getElementById(`dt-sphere_${n}_target_value`);
       if (el) responses[`sphere_${n}_target_value`] = el.value;
     }
-    // Merit label — only written when player opted in (gate = 'yes').
-    // Absent label means admin queue builder skips this slot entirely.
+    // Merit label — written whenever the player has picked an action.
+    // Issue #713: old form had a merit-toggle gate ('yes'/'no') that set
+    // gateValues; the tabbed sphere UI removed that toggle, so the gate is
+    // never 'yes'. Match the Status pattern (line ~885): write when action set.
     const m = detectedMerits.spheres[n - 1];
-    if (m && gateValues[`merit_${meritKey(m)}`] === 'yes') {
+    if (m && responses[`sphere_${n}_action`]) {
       responses[`sphere_${n}_merit`] = meritLabel(m);
     }
     // Cast hidden inputs (legacy — kept for backwards compat)

--- a/specs/stories/fix.713.dt-allies-actions-missing.story.md
+++ b/specs/stories/fix.713.dt-allies-actions-missing.story.md
@@ -1,0 +1,241 @@
+---
+title: 'DT Processing: allies sphere actions absent from queue and filter'
+type: 'fix'
+issue: 713
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/713
+branch: ms/issue-713-dt-allies-actions-missing
+created: '2026-06-12'
+status: review
+recommended_model: 'sonnet — two-file targeted fix, moderate scope'
+context:
+  - public/js/tabs/downtime-form.js
+  - public/js/admin/downtime-views.js
+---
+
+## Intent
+
+**Problem:** In DT4 processing, no Allies merit action cards appear in the ST processing
+queue. The Allies Source filter returns zero results and the unfiltered queue shows nothing
+for sphere actions.
+
+**Root cause confirmed via live data (2026-06-12):**
+
+Querying DT4 submissions in `tm_suite.downtime_submissions` shows every affected submission
+has `sphere_N_action` set but `sphere_N_merit` is entirely absent.
+
+**Two bugs compounding each other:**
+
+---
+
+### Bug A — Form never writes `sphere_N_merit` (primary cause)
+
+`collectResponses()` in `downtime-form.js:848` gates the `sphere_N_merit` write on:
+
+```js
+if (m && gateValues[`merit_${meritKey(m)}`] === 'yes') {
+  responses[`sphere_${n}_merit`] = meritLabel(m);
+}
+```
+
+This gate was originally set by a `data-merit-toggle` radio button (rendered by
+`renderMeritToggle()`) that asked "use this Downtime? Yes/No" per merit. The **tabbed
+sphere UI** (`renderMeritToggles` > Allies section, around line 6202) replaced that
+individual toggle with a tabbed pane interface — the "Yes/No" radio is gone. With no
+toggle rendered, `gateValues[merit_${key}]` is never 'yes', so `sphere_N_merit` is never
+written.
+
+Status actions (lines 882–887) already use the correct pattern:
+```js
+if (sm && responses[`status_${n}_action`]) {
+  responses[`status_${n}_merit`] = meritLabel(sm);
+}
+```
+
+Allies must match this: write the merit label whenever the player has picked an action,
+not when a removed gate toggle says 'yes'.
+
+---
+
+### Bug B — Processing guard skips entries with missing merit label
+
+`buildProcessingQueue()` in `downtime-views.js:3192–3196`:
+
+```js
+// Guard: require both merit label AND a non-empty action so existing submissions
+// with phantom labels (player never toggled gate) are retroactively suppressed.
+for (let n = 1; n <= 5; n++) {
+  const meritType = resp[`sphere_${n}_merit`];
+  const actionVal = resp[`sphere_${n}_action`];
+  if (!meritType || !actionVal) continue;
+```
+
+The guard comment says "phantom labels" — its original intent was to suppress old
+submissions where the player opened the gate without picking an action. For DT4, the
+opposite is true: `actionVal` is set but `meritType` is absent. All sphere entries
+are suppressed.
+
+**Fix B**: extend the fallback so that when `actionVal` is set but `meritType` is absent,
+we derive the label from the character's N-th Allies merit in `charMap`. This handles all
+existing DT4 submissions without a data backfill script.
+
+---
+
+## Root cause files
+
+| File | Lines | Role |
+|------|-------|------|
+| `public/js/tabs/downtime-form.js` | 845–850 | `collectResponses()` sphere merit write — gated on removed toggle |
+| `public/js/admin/downtime-views.js` | 3189–3196 | `buildProcessingQueue()` fallback guard — skips missing merit label |
+
+---
+
+## Tasks
+
+### T1 — Fix form: write `sphere_N_merit` when action is set ✅
+
+**File:** `public/js/tabs/downtime-form.js`, lines 845–850
+
+**Before:**
+```js
+// Merit label — only written when player opted in (gate = 'yes').
+// Absent label means admin queue builder skips this slot entirely.
+const m = detectedMerits.spheres[n - 1];
+if (m && gateValues[`merit_${meritKey(m)}`] === 'yes') {
+  responses[`sphere_${n}_merit`] = meritLabel(m);
+}
+```
+
+**After:**
+```js
+// Merit label — written whenever the player has picked an action.
+// Issue #713: old form had a merit-toggle gate ('yes'/'no') that set gateValues;
+// the tabbed sphere UI removed that toggle, so gate is never 'yes'. Match the
+// Status pattern (line ~885): write when action is set.
+const m = detectedMerits.spheres[n - 1];
+if (m && responses[`sphere_${n}_action`]) {
+  responses[`sphere_${n}_merit`] = meritLabel(m);
+}
+```
+
+---
+
+### T2 — Fix processing: derive merit label from character when missing ✅
+
+**File:** `public/js/admin/downtime-views.js`, lines 3187–3225
+
+The fallback loop currently requires `sphere_N_merit`. Extend it to derive the label from
+character data when it is absent but `sphere_N_action` is present.
+
+**Before (lines 3189–3196):**
+```js
+if (!spheres.length) {
+  // Guard: require both merit label AND a non-empty action so existing submissions
+  // with phantom labels (player never toggled gate) are retroactively suppressed.
+  for (let n = 1; n <= 5; n++) {
+    const meritType = resp[`sphere_${n}_merit`];
+    const actionVal = resp[`sphere_${n}_action`];
+    if (!meritType || !actionVal) continue;
+```
+
+**After:**
+```js
+if (!spheres.length) {
+  // Guard: require a non-empty action. Merit label may be absent for submissions
+  // made with the tabbed sphere UI (issue #713); derive from character data in that case.
+  for (let n = 1; n <= 5; n++) {
+    let meritType = resp[`sphere_${n}_merit`];
+    const actionVal = resp[`sphere_${n}_action`];
+    if (!actionVal) continue;
+    if (!meritType) {
+      // Derive: find character's N-th Allies merit (same order as form's detectedMerits.spheres)
+      const sphereChar = _subChar || charMap.get((sub.character_name || '').toLowerCase().trim());
+      const alliesMerits = (sphereChar?.merits || [])
+        .filter(m => m.category === 'influence' && m.name === 'Allies');
+      const am = alliesMerits[n - 1];
+      if (am) {
+        const dots = (am.rating || am.dots || 0) + (am.bonus || 0);
+        const area = am.area || am.qualifier || '';
+        meritType = area ? `Allies ${'●'.repeat(dots)} (${area})` : `Allies ${'●'.repeat(dots)}`;
+      }
+    }
+    if (!meritType) continue;
+```
+
+The remainder of the existing object literal (`merit_type: meritType`, etc.) is unchanged.
+Only the label derivation and guard are modified.
+
+---
+
+### T3 — Verify with live DT4 data
+
+After both fixes are deployed to dev:
+
+1. Open the ST DT processing panel for DT4
+2. Allies action cards should appear in the unfiltered queue for all characters who
+   submitted a sphere action (Henry St. John, Wan Yelong, Ludica Lachramore confirmed
+   as affected in T1 investigation)
+3. Click the Allies Source filter — should return only Allies action cards
+4. Cards should display correct merit label, dots, qualifier, territory, and action type
+5. No regression: Status, Contacts, Retainer actions still visible
+
+---
+
+## What not to change
+
+- The Status append loop in `buildProcessingQueue` (lines 3246–3263) — correct as-is
+- `_parseMeritType()` — regex detection is correct
+- `_entrySourceType()` and filter wiring — correct
+- Server-side schemas — `sphere_N_merit` schema field already exists
+  (`downtime_submission.schema.js:144`)
+- No data backfill script needed — T2's processing fix handles all existing DT4
+  submissions at render time without touching MongoDB
+
+---
+
+## Tests
+
+No automated test suite. Verify manually via T3 above.
+
+The key invariant to check:
+> For a DT4 submission where `sphere_N_action` is set, `buildProcessingQueue` must
+> produce a queue entry with `meritCategory === 'allies'` and `isAlliesAction === true`,
+> regardless of whether `sphere_N_merit` is present in the submission document.
+
+---
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-sonnet-4-6
+
+### Completion Notes
+
+**T1 — Form fix (`downtime-form.js:845–852`):**
+Changed gate condition from `gateValues[merit_${meritKey(m)}] === 'yes'` to
+`responses[sphere_N_action]`. The old gate was set by a `data-merit-toggle` radio button
+rendered by `renderMeritToggle()`; the tabbed sphere UI removed that toggle, so the gate
+was never 'yes', so `sphere_N_merit` was never written. New condition mirrors the Status
+pattern at line ~885.
+
+**T2 — Processing fix (`downtime-views.js:3189–3209`):**
+Changed `const meritType` → `let meritType`; changed guard from `!meritType || !actionVal`
+to `!actionVal`; added derivation block that, when `meritType` is absent, walks the
+character's Allies merits (filtered from `charMap`/`_subChar`) by slot index and
+constructs the label as `"Allies ●●● (Area)"`. Falls back to `continue` only if the
+character has no N-th Allies merit. Handles all existing DT4 submissions without a data
+backfill.
+
+Both files parse clean.
+
+### File List
+
+- `public/js/tabs/downtime-form.js` — `collectResponses()`: sphere merit gate replaced
+- `public/js/admin/downtime-views.js` — `buildProcessingQueue()`: fallback guard extended with merit label derivation
+
+### Change Log
+
+| Date | Version | Description | Author |
+|------|---------|-------------|--------|
+| 2026-06-12 | 1.0 | Initial draft | Claude (SM) |
+| 2026-06-12 | 1.1 | fix(#713) — sphere merit label now written on action set; processing derives label from character data for existing submissions | claude-sonnet-4-6 |

--- a/tests/fix-713-dt-processing-allies-actions-missing.spec.js
+++ b/tests/fix-713-dt-processing-allies-actions-missing.spec.js
@@ -1,0 +1,236 @@
+/**
+ * Regression tests for fix #713 — allies merit actions absent from DT processing queue.
+ *
+ * Root cause (two-part):
+ *   A. collectResponses() in downtime-form.js gated sphere_N_merit on a merit-toggle
+ *      'yes'/'no' radio that was removed when the tabbed sphere UI shipped. The gate
+ *      was never 'yes', so sphere_N_merit was never written. All DT4 Allies submissions
+ *      have sphere_N_action set but sphere_N_merit absent.
+ *   B. buildProcessingQueue() in downtime-views.js required sphere_N_merit to be
+ *      non-empty; if absent, the entry was skipped entirely.
+ *
+ * Fix A: collectResponses() writes sphere_N_merit when action is set (mirrors Status).
+ * Fix B: buildProcessingQueue() derives merit label from character's N-th Allies merit
+ *        when sphere_N_merit is missing, so existing DT4 submissions surface correctly.
+ *
+ * AC-1: DT4 submission (sphere_N_action set, sphere_N_merit absent) → action row appears in queue
+ * AC-2: Source filter "Allies" returns non-zero results for the above
+ * AC-3: Action row text contains the derived merit qualifier ("Criminal")
+ * AC-4: DT3 regression — submission with explicit sphere_N_merit in responses still works
+ * AC-5: DT3 regression — Source filter "Allies" still works when merit label is present
+ * AC-6: No regression — contacts/retainers unaffected; their entries still render
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Shared fixtures ────────────────────────────────────────────────────────────
+
+const ST_USER = {
+  id: '123000713', username: 'test_st_713', global_name: 'Test ST 713',
+  avatar: null, role: 'st', player_id: 'p-713', character_ids: [], is_dual_role: false,
+};
+
+const ACTIVE_CYCLE = {
+  _id: 'cycle-713', cycle_number: 4, status: 'active',
+  phase_signoff: {}, confirmed_ambience: {},
+};
+
+// Character with Allies ●●● (Criminal) and Contacts ● (Media) — covers both merits.
+const CHAR = {
+  _id: 'char-713',
+  name: 'Allies Test Char', moniker: null, honorific: null,
+  clan: 'Daeva', covenant: 'Invictus', player: 'Test Player',
+  blood_potency: 2, humanity: 6, humanity_base: 7, court_title: null,
+  home_territory: null, retired: false,
+  status: { city: 1, clan: 1, covenant: { Invictus: 1 } },
+  attributes: {
+    Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+    Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+    Presence: { dots: 3, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: {}, disciplines: {},
+  merits: [
+    { name: 'Allies',   category: 'influence', rating: 3, area: 'Criminal' },
+    { name: 'Contacts', category: 'influence', rating: 1, area: 'Media'    },
+  ],
+  powers: [], ordeals: [],
+};
+
+function baseSub(id) {
+  return {
+    _id: id,
+    cycle_id: 'cycle-713',
+    character_id: 'char-713',
+    character_name: 'Allies Test Char',
+    player_name: 'Test Player',
+    status: 'submitted',
+    submitted_at: '2026-06-12T00:00:00Z',
+    _raw: { sphere_actions: [], contact_actions: { requests: [] }, retainer_actions: { actions: [] } },
+    responses: {},
+    projects_resolved: [],
+    merit_actions_resolved: [],
+    acquisitions_resolved: [],
+    feeding_review: { pool_status: 'no_feed' },
+    st_review: { territory_overrides: {} },
+    st_narrative: { story_moment: { status: 'complete' } },
+  };
+}
+
+// ── AC-1/2/3: DT4 pattern — action set, merit label absent (the bug scenario) ──
+const SUB_DT4_NO_MERIT_LABEL = {
+  ...baseSub('sub-713-dt4-no-label'),
+  responses: {
+    // sphere_1_merit is intentionally absent — this is the DT4 bug shape
+    sphere_1_action:  'investigate',
+    sphere_1_outcome: 'Investigate rivals in the docks',
+  },
+};
+
+// ── AC-4/5: DT3 regression — merit label present in responses (old shape) ──
+const SUB_DT3_WITH_MERIT_LABEL = {
+  ...baseSub('sub-713-dt3-with-label'),
+  responses: {
+    sphere_1_merit:   'Allies ●●● (Criminal)',
+    sphere_1_action:  'investigate',
+    sphere_1_outcome: 'Investigate rivals in the docks',
+  },
+};
+
+// ── AC-6: Combined — Allies + Contacts, DT4 pattern ──
+const SUB_DT4_ALLIES_AND_CONTACTS = {
+  ...baseSub('sub-713-dt4-combo'),
+  responses: {
+    // Allies: no merit label (DT4 bug shape)
+    sphere_1_action:   'hide_protect',
+    sphere_1_outcome:  'Shield criminal network',
+    // Contacts: present as expected
+    contact_1_request: 'Who is watching the harbour?',
+    contact_1_merit:   'Contacts ● (Media)',
+  },
+};
+
+// ── Setup ──────────────────────────────────────────────────────────────────────
+
+async function setup(page, submissions) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'local-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url    = route.request().url();
+    const method = route.request().method();
+    const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+
+    if (['PUT', 'PATCH', 'POST'].includes(method)) return ok({ ok: true });
+
+    if (url.includes('/api/downtime_submissions')) return ok(submissions);
+    if (url.includes('/api/downtime_cycles'))      return ok([ACTIVE_CYCLE]);
+    if (url.includes('/api/characters/names'))     return ok([{ _id: CHAR._id, name: CHAR.name, moniker: CHAR.moniker, honorific: CHAR.honorific }]);
+    if (url.includes('/api/characters'))           return ok([CHAR]);
+    if (url.includes('/api/territories'))          return ok([]);
+    if (url.includes('/api/game_sessions'))        return ok([]);
+    if (url.includes('/api/session_logs'))         return ok([]);
+    if (url.includes('/api/st_mods'))              return ok([]);
+    return ok([]);
+  });
+
+  await page.goto('/admin.html');
+  await page.waitForSelector('#admin-app', { state: 'visible', timeout: 10000 });
+  await page.click('[data-domain="downtime"]');
+  await page.waitForTimeout(1000);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+test.describe('fix.713: allies sphere actions absent from queue and filter', () => {
+
+  // AC-1 ────────────────────────────────────────────────────────────────────────
+
+  test('AC-1: DT4 submission (no sphere_N_merit) — Allies action row appears in queue', async ({ page }) => {
+    await setup(page, [SUB_DT4_NO_MERIT_LABEL]);
+    await page.waitForSelector('.proc-action-row', { timeout: 8000 });
+
+    const rows = page.locator('.proc-action-row');
+    await expect(rows).not.toHaveCount(0);
+
+    // At least one row should relate to Allies
+    const rowTexts = await rows.allTextContents();
+    const hasAllies = rowTexts.some(t => /allies/i.test(t));
+    expect(hasAllies).toBe(true);
+  });
+
+  // AC-2 ────────────────────────────────────────────────────────────────────────
+
+  test('AC-2: Source filter "Allies" returns non-zero results for DT4 submission', async ({ page }) => {
+    await setup(page, [SUB_DT4_NO_MERIT_LABEL]);
+    await page.waitForSelector('.proc-action-row', { timeout: 8000 });
+
+    // Click the Allies source filter pill
+    const alliesPill = page.locator('.proc-filter-pill[data-filter-dim="sources"][data-filter-val="allies"]');
+    await expect(alliesPill).toBeVisible({ timeout: 5000 });
+    await alliesPill.click();
+    await page.waitForTimeout(300);
+
+    // Queue must not be empty after filtering
+    const rows = page.locator('.proc-action-row');
+    const count = await rows.count();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  // AC-3 ────────────────────────────────────────────────────────────────────────
+
+  test('AC-3: Action row text contains the derived merit qualifier ("Criminal")', async ({ page }) => {
+    await setup(page, [SUB_DT4_NO_MERIT_LABEL]);
+    await page.waitForSelector('.proc-action-row', { timeout: 8000 });
+
+    // The processing label is built as "Allies ●●● (Criminal): Investigate"
+    const alliesRow = page.locator('.proc-action-row', { hasText: 'Criminal' });
+    await expect(alliesRow).toBeVisible({ timeout: 5000 });
+  });
+
+  // AC-4 ────────────────────────────────────────────────────────────────────────
+
+  test('AC-4: DT3 regression — explicit sphere_N_merit in responses still surfaces correctly', async ({ page }) => {
+    await setup(page, [SUB_DT3_WITH_MERIT_LABEL]);
+    await page.waitForSelector('.proc-action-row', { timeout: 8000 });
+
+    const rows = page.locator('.proc-action-row');
+    const rowTexts = await rows.allTextContents();
+    const hasAllies = rowTexts.some(t => /allies/i.test(t));
+    expect(hasAllies).toBe(true);
+  });
+
+  // AC-5 ────────────────────────────────────────────────────────────────────────
+
+  test('AC-5: DT3 regression — Source filter "Allies" still works when merit label present', async ({ page }) => {
+    await setup(page, [SUB_DT3_WITH_MERIT_LABEL]);
+    await page.waitForSelector('.proc-action-row', { timeout: 8000 });
+
+    const alliesPill = page.locator('.proc-filter-pill[data-filter-dim="sources"][data-filter-val="allies"]');
+    await expect(alliesPill).toBeVisible({ timeout: 5000 });
+    await alliesPill.click();
+    await page.waitForTimeout(300);
+
+    const count = await page.locator('.proc-action-row').count();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  // AC-6 ────────────────────────────────────────────────────────────────────────
+
+  test('AC-6: Contacts entry still renders when Allies is present (no regression)', async ({ page }) => {
+    await setup(page, [SUB_DT4_ALLIES_AND_CONTACTS]);
+    await page.waitForSelector('.proc-action-row', { timeout: 8000 });
+
+    // Filter to Contacts source
+    const contactsPill = page.locator('.proc-filter-pill[data-filter-dim="sources"][data-filter-val="contacts"]');
+    await expect(contactsPill).toBeVisible({ timeout: 5000 });
+    await contactsPill.click();
+    await page.waitForTimeout(300);
+
+    const count = await page.locator('.proc-action-row').count();
+    expect(count).toBeGreaterThan(0);
+  });
+
+});


### PR DESCRIPTION
## Summary

- `collectResponses()` in `downtime-form.js` gated `sphere_N_merit` on a `data-merit-toggle` radio (Yes/No per merit) that was removed when the tabbed sphere UI shipped — so the label was never written. All DT4 Allies submissions have `sphere_N_action` set but `sphere_N_merit` absent.
- `buildProcessingQueue()` in `downtime-views.js` required `sphere_N_merit` to be non-empty; missing label caused every DT4 Allies entry to be silently skipped.
- Fix A mirrors the Status pattern: write the merit label whenever the player has set an action, not when a removed gate toggle says 'yes'.
- Fix B derives the label from the character's N-th Allies merit via `charMap` when absent — no MongoDB backfill needed; all existing DT4 submissions surface correctly at render time.

## Closes

- Closes #713

## Story

- specs/stories/fix.713.dt-allies-actions-missing.story.md

## Test plan

- [ ] Open ST DT processing panel for DT4 — Allies action cards appear in queue
- [ ] Allies Source filter returns non-zero results
- [ ] Action row label shows correct dots + qualifier (e.g. "Allies ●●● (Criminal)")
- [ ] No regression: Status, Contacts, Retainer entries still visible
- [ ] CI green (6/6 Playwright tests pass locally: `tests/fix-713-dt-processing-allies-actions-missing.spec.js`)

## Branch flow

- From: `ms/issue-713-dt-allies-actions-missing`
- Into: `dev`