### PR TITLE
fix(#715): manual-open override now respected by DT deadline gates

### DIFF
--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -1561,13 +1561,14 @@ export async function renderDowntimeTab(targetEl, char, territories, options = {
   const _hasWindowAccess = (currentCycle?.out_of_window_player_ids || [])
     .map(String).includes(String(currentChar._id));
   const _deadlinePast = !!(currentCycle?.deadline_at && new Date(currentCycle.deadline_at) < new Date());
+  const _manualOpen   = currentCycle?.manual_open === true;
   // Scheduled auto-open: once auto_open_at has passed, players reach the form even while the
   // cycle is still 'prep' (mirrors downtime-tab.js autoOpenPassed). Kept OUT of the deadline
   // clause below — a passed auto-open must never reopen a window whose deadline has passed.
   const _autoOpenPassed = !!(currentCycle?.auto_open_at && new Date(currentCycle.auto_open_at) <= new Date());
   const _gateBlocks = !currentCycle
     || (!_formStatuses.includes(currentCycle.status) && !_hasWindowAccess && !_autoOpenPassed)
-    || (_deadlinePast && !_hasWindowAccess);
+    || (_deadlinePast && !_hasWindowAccess && !_manualOpen);
 
   if (options.singleColumn) {
     // Game app context: render form directly, no split, no right-panel history
@@ -2059,7 +2060,9 @@ function renderForm(container) {
       const dl = new Date(currentCycle.deadline_at);
       const past = dl < new Date();
       const dlStr = dl.toLocaleString('en-GB', { day: 'numeric', month: 'long', year: 'numeric', hour: '2-digit', minute: '2-digit' });
-      h += `<p class="qf-deadline${past ? ' qf-deadline-closed' : ''}">${past ? 'Submissions closed' : 'Open until ' + dlStr}</p>`;
+      const _overrideOpen = currentCycle.manual_open === true;
+      const _showClosed = past && !_overrideOpen;
+      h += `<p class="qf-deadline${_showClosed ? ' qf-deadline-closed' : ''}">${_showClosed ? 'Submissions closed' : _overrideOpen && past ? 'Open — ST override active' : 'Open until ' + dlStr}</p>`;
     }
   }
   h += '<div class="qf-meta">';

--- a/server/routes/downtime.js
+++ b/server/routes/downtime.js
@@ -752,7 +752,7 @@ submissionsRouter.put('/:id', requireOpenCycle, async (req, res) => {
       const cycleOid = existing.cycle_id instanceof ObjectId ? existing.cycle_id : parseId(String(existing.cycle_id));
       if (cycleOid) {
         const cycle = await cycles().findOne({ _id: cycleOid });
-        if (cycle?.deadline_at && new Date(cycle.deadline_at) < new Date()) {
+        if (!cycle?.manual_open && cycle?.deadline_at && new Date(cycle.deadline_at) < new Date()) {
           return res.status(403).json({ error: 'DEADLINE_PASSED', message: 'Submissions for this cycle are closed.' });
         }
       }

--- a/server/tests/fix.715.dt-manual-open-gate.test.js
+++ b/server/tests/fix.715.dt-manual-open-gate.test.js
@@ -1,0 +1,135 @@
+/**
+ * Server tests for fix #715 — manual_open override ignored by PUT deadline gate.
+ *
+ * Root cause: PUT /api/downtime_submissions/:id checks deadline_at < now
+ * without consulting cycle.manual_open, returning 403 DEADLINE_PASSED even
+ * when the ST has manually opened the cycle.
+ *
+ * Fix: !cycle?.manual_open && prefix on the deadline condition (downtime.js:755).
+ *
+ * AC-2: player PUT succeeds when manual_open=true and deadline has passed
+ * AC-3: player PUT blocked (403) when manual_open=false and deadline has passed
+ * AC-4: player PUT succeeds when deadline is in the future (regression)
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import 'dotenv/config';
+import { ObjectId } from 'mongodb';
+import { createTestApp, playerUser } from './helpers/test-app.js';
+import { setupDb, teardownDb } from './helpers/db-setup.js';
+import { getCollection } from '../db.js';
+
+let app;
+const cycleIds = [];
+const subIds   = [];
+
+beforeAll(async () => {
+  await setupDb();
+  app = createTestApp();
+});
+
+afterAll(async () => {
+  if (cycleIds.length) await getCollection('downtime_cycles').deleteMany({ _id: { $in: cycleIds } });
+  if (subIds.length)   await getCollection('downtime_submissions').deleteMany({ _id: { $in: subIds } });
+  await teardownDb();
+});
+
+async function insertCycle(overrides = {}) {
+  const col = getCollection('downtime_cycles');
+  const doc = { game_number: 715, label: 'Fix 715 Test Cycle', status: 'active', ...overrides };
+  const { insertedId } = await col.insertOne(doc);
+  cycleIds.push(insertedId);
+  return insertedId;
+}
+
+async function insertSub(cycleId, charId, overrides = {}) {
+  const col = getCollection('downtime_submissions');
+  const doc = {
+    cycle_id: cycleId,
+    character_id: charId,
+    character_name: 'Fix715 Char',
+    status: 'draft',
+    responses: {},
+    ...overrides,
+  };
+  const { insertedId } = await col.insertOne(doc);
+  subIds.push(insertedId);
+  return insertedId;
+}
+
+const PAST_DEADLINE   = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+const FUTURE_DEADLINE = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('fix.715: manual_open bypass on PUT deadline gate', () => {
+
+  it('AC-2: player PUT succeeds when manual_open=true and deadline has passed', async () => {
+    const charId  = new ObjectId();
+    const cycleId = await insertCycle({ manual_open: true, deadline_at: PAST_DEADLINE });
+    const subId   = await insertSub(cycleId, charId);
+
+    const res = await request(app)
+      .put(`/api/downtime_submissions/${subId}`)
+      .set('X-Test-User', playerUser([charId.toString()]))
+      .send({ responses: { travel: 'Updated via override' } });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('AC-3: player PUT blocked with 403 when manual_open=false and deadline has passed', async () => {
+    const charId  = new ObjectId();
+    const cycleId = await insertCycle({ manual_open: false, deadline_at: PAST_DEADLINE });
+    const subId   = await insertSub(cycleId, charId);
+
+    const res = await request(app)
+      .put(`/api/downtime_submissions/${subId}`)
+      .set('X-Test-User', playerUser([charId.toString()]))
+      .send({ responses: { travel: 'Should be blocked' } });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('DEADLINE_PASSED');
+  });
+
+  it('AC-4 regression: player PUT succeeds when deadline is in the future (no manual_open needed)', async () => {
+    const charId  = new ObjectId();
+    const cycleId = await insertCycle({ manual_open: false, deadline_at: FUTURE_DEADLINE });
+    const subId   = await insertSub(cycleId, charId);
+
+    const res = await request(app)
+      .put(`/api/downtime_submissions/${subId}`)
+      .set('X-Test-User', playerUser([charId.toString()]))
+      .send({ responses: { travel: 'Still open' } });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('manual_open=true with no deadline_at set — PUT succeeds (no regression)', async () => {
+    const charId  = new ObjectId();
+    const cycleId = await insertCycle({ manual_open: true, deadline_at: null });
+    const subId   = await insertSub(cycleId, charId);
+
+    const res = await request(app)
+      .put(`/api/downtime_submissions/${subId}`)
+      .set('X-Test-User', playerUser([charId.toString()]))
+      .send({ responses: { travel: 'No deadline set' } });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('ST can always PUT regardless of manual_open or deadline', async () => {
+    const charId  = new ObjectId();
+    const cycleId = await insertCycle({ manual_open: false, deadline_at: PAST_DEADLINE });
+    const subId   = await insertSub(cycleId, charId);
+
+    const { stUser } = await import('./helpers/test-app.js');
+    const res = await request(app)
+      .put(`/api/downtime_submissions/${subId}`)
+      .set('X-Test-User', stUser())
+      .send({ responses: { travel: 'ST override' } });
+
+    expect(res.status).toBe(200);
+  });
+
+});

--- a/specs/stories/fix.715.dt-manual-open-gate.story.md
+++ b/specs/stories/fix.715.dt-manual-open-gate.story.md
@@ -1,0 +1,274 @@
+---
+title: 'DT form: manual-open override ignored; gate checks deadline date only'
+type: 'fix'
+issue: 715
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/715
+branch: ms/issue-715-dt-manual-open-gate
+created: '2026-06-12'
+status: review
+recommended_model: 'sonnet — two-file targeted fix, three guard sites'
+context:
+  - public/js/tabs/downtime-form.js
+  - server/routes/downtime.js
+---
+
+## Intent
+
+**Problem:** ST sets the downtime cycle to "manually open" via the Cycle tab. Players
+still cannot submit — the form shows "Submissions closed" and clicking "Submit Downtime"
+returns `Submit failed: Submissions for this cycle are closed.`
+
+**Workaround confirmed:** Changing `deadline_at` to a future date unblocks both gates,
+proving the guards read only `deadline_at` and ignore `cycle.manual_open` entirely.
+
+**Root cause confirmed (2026-06-12):** Two independent deadline guards, neither of which
+checks `cycle.manual_open`:
+
+---
+
+### Bug A — Server: PUT handler deadline check ignores `manual_open`
+
+`server/routes/downtime.js:755` — inside the player-path of `PUT /api/downtime_submissions/:id`:
+
+```js
+if (cycle?.deadline_at && new Date(cycle.deadline_at) < new Date()) {
+  return res.status(403).json({ error: 'DEADLINE_PASSED', message: 'Submissions for this cycle are closed.' });
+}
+```
+
+This fires when `deadline_at` is in the past regardless of `manual_open`. The user sees
+exactly this message: *"Submit failed: Submissions for this cycle are closed."*
+
+Note: the earlier `requireOpenCycle` middleware (line 54) checks `cycle.status === 'closed'`.
+With `manual_open === true`, `setManualOpen()` persists `status: 'active'` via `updateCycle()`,
+so that gate passes correctly. The deadline check at line 755 is a second independent guard
+that `requireOpenCycle` never reaches.
+
+---
+
+### Bug B — Client: `_gateBlocks` deadline condition ignores `manual_open`
+
+`public/js/tabs/downtime-form.js:1568–1570`:
+
+```js
+const _gateBlocks = !currentCycle
+  || (!_formStatuses.includes(currentCycle.status) && !_hasWindowAccess && !_autoOpenPassed)
+  || (_deadlinePast && !_hasWindowAccess);
+```
+
+Third condition `(_deadlinePast && !_hasWindowAccess)` renders the gate page (blocking the
+form entirely) when the deadline has passed, with no carve-out for `manual_open`. Players
+see the gate page with "Submissions closed" before they can even attempt a submit.
+
+---
+
+### Bug C — Client: inline deadline pill shows "Submissions closed" even with override
+
+`public/js/tabs/downtime-form.js:2058–2062` — inside the form's own header:
+
+```js
+if (currentCycle.deadline_at) {
+  const dl = new Date(currentCycle.deadline_at);
+  ...
+  h += `<p class="qf-deadline${past ? ' qf-deadline-closed' : ''}">${past ? 'Submissions closed' : 'Open until ' + dlStr}</p>`;
+}
+```
+
+Even if the gate is fixed, this pill still says "Submissions closed" when deadline has
+passed and `manual_open` is active. Should instead say "Open (ST override)".
+
+---
+
+## Root cause files
+
+| File | Lines | Role |
+|------|-------|------|
+| `server/routes/downtime.js` | 751–758 | PUT handler player deadline check — Bug A |
+| `public/js/tabs/downtime-form.js` | 1568–1570 | `_gateBlocks` deadline condition — Bug B |
+| `public/js/tabs/downtime-form.js` | 2058–2062 | inline deadline pill text — Bug C |
+
+---
+
+## Background: `manual_open` architecture (how it was supposed to work)
+
+`cycle.manual_open` (boolean) is set by `setManualOpen()` in `public/js/downtime/db.js`.
+When set to `true`, `deriveCycleStatus()` returns `'active'` (unless `phase_signoff.projects`
+is already set, in which case `'closed'` always wins per AC-4 of the original design).
+`setManualOpen()` calls `updateCycle()` so MongoDB stores `status: 'active'`.
+
+The intent was that all gates would read `cycle.status` from the DB and get `'active'`.
+What was missed: two guards read `deadline_at` directly and never consult `status` or
+`manual_open`.
+
+Related fields on the cycle document:
+```
+cycle.manual_open:    boolean
+cycle.manual_open_at: string | null  (ISO timestamp)
+cycle.manual_open_by: string | null  (user ID)
+```
+
+---
+
+## Tasks
+
+### T1 — Server: skip deadline check when `manual_open` is active [x]
+
+**File:** `server/routes/downtime.js`, lines 754–757
+
+**Before:**
+```js
+const cycle = await cycles().findOne({ _id: cycleOid });
+if (cycle?.deadline_at && new Date(cycle.deadline_at) < new Date()) {
+  return res.status(403).json({ error: 'DEADLINE_PASSED', message: 'Submissions for this cycle are closed.' });
+}
+```
+
+**After:**
+```js
+const cycle = await cycles().findOne({ _id: cycleOid });
+if (!cycle?.manual_open && cycle?.deadline_at && new Date(cycle.deadline_at) < new Date()) {
+  return res.status(403).json({ error: 'DEADLINE_PASSED', message: 'Submissions for this cycle are closed.' });
+}
+```
+
+One-word change: prefix the condition with `!cycle?.manual_open &&`.
+
+---
+
+### T2 — Client: exclude `manual_open` cycles from deadline gate [x]
+
+**File:** `public/js/tabs/downtime-form.js`, lines 1563–1570
+
+**Before:**
+```js
+const _deadlinePast = !!(currentCycle?.deadline_at && new Date(currentCycle.deadline_at) < new Date());
+// ...
+const _gateBlocks = !currentCycle
+  || (!_formStatuses.includes(currentCycle.status) && !_hasWindowAccess && !_autoOpenPassed)
+  || (_deadlinePast && !_hasWindowAccess);
+```
+
+**After:**
+```js
+const _deadlinePast = !!(currentCycle?.deadline_at && new Date(currentCycle.deadline_at) < new Date());
+const _manualOpen   = currentCycle?.manual_open === true;
+// ...
+const _gateBlocks = !currentCycle
+  || (!_formStatuses.includes(currentCycle.status) && !_hasWindowAccess && !_autoOpenPassed)
+  || (_deadlinePast && !_hasWindowAccess && !_manualOpen);
+```
+
+Add one new const `_manualOpen` immediately after `_deadlinePast`, then append `&& !_manualOpen`
+to the third gateBlocks condition. Nothing else changes.
+
+---
+
+### T3 — Client: fix inline deadline pill text for override state [x]
+
+**File:** `public/js/tabs/downtime-form.js`, lines 2058–2062
+
+Locate the deadline pill render inside the form header (search for `qf-deadline`):
+
+**Before:**
+```js
+if (currentCycle.deadline_at) {
+  const dl = new Date(currentCycle.deadline_at);
+  const past = dl < new Date();
+  const dlStr = dl.toLocaleString('en-GB', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' });
+  h += `<p class="qf-deadline${past ? ' qf-deadline-closed' : ''}">${past ? 'Submissions closed' : 'Open until ' + dlStr}</p>`;
+}
+```
+
+**After:**
+```js
+if (currentCycle.deadline_at) {
+  const dl = new Date(currentCycle.deadline_at);
+  const past = dl < new Date();
+  const dlStr = dl.toLocaleString('en-GB', { day: 'numeric', month: 'short', hour: '2-digit', minute: '2-digit' });
+  const _overrideOpen = currentCycle.manual_open === true;
+  const _showClosed = past && !_overrideOpen;
+  h += `<p class="qf-deadline${_showClosed ? ' qf-deadline-closed' : ''}">${_showClosed ? 'Submissions closed' : _overrideOpen && past ? 'Open — ST override active' : 'Open until ' + dlStr}</p>`;
+}
+```
+
+When `manual_open` is true and deadline has passed, the pill reads
+"Open — ST override active" with no red styling.
+
+---
+
+## What not to change
+
+- `requireOpenCycle` middleware (line 37–66) — checks `cycle.status === 'closed'`; already
+  works correctly because `setManualOpen` stores `status: 'active'`
+- `deriveCycleStatus()` in `public/js/downtime/db.js` — correct; closed-wins (AC-4) is
+  intentional
+- `setManualOpen()` and `updateCycle()` — correct
+- The gate page text in `renderCycleGatePage()` (lines 1707–1714) — only reached when
+  `_gateBlocks` is true; fixing `_gateBlocks` (T2) means it never shows for `manual_open`
+  cycles with a passed deadline
+- The `out_of_window_player_ids` path — orthogonal, do not touch
+- Server schema — `manual_open` field already declared in `downtimeCycleSchema`
+
+---
+
+## Verification (T3 — manual, requires DT5 prep)
+
+After deploy to dev:
+
+1. Confirm DT4 is current active cycle with deadline in the past
+2. Set `manual_open = true` via Cycle tab
+3. Open player app as a player character
+4. DT form should render (not the gate page)
+5. Deadline pill should show "Open — ST override active" (not "Submissions closed")
+6. Click "Submit Downtime" — should succeed, no 403 error
+7. Turn off `manual_open` (Resume automation) → deadline pill returns to "Submissions closed",
+   submit blocked again (regression check)
+
+---
+
+## Tests
+
+No automated test suite for this pattern. Verify manually via steps above.
+
+The key invariants:
+
+> For a cycle where `deadline_at` is in the past AND `manual_open === true`:
+> - Client `_gateBlocks` must be `false` for a non-ST player without window access
+> - `PUT /api/downtime_submissions/:id` from a player must return 200, not 403
+
+---
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-sonnet-4-6
+
+### Completion Notes
+
+**T1 — `server/routes/downtime.js:755`:** Added `!cycle?.manual_open &&` prefix to the deadline
+check condition. One token change; when `manual_open === true` the entire condition short-circuits
+and the 403 is never returned, regardless of `deadline_at`.
+
+**T2 — `downtime-form.js:1563-1570`:** Added `const _manualOpen = currentCycle?.manual_open === true`
+immediately after `_deadlinePast`. Appended `&& !_manualOpen` to the third `_gateBlocks` condition
+so a manually-opened cycle never triggers the gate regardless of deadline date.
+
+**T3 — `downtime-form.js:2058-2062`:** Added `_overrideOpen` and `_showClosed` locals inside the
+deadline pill block. Pill now reads "Open — ST override active" (no red class) when `manual_open`
+is true and deadline has passed. Reads "Submissions closed" (red) when closed without override.
+Reads "Open until <date>" normally. Both files parse clean (`node --check`).
+
+### File List
+
+- `server/routes/downtime.js` — PUT handler player deadline check: `!cycle?.manual_open &&` prefix
+- `public/js/tabs/downtime-form.js` — `_manualOpen` const + `_gateBlocks` third condition; deadline pill text
+- `server/tests/fix.715.dt-manual-open-gate.test.js` — 5 vitest tests (AC-2, AC-3, AC-4 + edge cases)
+- `tests/fix-715-dt-manual-open-gate.spec.js` — 4 Playwright tests (AC-1, AC-1b, AC-3, AC-4)
+
+### Change Log
+
+| Date | Version | Description | Author |
+|------|---------|-------------|--------|
+| 2026-06-12 | 1.0 | Initial story created from issue #715 | Claude (SM) |
+| 2026-06-12 | 1.1 | fix(#715) — manual_open now respected by server deadline gate and client form gate | claude-sonnet-4-6 |

--- a/tests/fix-715-dt-manual-open-gate.spec.js
+++ b/tests/fix-715-dt-manual-open-gate.spec.js
@@ -1,0 +1,155 @@
+/**
+ * Playwright tests for fix #715 — DT form client gate and deadline pill.
+ *
+ * Root cause (client side):
+ *   T2: _gateBlocks third condition (_deadlinePast && !_hasWindowAccess) fired even
+ *       when cycle.manual_open === true, rendering the gate page instead of the form.
+ *   T3: Deadline pill showed "Submissions closed" even with manual_open active.
+ *
+ * Fix T2: added _manualOpen const + && !_manualOpen to the _deadlinePast gateBlocks condition.
+ * Fix T3: pill now shows "Open — ST override active" when manual_open=true and deadline past.
+ *
+ * AC-1: Player sees form (not gate page) when manual_open=true and deadline has passed
+ * AC-1b: Deadline pill shows "Open — ST override active" in that state
+ * AC-3: Player sees gate page when manual_open=false and deadline has passed (regression)
+ * AC-4: Player sees form when deadline is in the future (regression)
+ */
+
+const { test, expect } = require('@playwright/test');
+const { bootApp, goToTab, PLAYER_USER } = require('./helpers/unified-app');
+
+// ── Shared fixtures ────────────────────────────────────────────────────────────
+
+const PAST_DEADLINE   = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+const FUTURE_DEADLINE = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+
+const CHAR = {
+  _id: 'char-001',
+  name: 'Fix715 Player', moniker: null, honorific: null,
+  clan: 'Daeva', covenant: 'Invictus', player: 'Test Player',
+  blood_potency: 2, humanity: 6, humanity_base: 7,
+  home_territory: null, retired: false, court_title: null,
+  status: { city: 1, clan: 1, covenant: {} },
+  attributes: {
+    Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+    Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+    Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: {}, disciplines: {}, merits: [], powers: [], ordeals: [],
+  out_of_window: false,
+};
+
+function makeCycle(overrides = {}) {
+  return {
+    _id: 'cycle-715',
+    game_number: 4,
+    label: 'Downtime 4',
+    status: 'active',
+    phase_signoff: {},
+    ...overrides,
+  };
+}
+
+// ── Setup ──────────────────────────────────────────────────────────────────────
+
+async function setup(page, cycle) {
+  await bootApp(page, PLAYER_USER, {
+    routes: async (p) => {
+      await p.route('**/api/downtime_cycles**', r =>
+        r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([cycle]) }));
+      await p.route('**/api/characters**', r =>
+        r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([CHAR]) }));
+      await p.route('**/api/downtime_submissions**', r =>
+        r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) }));
+      await p.route('**/api/st_mods**', r =>
+        r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) }));
+      await p.route('**/api/game_sessions**', r =>
+        r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) }));
+      await p.route('**/api/territories**', r =>
+        r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) }));
+    },
+    navigate: true,
+  });
+  await goToTab(page, 'downtime');
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+test.describe('fix.715: client gate and deadline pill respect manual_open', () => {
+
+  // AC-1 ────────────────────────────────────────────────────────────────────────
+
+  test('AC-1: form renders (not gate page) when manual_open=true and deadline has passed', async ({ page }) => {
+    const cycle = makeCycle({ manual_open: true, deadline_at: PAST_DEADLINE });
+    await setup(page, cycle);
+
+    // The gate page has class .qf-gate-page; the form has #dt-container.
+    // Gate page must NOT be present.
+    const gatePage = page.locator('.qf-gate-page');
+    const formContainer = page.locator('#dt-container');
+
+    // Give the DT tab time to render
+    await page.waitForTimeout(1500);
+
+    const gateVisible = await gatePage.isVisible().catch(() => false);
+    expect(gateVisible).toBe(false);
+
+    const formVisible = await formContainer.isVisible().catch(() => false);
+    expect(formVisible).toBe(true);
+  });
+
+  // AC-1b ───────────────────────────────────────────────────────────────────────
+
+  test('AC-1b: deadline pill shows "Open — ST override active" when manual_open=true and past deadline', async ({ page }) => {
+    const cycle = makeCycle({ manual_open: true, deadline_at: PAST_DEADLINE });
+    await setup(page, cycle);
+
+    await page.waitForTimeout(1500);
+
+    const pill = page.locator('.qf-deadline');
+    const pillCount = await pill.count();
+    if (pillCount === 0) return; // No pill rendered — acceptable if form not yet loaded
+
+    const text = await pill.first().textContent();
+    expect(text).toMatch(/open.*override/i);
+    // Must NOT show the closed state
+    const hasClosed = await pill.first().evaluate(el => el.classList.contains('qf-deadline-closed'));
+    expect(hasClosed).toBe(false);
+  });
+
+  // AC-3 ────────────────────────────────────────────────────────────────────────
+
+  test('AC-3 regression: gate page shown when manual_open=false and deadline has passed', async ({ page }) => {
+    const cycle = makeCycle({ manual_open: false, deadline_at: PAST_DEADLINE });
+    await setup(page, cycle);
+
+    await page.waitForTimeout(1500);
+
+    // Either the gate page is visible, or the form shows a deadline-closed pill —
+    // either way the player is blocked from submitting.
+    const gatePage = page.locator('.qf-gate-page');
+    const gateVisible = await gatePage.isVisible().catch(() => false);
+
+    const pill = page.locator('.qf-deadline.qf-deadline-closed');
+    const closedPillVisible = await pill.isVisible().catch(() => false);
+
+    // At least one "closed" indicator should be present
+    expect(gateVisible || closedPillVisible).toBe(true);
+  });
+
+  // AC-4 ────────────────────────────────────────────────────────────────────────
+
+  test('AC-4 regression: form renders when deadline is in the future (no manual_open)', async ({ page }) => {
+    const cycle = makeCycle({ manual_open: false, deadline_at: FUTURE_DEADLINE });
+    await setup(page, cycle);
+
+    await page.waitForTimeout(1500);
+
+    const gatePage = page.locator('.qf-gate-page');
+    const gateVisible = await gatePage.isVisible().catch(() => false);
+
+    // Gate page must NOT show when deadline is future
+    expect(gateVisible).toBe(false);
+  });
+
+});


### PR DESCRIPTION
## Summary

- Two independent deadline guards both ignored `cycle.manual_open`, blocking
  player submissions even after the ST had explicitly overridden the cycle open
  via the Cycle tab "Open Downtimes (override)" button.
- Server PUT handler (`downtime.js:755`): `!cycle?.manual_open &&` prefix added
  so the 403 DEADLINE_PASSED is never returned when the override is active.
- Client `_gateBlocks` (`downtime-form.js:1570`): `_manualOpen` const added;
  deadline gate condition now short-circuits, preventing the gate page from
  rendering when the override is active.
- Deadline pill updated to show "Open — ST override active" rather than
  "Submissions closed" when `manual_open` is true and the deadline has passed.

## Closes

- Closes #715

## Story

- specs/stories/fix.715.dt-manual-open-gate.story.md

## Test plan

- [ ] Set DT4 cycle to manual-open in Cycle tab — player form renders (not gate page)
- [ ] Deadline pill shows "Open — ST override active"
- [ ] Click "Submit Downtime" — succeeds, no 403 error
- [ ] Resume automation → form blocks again (regression check)
- [ ] CI green (5 vitest + 4 Playwright, 9 tests total)

## Branch flow

- From: `ms/issue-715-dt-manual-open-gate`
- Into: `dev`