### PR TITLE
fix(#719): territory pill row missing The Second City

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -6728,12 +6728,9 @@ function _poolTotalDisplay(attr, attrDots, skill, skillDots, disc, discDots, mod
  */
 function _renderInlineTerrPills(subId, terrContext, currentTerrId, feedingSet = null, noLabel = false) {
   const TERR_PILLS = [
-    { id: 'academy',   label: 'Academy' },
-    { id: 'harbour',   label: 'Harbour' },
-    { id: 'dockyards', label: 'Dockyards' },
-    { id: 'northshore', label: 'N. Shore' },
-    { id: 'barrens',   label: 'Barrens' },
-    { id: '',          label: 'N/A' },
+    ...TERRITORY_DATA.map(t => ({ id: t.slug, label: t.shortLabel })),
+    { id: 'barrens', label: 'Barrens' },
+    { id: '',        label: 'N/A' },
   ];
   let h = `<span class="proc-terr-pill-row proc-terr-inline-pills" data-sub-id="${esc(subId)}" data-terr-context="${esc(terrContext)}">`;
   if (!noLabel) h += `<span class="proc-feed-lbl">Terr.</span>`;

--- a/public/js/tabs/downtime-data.js
+++ b/public/js/tabs/downtime-data.js
@@ -120,11 +120,11 @@ export const AMBIENCE_MODS = {
 // (renamed from `id` in ADR-002 / story #3c). TERRITORY_DATA is reference
 // data only — never used as a foreign key.
 export const TERRITORY_DATA = [
-  { slug: 'academy',    name: 'The Academy',    ambience: 'Curated',  ambienceMod: +3 },
-  { slug: 'dockyards',  name: 'The Dockyards',  ambience: 'Settled',  ambienceMod:  0 },
-  { slug: 'harbour',    name: 'The Harbour',    ambience: 'Untended', ambienceMod: -2 },
-  { slug: 'northshore', name: 'The North Shore', ambience: 'Tended',  ambienceMod: +2 },
-  { slug: 'secondcity', name: 'The Second City', ambience: 'Tended',  ambienceMod: +2 },
+  { slug: 'academy',    name: 'The Academy',    shortLabel: 'Academy',      ambience: 'Curated',  ambienceMod: +3 },
+  { slug: 'dockyards',  name: 'The Dockyards',  shortLabel: 'Dockyards',    ambience: 'Settled',  ambienceMod:  0 },
+  { slug: 'harbour',    name: 'The Harbour',    shortLabel: 'Harbour',      ambience: 'Untended', ambienceMod: -2 },
+  { slug: 'northshore', name: 'The North Shore', shortLabel: 'N. Shore',    ambience: 'Tended',   ambienceMod: +2 },
+  { slug: 'secondcity', name: 'The Second City', shortLabel: 'Second City', ambience: 'Tended',   ambienceMod: +2 },
 ];
 
 // Helper: generate select options for a numeric range (inclusive)

--- a/specs/stories/fix.719.dt-terr-pills-second-city.story.md
+++ b/specs/stories/fix.719.dt-terr-pills-second-city.story.md
@@ -1,0 +1,188 @@
+---
+title: 'Territory pill switcher missing The Second City (hardcoded list out of sync)'
+type: 'fix'
+issue: 719
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/719
+branch: ms/issue-719-dt-terr-pills-second-city
+created: '2026-06-14'
+status: done
+recommended_model: 'sonnet — two small edits across two files; low scope'
+context:
+  - public/js/admin/downtime-views.js
+  - public/js/tabs/downtime-data.js
+---
+
+## Intent
+
+**Problem:** The territory pill row in DT processing is built from a hardcoded array in
+`_renderInlineTerrPills` that is missing The Second City. Aleksei selected The Second City
+in the player DT form but the ST cannot assign that territory in the processing panel —
+only Academy, Harbour, Dockyards, N. Shore, Barrens, N/A appear.
+
+**Domain model (important):**
+- `TERRITORY_DATA` (5 entries) = the **formal** territories: Academy, Harbour, Dockyards, North Shore, Second City.
+- **The Barrens** = everywhere outside formal territories — not a territory itself, never in `TERRITORY_DATA`.
+- **N/A** = territory not applicable to this action — a UI-only sentinel (`id: ''`).
+
+The issue body suggested adding Barrens to `TERRITORY_DATA`. **Do NOT do this.** `TERRITORY_DATA` is iterated by Territory Pulse (line 2483 of `downtime-views.js`) — adding Barrens would generate a spurious "Territory Pulse: The Barrens" panel. Barrens belongs in the pill row as an explicit append, not as a territory record.
+
+**Fix:** Two changes:
+
+1. Add a `shortLabel` field to each entry in `TERRITORY_DATA` so the pill row can use a compact display name without re-deriving it.
+
+2. Replace the hardcoded `TERR_PILLS` array in `_renderInlineTerrPills` with a list derived from `TERRITORY_DATA`, then explicitly append Barrens + N/A.
+
+---
+
+## Root cause file
+
+| File | Lines | Role |
+|------|-------|------|
+| `public/js/tabs/downtime-data.js` | 122–128 | `TERRITORY_DATA` — missing `shortLabel` field |
+| `public/js/admin/downtime-views.js` | 6729–6737 | `_renderInlineTerrPills` — hardcoded `TERR_PILLS` array |
+
+---
+
+## Current code (verbatim)
+
+### `TERRITORY_DATA` (downtime-data.js lines 122–128)
+
+```js
+export const TERRITORY_DATA = [
+  { slug: 'academy',    name: 'The Academy',    ambience: 'Curated',  ambienceMod: +3 },
+  { slug: 'dockyards',  name: 'The Dockyards',  ambience: 'Settled',  ambienceMod:  0 },
+  { slug: 'harbour',    name: 'The Harbour',    ambience: 'Untended', ambienceMod: -2 },
+  { slug: 'northshore', name: 'The North Shore', ambience: 'Tended',  ambienceMod: +2 },
+  { slug: 'secondcity', name: 'The Second City', ambience: 'Tended',  ambienceMod: +2 },
+];
+```
+
+### `_renderInlineTerrPills` (downtime-views.js lines 6729–6737)
+
+```js
+function _renderInlineTerrPills(subId, terrContext, currentTerrId, feedingSet = null, noLabel = false) {
+  const TERR_PILLS = [
+    { id: 'academy',    label: 'Academy' },
+    { id: 'harbour',    label: 'Harbour' },
+    { id: 'dockyards',  label: 'Dockyards' },
+    { id: 'northshore', label: 'N. Shore' },
+    { id: 'barrens',    label: 'Barrens' },
+    { id: '',           label: 'N/A' },
+  ];
+  // ... loop renders pills
+}
+```
+
+---
+
+## Tasks
+
+### T1 — Add `shortLabel` to `TERRITORY_DATA` [x]
+
+**File:** `public/js/tabs/downtime-data.js`, lines 122–128.
+
+```js
+// BEFORE:
+export const TERRITORY_DATA = [
+  { slug: 'academy',    name: 'The Academy',    ambience: 'Curated',  ambienceMod: +3 },
+  { slug: 'dockyards',  name: 'The Dockyards',  ambience: 'Settled',  ambienceMod:  0 },
+  { slug: 'harbour',    name: 'The Harbour',    ambience: 'Untended', ambienceMod: -2 },
+  { slug: 'northshore', name: 'The North Shore', ambience: 'Tended',  ambienceMod: +2 },
+  { slug: 'secondcity', name: 'The Second City', ambience: 'Tended',  ambienceMod: +2 },
+];
+
+// AFTER:
+export const TERRITORY_DATA = [
+  { slug: 'academy',    name: 'The Academy',    shortLabel: 'Academy',      ambience: 'Curated',  ambienceMod: +3 },
+  { slug: 'dockyards',  name: 'The Dockyards',  shortLabel: 'Dockyards',    ambience: 'Settled',  ambienceMod:  0 },
+  { slug: 'harbour',    name: 'The Harbour',    shortLabel: 'Harbour',      ambience: 'Untended', ambienceMod: -2 },
+  { slug: 'northshore', name: 'The North Shore', shortLabel: 'N. Shore',    ambience: 'Tended',  ambienceMod: +2 },
+  { slug: 'secondcity', name: 'The Second City', shortLabel: 'Second City', ambience: 'Tended',  ambienceMod: +2 },
+];
+```
+
+**Note:** All existing consumers of `TERRITORY_DATA` use `.slug`, `.name`, `.ambience`, or `.ambienceMod` — adding `shortLabel` is purely additive and will not break anything.
+
+**Do NOT add a Barrens entry.** The Barrens is not a formal territory; adding it here would cause a spurious entry in Territory Pulse (line 2483 of `downtime-views.js`) and `ensureTerritories()` fallback (line 3763).
+
+---
+
+### T2 — Derive `TERR_PILLS` from `TERRITORY_DATA` in `_renderInlineTerrPills` [x]
+
+**File:** `public/js/admin/downtime-views.js`, lines 6730–6737 (inside `_renderInlineTerrPills`).
+
+```js
+// BEFORE:
+  const TERR_PILLS = [
+    { id: 'academy',    label: 'Academy' },
+    { id: 'harbour',    label: 'Harbour' },
+    { id: 'dockyards',  label: 'Dockyards' },
+    { id: 'northshore', label: 'N. Shore' },
+    { id: 'barrens',    label: 'Barrens' },
+    { id: '',           label: 'N/A' },
+  ];
+
+// AFTER:
+  const TERR_PILLS = [
+    ...TERRITORY_DATA.map(t => ({ id: t.slug, label: t.shortLabel })),
+    { id: 'barrens', label: 'Barrens' },
+    { id: '',        label: 'N/A' },
+  ];
+```
+
+`TERRITORY_DATA` is already imported at line 9 of `downtime-views.js` — no new import needed.
+
+**Pill order after change:** Academy, Dockyards, Harbour, N. Shore, Second City, Barrens, N/A.
+
+The order of the first five follows `TERRITORY_DATA` declaration order (academy, dockyards, harbour, northshore, secondcity). This is a minor visual reorder vs the old hardcoded list (which had Harbour before Dockyards). That reorder is acceptable — the issue doesn't mandate a specific order, and the critical fix is Second City appearing.
+
+---
+
+### T3 — QA: write and run Playwright spec [x]
+
+**File:** `tests/fix-719-dt-terr-pills-second-city.spec.js`
+
+Use the `setupDowntimeProcessing` pattern from `tests/downtime-processing-dt-fixes.spec.js` (lines 305–337). Open a feeding action to get to a card that renders `_renderInlineTerrPills`.
+
+Test cases required:
+
+| # | Assertion |
+|---|-----------|
+| 1 | `.proc-terr-pill[data-terr-id="secondcity"]` exists in the pill row |
+| 2 | `.proc-terr-pill[data-terr-id="secondcity"]` text is "Second City" |
+| 3 | `.proc-terr-pill[data-terr-id="barrens"]` still exists |
+| 4 | `.proc-terr-pill[data-terr-id="academy"]` still exists |
+| 5 | `.proc-terr-pill[data-terr-id=""]` (N/A) still exists and is the last pill |
+| 6 | Total pill count is 7 (5 territories + Barrens + N/A) |
+
+---
+
+## Acceptance criteria
+
+- [ ] The Second City pill appears in the territory pill row for all action types (feeding, project, merit) in DT processing
+- [ ] `_renderInlineTerrPills` derives its list from `TERRITORY_DATA` rather than a hardcoded array
+- [ ] `TERRITORY_DATA` gains a `shortLabel` field on every entry; no existing field is removed or renamed
+- [ ] The Barrens pill (`id: 'barrens'`) remains present and is the second-to-last pill
+- [ ] The N/A pill (`id: ''`) remains present and is the last pill
+- [ ] All five formal territory pills (Academy, Dockyards, Harbour, N. Shore, Second City) are present
+
+---
+
+## Guardrails
+
+- **Do NOT add Barrens to `TERRITORY_DATA`** — it is not a territory, it is "everywhere outside formal territories". Adding it pollutes Territory Pulse and `ensureTerritories`.
+- `TERRITORY_DATA` is imported at line 9 of `downtime-views.js` — no import change needed.
+- Only two files change: `downtime-data.js` (T1) and `downtime-views.js` (T2).
+- The rest of `_renderInlineTerrPills` (the loop, the active-state logic, the button HTML) is unchanged.
+
+---
+
+## Dev Agent Record
+
+### Files changed
+- `public/js/tabs/downtime-data.js` — T1: added `shortLabel` field to each of the 5 `TERRITORY_DATA` entries. No existing fields removed. Barrens NOT added (not a formal territory).
+- `public/js/admin/downtime-views.js` — T2: replaced 6-entry hardcoded `TERR_PILLS` array in `_renderInlineTerrPills` with `[...TERRITORY_DATA.map(t => ({id: t.slug, label: t.shortLabel})), {id:'barrens',...}, {id:'',...}]`.
+- `tests/fix-719-dt-terr-pills-second-city.spec.js` — T3: 5 Playwright tests covering ACs 1-6.
+
+### Completion notes
+T1: `shortLabel` is purely additive. All existing consumers of `TERRITORY_DATA` use `.slug`, `.name`, `.ambience`, `.ambienceMod` — unaffected. T2: Pill order is now driven by `TERRITORY_DATA` declaration order (academy, dockyards, harbour, northshore, secondcity), then Barrens, then N/A — 7 total, matching the AC. `TERRITORY_DATA` is already imported at line 9 of `downtime-views.js`; no import change needed. 5/5 Playwright tests pass.

--- a/tests/fix-719-dt-terr-pills-second-city.spec.js
+++ b/tests/fix-719-dt-terr-pills-second-city.spec.js
@@ -1,0 +1,162 @@
+/**
+ * fix.719 — DT processing territory pill row missing The Second City
+ *
+ * Acceptance criteria:
+ *   1. .proc-terr-pill[data-terr-id="secondcity"] exists in the pill row
+ *   2. That pill's text content is "Second City"
+ *   3. Barrens pill (data-terr-id="barrens") still exists
+ *   4. Academy pill (data-terr-id="academy") still exists
+ *   5. N/A pill (data-terr-id="") still exists and is the last pill
+ *   6. Total pill count is 7 (5 formal territories + Barrens + N/A)
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+
+const ST_USER = {
+  id: '123456789', username: 'test_st', global_name: 'Test ST',
+  avatar: null, role: 'st', player_id: 'p-001', character_ids: [], is_dual_role: false,
+};
+
+const CHAR_PROJ = {
+  _id: 'char-proj-719', name: 'Test Character', moniker: null, honorific: null,
+  clan: 'Mekhet', covenant: 'Invictus', player: 'Test Player',
+  blood_potency: 2, humanity: 6, humanity_base: 7, court_title: null,
+  retired: false,
+  status: { city: 1, clan: 1, covenant: { 'Carthian Movement': 0, 'Circle of the Crone': 0, 'Invictus': 1, 'Lancea et Sanctum': 0, 'Ordo Dracul': 0 } },
+  attributes: {
+    Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+    Intelligence: { dots: 3, bonus: 0 }, Wits: { dots: 3, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+    Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: {},
+  disciplines: {},
+  merits: [],
+  ordeals: [],
+};
+
+const TEST_CYCLE = {
+  _id: 'cycle-001', cycle_number: 4, status: 'active',
+  confirmed_ambience: {}, narrative_notes: '',
+};
+
+// Project submission — territory set to secondcity (the missing territory in the old hardcoded list)
+const PROJECT_SUB = {
+  _id: 'sub-proj-719',
+  cycle_id: 'cycle-001',
+  character_name: 'Test Character',
+  character_id: 'char-proj-719',
+  player_name: 'Test Player',
+  submitted_at: '2026-06-14T00:00:00Z',
+  _raw: {
+    projects: [],
+    feeding: null,
+    sphere_actions: [],
+    contact_actions: { requests: [] },
+    retainer_actions: { actions: [] },
+  },
+  responses: {
+    project_1_action: 'misc',
+    project_1_title: 'Second City Survey',
+    project_1_description: 'Scouting The Second City for opportunities.',
+    project_1_territory: 'secondcity',
+  },
+  projects_resolved: [],
+  feeding_review: null,
+  merit_actions_resolved: [],
+  sorcery_review: {},
+  st_review: { territory_overrides: {} },
+};
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+async function setupProcessing(page) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'local-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url    = route.request().url();
+    const method = route.request().method();
+    const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+    if (method === 'PUT' || method === 'PATCH' || method === 'POST') return ok({ ok: true });
+    if (url.includes('/api/downtime_submissions'))  return ok([PROJECT_SUB]);
+    if (url.includes('/api/downtime_cycles'))       return ok([TEST_CYCLE]);
+    if (url.includes('/api/characters/names'))      return ok([CHAR_PROJ].map(c => ({ _id: c._id, name: c.name, moniker: c.moniker, honorific: c.honorific })));
+    if (url.includes('/api/characters'))            return ok([CHAR_PROJ]);
+    if (url.includes('/api/territories'))           return ok([]);
+    if (url.includes('/api/game_sessions'))         return ok([]);
+    if (url.includes('/api/session_logs'))          return ok([]);
+    return ok([]);
+  });
+
+  await page.goto('/admin.html');
+  await page.waitForSelector('#admin-app', { state: 'visible', timeout: 10000 });
+  await page.click('[data-domain="downtime"]');
+  await page.waitForTimeout(1000);
+}
+
+async function openProjectAction(page) {
+  await page.waitForSelector('.proc-action-row', { timeout: 8000 });
+  // Filter to misc phase so only our project action is visible
+  const miscPill = page.locator('.proc-filter-pill[data-filter-dim="phases"][data-filter-val="misc"]');
+  if (await miscPill.count() > 0) {
+    await miscPill.first().click();
+    await page.waitForTimeout(300);
+  }
+  await page.locator('.proc-action-row').first().click();
+  await page.waitForSelector('.proc-action-detail', { timeout: 8000 });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+test.describe('fix.719 — territory pill row includes The Second City', () => {
+
+  test('AC1+2: Second City pill exists with correct label', async ({ page }) => {
+    await setupProcessing(page);
+    await openProjectAction(page);
+
+    const pill = page.locator('.proc-terr-pill[data-terr-id="secondcity"]');
+    await expect(pill).toBeVisible();
+    await expect(pill).toHaveText('Second City');
+  });
+
+  test('AC3: Barrens pill still present', async ({ page }) => {
+    await setupProcessing(page);
+    await openProjectAction(page);
+
+    await expect(page.locator('.proc-terr-pill[data-terr-id="barrens"]')).toBeVisible();
+  });
+
+  test('AC4: Academy pill still present', async ({ page }) => {
+    await setupProcessing(page);
+    await openProjectAction(page);
+
+    await expect(page.locator('.proc-terr-pill[data-terr-id="academy"]')).toBeVisible();
+  });
+
+  test('AC5: N/A pill still present and is the last pill', async ({ page }) => {
+    await setupProcessing(page);
+    await openProjectAction(page);
+
+    const pills = page.locator('.proc-terr-pill');
+    const count = await pills.count();
+    expect(count).toBeGreaterThan(0);
+
+    const lastPill = pills.nth(count - 1);
+    await expect(lastPill).toHaveAttribute('data-terr-id', '');
+    await expect(lastPill).toHaveText('N/A');
+  });
+
+  test('AC6: Total pill count is 7 (5 territories + Barrens + N/A)', async ({ page }) => {
+    await setupProcessing(page);
+    await openProjectAction(page);
+
+    const pills = page.locator('.proc-terr-pill');
+    await expect(pills).toHaveCount(7);
+  });
+
+});


### PR DESCRIPTION
## Summary

- The territory pill switcher in DT processing was built from a hardcoded array that was missing The Second City, so STs could not assign that territory to any player action (Aleksei's feeding action surfaced this in DT4)
- `TERR_PILLS` is now derived from `TERRITORY_DATA` (the SSOT for formal territories) so it stays in sync automatically; Barrens and N/A are appended explicitly as they are not formal territory records
- Added `shortLabel` to each `TERRITORY_DATA` entry for compact pill display without re-deriving from the long name string

## Closes

- Closes #719

## Story

- specs/stories/fix.719.dt-terr-pills-second-city.story.md

## Test plan

- [x] 5/5 Playwright tests pass (`tests/fix-719-dt-terr-pills-second-city.spec.js`)
- [ ] CI green
- [ ] Manual: open DT4 processing, find any action card — verify 7 pills appear (Academy, Dockyards, Harbour, N. Shore, Second City, Barrens, N/A)

## Branch flow

- From: `ms/issue-719-dt-terr-pills-second-city`
- Into: `dev`