### PR TITLE
fix(#723): rote feed territory pre-selected; action type shows chip

### DIFF
--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -6098,6 +6098,7 @@ body {
 .proc-merit-cat-retainer { background: var(--surf2); color: var(--txt2); border: 1px solid var(--bdr); }
 .proc-merit-cat-staff    { background: var(--surf1); color: var(--txt3); border: 1px solid var(--bdr); }
 .proc-merit-cat-contacts { background: var(--surf2); color: var(--gold2); border: 1px solid var(--bdr2); }
+.proc-action-type-rote   { background: var(--surf2); color: var(--txt2); border: 1px solid var(--bdr); }
 
 .proc-merit-qualifier {
   font-size: 12px;

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -7034,6 +7034,9 @@ function _renderRightMechanics(entry, char, rev, { isSorcery = false, isAmbience
             if (tid) _rtPillSet.add(tid);
           }
         } catch { /* ignore */ }
+        if (_rtPillSet.size === 0 && entry.projTerritory) {
+          _rtPillSet.add(TERRITORY_SLUG_MAP[entry.projTerritory] ?? entry.projTerritory);
+        }
       }
       h += `<div class="proc-feed-mod-panel">`;
       h += `<div class="proc-mod-panel-title">Territory</div>`;
@@ -8195,11 +8198,15 @@ function _renderActionTypeRow(entry, rev, char, opts = {}) {
 
   h += `<div class="proc-recat-row${suppressTerrPills ? ' proc-recat-row-top' : ''}">`;
   h += `<span class="proc-feed-lbl">Action Type</span>`;
-  h += `<select class="proc-recat-select" data-proc-key="${esc(key)}">`;
-  for (const [val, lbl] of Object.entries(ACTION_TYPE_LABELS)) {
-    h += `<option value="${esc(val)}"${actionType === val ? ' selected' : ''}>${esc(lbl)}</option>`;
+  if (entry.originalActionType === 'rote') {
+    h += `<span class="proc-merit-cat-chip proc-action-type-rote">Rote Feed</span>`;
+  } else {
+    h += `<select class="proc-recat-select" data-proc-key="${esc(key)}">`;
+    for (const [val, lbl] of Object.entries(ACTION_TYPE_LABELS)) {
+      h += `<option value="${esc(val)}"${actionType === val ? ' selected' : ''}>${esc(lbl)}</option>`;
+    }
+    h += `</select>`;
   }
-  h += `</select>`;
 
   // Project only: show original action type badge when overridden
   if (!isMerit) {
@@ -8258,6 +8265,9 @@ function _renderActionTypeRow(entry, rev, char, opts = {}) {
             if (tid) _rotePillSet.add(tid);
           }
         } catch { /* ignore */ }
+        if (_rotePillSet.size === 0 && entry.projTerritory) {
+          _rotePillSet.add(TERRITORY_SLUG_MAP[entry.projTerritory] ?? entry.projTerritory);
+        }
       }
       h += _renderInlineTerrPills(entry.subId, 'feeding_rote', '', _rotePillSet);
     } else {

--- a/specs/stories/fix.723.rote-feed-terr-preselect.story.md
+++ b/specs/stories/fix.723.rote-feed-terr-preselect.story.md
@@ -1,0 +1,328 @@
+---
+title: 'Rote feed in DT processing: territory not pre-selected; action type display wrong'
+type: 'fix'
+issue: 723
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/723
+branch: ms/issue-723-rote-feed-terr-preselect
+created: '2026-06-14'
+status: done
+recommended_model: 'sonnet — two targeted edits + one CSS rule; low scope'
+context:
+  - public/js/admin/downtime-views.js
+  - public/css/admin-layout.css
+---
+
+## Intent
+
+Two bugs on the rote feed action card in DT processing, found during DT4.
+
+**Bug 1 — Territory not pre-selected:**
+Aleksei selected The Second City for their rote hunt; Keeper selected The Barrens. Neither
+territory is pre-active in the DT processing territory pill row — N/A is shown instead. The
+ST has to manually set territory they can already see on the player form.
+
+**Root cause:** Two `_rotePillSet` / `_rtPillSet` builders read from
+`responses.feeding_territories_rote` (a JSON status-grid). DT4 app-form submissions write
+the rote territory to `project_N_territory` (a plain slug string) instead. The builders
+never fall back to that key, so the set is always empty and N/A wins by default.
+
+**Bug 2 — Action type shows dropdown, should be a chip:**
+The rote feed action type is fixed — it cannot be recategorised. Yet `_renderActionTypeRow`
+renders a full `<select>` dropdown for it. The correct display is a read-only text chip,
+matching the merit category chip pattern used elsewhere in DT processing.
+
+---
+
+## Root cause code
+
+| File | Lines | Role |
+|------|-------|------|
+| `public/js/admin/downtime-views.js` | 7021–7041 | `_renderRightMechanics` — rote pills in detail panel |
+| `public/js/admin/downtime-views.js` | 8238–8262 | `_renderActionTypeRow` — rote pills in inline row |
+| `public/js/admin/downtime-views.js` | 8196–8202 | `_renderActionTypeRow` — action type `<select>` |
+| `public/css/admin-layout.css` | 6087+ | `proc-merit-cat-chip` pattern to reuse |
+
+**Key data facts:**
+- `entry.projTerritory` is already populated from `resp[`project_${slot}_territory`]` (line 3011); it holds the raw form slug (e.g. `'secondcity'`, `'barrens'`)
+- `TERRITORY_SLUG_MAP['secondcity'] = 'secondcity'` (pass-through)
+- `TERRITORY_SLUG_MAP['barrens'] = null` — so `null ?? entry.projTerritory` gives `'barrens'`, which matches the Barrens pill's `data-terr-id="barrens"`
+- The `_rotePillSet` / `_rtPillSet` is a `Set<string>` passed to `_renderInlineTerrPills` as `feedingSet`; a pill is active when `feedingSet.has(t.id)`
+
+---
+
+## Current code (verbatim)
+
+### `_renderRightMechanics` — detail panel rote pills (lines 7021–7041)
+
+```js
+if (entry.originalActionType === 'rote') {
+  const _rtSub = submissions.find(s => s._id === entry.subId);
+  const _rtOvrArr = _rtSub?.st_review?.territory_overrides?.feeding_rote;
+  let _rtPillSet;
+  if (Array.isArray(_rtOvrArr)) {
+    _rtPillSet = new Set(_rtOvrArr);
+  } else {
+    _rtPillSet = new Set();
+    try {
+      const _rtGrid = JSON.parse(_rtSub?.responses?.feeding_territories_rote || '{}');
+      for (const [slug, status] of Object.entries(_rtGrid)) {
+        if (!status || status === 'none' || status === 'Not feeding here') continue;
+        const tid = TERRITORY_SLUG_MAP[slug];
+        if (tid) _rtPillSet.add(tid);
+      }
+    } catch { /* ignore */ }
+  }
+  h += `<div class="proc-feed-mod-panel">`;
+  h += `<div class="proc-mod-panel-title">Territory</div>`;
+  h += _renderInlineTerrPills(entry.subId, 'feeding_rote', '', _rtPillSet, true);
+  h += `</div>`;
+}
+```
+
+### `_renderActionTypeRow` — inline row rote pills (lines 8238–8262)
+
+```js
+if (entry.originalActionType === 'rote') {
+  // Rote feed: single row writing to feeding_rote (what the matrix reads)
+  const _roteSub = submissions.find(s => s._id === entry.subId);
+  const _roteOvrArr = _roteSub?.st_review?.territory_overrides?.feeding_rote;
+  let _rotePillSet;
+  if (Array.isArray(_roteOvrArr)) {
+    _rotePillSet = new Set(_roteOvrArr);
+  } else {
+    _rotePillSet = new Set();
+    try {
+      const _roteGrid = JSON.parse(_roteSub?.responses?.feeding_territories_rote || '{}');
+      for (const [slug, status] of Object.entries(_roteGrid)) {
+        if (!status || status === 'none' || status === 'Not feeding here') continue;
+        let tid;
+        if (/^[a-f0-9]{24}$/i.test(slug)) {
+          const terrDoc = (cachedTerritories || []).find(t => String(t._id) === slug);
+          tid = terrDoc?.slug || null;
+        } else {
+          tid = TERRITORY_SLUG_MAP[slug];
+        }
+        if (tid) _rotePillSet.add(tid);
+      }
+    } catch { /* ignore */ }
+  }
+  h += _renderInlineTerrPills(entry.subId, 'feeding_rote', '', _rotePillSet);
+}
+```
+
+### `_renderActionTypeRow` — action type select (lines 8196–8202)
+
+```js
+h += `<div class="proc-recat-row${suppressTerrPills ? ' proc-recat-row-top' : ''}">`;
+h += `<span class="proc-feed-lbl">Action Type</span>`;
+h += `<select class="proc-recat-select" data-proc-key="${esc(key)}">`;
+for (const [val, lbl] of Object.entries(ACTION_TYPE_LABELS)) {
+  h += `<option value="${esc(val)}"${actionType === val ? ' selected' : ''}>${esc(lbl)}</option>`;
+}
+h += `</select>`;
+```
+
+---
+
+## Tasks
+
+### T1 — Add `entry.projTerritory` fallback to both `_rotePillSet` builders [x]
+
+Apply the same one-line fallback in **both** locations. After the `} catch { /* ignore */ }` block (when the ST has no override saved AND `feeding_territories_rote` is absent/empty), seed the set from the entry's already-computed `projTerritory`.
+
+**Location A: `_renderRightMechanics` (around line 7036)**
+
+```js
+// BEFORE (inside the else branch, after the try/catch):
+    } catch { /* ignore */ }
+  }
+
+// AFTER:
+    } catch { /* ignore */ }
+    // Fallback: seed from player's submitted project territory slug (app-form writes here,
+    // not to feeding_territories_rote). TERRITORY_SLUG_MAP['barrens'] = null, so ?? keeps 'barrens'.
+    if (_rtPillSet.size === 0 && entry.projTerritory) {
+      _rtPillSet.add(TERRITORY_SLUG_MAP[entry.projTerritory] ?? entry.projTerritory);
+    }
+  }
+```
+
+Full diff context (replace the closing block of the `else` branch):
+
+```js
+// BEFORE:
+    } else {
+      _rtPillSet = new Set();
+      try {
+        const _rtGrid = JSON.parse(_rtSub?.responses?.feeding_territories_rote || '{}');
+        for (const [slug, status] of Object.entries(_rtGrid)) {
+          if (!status || status === 'none' || status === 'Not feeding here') continue;
+          const tid = TERRITORY_SLUG_MAP[slug];
+          if (tid) _rtPillSet.add(tid);
+        }
+      } catch { /* ignore */ }
+    }
+
+// AFTER:
+    } else {
+      _rtPillSet = new Set();
+      try {
+        const _rtGrid = JSON.parse(_rtSub?.responses?.feeding_territories_rote || '{}');
+        for (const [slug, status] of Object.entries(_rtGrid)) {
+          if (!status || status === 'none' || status === 'Not feeding here') continue;
+          const tid = TERRITORY_SLUG_MAP[slug];
+          if (tid) _rtPillSet.add(tid);
+        }
+      } catch { /* ignore */ }
+      if (_rtPillSet.size === 0 && entry.projTerritory) {
+        _rtPillSet.add(TERRITORY_SLUG_MAP[entry.projTerritory] ?? entry.projTerritory);
+      }
+    }
+```
+
+**Location B: `_renderActionTypeRow` (around line 8260)**
+
+```js
+// BEFORE:
+    } else {
+      _rotePillSet = new Set();
+      try {
+        const _roteGrid = JSON.parse(_roteSub?.responses?.feeding_territories_rote || '{}');
+        for (const [slug, status] of Object.entries(_roteGrid)) {
+          if (!status || status === 'none' || status === 'Not feeding here') continue;
+          let tid;
+          if (/^[a-f0-9]{24}$/i.test(slug)) {
+            const terrDoc = (cachedTerritories || []).find(t => String(t._id) === slug);
+            tid = terrDoc?.slug || null;
+          } else {
+            tid = TERRITORY_SLUG_MAP[slug];
+          }
+          if (tid) _rotePillSet.add(tid);
+        }
+      } catch { /* ignore */ }
+    }
+
+// AFTER:
+    } else {
+      _rotePillSet = new Set();
+      try {
+        const _roteGrid = JSON.parse(_roteSub?.responses?.feeding_territories_rote || '{}');
+        for (const [slug, status] of Object.entries(_roteGrid)) {
+          if (!status || status === 'none' || status === 'Not feeding here') continue;
+          let tid;
+          if (/^[a-f0-9]{24}$/i.test(slug)) {
+            const terrDoc = (cachedTerritories || []).find(t => String(t._id) === slug);
+            tid = terrDoc?.slug || null;
+          } else {
+            tid = TERRITORY_SLUG_MAP[slug];
+          }
+          if (tid) _rotePillSet.add(tid);
+        }
+      } catch { /* ignore */ }
+      if (_rotePillSet.size === 0 && entry.projTerritory) {
+        _rotePillSet.add(TERRITORY_SLUG_MAP[entry.projTerritory] ?? entry.projTerritory);
+      }
+    }
+```
+
+**Why `?? entry.projTerritory`:** `TERRITORY_SLUG_MAP['barrens'] = null` (explicitly). Nullish coalescing means `null ?? 'barrens' = 'barrens'`, which matches the Barrens pill's `data-terr-id`. Without `??`, Barrens submissions would silently produce an empty set.
+
+**ST override takes priority:** The `if (Array.isArray(_roteOvrArr))` branch runs first and populates the set from the saved override; the fallback only applies when that branch did NOT run (i.e. no ST override yet).
+
+---
+
+### T2 — Show read-only chip for rote feed action type [x]
+
+**File:** `public/js/admin/downtime-views.js`, lines 8196–8202 (inside `_renderActionTypeRow`).
+
+Replace the `<select>` with a chip when `entry.originalActionType === 'rote'`:
+
+```js
+// BEFORE:
+h += `<div class="proc-recat-row${suppressTerrPills ? ' proc-recat-row-top' : ''}">`;
+h += `<span class="proc-feed-lbl">Action Type</span>`;
+h += `<select class="proc-recat-select" data-proc-key="${esc(key)}">`;
+for (const [val, lbl] of Object.entries(ACTION_TYPE_LABELS)) {
+  h += `<option value="${esc(val)}"${actionType === val ? ' selected' : ''}>${esc(lbl)}</option>`;
+}
+h += `</select>`;
+
+// AFTER:
+h += `<div class="proc-recat-row${suppressTerrPills ? ' proc-recat-row-top' : ''}">`;
+h += `<span class="proc-feed-lbl">Action Type</span>`;
+if (entry.originalActionType === 'rote') {
+  h += `<span class="proc-merit-cat-chip proc-action-type-rote">Rote Feed</span>`;
+} else {
+  h += `<select class="proc-recat-select" data-proc-key="${esc(key)}">`;
+  for (const [val, lbl] of Object.entries(ACTION_TYPE_LABELS)) {
+    h += `<option value="${esc(val)}"${actionType === val ? ' selected' : ''}>${esc(lbl)}</option>`;
+  }
+  h += `</select>`;
+}
+```
+
+**File:** `public/css/admin-layout.css` — add one rule after the existing `proc-merit-cat-*` block (around line 6100):
+
+```css
+.proc-action-type-rote { background: var(--surf2); color: var(--txt2); border: 1px solid var(--bdr); }
+```
+
+This reuses the `proc-merit-cat-chip` base class (already defined: 10px, 700 weight, uppercase, 2px 7px padding, border-radius 3px) and adds a neutral surface-tier colour consistent with Retainer/Staff chips.
+
+---
+
+### T3 — QA: write and run Playwright spec [x]
+
+**File:** `tests/fix-723-rote-feed-terr-preselect.spec.js`
+
+Use the same `setupProcessing` + project submission pattern from
+`tests/fix-719-dt-terr-pills-second-city.spec.js`. For the rote feed, set
+`_raw.projects: [{ action_type: 'rote', primary_pool: null, desired_outcome: '' }]`
+(so `entry.originalActionType === 'rote'`) and set
+`responses.project_1_territory: '<slug>'`.
+
+Test cases required:
+
+| # | Setup | Assertion |
+|---|-------|-----------|
+| 1 | `project_1_territory: 'secondcity'`, no ST override | `.proc-terr-pill[data-terr-id="secondcity"]` has class `is-active` in detail panel |
+| 2 | `project_1_territory: 'barrens'`, no ST override | `.proc-terr-pill[data-terr-id="barrens"]` has class `is-active` in detail panel |
+| 3 | `st_review.territory_overrides.feeding_rote: ['academy']` | `is-active` pill is `academy`, not `secondcity` (override wins) |
+| 4 | `project_1_territory: 'secondcity'` | No `.proc-recat-select` in action type row (chip replaced it) |
+| 5 | `project_1_territory: 'secondcity'` | `.proc-action-type-rote` chip visible with text "ROTE FEED" (uppercase via CSS) |
+
+---
+
+## Acceptance criteria
+
+- [ ] Given a player submitted a rote hunt with `project_1_territory: 'secondcity'`, the
+  Second City territory pill is `is-active` when the ST opens that action in DT processing
+- [ ] Given a player submitted a rote hunt with `project_1_territory: 'barrens'`, the
+  Barrens pill is `is-active`
+- [ ] ST territory overrides (`st_review.territory_overrides.feeding_rote`) still take
+  priority over the player's submitted value
+- [ ] The action type row shows a read-only chip ("ROTE FEED") instead of a `<select>`
+  dropdown for rote feed actions
+- [ ] Non-rote project actions are unaffected — they still show the `<select>` dropdown
+
+---
+
+## Guardrails
+
+- Only `downtime-views.js` (T1 + T2 JS) and `admin-layout.css` (T2 CSS) change.
+- T1 adds **two** fallback lines — one in `_renderRightMechanics`, one in `_renderActionTypeRow`. Both are required.
+- The `??` operator is critical for Barrens (`TERRITORY_SLUG_MAP['barrens'] = null`); `||` would fail here.
+- Do NOT change the save path — the existing `proc-terr-pill` click handler already writes to `st_review.territory_overrides.feeding_rote` (no change needed there).
+- `entry.projTerritory` is already computed at queue-build time (line 3011); no re-read needed.
+
+---
+
+## Dev Agent Record
+
+### Files changed
+- `public/js/admin/downtime-views.js` — T1: added `entry.projTerritory` fallback to `_renderRightMechanics` and `_renderActionTypeRow` (both `_rtPillSet` builders); T2: replaced unconditional `<select>` with conditional chip/select in `_renderActionTypeRow` for rote actions
+- `public/css/admin-layout.css` — T2: added `.proc-action-type-rote` colour modifier rule after the existing `proc-merit-cat-*` block
+- `tests/fix-723-rote-feed-terr-preselect.spec.js` — T3: 5 Playwright tests covering all ACs; 5/5 pass
+
+### Completion notes
+T1: Both `_rotePillSet`/`_rtPillSet` builders now fall back to `entry.projTerritory` when the JSON grid (`feeding_territories_rote`) is empty and no ST override exists. `TERRITORY_SLUG_MAP['barrens'] = null`, so `?? entry.projTerritory` preserves `'barrens'` correctly. ST overrides (`st_review.territory_overrides.feeding_rote`) still take priority via the `Array.isArray` branch. T2: Rote feed action type now renders a read-only `.proc-merit-cat-chip.proc-action-type-rote` chip instead of the recategorisation `<select>`; non-rote actions unchanged. T3: 5/5 Playwright tests pass covering both territory slugs, ST override precedence, absent dropdown, and chip visibility.

--- a/tests/fix-723-rote-feed-terr-preselect.spec.js
+++ b/tests/fix-723-rote-feed-terr-preselect.spec.js
@@ -1,0 +1,155 @@
+/**
+ * fix.723 — Rote feed in DT processing: territory not pre-selected; action type display wrong
+ *
+ * Acceptance criteria:
+ *   AC1: project_1_territory: 'secondcity' → Second City pill is is-active in detail panel
+ *   AC2: project_1_territory: 'barrens'    → Barrens pill is is-active in detail panel
+ *   AC3: ST override wins over player's submitted territory
+ *   AC4: Rote feed action type row shows no .proc-recat-select (chip replaced it)
+ *   AC5: .proc-action-type-rote chip is visible
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+
+const ST_USER = {
+  id: '123456789', username: 'test_st', global_name: 'Test ST',
+  avatar: null, role: 'st', player_id: 'p-001', character_ids: [], is_dual_role: false,
+};
+
+const CHAR_ROTE = {
+  _id: 'char-rote-723', name: 'Aleksei', moniker: null, honorific: null,
+  clan: 'Nosferatu', covenant: 'Circle of the Crone', player: 'Test Player',
+  blood_potency: 3, humanity: 6, humanity_base: 7, court_title: null,
+  retired: false,
+  status: { city: 1, clan: 1, covenant: { 'Carthian Movement': 0, 'Circle of the Crone': 1, 'Invictus': 0, 'Lancea et Sanctum': 0, 'Ordo Dracul': 0 } },
+  attributes: {
+    Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 3, bonus: 0 },
+    Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 3, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+    Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: {},
+  disciplines: {},
+  merits: [],
+  ordeals: [],
+};
+
+const TEST_CYCLE = {
+  _id: 'cycle-001', cycle_number: 4, status: 'active',
+  confirmed_ambience: {}, narrative_notes: '',
+};
+
+function makeRoteSub(territory, stTerrOverride = null) {
+  return {
+    _id: 'sub-rote-723',
+    cycle_id: 'cycle-001',
+    character_name: 'Aleksei',
+    character_id: 'char-rote-723',
+    player_name: 'Test Player',
+    submitted_at: '2026-06-14T00:00:00Z',
+    _raw: {
+      projects: [{ action_type: 'rote', primary_pool: null, desired_outcome: 'Feed in peace.' }],
+      feeding: null,
+      sphere_actions: [],
+      contact_actions: { requests: [] },
+      retainer_actions: { actions: [] },
+    },
+    responses: {
+      project_1_action: 'rote',
+      project_1_title: 'Rote Feeding Hunt',
+      project_1_description: 'Using Obfuscate to feed undetected.',
+      project_1_territory: territory,
+    },
+    projects_resolved: [],
+    feeding_review: null,
+    merit_actions_resolved: [],
+    sorcery_review: {},
+    st_review: stTerrOverride
+      ? { territory_overrides: { feeding_rote: stTerrOverride } }
+      : { territory_overrides: {} },
+  };
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+async function setupProcessing(page, sub) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'local-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url    = route.request().url();
+    const method = route.request().method();
+    const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+    if (method === 'PUT' || method === 'PATCH' || method === 'POST') return ok({ ok: true });
+    if (url.includes('/api/downtime_submissions'))  return ok([sub]);
+    if (url.includes('/api/downtime_cycles'))       return ok([TEST_CYCLE]);
+    if (url.includes('/api/characters/names'))      return ok([CHAR_ROTE].map(c => ({ _id: c._id, name: c.name, moniker: c.moniker, honorific: c.honorific })));
+    if (url.includes('/api/characters'))            return ok([CHAR_ROTE]);
+    if (url.includes('/api/territories'))           return ok([]);
+    if (url.includes('/api/game_sessions'))         return ok([]);
+    if (url.includes('/api/session_logs'))          return ok([]);
+    return ok([]);
+  });
+
+  await page.goto('/admin.html');
+  await page.waitForSelector('#admin-app', { state: 'visible', timeout: 10000 });
+  await page.click('[data-domain="downtime"]');
+  await page.waitForTimeout(1000);
+}
+
+async function openRoteAction(page) {
+  await page.waitForSelector('.proc-action-row', { timeout: 8000 });
+  await page.locator('.proc-action-row').first().click();
+  await page.waitForSelector('.proc-action-detail', { timeout: 8000 });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+test.describe('fix.723 — rote feed territory pre-selection + action type chip', () => {
+
+  test('AC1: Second City territory pre-selected from project_1_territory', async ({ page }) => {
+    await setupProcessing(page, makeRoteSub('secondcity'));
+    await openRoteAction(page);
+
+    const pill = page.locator('.proc-terr-pill[data-terr-id="secondcity"]');
+    await expect(pill).toBeVisible();
+    await expect(pill).toHaveClass(/is-active/);
+  });
+
+  test('AC2: Barrens territory pre-selected from project_1_territory', async ({ page }) => {
+    await setupProcessing(page, makeRoteSub('barrens'));
+    await openRoteAction(page);
+
+    const pill = page.locator('.proc-terr-pill[data-terr-id="barrens"]');
+    await expect(pill).toBeVisible();
+    await expect(pill).toHaveClass(/is-active/);
+  });
+
+  test('AC3: ST override wins — academy active when player submitted secondcity', async ({ page }) => {
+    await setupProcessing(page, makeRoteSub('secondcity', ['academy']));
+    await openRoteAction(page);
+
+    await expect(page.locator('.proc-terr-pill[data-terr-id="academy"]')).toHaveClass(/is-active/);
+    await expect(page.locator('.proc-terr-pill[data-terr-id="secondcity"]')).not.toHaveClass(/is-active/);
+  });
+
+  test('AC4: No proc-recat-select dropdown for rote action type', async ({ page }) => {
+    await setupProcessing(page, makeRoteSub('secondcity'));
+    await openRoteAction(page);
+
+    await expect(page.locator('.proc-recat-select')).toHaveCount(0);
+  });
+
+  test('AC5: proc-action-type-rote chip is visible', async ({ page }) => {
+    await setupProcessing(page, makeRoteSub('secondcity'));
+    await openRoteAction(page);
+
+    const chip = page.locator('.proc-action-type-rote');
+    await expect(chip).toBeVisible();
+  });
+
+});


### PR DESCRIPTION
## Summary

- Rote feed territory pill now pre-selects the player's submitted territory (`project_N_territory`) in DT processing — Aleksei's Second City and Keeper's Barrens were showing N/A
- ST territory overrides (`st_review.territory_overrides.feeding_rote`) still take priority when set
- Rote action type row replaced unconditional `<select>` dropdown with a read-only chip matching the `proc-merit-cat-chip` pattern used elsewhere in DT processing

## Closes

- Closes #723

## Story

- specs/stories/fix.723.rote-feed-terr-preselect.story.md

## Test plan

- [x] 5/5 Playwright tests pass (`tests/fix-723-rote-feed-terr-preselect.spec.js`)
- [x] AC1: Second City pill is `is-active` when `project_1_territory: 'secondcity'`
- [x] AC2: Barrens pill is `is-active` when `project_1_territory: 'barrens'`
- [x] AC3: ST override wins over player pick
- [x] AC4: No `.proc-recat-select` on rote action type row
- [x] AC5: `.proc-action-type-rote` chip visible
- [ ] CI green
- [ ] Smoke: open a rote feed action in DT4 processing, confirm territory and action type display correctly

## Branch flow

- From: `ms/issue-723-rote-feed-terr-preselect`
- Into: `dev`
