### PR TITLE
fix(#725): rote feed now inherits primary hunt pool in DT Processing

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -2865,6 +2865,24 @@ function buildProcessingQueue(subs) {
       });
     }
 
+    // Hoist primary feed pool label so the rote queue entry can inherit it (fix.725)
+    const _feedMethod      = resp['_feed_method'] || '';
+    const _feedDisc        = resp['_feed_disc']   || '';
+    const _feedCustomAttr  = resp['_feed_custom_attr']  || '';
+    const _feedCustomSkill = resp['_feed_custom_skill'] || '';
+    const _feedCustomDisc  = resp['_feed_custom_disc']  || '';
+    const _feedDesc        = sub._raw?.feeding?.method || resp['feeding_description'] || '';
+    const _feedTrunc       = _feedDesc.length > 40 ? _feedDesc.slice(0, 40) + '…' : _feedDesc;
+    const _feedBaseLabel   = FEED_METHOD_LABELS_MAP[_feedMethod] || _feedMethod;
+    const _feedMethodLabel = _feedMethod === 'other' && _feedTrunc
+      ? _feedTrunc
+      : (_feedTrunc && _feedTrunc !== _feedBaseLabel
+          ? `${_feedBaseLabel} — ${_feedTrunc}`
+          : _feedBaseLabel);
+    const feedPoolLabel = _feedMethod === 'other' && (_feedCustomAttr || _feedCustomSkill)
+      ? [_feedCustomAttr, _feedCustomSkill, _feedCustomDisc || _feedDisc].filter(Boolean).join(' + ')
+      : [_feedMethodLabel, _feedDisc].filter(Boolean).join(' + ');
+
     // ── Feeding (all submissions get an entry; no-method submissions show as undeclared) ──
     {
       const feedMethod      = resp['_feed_method'] || '';
@@ -2904,9 +2922,7 @@ function buildProcessingQueue(subs) {
         }
       }
       // For "other" method, use the player's custom attr/skill/disc as the pool label
-      const poolLabel = feedMethod === 'other' && (feedCustomAttr || feedCustomSkill)
-        ? [feedCustomAttr, feedCustomSkill, feedCustomDisc || feedDisc].filter(Boolean).join(' + ')
-        : [methodLabel, feedDisc].filter(Boolean).join(' + ');
+      const poolLabel = feedPoolLabel; // hoisted above the feeding block; same computation
       queue.push({
         key: `${sub._id}:feeding`,
         subId: sub._id,
@@ -3002,7 +3018,7 @@ function buildProcessingQueue(subs) {
           source: 'project',
           actionIdx: idx,
           projSlot: slot,
-          poolPlayer: proj.primary_pool?.expression || resp[`project_${slot}_pool_expr`] || '',
+          poolPlayer: proj.primary_pool?.expression || resp[`project_${slot}_pool_expr`] || feedPoolLabel,
           projTitle:       resp[`project_${slot}_title`]     || '',
           projOutcome:     proj.desired_outcome || resp[`project_${slot}_outcome`] || '',
           projDescription: descWithMethod,

--- a/specs/stories/fix.725.rote-feed-inherited-pool.story.md
+++ b/specs/stories/fix.725.rote-feed-inherited-pool.story.md
@@ -1,0 +1,262 @@
+---
+title: 'Rote feed: inherited pool from primary hunt not surfacing in DT Processing'
+type: 'fix'
+issue: 725
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/725
+branch: ms/issue-725-rote-feed-inherited-pool
+created: '2026-06-14'
+status: done
+recommended_model: 'sonnet — one targeted edit + one Playwright spec; low scope'
+context:
+  - public/js/admin/downtime-views.js
+---
+
+## Intent
+
+The rote feed action card in DT Processing shows a blank dice pool builder
+("— + — ±0 = 0") even though the player form displays the full inherited pool
+("Pool: 9 (inherited from primary hunt) — 3 Presence · 4 Empathy · 1 Majesty
+· +1 Groups").
+
+The pool data exists in the submission — the primary feeding method and
+components are in `resp['_feed_method']`, `resp['_feed_disc']`,
+`resp['_feed_custom_attr']`, `resp['_feed_custom_skill']` etc. It just isn't
+reaching `entry.poolPlayer` for rote actions.
+
+---
+
+## Root cause
+
+### Code path
+
+| File | Lines | Role |
+|------|-------|------|
+| `public/js/admin/downtime-views.js` | 2868–2932 | Feeding block — builds `poolLabel` from `resp` keys, pushes feeding queue entry |
+| `public/js/admin/downtime-views.js` | 2934–3014 | Projects loop — rote action entry built here |
+| `public/js/admin/downtime-views.js` | 3005 | `poolPlayer` for rote entry — the broken line |
+
+### Why it's empty
+
+Line 3005 reads:
+```js
+poolPlayer: proj.primary_pool?.expression || resp[`project_${slot}_pool_expr`] || '',
+```
+
+- `proj.primary_pool` is `null` for rote projects (DT4 player form writes `project_N_action: 'rote'` but no `project_N_pool_expr` — the pool is displayed client-side as "inherited")
+- `resp[`project_${slot}_pool_expr`]` is also empty for the same reason
+
+`poolLabel` (the correctly-derived primary feed pool string) is a `const` scoped
+inside the feeding `{}` block (lines 2868–2932) and is **out of scope** at line 3005.
+
+### The pool label computation (lines 2907–2909)
+
+```js
+const poolLabel = feedMethod === 'other' && (feedCustomAttr || feedCustomSkill)
+  ? [feedCustomAttr, feedCustomSkill, feedCustomDisc || feedDisc].filter(Boolean).join(' + ')
+  : [methodLabel, feedDisc].filter(Boolean).join(' + ');
+```
+
+Where:
+- `feedMethod`      = `resp['_feed_method'] || ''`
+- `feedDisc`        = `resp['_feed_disc'] || ''`
+- `feedCustomAttr`  = `resp['_feed_custom_attr'] || ''`
+- `feedCustomSkill` = `resp['_feed_custom_skill'] || ''`
+- `feedCustomDisc`  = `resp['_feed_custom_disc'] || ''`
+- `methodLabel`     = human label for feedMethod (from `FEED_METHOD_LABELS_MAP`)
+
+All these `resp` keys are available throughout the whole submission loop — the problem
+is purely block scoping.
+
+---
+
+## Fix
+
+**Hoist `feedPoolLabel` before the feeding block** so it's in scope at line 3005.
+
+The feeding block already computes `poolLabel` from these keys. We just need to
+compute an equivalent variable before the block opens (around line 2868), then:
+1. Use it as the feeding entry's `poolPlayer` (replacing the inline `poolLabel`)
+2. Reference it as a third fallback at line 3005 for the rote entry
+
+### Exact change
+
+**Before the feeding block** (insert around line 2868, before the `{` that opens
+the feeding block):
+
+```js
+// Hoist primary feed pool label so the rote queue entry can inherit it
+const _feedMethod      = resp['_feed_method'] || '';
+const _feedDisc        = resp['_feed_disc']   || '';
+const _feedCustomAttr  = resp['_feed_custom_attr']  || '';
+const _feedCustomSkill = resp['_feed_custom_skill'] || '';
+const _feedCustomDisc  = resp['_feed_custom_disc']  || '';
+const _feedDesc        = sub._raw?.feeding?.method || resp['feeding_description'] || '';
+const _feedTrunc       = _feedDesc.length > 40 ? _feedDesc.slice(0, 40) + '…' : _feedDesc;
+const _feedBaseLabel   = FEED_METHOD_LABELS_MAP[_feedMethod] || _feedMethod;
+const _feedMethodLabel = _feedMethod === 'other' && _feedTrunc
+  ? _feedTrunc
+  : (_feedTrunc && _feedTrunc !== _feedBaseLabel ? `${_feedBaseLabel} — ${_feedTrunc}` : _feedBaseLabel);
+const feedPoolLabel = _feedMethod === 'other' && (_feedCustomAttr || _feedCustomSkill)
+  ? [_feedCustomAttr, _feedCustomSkill, _feedCustomDisc || _feedDisc].filter(Boolean).join(' + ')
+  : [_feedMethodLabel, _feedDisc].filter(Boolean).join(' + ');
+```
+
+**Inside the feeding block** — replace `poolPlayer: poolLabel` (line 2921) with
+`poolPlayer: feedPoolLabel`. The internal `poolLabel` can be removed or left; if
+left it will shadow `feedPoolLabel` inside the block but both are identical.
+
+Simplest approach: replace the internal `poolLabel` const at line 2907 with a
+reference to `feedPoolLabel`:
+
+```js
+// BEFORE (line 2907):
+const poolLabel = feedMethod === 'other' && (feedCustomAttr || feedCustomSkill)
+  ? [feedCustomAttr, feedCustomSkill, feedCustomDisc || feedDisc].filter(Boolean).join(' + ')
+  : [methodLabel, feedDisc].filter(Boolean).join(' + ');
+
+// AFTER:
+const poolLabel = feedPoolLabel; // computed above the feeding block; same value
+```
+
+**Line 3005 — rote entry `poolPlayer`:**
+
+```js
+// BEFORE:
+poolPlayer: proj.primary_pool?.expression || resp[`project_${slot}_pool_expr`] || '',
+
+// AFTER:
+poolPlayer: proj.primary_pool?.expression || resp[`project_${slot}_pool_expr`] || feedPoolLabel,
+```
+
+### Why this is correct
+
+- `feedPoolLabel` is the exact same string that the feeding queue entry uses as
+  `poolPlayer` — the ST already sees it on the feeding card. We're just surfacing
+  it on the rote card too.
+- If `project_N_pool_expr` is ever populated (future form change), it still wins
+  via the middle fallback — `feedPoolLabel` is the last resort.
+- No schema or API change needed; `sub.feeding_review.pool_player` is not required
+  (that's the ST-validated value; what we want here is the player-submitted
+  expression so the ST can see what to validate).
+
+---
+
+## Tasks
+
+### T1 — Hoist `feedPoolLabel` and wire it to rote entry [x]
+
+**File:** `public/js/admin/downtime-views.js`
+
+Three edits in sequence:
+
+**Edit A** — Insert `feedPoolLabel` block **immediately before** the feeding `{` block
+(the line `// ── Feeding ...` around line 2868). The exact insertion point is after
+the sorcery loop closes and before the feeding comment:
+
+```js
+// INSERT BEFORE: // ── Feeding (all submissions get an entry …
+const _feedMethod      = resp['_feed_method'] || '';
+const _feedDisc        = resp['_feed_disc']   || '';
+const _feedCustomAttr  = resp['_feed_custom_attr']  || '';
+const _feedCustomSkill = resp['_feed_custom_skill'] || '';
+const _feedCustomDisc  = resp['_feed_custom_disc']  || '';
+const _feedDesc        = sub._raw?.feeding?.method || resp['feeding_description'] || '';
+const _feedTrunc       = _feedDesc.length > 40 ? _feedDesc.slice(0, 40) + '…' : _feedDesc;
+const _feedBaseLabel   = FEED_METHOD_LABELS_MAP[_feedMethod] || _feedMethod;
+const _feedMethodLabel = _feedMethod === 'other' && _feedTrunc
+  ? _feedTrunc
+  : (_feedTrunc && _feedTrunc !== _feedBaseLabel
+      ? `${_feedBaseLabel} — ${_feedTrunc}`
+      : _feedBaseLabel);
+const feedPoolLabel = _feedMethod === 'other' && (_feedCustomAttr || _feedCustomSkill)
+  ? [_feedCustomAttr, _feedCustomSkill, _feedCustomDisc || _feedDisc].filter(Boolean).join(' + ')
+  : [_feedMethodLabel, _feedDisc].filter(Boolean).join(' + ');
+```
+
+**Edit B** — Inside the feeding `{}` block, replace the standalone `poolLabel`
+computation (~line 2907) so it reuses the hoisted value instead of re-deriving:
+
+```js
+// BEFORE:
+const poolLabel = feedMethod === 'other' && (feedCustomAttr || feedCustomSkill)
+  ? [feedCustomAttr, feedCustomSkill, feedCustomDisc || feedDisc].filter(Boolean).join(' + ')
+  : [methodLabel, feedDisc].filter(Boolean).join(' + ');
+
+// AFTER:
+const poolLabel = feedPoolLabel;
+```
+
+This keeps all existing references to `poolLabel` inside the feeding block
+unchanged (`poolPlayer: poolLabel`, `description: poolLabel || ...`).
+
+**Edit C** — At the rote queue-entry push (~line 3005), add `feedPoolLabel` as
+third fallback:
+
+```js
+// BEFORE:
+poolPlayer: proj.primary_pool?.expression || resp[`project_${slot}_pool_expr`] || '',
+
+// AFTER:
+poolPlayer: proj.primary_pool?.expression || resp[`project_${slot}_pool_expr`] || feedPoolLabel,
+```
+
+---
+
+### T2 — QA: write and run Playwright spec [x]
+
+**File:** `tests/fix-725-rote-feed-inherited-pool.spec.js`
+
+Use the same `setupProcessing` pattern from `tests/fix-723-rote-feed-terr-preselect.spec.js`.
+
+Set `resp['_feed_method']` and `resp['_feed_disc']` on the submission so the feeding
+pool label has a known value, then open the rote action card and assert that
+`entry.poolPlayer` (surfaced as `.proc-pool-player-label` or equivalent) shows
+the correct inherited string.
+
+Test cases:
+
+| # | Setup | Assertion |
+|---|-------|-----------|
+| 1 | `_feed_method: 'empathy'`, `_feed_disc: 'Majesty'` | Rote card pool display contains "Empathy" and "Majesty" |
+| 2 | `_feed_method: 'other'`, `_feed_custom_attr: 'Presence'`, `_feed_custom_skill: 'Socialise'` | Rote card shows "Presence + Socialise" |
+| 3 | No `_feed_method` | Rote card pool display is blank/empty (no crash) |
+
+> **Note:** If `entry.poolPlayer` is displayed as the "Player Pool" button label or
+> a text display in the pool builder, locate the correct selector first by reading
+> `_renderActionTypeRow` around where `entry.poolPlayer` is used.
+
+---
+
+## Acceptance criteria
+
+- [ ] Given a submission with `_feed_method: 'empathy'` and `_feed_disc: 'Majesty'`,
+  the rote action card in DT Processing shows the inherited pool string in the pool
+  builder area
+- [ ] Given a submission with `_feed_method: 'other'` and custom attr/skill, the
+  rote card shows the custom expression
+- [ ] Given no primary feed method is set, the rote card pool area is blank — no
+  crash, no regression
+- [ ] The standard feeding action card is unaffected (its `poolPlayer` is unchanged)
+
+---
+
+## Guardrails
+
+- Only `downtime-views.js` changes (one hoist block + two single-line edits).
+- `feedPoolLabel` must be computed **outside** the feeding `{}` block scope.
+- The feeding entry's `poolPlayer` must remain identical to what it was before —
+  `poolLabel = feedPoolLabel` is a value alias, not a behaviour change.
+- Do NOT read `sub.feeding_review.pool_validated` here — that's the ST's validated
+  result, not the player's input. We want the raw player-submitted expression as
+  the pool builder starting point.
+
+---
+
+## Dev Agent Record
+
+### Files changed
+- `public/js/admin/downtime-views.js` — Edit A: hoisted `feedPoolLabel` block before the feeding `{}` block; Edit B: aliased internal `poolLabel = feedPoolLabel`; Edit C: added `|| feedPoolLabel` as third fallback on rote entry's `poolPlayer`
+- `tests/fix-725-rote-feed-inherited-pool.spec.js` — 3 Playwright tests, 3/3 passing
+
+### Completion notes
+Root cause was pure block scoping: `poolLabel` was `const`-scoped inside the feeding `{}` block and unavailable at the rote entry build site. Hoisted equivalent computation as `feedPoolLabel`, aliased inside the block to keep existing references intact, and added as fallback on the rote entry. `FEED_METHOD_LABELS_MAP` has keys `seduction/stalking/force/familiar/intimidation/other` — tests use `seduction` and `other`; unknown slugs fall back to raw slug string (lowercase).

--- a/tests/fix-725-rote-feed-inherited-pool.spec.js
+++ b/tests/fix-725-rote-feed-inherited-pool.spec.js
@@ -1,0 +1,157 @@
+/**
+ * fix.725 — Rote feed in DT Processing: inherited pool from primary hunt not surfacing
+ *
+ * Acceptance criteria:
+ *   AC1: _feed_method:'seduction' + _feed_disc:'Majesty' → rote card shows "Seduction" and "Majesty"
+ *   AC2: _feed_method:'other' + custom attr/skill → rote card shows "Presence + Socialise"
+ *   AC3: No _feed_method set → rote card pool area is blank (no crash)
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Fixtures ───────────────────────────────────────────────────────────────────
+
+const ST_USER = {
+  id: '123456789', username: 'test_st', global_name: 'Test ST',
+  avatar: null, role: 'st', player_id: 'p-001', character_ids: [], is_dual_role: false,
+};
+
+const CHAR_ROTE = {
+  _id: 'char-rote-725', name: 'Aleksei', moniker: null, honorific: null,
+  clan: 'Nosferatu', covenant: 'Circle of the Crone', player: 'Test Player',
+  blood_potency: 3, humanity: 6, humanity_base: 7, court_title: null,
+  retired: false,
+  status: { city: 1, clan: 1, covenant: { 'Carthian Movement': 0, 'Circle of the Crone': 1, 'Invictus': 0, 'Lancea et Sanctum': 0, 'Ordo Dracul': 0 } },
+  attributes: {
+    Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 3, bonus: 0 },
+    Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 3, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+    Presence: { dots: 3, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: {},
+  disciplines: {},
+  merits: [],
+  ordeals: [],
+};
+
+const TEST_CYCLE = {
+  _id: 'cycle-001', cycle_number: 4, status: 'active',
+  confirmed_ambience: {}, narrative_notes: '',
+};
+
+function makeRoteSub(feedOverrides = {}) {
+  return {
+    _id: 'sub-rote-725',
+    cycle_id: 'cycle-001',
+    character_name: 'Aleksei',
+    character_id: 'char-rote-725',
+    player_name: 'Test Player',
+    submitted_at: '2026-06-14T00:00:00Z',
+    _raw: {
+      projects: [{ action_type: 'rote', primary_pool: null, desired_outcome: 'Feed in peace.' }],
+      feeding: null,
+      sphere_actions: [],
+      contact_actions: { requests: [] },
+      retainer_actions: { actions: [] },
+    },
+    responses: {
+      project_1_action: 'rote',
+      project_1_title: 'Rote Feeding Hunt',
+      project_1_description: 'Using Obfuscate to feed undetected.',
+      project_1_territory: 'secondcity',
+      ...feedOverrides,
+    },
+    projects_resolved: [],
+    feeding_review: null,
+    merit_actions_resolved: [],
+    sorcery_review: {},
+    st_review: { territory_overrides: {} },
+  };
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+async function setupProcessing(page, sub) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'local-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url    = route.request().url();
+    const method = route.request().method();
+    const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+    if (method === 'PUT' || method === 'PATCH' || method === 'POST') return ok({ ok: true });
+    if (url.includes('/api/downtime_submissions'))  return ok([sub]);
+    if (url.includes('/api/downtime_cycles'))       return ok([TEST_CYCLE]);
+    if (url.includes('/api/characters/names'))      return ok([CHAR_ROTE].map(c => ({ _id: c._id, name: c.name, moniker: c.moniker, honorific: c.honorific })));
+    if (url.includes('/api/characters'))            return ok([CHAR_ROTE]);
+    if (url.includes('/api/territories'))           return ok([]);
+    if (url.includes('/api/game_sessions'))         return ok([]);
+    if (url.includes('/api/session_logs'))          return ok([]);
+    return ok([]);
+  });
+
+  await page.goto('/admin.html');
+  await page.waitForSelector('#admin-app', { state: 'visible', timeout: 10000 });
+  await page.click('[data-domain="downtime"]');
+  await page.waitForTimeout(1000);
+}
+
+async function openRoteAction(page) {
+  await page.waitForSelector('.proc-action-row', { timeout: 8000 });
+  await page.locator('.proc-action-row').first().click();
+  await page.waitForSelector('.proc-action-detail', { timeout: 8000 });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+test.describe('fix.725 — rote feed inherited pool surfaces in DT Processing', () => {
+
+  test('AC1: seduction + Majesty feed method → rote card shows inherited pool string', async ({ page }) => {
+    const sub = makeRoteSub({ _feed_method: 'seduction', _feed_disc: 'Majesty' });
+    await setupProcessing(page, sub);
+    await openRoteAction(page);
+
+    // Pool builder "Player's Pool" row must be visible
+    const poolMeta = page.locator('.proc-pool-player-meta');
+    await expect(poolMeta).toBeVisible({ timeout: 6000 });
+
+    const poolRow = poolMeta.locator('.proc-pool-meta-row').filter({ hasText: "Player's Pool" });
+    await expect(poolRow).toBeVisible();
+    await expect(poolRow).toContainText('Seduction');
+    await expect(poolRow).toContainText('Majesty');
+  });
+
+  test('AC2: other method with custom attr/skill → rote card shows Presence + Socialise', async ({ page }) => {
+    const sub = makeRoteSub({
+      _feed_method: 'other',
+      _feed_custom_attr: 'Presence',
+      _feed_custom_skill: 'Socialise',
+    });
+    await setupProcessing(page, sub);
+    await openRoteAction(page);
+
+    const poolMeta = page.locator('.proc-pool-player-meta');
+    await expect(poolMeta).toBeVisible({ timeout: 6000 });
+
+    const poolRow = poolMeta.locator('.proc-pool-meta-row').filter({ hasText: "Player's Pool" });
+    await expect(poolRow).toBeVisible();
+    await expect(poolRow).toContainText('Presence');
+    await expect(poolRow).toContainText('Socialise');
+  });
+
+  test('AC3: no feed method → rote card pool area is blank, no crash', async ({ page }) => {
+    const sub = makeRoteSub({}); // no _feed_method
+    await setupProcessing(page, sub);
+    await openRoteAction(page);
+
+    // Pool builder must render (no JS crash)
+    await expect(page.locator('.proc-pool-builder')).toBeVisible({ timeout: 6000 });
+
+    // Player's Pool row should NOT appear (nothing to show)
+    const poolRow = page.locator('.proc-pool-meta-row').filter({ hasText: "Player's Pool" });
+    await expect(poolRow).toHaveCount(0);
+  });
+
+});


### PR DESCRIPTION
## Summary

- Rote feed actions in DT Processing showed a blank pool builder ("— + — ±0 = 0") even though the player form displayed the inherited pool from the primary hunt
- Root cause: `poolLabel` was `const`-scoped inside the feeding `{}` block and out of scope at the rote queue-entry build site
- Fix: hoist equivalent `feedPoolLabel` computation before the block and add it as third fallback on `entry.poolPlayer` for rote entries

## Closes

- Closes #725

## Story

- specs/stories/fix.725.rote-feed-inherited-pool.story.md

## Test plan

- [ ] 3/3 Playwright tests passing (seduction+Majesty inherited, other custom expr, no-method no crash)
- [ ] Manual: open a DT4 rote feed submission in DT Processing — pool builder "Player's Pool" row shows the feed method + disc from the primary hunt

## Branch flow

- From: `ms/issue-725-rote-feed-inherited-pool`
- Into: `dev`
