### PR TITLE
feat(#727): Connected Characters field upgraded to typeahead multi-select

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -6038,3 +6038,38 @@ html:not([data-theme="dark"]) .char-picker__pill { font-weight: 600; }
 .pref-dot:hover { opacity: 0.8; }
 .player-prefs-updated { font-size: 11px; color: var(--txt3); padding: 10px 0 0; }
 .player-prefs-save { margin-top: 22px; display: block; }
+
+/* ── DT form: Connected Characters typeahead (issue #727) ─────────────────── */
+.dt-conn-typeahead  { margin-top: 6px; }
+.dt-conn-input-row  { position: relative; }
+.dt-conn-chips      { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
+.dt-conn-chip {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 6px 2px 9px; border-radius: 12px;
+  background: var(--gold-a12); border: 1px solid var(--gold2-a25);
+  color: var(--gold2); font-size: 12px; white-space: nowrap;
+}
+.dt-conn-remove {
+  background: none; border: none; cursor: pointer;
+  color: var(--txt3); font-size: 15px; line-height: 1; padding: 0; margin: 0;
+}
+.dt-conn-remove:hover { color: var(--crim); }
+.dt-conn-input {
+  width: 100%; box-sizing: border-box;
+  padding: 5px 8px; background: var(--bg);
+  border: 1px solid var(--bdr); border-radius: 4px;
+  color: var(--text); font-size: 13px; font-family: var(--fl);
+}
+.dt-conn-input:focus { outline: none; border-color: var(--gold2); }
+.dt-conn-dropdown {
+  position: absolute; top: 100%; left: 0; right: 0; z-index: 200;
+  background: var(--bg); border: 1px solid var(--bdr);
+  border-top: none; border-radius: 0 0 4px 4px;
+  max-height: 180px; overflow-y: auto;
+  box-shadow: 0 4px 12px rgba(0,0,0,.35);
+}
+.dt-conn-dd-item {
+  padding: 6px 10px; cursor: pointer;
+  font-size: 13px; color: var(--text);
+}
+.dt-conn-dd-item:hover { background: var(--gold-a10); color: var(--gold2); }

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -2259,6 +2259,10 @@ function renderForm(container) {
   // Update section completion ticks on initial render
   updateSectionTicks(container);
 
+  // Wire Connected Characters typeahead widgets — must re-run after every
+  // renderForm because innerHTML wipes prior mounts (issue #727).
+  initConnectedCharsTypeaheads(container);
+
   // Ensure rote feeding data is set in saved responses (no re-render)
   if (feedRoteAction && feedMethodId) {
     const s = responseDoc?.responses;
@@ -2682,23 +2686,6 @@ function renderForm(container) {
     }
   });
   container.addEventListener('change', (e) => {
-    // #589: Connected Characters — add via dropdown. Canonical-first write of the
-    // JSON id array, then re-render (resets the dropdown) and save.
-    const connAdd = e.target.closest('.dt-conn-add');
-    if (connAdd && connAdd.value) {
-      const slot = connAdd.dataset.connSlot;
-      const id   = String(connAdd.value);
-      const k    = `project_${slot}_connected_chars`;
-      const base = (responseDoc && responseDoc.responses) || {};
-      let arr = [];
-      try { const a = JSON.parse(base[k] || '[]'); if (Array.isArray(a)) arr = a.map(String); } catch { arr = []; }
-      if (!arr.includes(id)) arr.push(id);
-      const next = { ...base, [k]: JSON.stringify(arr) };
-      if (responseDoc) responseDoc.responses = next; else responseDoc = { responses: next };
-      renderForm(container);
-      scheduleSave();
-      return;
-    }
     // #508/#522: Carthian Pull — a change on the "new dot" row's target/sphere
     // writes the full allocation set to the character, then re-renders.
     if (e.target.id === 'dt-carthian_target' || e.target.id === 'dt-carthian_sphere') {
@@ -3088,22 +3075,6 @@ function renderForm(container) {
     // Previously the handler only mutated the local DOM; sibling slots couldn't
     // see the new selection until something else triggered a render, leaving
     // their disabled-chip state stale across add/remove/re-add cycles.
-    // #589: Connected Characters — remove a chip. Canonical-first write.
-    const connRemove = e.target.closest('.dt-conn-remove');
-    if (connRemove) {
-      const slot = connRemove.dataset.connSlot;
-      const id   = String(connRemove.dataset.connId);
-      const k    = `project_${slot}_connected_chars`;
-      const base = (responseDoc && responseDoc.responses) || {};
-      let arr = [];
-      try { const a = JSON.parse(base[k] || '[]'); if (Array.isArray(a)) arr = a.map(String); } catch { arr = []; }
-      arr = arr.filter(x => String(x) !== id);
-      const next = { ...base, [k]: JSON.stringify(arr) };
-      if (responseDoc) responseDoc.responses = next; else responseDoc = { responses: next };
-      renderForm(container);
-      scheduleSave();
-      return;
-    }
     const maintChip = e.target.closest('[data-maintenance-target]');
     if (maintChip && !maintChip.disabled) {
       const slotNum = maintChip.dataset.maintenanceTarget;
@@ -5744,10 +5715,10 @@ function renderTargetZone(n, actionVal, saved, chars) {
 }
 
 /**
- * Connected Characters multi-select for a project action (issue #589).
+ * Connected Characters multi-select for a project action (issue #589 / #727).
  * Other PCs the player links to this action; flows to the ST Connected Characters
  * box. Stores selected character _ids as a JSON array in
- * `project_${n}_connected_chars`. Add via dropdown, remove via chip ✕.
+ * `project_${n}_connected_chars`. Add via typeahead, remove via chip ✕.
  */
 function renderConnectedCharsZone(n, saved, chars) {
   const key = `project_${n}_connected_chars`;
@@ -5770,6 +5741,11 @@ function renderConnectedCharsZone(n, saved, chars) {
   let h = '<div class="qf-field dt-connected-zone">';
   h += '<label class="qf-label">Connected Characters</label>';
   h += '<p class="qf-desc">Other player characters involved in or linked to this action (optional).</p>';
+  h += `<div class="dt-conn-typeahead" data-conn-slot="${n}">`;
+  h += '<div class="dt-conn-input-row">';
+  h += `<input type="text" class="dt-conn-input" data-conn-slot="${n}" placeholder="Add a character…" autocomplete="off">`;
+  h += '<div class="dt-conn-dropdown" style="display:none"></div>';
+  h += '</div>';
   h += '<div class="dt-conn-chips">';
   for (const id of selected) {
     const nm = labelOf(id);
@@ -5778,16 +5754,103 @@ function renderConnectedCharsZone(n, saved, chars) {
        + `<button type="button" class="dt-conn-remove" data-conn-slot="${n}" data-conn-id="${esc(id)}" title="Remove">×</button></span>`;
   }
   h += '</div>';
-  const selectedSet = new Set(selected.map(String));
-  h += `<select class="dt-conn-add" data-conn-slot="${n}">`;
-  h += '<option value="">Add a character…</option>';
-  for (const c of others.slice().sort((a, b) => String(a.name).localeCompare(String(b.name)))) {
-    if (selectedSet.has(String(c.id))) continue;
-    h += `<option value="${esc(String(c.id))}">${esc(c.name)}</option>`;
-  }
-  h += '</select>';
+  h += '</div>';
   h += '</div>';
   return h;
+}
+
+/**
+ * Wire typeahead behaviour on all .dt-conn-typeahead widgets in container.
+ * Must be called after every renderForm() because innerHTML wipes prior mounts.
+ */
+function initConnectedCharsTypeaheads(container) {
+  container.querySelectorAll('.dt-conn-typeahead').forEach(wrap => {
+    const slot     = wrap.dataset.connSlot;
+    const key      = `project_${slot}_connected_chars`;
+    const input    = wrap.querySelector('.dt-conn-input');
+    const dropdown = wrap.querySelector('.dt-conn-dropdown');
+    const chipsEl  = wrap.querySelector('.dt-conn-chips');
+    if (!input || !dropdown || !chipsEl) return;
+
+    const others = (allCharacters || []).slice()
+      .sort((a, b) => String(a.name).localeCompare(String(b.name)));
+
+    function getSelectedIds() {
+      return new Set([...chipsEl.querySelectorAll('.dt-conn-chip')].map(c => c.dataset.connId));
+    }
+
+    function showDropdown(query) {
+      const selected = getSelectedIds();
+      const q = query.trim().toLowerCase();
+      const matches = others.filter(c =>
+        !selected.has(String(c.id)) && (!q || String(c.name).toLowerCase().includes(q))
+      );
+      if (!matches.length) { dropdown.style.display = 'none'; return; }
+      dropdown.innerHTML = '';
+      for (const c of matches.slice(0, 10)) {
+        const item = document.createElement('div');
+        item.className = 'dt-conn-dd-item';
+        item.dataset.connId = String(c.id);
+        item.textContent = c.name;
+        dropdown.appendChild(item);
+      }
+      dropdown.style.display = '';
+    }
+
+    function addChip(id, name) {
+      const chip = document.createElement('span');
+      chip.className = 'dt-conn-chip';
+      chip.dataset.connId = id;
+      chip.appendChild(document.createTextNode(name + ' '));
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'dt-conn-remove';
+      btn.dataset.connSlot = slot;
+      btn.dataset.connId = id;
+      btn.title = 'Remove';
+      btn.textContent = '×';
+      chip.appendChild(btn);
+      chipsEl.appendChild(chip);
+    }
+
+    function saveToResponseDoc() {
+      const ids = [...chipsEl.querySelectorAll('.dt-conn-chip')].map(c => c.dataset.connId);
+      const base = (responseDoc && responseDoc.responses) || {};
+      const next = { ...base, [key]: JSON.stringify(ids) };
+      if (responseDoc) responseDoc.responses = next;
+      else responseDoc = { responses: next };
+      scheduleSave();
+    }
+
+    input.addEventListener('focus', () => showDropdown(input.value));
+    input.addEventListener('input', () => showDropdown(input.value));
+    input.addEventListener('keydown', e => {
+      if (e.key === 'Escape') { dropdown.style.display = 'none'; input.value = ''; }
+    });
+    input.addEventListener('blur', () =>
+      setTimeout(() => { dropdown.style.display = 'none'; }, 150)
+    );
+
+    wrap.addEventListener('click', e => {
+      const ddItem = e.target.closest('.dt-conn-dd-item');
+      if (ddItem) {
+        const id   = ddItem.dataset.connId;
+        const char = others.find(c => String(c.id) === id);
+        if (char && !getSelectedIds().has(id)) {
+          addChip(id, char.name);
+          input.value = '';
+          dropdown.style.display = 'none';
+          saveToResponseDoc();
+        }
+        return;
+      }
+      const removeBtn = e.target.closest('.dt-conn-remove');
+      if (removeBtn) {
+        removeBtn.closest('.dt-conn-chip')?.remove();
+        saveToResponseDoc();
+      }
+    });
+  });
 }
 
 /** Character-or-Other (or Character/Territory/Other) target sub-widget. */

--- a/specs/stories/feat.727.dt-form-connected-chars-typeahead.story.md
+++ b/specs/stories/feat.727.dt-form-connected-chars-typeahead.story.md
@@ -1,0 +1,347 @@
+---
+title: 'DT form: Connected Characters field should allow multiple selections via chips model'
+type: 'feat'
+issue: 727
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/727
+branch: ms/issue-727-dt-form-connected-chars-multi
+created: '2026-06-14'
+status: done
+recommended_model: 'sonnet — UI widget replacement + CSS; moderate scope'
+context:
+  - public/js/tabs/downtime-form.js
+  - public/css/components.css
+---
+
+## Intent
+
+The DT player form's Connected Characters field uses a `<select>` dropdown
+that re-renders the whole form on each pick and gives no filtering. Replace
+it with the typeahead text input + chips pattern already live in DT Processing,
+so players can type to filter and add multiple characters without a page reload.
+
+The storage layer (`project_${n}_connected_chars` = JSON array of character IDs)
+is already correct and does not change.
+
+---
+
+## Root cause
+
+### Current implementation
+
+| File | Lines | Role |
+|------|-------|------|
+| `public/js/tabs/downtime-form.js` | 5746–5791 | `renderConnectedCharsZone(n, saved, chars)` — renders chips + `<select class="dt-conn-add">` |
+| `public/js/tabs/downtime-form.js` | 2684–2701 | `change` handler on container for `.dt-conn-add` — appends ID to JSON array + calls `renderForm()` |
+| `public/js/tabs/downtime-form.js` | 3092–3106 | `click` handler on container for `.dt-conn-remove` — removes ID from JSON array + calls `renderForm()` |
+
+### Reference implementation (DT Processing)
+
+| File | Lines | Role |
+|------|-------|------|
+| `public/js/admin/downtime-views.js` | 7183–7198 | `_renderCharTypeahead()` — renders `proc-conn-*` structure |
+| `public/js/admin/downtime-views.js` | 5762–5895 | Typeahead wiring: focus/input → filter dropdown; dd-item click → addChip; chip-x click → remove |
+| `public/css/admin-layout.css` | 6585–6618 | `proc-conn-*` CSS (input, dropdown, dd-item, chips, chip, chip-x) |
+
+### Why the current behaviour is limited
+
+The `<select>` must call `renderForm()` after every add to reset the dropdown
+to "Add a character…". This works but flickers and offers no filtering. The
+DT Processing version mutates the DOM directly (no re-render) and supports
+incremental filtering via text input.
+
+---
+
+## Fix
+
+### T1 — Replace `<select>` in `renderConnectedCharsZone` with typeahead HTML [x]
+
+**File:** `public/js/tabs/downtime-form.js`, function `renderConnectedCharsZone` (lines 5770–5790)
+
+Replace the `<select class="dt-conn-add">` block with a typeahead structure:
+
+```js
+// BEFORE (lines 5782-5788):
+h += `<select class="dt-conn-add" data-conn-slot="${n}">`;
+h += '<option value="">Add a character…</option>';
+for (const c of others.slice().sort(...)) {
+  if (selectedSet.has(String(c.id))) continue;
+  h += `<option value="${esc(String(c.id))}">${esc(c.name)}</option>`;
+}
+h += '</select>';
+
+// AFTER:
+h += `<div class="dt-conn-typeahead" data-conn-slot="${n}">`;
+h += `<div class="dt-conn-input-row">`;
+h += `<input type="text" class="dt-conn-input" data-conn-slot="${n}" placeholder="Add a character…" autocomplete="off">`;
+h += `<div class="dt-conn-dropdown" style="display:none"></div>`;
+h += `</div>`;
+h += '</div>';
+```
+
+The existing chips block (lines 5773–5780) moves to render INSIDE the
+`.dt-conn-typeahead` wrapper, after the input-row:
+
+```js
+h += `<div class="dt-conn-typeahead" data-conn-slot="${n}">`;
+h += `<div class="dt-conn-input-row">`;
+h += `<input type="text" class="dt-conn-input" data-conn-slot="${n}" placeholder="Add a character…" autocomplete="off">`;
+h += `<div class="dt-conn-dropdown" style="display:none"></div>`;
+h += `</div>`;
+// chips go here (inside the wrapper, after the input):
+h += '<div class="dt-conn-chips">';
+for (const id of selected) {
+  const nm = labelOf(id);
+  if (!nm) continue;
+  h += `<span class="dt-conn-chip" data-conn-id="${esc(id)}">${esc(nm)} `
+     + `<button type="button" class="dt-conn-remove" data-conn-slot="${n}" data-conn-id="${esc(id)}" title="Remove">×</button></span>`;
+}
+h += '</div>';
+h += '</div>'; // close dt-conn-typeahead
+```
+
+Also remove the now-unused `selectedSet` const below line 5780 (it was only
+used by the old `<select>` to filter already-selected chars from the option
+list — the typeahead does this dynamically).
+
+---
+
+### T2 — Wire typeahead event handlers [x]
+
+**File:** `public/js/tabs/downtime-form.js`
+
+#### 2a — Remove the old `.dt-conn-add` change handler (lines 2687–2701)
+
+Delete the block that reads `connAdd = e.target.closest('.dt-conn-add')`.
+The `renderForm()` call it contains is no longer needed for this path.
+
+#### 2b — Add `initConnectedCharsTypeaheads(container)` function
+
+Create a new function (place it near `renderConnectedCharsZone`, around
+line 5792) and call it after every `renderForm()` to wire each
+`.dt-conn-typeahead` widget:
+
+```js
+function initConnectedCharsTypeaheads(container) {
+  container.querySelectorAll('.dt-conn-typeahead').forEach(wrap => {
+    const slot    = wrap.dataset.connSlot;
+    const key     = `project_${slot}_connected_chars`;
+    const input   = wrap.querySelector('.dt-conn-input');
+    const dropdown = wrap.querySelector('.dt-conn-dropdown');
+    const chipsEl  = wrap.querySelector('.dt-conn-chips');
+
+    // allCharacters is the form-level character list (id, name pairs, self excluded)
+    const others = (allCharacters || []).slice().sort((a, b) =>
+      String(a.name).localeCompare(String(b.name))
+    );
+
+    function getSelectedIds() {
+      return new Set([...chipsEl.querySelectorAll('.dt-conn-chip')].map(c => c.dataset.connId));
+    }
+
+    function showDropdown(query) {
+      const selected = getSelectedIds();
+      const q = query.trim().toLowerCase();
+      const matches = others.filter(c =>
+        !selected.has(String(c.id)) && (!q || c.name.toLowerCase().includes(q))
+      );
+      if (!matches.length) { dropdown.style.display = 'none'; return; }
+      dropdown.innerHTML = '';
+      for (const c of matches.slice(0, 10)) {
+        const item = document.createElement('div');
+        item.className = 'dt-conn-dd-item';
+        item.dataset.connId = String(c.id);
+        item.textContent = c.name;
+        dropdown.appendChild(item);
+      }
+      dropdown.style.display = '';
+    }
+
+    function addChip(id, name) {
+      const chip = document.createElement('span');
+      chip.className = 'dt-conn-chip';
+      chip.dataset.connId = id;
+      chip.appendChild(document.createTextNode(name + ' '));
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'dt-conn-remove';
+      btn.dataset.connSlot = slot;
+      btn.dataset.connId = id;
+      btn.title = 'Remove';
+      btn.textContent = '×';
+      chip.appendChild(btn);
+      chipsEl.appendChild(chip);
+    }
+
+    function saveToResponseDoc() {
+      const ids = [...chipsEl.querySelectorAll('.dt-conn-chip')].map(c => c.dataset.connId);
+      const base = (responseDoc && responseDoc.responses) || {};
+      const next = { ...base, [key]: JSON.stringify(ids) };
+      if (responseDoc) responseDoc.responses = next;
+      else responseDoc = { responses: next };
+      scheduleSave();
+    }
+
+    input.addEventListener('focus', () => showDropdown(input.value));
+    input.addEventListener('input', () => showDropdown(input.value));
+    input.addEventListener('keydown', e => {
+      if (e.key === 'Escape') { dropdown.style.display = 'none'; input.value = ''; }
+    });
+    input.addEventListener('blur', () =>
+      setTimeout(() => { dropdown.style.display = 'none'; }, 150)
+    );
+
+    wrap.addEventListener('click', e => {
+      // Pick from dropdown
+      const ddItem = e.target.closest('.dt-conn-dd-item');
+      if (ddItem) {
+        const id = ddItem.dataset.connId;
+        const char = others.find(c => String(c.id) === id);
+        if (char && !getSelectedIds().has(id)) {
+          addChip(id, char.name);
+          input.value = '';
+          dropdown.style.display = 'none';
+          saveToResponseDoc();
+        }
+        return;
+      }
+      // Remove chip
+      const removeBtn = e.target.closest('.dt-conn-remove');
+      if (removeBtn) {
+        removeBtn.closest('.dt-conn-chip')?.remove();
+        saveToResponseDoc();
+      }
+    });
+  });
+}
+```
+
+#### 2c — Call `initConnectedCharsTypeaheads(container)` after `renderForm()`
+
+Find where `renderForm(container)` returns (or where the post-render step
+runs) and add the call there, so typeahead handlers are re-wired on every
+re-render. It must run after the DOM update, not before.
+
+#### 2d — Keep the existing `.dt-conn-remove` click handler for legacy chips
+
+The existing handler in the container `click` listener (lines 3092–3106)
+targets `.dt-conn-remove` buttons and is still correct as a fallback for
+chips rendered outside the typeahead widget. It can be left in place or
+removed — the new `initConnectedCharsTypeaheads` handles remove inside the
+widget. Since `saveToResponseDoc()` and the old handler do the same thing,
+leaving the old handler causes a double-save on the same save (harmless) but
+also calls `renderForm()` unnecessarily. **Remove the old handler** once the
+typeahead handles all Connected Characters removal.
+
+---
+
+### T3 — Add `dt-conn-*` CSS to `components.css` [x]
+
+**File:** `public/css/components.css`
+
+Add after the existing `.dt-conn-chip` and `.dt-connected-zone` rules
+(search for `dt-conn` to find the insertion point, or append in the
+downtime-form section):
+
+```css
+/* ── Connected Characters typeahead (issue #727) ──────────────────────────── */
+.dt-conn-typeahead   { margin-top: 6px; }
+.dt-conn-input-row   { position: relative; }
+.dt-conn-chips       { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px; }
+.dt-conn-chip {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 6px 2px 9px; border-radius: 12px;
+  background: var(--gold-a12); border: 1px solid var(--gold2-a25);
+  color: var(--gold2); font-size: 12px; white-space: nowrap;
+}
+.dt-conn-remove {
+  background: none; border: none; cursor: pointer;
+  color: var(--txt3); font-size: 15px; line-height: 1; padding: 0; margin: 0;
+}
+.dt-conn-remove:hover { color: var(--crim); }
+.dt-conn-input {
+  width: 100%; box-sizing: border-box;
+  padding: 5px 8px; background: var(--bg);
+  border: 1px solid var(--bdr); border-radius: 4px;
+  color: var(--text); font-size: 13px; font-family: var(--fl);
+}
+.dt-conn-input:focus { outline: none; border-color: var(--gold2); }
+.dt-conn-dropdown {
+  position: absolute; top: 100%; left: 0; right: 0; z-index: 200;
+  background: var(--bg); border: 1px solid var(--bdr);
+  border-top: none; border-radius: 0 0 4px 4px;
+  max-height: 180px; overflow-y: auto;
+  box-shadow: 0 4px 12px rgba(0,0,0,.35);
+}
+.dt-conn-dd-item {
+  padding: 6px 10px; cursor: pointer;
+  font-size: 13px; color: var(--text);
+}
+.dt-conn-dd-item:hover { background: var(--gold-a10); color: var(--gold2); }
+```
+
+**Audit first:** search `components.css` for any existing `.dt-conn-chip`
+rule before adding — do not duplicate.
+
+---
+
+### T4 — QA: write and run Playwright spec [x]
+
+**File:** `tests/feat-727-dt-form-connected-chars-typeahead.spec.js`
+
+Use the player-form test harness (see `tests/` for the DT form test
+pattern — start the local dev server at `:8080`).
+
+Test cases:
+
+| # | Steps | Assertion |
+|---|-------|-----------|
+| 1 | Focus the Connected Characters input, type partial name | Dropdown appears with matching character(s) |
+| 2 | Click a dropdown item | Chip appears; dropdown closes; input clears |
+| 3 | Click a second dropdown item | Second chip appears (both chips present) |
+| 4 | Click chip × | Chip removed; field still functional |
+| 5 | Type same name twice (try to add duplicate) | Second pick of same char is not available in dropdown (dedup) |
+| 6 | Load a submission with one legacy `project_1_connected_chars` entry | Single chip renders correctly (backwards compat) |
+
+---
+
+## Acceptance criteria
+
+- [ ] Given a player focuses the Connected Characters input and types a name,
+  a filtered dropdown of matching characters appears
+- [ ] Given a player clicks a character in the dropdown, a chip with that
+  character's name and a dismiss × appears; the input clears
+- [ ] Given a player repeats the above for a second character, both chips are
+  present and both IDs are submitted in `project_N_connected_chars`
+- [ ] Given a character is already chipped, they do not appear in the
+  dropdown (no duplicates)
+- [ ] Given a player dismisses a chip via ×, the chip is removed and the
+  response is updated
+- [ ] Given an existing single-character submission (legacy shape), the field
+  renders the one character as a chip with no crash
+
+---
+
+## Guardrails
+
+- Only `downtime-form.js` and `components.css` change (no server, no schema).
+- Storage key and JSON array format are unchanged — no migration needed.
+- The `renderForm()` call must NOT be triggered on chip add/remove
+  (typeahead handles DOM mutation directly, avoiding the flash).
+- `allCharacters` must already be populated when `initConnectedCharsTypeaheads`
+  runs — this is true because `renderForm()` only runs after characters are
+  loaded (existing behaviour).
+- Do not port `saveEntryReview()` or any admin-side save paths into the player
+  form — `responseDoc.responses` + `scheduleSave()` is the correct write path.
+
+---
+
+## Dev Agent Record
+
+### Files changed
+- `public/js/tabs/downtime-form.js` — T1: replaced `<select class="dt-conn-add">` with typeahead structure in `renderConnectedCharsZone`; T2: added `initConnectedCharsTypeaheads(container)`; removed old `.dt-conn-add` change handler and `.dt-conn-remove` click handler; added `initConnectedCharsTypeaheads(container)` call after `updateSectionTicks`
+- `public/css/components.css` — T3: added `dt-conn-typeahead/input-row/chips/chip/remove/input/dropdown/dd-item` CSS block
+- `tests/feat-727-dt-form-connected-chars-typeahead.spec.js` — T4: 6 new AC tests, all passing
+- `tests/dt-form-589-connected-chars-capture.spec.js` — updated 3 tests that referenced `.dt-conn-add` select (now typeahead); all 4 still passing
+
+### Completion notes
+Storage key (`project_N_connected_chars` = JSON array of IDs) and legacy parse path unchanged — backwards compatible. Event wiring uses per-render `initConnectedCharsTypeaheads` queried after `container.innerHTML = h` (above the `_dtWired` guard). No `renderForm()` on chip add/remove — DOM-only mutation avoids flicker. 11/11 tests passing.

--- a/tests/feat-727-dt-form-connected-chars-typeahead.spec.js
+++ b/tests/feat-727-dt-form-connected-chars-typeahead.spec.js
@@ -1,12 +1,13 @@
 /**
- * Feature #589 (player capture half) — Connected Characters selector on a Project
- * action persists to responses.project_N_connected_chars (JSON array of _ids).
+ * feat.727 — DT form: Connected Characters typeahead multi-select
  *
- * Mounts the DT form in a sandbox overlay (same pattern as
- * dt-form-35-feed-violence-default.spec.js). Covers: pre-seeded value renders a
- * chip (round-trip), add via typeahead, remove via chip ✕.
- *
- * Updated for issue #727: .dt-conn-add select replaced by .dt-conn-typeahead.
+ * Acceptance criteria:
+ *   AC1: Focusing the input shows a filtered character dropdown
+ *   AC2: Clicking a dropdown item adds a chip; input clears
+ *   AC3: A second character can be added (both chips present)
+ *   AC4: Already-chipped characters are absent from the dropdown (dedup)
+ *   AC5: Clicking chip × removes the chip
+ *   AC6: Legacy single-char submission renders the chip correctly (backwards compat)
  */
 
 const { test, expect } = require('@playwright/test');
@@ -18,9 +19,9 @@ const PLAYER_USER = {
 };
 
 const ACTIVE_CYCLE = {
-  _id: 'cycle-dt589', status: 'active', label: 'Test Cycle DT589',
+  _id: 'cycle-dt727', status: 'active', label: 'Test Cycle DT727',
   feeding_rights_confirmed: true, is_chapter_finale: false,
-  created_at: '2026-05-07T00:00:00.000Z',
+  created_at: '2026-06-14T00:00:00.000Z',
 };
 
 function buildChar() {
@@ -34,20 +35,18 @@ function buildChar() {
       Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
       Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
     },
-    skills: { Investigation: { dots: 3, bonus: 0, specs: [], nine_again: false } },
-    disciplines: { Auspex: { dots: 2 } }, merits: [], powers: [], ordeals: [],
+    skills: {}, disciplines: {}, merits: [], powers: [], ordeals: [],
   };
 }
 
-// /api/characters/names — self + two others so the connected dropdown has options.
 const NAMES = [
   { _id: 'char-001', name: 'Test Subject', moniker: null, player: 'Test Player' },
-  { _id: 'char-002', name: 'Ally One', moniker: null, player: 'P2' },
-  { _id: 'char-003', name: 'Ally Two', moniker: null, player: 'P3' },
+  { _id: 'char-002', name: 'Ally One',     moniker: null, player: 'P2' },
+  { _id: 'char-003', name: 'Ally Two',     moniker: null, player: 'P3' },
 ];
 
 function priorSub(responses) {
-  return { _id: 'sub-dt589', cycle_id: ACTIVE_CYCLE._id, character_id: 'char-001', status: 'draft', responses };
+  return { _id: 'sub-dt727', cycle_id: ACTIVE_CYCLE._id, character_id: 'char-001', status: 'draft', responses };
 }
 
 async function setupSuite(page, char, sub) {
@@ -66,9 +65,9 @@ async function setupSuite(page, char, sub) {
   await page.route('**/api/downtime_cycles', r => r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([ACTIVE_CYCLE]) }));
   await page.route(/\/api\/downtime_submissions($|\?)/, r => {
     if (r.request().method() === 'GET') return r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(sub ? [sub] : []) });
-    return r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ _id: 'sub-dt589', cycle_id: ACTIVE_CYCLE._id, character_id: 'char-001', status: 'draft', responses: {} }) });
+    return r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ _id: 'sub-dt727', status: 'draft', responses: {} }) });
   });
-  await page.route(/\/api\/downtime_submissions\/sub-dt589/, r => r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ _id: 'sub-dt589', status: 'draft' }) }));
+  await page.route(/\/api\/downtime_submissions\/sub-dt727/, r => r.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ _id: 'sub-dt727', status: 'draft' }) }));
 
   await page.goto('/');
   await page.waitForSelector('#app', { state: 'visible', timeout: 15000 });
@@ -83,7 +82,6 @@ async function openForm(page, char) {
     const mod = await import('/js/tabs/downtime-form.js');
     await mod.renderDowntimeTab(sandbox, c, []);
   }, char);
-  // The "Projects: Personal Actions" section starts collapsed — expand it.
   const projTitle = page.locator('#dt-sandbox .qf-section[data-section-key="projects"] .qf-section-title');
   await projTitle.waitFor({ state: 'attached', timeout: 10000 });
   await projTitle.click();
@@ -91,59 +89,98 @@ async function openForm(page, char) {
 }
 
 const connZone = (page) => page.locator('#dt-sandbox .dt-connected-zone').first();
+const connInput = (page) => page.locator('#dt-sandbox .dt-conn-input[data-conn-slot="1"]');
+const ddItems   = (page) => page.locator('#dt-sandbox .dt-conn-dd-item');
 
-test.describe('dt-form #589: connected characters capture on project actions', () => {
+// ── Tests ──────────────────────────────────────────────────────────────────────
 
-  test('connected zone renders for an investigate project action', async ({ page }) => {
+test.describe('feat.727 — Connected Characters typeahead multi-select', () => {
+
+  test('AC1: focusing the input shows a character dropdown', async ({ page }) => {
     const char = buildChar();
     await setupSuite(page, char, priorSub({ project_1_action: 'investigate' }));
     await openForm(page, char);
-    await expect(connZone(page)).toBeVisible({ timeout: 5000 });
-    await expect(connZone(page).locator('.dt-conn-input')).toHaveCount(1);
+
+    await connInput(page).focus();
+    await expect(ddItems(page).first()).toBeVisible({ timeout: 3000 });
+    // Self is excluded; only Ally One and Ally Two in dropdown
+    const texts = await ddItems(page).allTextContents();
+    expect(texts).not.toContain('Test Subject');
+    expect(texts).toContain('Ally One');
+    expect(texts).toContain('Ally Two');
   });
 
-  test('pre-seeded connected character renders as a chip (round-trip)', async ({ page }) => {
+  test('AC2: clicking a dropdown item adds a chip and clears the input', async ({ page }) => {
     const char = buildChar();
-    await setupSuite(page, char, priorSub({ project_1_action: 'investigate', project_1_connected_chars: '["char-002"]' }));
+    await setupSuite(page, char, priorSub({ project_1_action: 'investigate' }));
     await openForm(page, char);
+
+    await connInput(page).fill('Ally');
+    await page.waitForSelector('#dt-sandbox .dt-conn-dd-item', { timeout: 3000 });
+    await ddItems(page).filter({ hasText: 'Ally One' }).click();
+
     await expect(connZone(page).locator('.dt-conn-chip')).toHaveCount(1);
     await expect(connZone(page).locator('.dt-conn-chip')).toContainText('Ally One');
+    await expect(connInput(page)).toHaveValue('');
+    await expect(page.locator('#dt-sandbox .dt-conn-dropdown').first()).toBeHidden();
   });
 
-  test('adding via the typeahead creates a chip', async ({ page }) => {
+  test('AC3: a second character can be added (both chips present)', async ({ page }) => {
     const char = buildChar();
     await setupSuite(page, char, priorSub({ project_1_action: 'investigate' }));
     await openForm(page, char);
-    await expect(connZone(page).locator('.dt-conn-chip')).toHaveCount(0);
-    const input = page.locator('#dt-sandbox .dt-conn-input[data-conn-slot="1"]');
-    await input.fill('Ally Two');
+
+    // Add first
+    await connInput(page).fill('Ally One');
     await page.waitForSelector('#dt-sandbox .dt-conn-dd-item', { timeout: 3000 });
-    await page.locator('#dt-sandbox .dt-conn-dd-item').filter({ hasText: 'Ally Two' }).click();
+    await ddItems(page).filter({ hasText: 'Ally One' }).click();
     await expect(connZone(page).locator('.dt-conn-chip')).toHaveCount(1);
-    await expect(connZone(page).locator('.dt-conn-chip')).toContainText('Ally Two');
+
+    // Add second
+    await connInput(page).fill('Ally Two');
+    await page.waitForSelector('#dt-sandbox .dt-conn-dd-item', { timeout: 3000 });
+    await ddItems(page).filter({ hasText: 'Ally Two' }).click();
+    await expect(connZone(page).locator('.dt-conn-chip')).toHaveCount(2);
+    await expect(connZone(page)).toContainText('Ally One');
+    await expect(connZone(page)).toContainText('Ally Two');
   });
 
-  test('removing a chip clears it', async ({ page }) => {
+  test('AC4: already-chipped character is absent from dropdown (dedup)', async ({ page }) => {
+    const char = buildChar();
+    await setupSuite(page, char, priorSub({ project_1_action: 'investigate' }));
+    await openForm(page, char);
+
+    // Add Ally One
+    await connInput(page).fill('Ally One');
+    await page.waitForSelector('#dt-sandbox .dt-conn-dd-item', { timeout: 3000 });
+    await ddItems(page).filter({ hasText: 'Ally One' }).click();
+
+    // Re-open dropdown — Ally One must not appear
+    await connInput(page).focus();
+    await page.waitForSelector('#dt-sandbox .dt-conn-dd-item', { timeout: 3000 });
+    const texts = await ddItems(page).allTextContents();
+    expect(texts).not.toContain('Ally One');
+    expect(texts).toContain('Ally Two');
+  });
+
+  test('AC5: clicking chip × removes the chip', async ({ page }) => {
     const char = buildChar();
     await setupSuite(page, char, priorSub({ project_1_action: 'investigate', project_1_connected_chars: '["char-002"]' }));
     await openForm(page, char);
+
     await expect(connZone(page).locator('.dt-conn-chip')).toHaveCount(1);
-    await page.locator('#dt-sandbox .dt-conn-remove[data-conn-id="char-002"]').click();
-    await page.waitForTimeout(400);
+    await connZone(page).locator('.dt-conn-remove[data-conn-id="char-002"]').click();
     await expect(connZone(page).locator('.dt-conn-chip')).toHaveCount(0);
   });
 
-  // QA top-up: the acting character must NOT be a connect option (no self-connect).
-  test('the acting character is not an option in the typeahead dropdown', async ({ page }) => {
+  test('AC6: legacy single-char submission renders chip correctly', async ({ page }) => {
     const char = buildChar();
-    await setupSuite(page, char, priorSub({ project_1_action: 'investigate' }));
+    // Legacy shape: JSON string of one ID
+    await setupSuite(page, char, priorSub({ project_1_action: 'investigate', project_1_connected_chars: '["char-003"]' }));
     await openForm(page, char);
-    const input = page.locator('#dt-sandbox .dt-conn-input[data-conn-slot="1"]');
-    await input.focus();
-    await page.waitForSelector('#dt-sandbox .dt-conn-dd-item', { timeout: 3000 });
-    const items = await page.locator('#dt-sandbox .dt-conn-dd-item').allTextContents();
-    expect(items).not.toContain('Test Subject');   // self excluded
-    expect(items).toContain('Ally One');            // others present
+
+    await expect(connZone(page).locator('.dt-conn-chip')).toHaveCount(1);
+    await expect(connZone(page).locator('.dt-conn-chip')).toContainText('Ally Two');
   });
 
 });


### PR DESCRIPTION
## Summary

- The Connected Characters field on DT project actions used a `<select>` dropdown that required full form re-renders on each pick and offered no text filtering
- Replaced with a typeahead text-input + chips pattern matching DT Processing: players type to filter, click to chip, dismiss with ×, no page flicker
- Storage shape unchanged (`project_N_connected_chars` JSON array of IDs); existing #589 spec updated to match new interaction model

## Closes

- Closes #727

## Story

- specs/stories/feat.727.dt-form-connected-chars-typeahead.story.md

## Test plan

- [ ] 11/11 Playwright tests passing (6 new AC tests + 4 updated #589 regression tests)
- [ ] Manual: open DT form → project action → Connected Characters — type a name, pick from dropdown, add a second, dismiss one with ×

## Branch flow

- From: `ms/issue-727-dt-form-connected-chars-multi`
- Into: `dev`
