### PR TITLE
fix(#729): project action roll missing spec bonus dice

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -5653,8 +5653,9 @@ function renderProcessingMode(container) {
       }
       if (!poolValidated) return;
       const match = poolValidated.match(/(\d+)\s*$/);
-      const diceCount = match ? parseInt(match[1], 10) : 0;
+      let diceCount = match ? parseInt(match[1], 10) : 0;
       if (!diceCount) { alert('Cannot parse dice count from validated pool expression.'); return; }
+      diceCount += (review?.pool_mod_spec || 0);
       // Read toggle states from sidebar
       const rightPanel = container.querySelector(`.proc-feed-right[data-proc-key="${key}"]`);
       const roteChecked      = rightPanel?.querySelector('.proc-pool-rote')?.checked  || false;

--- a/specs/stories/fix.729.dt-proc-dice-roll-count.story.md
+++ b/specs/stories/fix.729.dt-proc-dice-roll-count.story.md
@@ -1,0 +1,159 @@
+---
+title: 'DT Processing: spec bonus dice missing from project action roll'
+type: 'fix'
+issue: 729
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/729
+branch: ms/issue-729-dt-proc-dice-roll-count
+created: '2026-06-14'
+status: done
+recommended_model: 'sonnet — one-line handler fix + test'
+context:
+  - public/js/admin/downtime-views.js
+---
+
+## Intent
+
+When an ST rolls dice in DT Processing for a **project-type action** (including
+rote feed), the `.proc-pool-total` display includes active specialty (+1/+2)
+bonuses but the actual dice roll uses only the base pool from `pool_validated`,
+producing one fewer die than shown.
+
+---
+
+## Root cause
+
+`pool_mod_spec` is saved to the review document whenever an ST toggles a spec
+chip (`proc-spec-chip` click handler, line 5514). The **feeding** roll handler
+(`.proc-feed-roll-btn`, line 5548) correctly adds this saved value to
+`diceCount` before calling `showRollModal`. The **project** roll handler
+(`.proc-proj-roll-btn`, lines 5655-5656) does not — it reads `diceCount` from
+`pool_validated` and passes it directly to `showRollModal` without adding
+`pool_mod_spec`.
+
+The display is correct: `_augmentPoolWithSpecs` (line 795) appends spec labels
+and increments the `= N` total in `.proc-pool-total`, so the ST sees the right
+number. The roll uses the wrong number.
+
+### File locations
+
+| File | Lines | Notes |
+|------|-------|-------|
+| `public/js/admin/downtime-views.js` | 5628–5690 | `.proc-proj-roll-btn` click handler — missing `pool_mod_spec` addition |
+| `public/js/admin/downtime-views.js` | 5519–5595 | `.proc-feed-roll-btn` click handler — correct reference; has `pool_mod_spec` at line 5548 |
+| `public/js/admin/downtime-views.js` | 5465–5481 | `.proc-action-roll-btn` handler — wired but never rendered (dead); ignore |
+| `public/js/admin/downtime-views.js` | 6691–6698 | `_buildPoolExpr` — pool expression format `"Attr N + Skill N ±0 = total"` |
+
+---
+
+## Fix
+
+### T1 — Add `pool_mod_spec` to project roll count [x]
+
+**File:** `public/js/admin/downtime-views.js`
+
+In the `.proc-proj-roll-btn` click handler, after the `diceCount` parse (line
+5656), add the spec bonus and use the corrected total throughout:
+
+```js
+// BEFORE (lines 5655-5677):
+const match = poolValidated.match(/(\d+)\s*$/);
+const diceCount = match ? parseInt(match[1], 10) : 0;
+if (!diceCount) { alert('Cannot parse dice count from validated pool expression.'); return; }
+// ... later:
+showRollModal({
+  size: diceCount, expression: poolValidated,
+  ...
+}, async result => {
+  await saveEntryReview(entry, {
+    roll: result,
+    pool: { expression: poolValidated, total: diceCount },
+    ...
+  });
+```
+
+```js
+// AFTER:
+const match = poolValidated.match(/(\d+)\s*$/);
+let diceCount = match ? parseInt(match[1], 10) : 0;
+if (!diceCount) { alert('Cannot parse dice count from validated pool expression.'); return; }
+diceCount += (review?.pool_mod_spec || 0);
+// ... later (no other changes needed — diceCount is already used):
+showRollModal({
+  size: diceCount, expression: poolValidated,
+  ...
+}, async result => {
+  await saveEntryReview(entry, {
+    roll: result,
+    pool: { expression: poolValidated, total: diceCount },
+    ...
+  });
+```
+
+The only changes are:
+1. `const diceCount` → `let diceCount` (line 5656)
+2. Add `diceCount += (review?.pool_mod_spec || 0)` immediately after (new line 5657)
+
+Everything else in the handler stays identical — `diceCount` is already used in
+`size`, `pool.total`, and `pool_snapshot`.
+
+---
+
+### T2 — QA: Playwright spec [x]
+
+**File:** `tests/fix-729-dt-proc-dice-roll-count.spec.js`
+
+Use the DT processing test harness (fixture pattern from
+`tests/fix-725-rote-feed-inherited-pool.spec.js`).
+
+Mount `renderNormalisedCard` (or `renderProcessingMode`) in a container, inject
+a project entry with `pool_validated = "Presence 3 + Empathy 4 ±0 = 7"` and
+`pool_mod_spec = 1` in the review document.
+
+Intercept `showRollModal` (or the pool size data written before the modal call)
+and assert `size === 8`, not 7.
+
+| # | Setup | Assertion |
+|---|-------|-----------|
+| AC1 | `pool_validated = "Presence 3 + Empathy 4 ±0 = 7"`, `pool_mod_spec = 1` | Roll button triggers `showRollModal` with `size = 8` |
+| AC2 | `pool_validated = "Wits 3 + Stealth 2 ±0 = 5"`, `pool_mod_spec = 0` | Roll triggers `showRollModal` with `size = 5` (zero spec — no regression) |
+
+Because `showRollModal` opens a modal (which would need interaction to
+confirm), the cleanest test approach is to spy on `rollPool` or mock
+`showRollModal` to capture the `size` argument before it fires.
+
+---
+
+## Acceptance criteria
+
+- [ ] Given a project action with `pool_mod_spec = 1` and `pool_validated` total
+  of 7, clicking the roll button triggers a roll with **8 dice** (not 7)
+- [ ] Given `pool_mod_spec = 0` (or absent), the roll count is unchanged
+  (no regression for entries without active spec chips)
+- [ ] The stored `pool.total` in the review document reflects the spec-adjusted
+  count (for consistent replay in the roll history)
+
+---
+
+## Guardrails
+
+- Only `public/js/admin/downtime-views.js` changes — one `const` → `let` and
+  one line added.
+- No schema change. `pool_mod_spec` already exists in the review document.
+- Do NOT touch the feeding roll handler (`.proc-feed-roll-btn`) — it already
+  handles `pool_mod_spec` correctly at line 5548.
+- Do NOT touch `.proc-action-roll-btn` — it is wired but never rendered.
+- The fix applies to ALL project-type actions, not just rote feed.
+
+---
+
+## Dev Agent Record
+
+### Files changed
+
+- `public/js/admin/downtime-views.js` — T1: `const diceCount` → `let diceCount` + `diceCount += (review?.pool_mod_spec || 0)` in `.proc-proj-roll-btn` handler (lines 5655-5658)
+- `specs/stories/fix.729.dt-proc-dice-roll-count.story.md` — this file
+- `tests/fix-729-dt-proc-dice-roll-count.spec.js` — T2: 2 Playwright tests, both passing
+
+### Completion notes
+
+One-line fix. The project roll handler was the only roll handler that didn't add `pool_mod_spec`. The feeding handler already did this at line 5548. Now both handlers are consistent. 2/2 tests passing.

--- a/tests/fix-729-dt-proc-dice-roll-count.spec.js
+++ b/tests/fix-729-dt-proc-dice-roll-count.spec.js
@@ -1,0 +1,166 @@
+/**
+ * fix.729 — DT Processing: spec bonus dice missing from project action roll
+ *
+ * Root cause: .proc-proj-roll-btn handler extracted diceCount from pool_validated
+ * only, ignoring pool_mod_spec (active specialty bonus). The feeding handler
+ * (.proc-feed-roll-btn) correctly added pool_mod_spec.
+ *
+ * Fix: add `diceCount += (review?.pool_mod_spec || 0)` in the project handler.
+ *
+ * Acceptance criteria:
+ *   AC1: pool_validated=7, pool_mod_spec=1 → roll modal opens with "8 dice"
+ *   AC2: pool_validated=5, pool_mod_spec=0 → roll modal opens with "5 dice" (no regression)
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const ST_USER = {
+  id: '123456789', username: 'test_st', global_name: 'Test ST',
+  avatar: null, role: 'st', player_id: 'p-001', character_ids: [], is_dual_role: false,
+};
+
+const TEST_CHAR = {
+  _id: 'char-729', name: 'Aleksei', moniker: null, honorific: null,
+  clan: 'Gangrel', covenant: 'Carthian Movement', player: 'Test Player',
+  blood_potency: 3, humanity: 6, humanity_base: 7, court_title: null, retired: false,
+  status: { city: 1, clan: 1, covenant: { 'Carthian Movement': 1, 'Circle of the Crone': 0, 'Invictus': 0, 'Lancea et Sanctum': 0, 'Ordo Dracul': 0 } },
+  attributes: {
+    Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+    Strength: { dots: 3, bonus: 0 }, Dexterity: { dots: 3, bonus: 0 }, Stamina: { dots: 3, bonus: 0 },
+    Presence: { dots: 3, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: {
+    Empathy: { dots: 4, bonus: 0, specs: ['Groups'], nine_again: false },
+  },
+  disciplines: {}, merits: [], powers: [], ordeals: [],
+};
+
+const TEST_CYCLE = {
+  _id: 'cycle-729', cycle_number: 5, status: 'active',
+  confirmed_ambience: {}, narrative_notes: '',
+};
+
+function makeSub(projectsResolved) {
+  return {
+    _id: 'sub-729',
+    cycle_id: 'cycle-729',
+    character_name: 'Aleksei',
+    character_id: 'char-729',
+    player_name: 'Test Player',
+    submitted_at: '2026-06-14T00:00:00Z',
+    _raw: {
+      projects: [{ action_type: 'rote', primary_pool: null, desired_outcome: 'Feed.' }],
+      feeding: null, sphere_actions: [], contact_actions: { requests: [] }, retainer_actions: { actions: [] },
+    },
+    responses: {
+      project_1_action: 'rote',
+      project_1_title: 'Rote Feed',
+      project_1_description: 'Feed using rote.',
+      project_1_territory: 'firstcity',
+    },
+    projects_resolved: projectsResolved || [],
+    feeding_review: null,
+    merit_actions_resolved: [],
+    sorcery_review: {},
+    st_review: { territory_overrides: {} },
+  };
+}
+
+async function setupProcessing(page, sub) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'local-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url    = route.request().url();
+    const method = route.request().method();
+    const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+    if (method === 'PUT' || method === 'PATCH' || method === 'POST') return ok({ ok: true });
+    if (url.includes('/api/downtime_submissions'))  return ok([sub]);
+    if (url.includes('/api/downtime_cycles'))       return ok([TEST_CYCLE]);
+    if (url.includes('/api/characters/names'))      return ok([{ _id: TEST_CHAR._id, name: TEST_CHAR.name, moniker: null, honorific: null }]);
+    if (url.includes('/api/characters'))            return ok([TEST_CHAR]);
+    if (url.includes('/api/territories'))           return ok([]);
+    if (url.includes('/api/game_sessions'))         return ok([]);
+    if (url.includes('/api/session_logs'))          return ok([]);
+    return ok([]);
+  });
+
+  await page.goto('/admin.html');
+  await page.waitForSelector('#admin-app', { state: 'visible', timeout: 10000 });
+  await page.click('[data-domain="downtime"]');
+  await page.waitForTimeout(1000);
+}
+
+async function openAction(page) {
+  await page.waitForSelector('.proc-action-row', { timeout: 8000 });
+  await page.locator('.proc-action-row').first().click();
+  await page.waitForSelector('.proc-action-detail', { timeout: 8000 });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+test.describe('fix.729 — project roll includes pool_mod_spec in dice count', () => {
+
+  test('AC1: pool_mod_spec=1 is added to the roll size — modal shows 8 dice', async ({ page }) => {
+    const sub = makeSub([{
+      action_type: 'rote',
+      pool_validated: 'Presence 3 + Empathy 4 ±0 = 7',
+      pool_status: 'confirmed',
+      pool_mod_spec: 1,
+      active_feed_specs: ['Groups'],
+      roll: null,
+    }]);
+
+    await setupProcessing(page, sub);
+    await openAction(page);
+
+    // Confirm button advances pool_status → proceed to roll
+    const rollBtn = page.locator('.proc-proj-roll-btn').first();
+    await rollBtn.waitFor({ state: 'visible', timeout: 8000 });
+    await rollBtn.click();
+
+    // Roll modal should appear
+    const modal = page.locator('#roll-modal-overlay');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    // The .roll-param element showing dice count must say "8 dice"
+    const diceParam = modal.locator('.roll-param').first();
+    await expect(diceParam).toHaveText('8 dice');
+  });
+
+  test('AC2: pool_mod_spec=0 does not inflate the roll — modal shows 5 dice', async ({ page }) => {
+    const char = { ...TEST_CHAR, skills: { Stealth: { dots: 2, bonus: 0, specs: [], nine_again: false } } };
+
+    const sub = makeSub([{
+      action_type: 'investigate',
+      pool_validated: 'Wits 3 + Stealth 2 ±0 = 5',
+      pool_status: 'confirmed',
+      pool_mod_spec: 0,
+      active_feed_specs: [],
+      roll: null,
+    }]);
+    // Override character route to use modified char
+    await page.route('http://localhost:3000/api/characters*', route =>
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([char]) })
+    );
+    // Override responses for investigate action type
+    sub.responses = { ...sub.responses, project_1_action: 'investigate' };
+
+    await setupProcessing(page, sub);
+    await openAction(page);
+
+    const rollBtn = page.locator('.proc-proj-roll-btn').first();
+    await rollBtn.waitFor({ state: 'visible', timeout: 8000 });
+    await rollBtn.click();
+
+    const modal = page.locator('#roll-modal-overlay');
+    await expect(modal).toBeVisible({ timeout: 5000 });
+
+    const diceParam = modal.locator('.roll-param').first();
+    await expect(diceParam).toHaveText('5 dice');
+  });
+
+});


### PR DESCRIPTION
## Summary

- The `.proc-proj-roll-btn` handler (used by all project-type actions, including rote feed) read `diceCount` from `pool_validated` only, ignoring `pool_mod_spec` (the specialty chip bonus saved to the review doc)
- The display correctly showed the augmented total via `_augmentPoolWithSpecs`, so the ST saw 8 dice but the roll fired with 7 -- a shortfall exactly matching the active spec bonus
- Fix mirrors what `.proc-feed-roll-btn` already did at line 5548: `diceCount += (review?.pool_mod_spec || 0)` added after parsing the base count

## Closes

- Closes #729

## Story

- specs/stories/fix.729.dt-proc-dice-roll-count.story.md

## Test plan

- [ ] `npx playwright test tests/fix-729-dt-proc-dice-roll-count.spec.js` -- 2/2 passing
- [ ] CI green
- [ ] Manual: open DT Processing, activate a spec chip on a project action pool, confirm roll modal shows the spec-augmented count

## Branch flow

- From: `ms/issue-729-dt-proc-dice-roll-count`
- Into: `dev`
