### PR TITLE
fix(#731): spec bonus inflated when 9-Again active in DT proc pool builder

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -5655,7 +5655,9 @@ function renderProcessingMode(container) {
       const match = poolValidated.match(/(\d+)\s*$/);
       let diceCount = match ? parseInt(match[1], 10) : 0;
       if (!diceCount) { alert('Cannot parse dice count from validated pool expression.'); return; }
-      diceCount += (review?.pool_mod_spec || 0);
+      const _specSub = submissions.find(s => s._id === entry.subId);
+      const _specChar = _charForSub(_specSub);
+      diceCount += (review?.active_feed_specs || []).reduce((sum, sp) => sum + (_specChar && hasAoE(_specChar, sp) ? 2 : 1), 0);
       // Read toggle states from sidebar
       const rightPanel = container.querySelector(`.proc-feed-right[data-proc-key="${key}"]`);
       const roteChecked      = rightPanel?.querySelector('.proc-pool-rote')?.checked  || false;
@@ -6884,13 +6886,13 @@ function _updateFeedBuilderMeta(container, key) {
     let h = '';
     for (const sp of specs) {
       const checked = activeSpecs.includes(sp);
-      const bon = (nineA || hasAoE(char, sp)) ? 2 : 1;
+      const bon = hasAoE(char, sp) ? 2 : 1;
       h += `<button type="button" class="proc-spec-chip${checked ? ' is-active' : ''}" data-proc-key="${key}" data-spec="${esc(sp)}">${esc(sp)} +${bon}</button>`;
     }
     for (const { spec: isSp, fromSkill } of isSpecs(char)) {
       if (fromSkill === skillName) continue; // already present as a native spec on this skill
       const checked = activeSpecs.includes(isSp);
-      const bon = (nineA || hasAoE(char, isSp)) ? 2 : 1;
+      const bon = hasAoE(char, isSp) ? 2 : 1;
       h += `<button type="button" class="proc-spec-chip${checked ? ' is-active' : ''}" data-proc-key="${key}" data-spec="${esc(isSp)}">${esc(isSp)} (${esc(fromSkill)}) +${bon}</button>`;
     }
     metaEl.innerHTML = h;
@@ -6904,7 +6906,7 @@ function _updateFeedBuilderMeta(container, key) {
         const isNowActive = btn.classList.toggle('is-active');
         if (isNowActive) { if (!activeSpecs2.includes(btn.dataset.spec)) activeSpecs2.push(btn.dataset.spec); }
         else { const i = activeSpecs2.indexOf(btn.dataset.spec); if (i !== -1) activeSpecs2.splice(i, 1); }
-        const specBonus2 = activeSpecs2.reduce((sum, sp) => sum + ((nineA || hasAoE(char, sp)) ? 2 : 1), 0);
+        const specBonus2 = activeSpecs2.reduce((sum, sp) => sum + (hasAoE(char, sp) ? 2 : 1), 0);
         await saveEntryReview(entry2, { active_feed_specs: activeSpecs2, pool_mod_spec: specBonus2 });
         _updatePoolTotal(container, btn.dataset.procKey);
       });
@@ -6928,13 +6930,13 @@ function _updateFeedBuilderMeta(container, key) {
   let h = '';
   for (const sp of specs) {
     const checked = activeSpecs.includes(sp);
-    const bon = (nineA || hasAoE(char, sp)) ? 2 : 1;
+    const bon = hasAoE(char, sp) ? 2 : 1;
     h += `<button type="button" class="proc-spec-chip${checked ? ' is-active' : ''}" data-proc-key="${key}" data-spec="${esc(sp)}">${esc(sp)} +${bon}</button>`;
   }
   for (const { spec: isSp, fromSkill } of isSpecs(char)) {
     if (fromSkill === skillName) continue; // already present as a native spec on this skill
     const checked = activeSpecs.includes(isSp);
-    const bon = (nineA || hasAoE(char, isSp)) ? 2 : 1;
+    const bon = hasAoE(char, isSp) ? 2 : 1;
     h += `<button type="button" class="proc-spec-chip${checked ? ' is-active' : ''}" data-proc-key="${key}" data-spec="${esc(isSp)}">${esc(isSp)} (${esc(fromSkill)}) +${bon}</button>`;
   }
   metaEl.innerHTML = h;
@@ -6948,7 +6950,7 @@ function _updateFeedBuilderMeta(container, key) {
       const isNowActive = btn.classList.toggle('is-active');
       if (isNowActive) { if (!activeSpecs2.includes(btn.dataset.spec)) activeSpecs2.push(btn.dataset.spec); }
       else { const i = activeSpecs2.indexOf(btn.dataset.spec); if (i !== -1) activeSpecs2.splice(i, 1); }
-      const specBonus2 = activeSpecs2.reduce((sum, sp) => sum + ((nineA || hasAoE(char, sp)) ? 2 : 1), 0);
+      const specBonus2 = activeSpecs2.reduce((sum, sp) => sum + (hasAoE(char, sp) ? 2 : 1), 0);
       await saveEntryReview(entry2, { active_feed_specs: activeSpecs2, pool_mod_spec: specBonus2 });
       _updatePoolTotal(container, btn.dataset.procKey);
     });


### PR DESCRIPTION
## Summary

- `_updateFeedBuilderMeta` computed spec chip labels and the saved `pool_mod_spec` value using `(nineA || hasAoE)` — when 9-Again was active on the selected skill, a non-AoE spec (e.g. Groups on Empathy) was counted as +2 dice instead of +1
- The pool-total display (`_augmentPoolWithSpecs`) correctly used `hasAoE` only and showed 8, but `pool_mod_spec = 2` was persisted to the DB; fix.729's roll handler read that value and fired with 9 dice
- Three-part fix: chip labels now use `hasAoE` only in both project and feeding meta blocks; specBonus2 save formula now uses `hasAoE` only; project roll handler now recomputes spec bonus live from `active_feed_specs` rather than reading the potentially stale `pool_mod_spec`

## Closes

- Closes #731

## Test plan

- [ ] Manual: open DT Processing, select a skill with 9-Again for a project action, toggle a spec chip -- confirm chip shows "+1" (not "+2") and pool total matches
- [ ] Manual: open roll modal -- confirm dice count matches the pool total expression exactly
- [ ] Manual: toggle spec chip on feeding entry with 9-Again -- same result, +1 not +2
- [ ] CI green

## Branch flow

- From: `ms/issue-731-dt-spec-bonus-nineagain`
- Into: `dev`
