### PR TITLE
fix(#733): feeding territory ObjectID resolved to name in DT Processing

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -8607,8 +8607,9 @@ function _renderSnapshotFeedingPanel(entry, feedChar) {
       h += '<div class="proc-snap-subheading">Territories</div>';
       const STATUS_LABELS = { feeding_rights: 'Rights', resident: 'Resident', poaching: 'Poaching', poacher: 'Poaching' };
       for (const [slug, status] of activeTerrs) {
-        const terrRec = terrList.find(t => t.slug === slug || t.name?.toLowerCase().replace(/\s+/g, '_') === slug);
-        const terrName = terrRec?.name || slug.replace(/_/g, ' ');
+        const resolvedSlug = resolveTerrId(slug) || slug;
+        const terrRec = terrList.find(t => t.slug === resolvedSlug || t.name?.toLowerCase().replace(/\s+/g, '_') === resolvedSlug);
+        const terrName = terrRec?.name || resolvedSlug.replace(/_/g, ' ');
         const statusLabel = STATUS_LABELS[status] || status;
         const statusMod = (status === 'poaching' || status === 'poacher') ? ' proc-snap-terr-poach' : ' proc-snap-terr-claim';
         h += _terrRow(terrName, terrRec, statusLabel, statusMod);
@@ -8631,8 +8632,9 @@ function _renderSnapshotFeedingPanel(entry, feedChar) {
       h += '<div class="proc-snap-subheading">Territories</div>';
       const STATUS_LABELS = { feeding_rights: 'Rights', resident: 'Resident', poaching: 'Poaching', poacher: 'Poaching' };
       for (const [slug, status] of activeTerrs) {
-        const terrRec = terrList.find(t => t.slug === slug || t.name?.toLowerCase().replace(/\s+/g, '_') === slug);
-        const terrName = terrRec?.name || slug.replace(/_/g, ' ');
+        const resolvedSlug = resolveTerrId(slug) || slug;
+        const terrRec = terrList.find(t => t.slug === resolvedSlug || t.name?.toLowerCase().replace(/\s+/g, '_') === resolvedSlug);
+        const terrName = terrRec?.name || resolvedSlug.replace(/_/g, ' ');
         const statusLabel = STATUS_LABELS[status] || status;
         const statusMod = (status === 'poaching' || status === 'poacher') ? ' proc-snap-terr-poach' : ' proc-snap-terr-claim';
         h += _terrRow(terrName, terrRec, statusLabel, statusMod);

--- a/specs/stories/fix.733.dt-proc-feeding-territory-name.story.md
+++ b/specs/stories/fix.733.dt-proc-feeding-territory-name.story.md
@@ -1,0 +1,157 @@
+---
+title: 'DT Processing: feeding territory shows raw ObjectID instead of name'
+type: 'fix'
+issue: 733
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/733
+branch: ms/issue-733-feeding-territory-name
+created: '2026-06-15'
+status: review
+recommended_model: 'sonnet — two-line change, duplicate in two branches'
+context:
+  - public/js/admin/downtime-views.js
+---
+
+## Intent
+
+Fix the Feeding Intelligence panel in DT Processing so territory rows display
+the human-readable territory name (e.g. "The Academy") instead of the raw
+MongoDB ObjectID string (e.g. `69D9E54C00815D471503BEA9`).
+
+---
+
+## Root cause
+
+`feeding_territories` in DT submissions is stored as a JSON object keyed by
+MongoDB ObjectID strings (e.g. `{ "69D9E54C...": "feeding_rights" }`).
+
+`_renderSnapshotFeedingPanel()` iterates those entries and tries to resolve the
+key to a territory record with:
+
+```js
+terrList.find(t => t.slug === slug || t.name?.toLowerCase().replace(/\s+/g, '_') === slug)
+```
+
+Neither branch matches an ObjectID. The fallback `terrName = terrRec?.name || slug.replace(/_/g, ' ')` then displays the formatted ObjectID as the territory name.
+
+`resolveTerrId()` (line 3799) already solves the conversion:
+
+```js
+function resolveTerrId(raw) {
+  if (!raw) return null;
+  const t = (cachedTerritories || []).find(td => String(td._id) === raw);
+  return t?.slug || null;
+}
+```
+
+It is already used correctly in `_entryTerritories()` (line 4454) and throughout
+the queue-building code. The snapshot rendering function simply doesn't call it.
+
+**Secondary impact:** when `terrRec` is `undefined` due to the lookup failure,
+`_terrRow` also silently skips the ambience label and Regent badge for affected
+rows. The fix restores those too at no extra cost.
+
+### File locations
+
+| File | Lines | Notes |
+|------|-------|-------|
+| `public/js/admin/downtime-views.js` | 8609–8610 | Rote-feed branch — slug lookup without `resolveTerrId` |
+| `public/js/admin/downtime-views.js` | 8633–8635 | Regular-feed branch — same slug lookup, same bug |
+| `public/js/admin/downtime-views.js` | 3799–3803 | `resolveTerrId()` — existing helper that handles ObjectID → slug |
+| `public/js/admin/downtime-views.js` | 8588–8600 | `_terrRow()` — uses `terrRec?._id` for ambience + regent; broken when `terrRec` is `undefined` |
+| `public/js/admin/downtime-views.js` | 4451–4469 | `_entryTerritories()` — uses `resolveTerrId` correctly; reference for the pattern |
+
+---
+
+## Fix
+
+### T1 — Add `resolveTerrId` call before the slug lookup in both branches
+
+**File:** `public/js/admin/downtime-views.js`
+
+There are two identical loops inside `_renderSnapshotFeedingPanel()` — one for
+rote feed entries (around line 8609) and one for regular feed entries (around
+line 8633). Apply the same change to both.
+
+**Rote feed branch (around line 8609):**
+
+```js
+// BEFORE:
+for (const [slug, status] of activeTerrs) {
+  const terrRec = terrList.find(t => t.slug === slug || t.name?.toLowerCase().replace(/\s+/g, '_') === slug);
+  const terrName = terrRec?.name || slug.replace(/_/g, ' ');
+```
+
+```js
+// AFTER:
+for (const [slug, status] of activeTerrs) {
+  const resolvedSlug = resolveTerrId(slug) || slug;
+  const terrRec = terrList.find(t => t.slug === resolvedSlug || t.name?.toLowerCase().replace(/\s+/g, '_') === resolvedSlug);
+  const terrName = terrRec?.name || resolvedSlug.replace(/_/g, ' ');
+```
+
+**Regular feed branch (around line 8633) — identical change:**
+
+```js
+// BEFORE:
+for (const [slug, status] of activeTerrs) {
+  const terrRec = terrList.find(t => t.slug === slug || t.name?.toLowerCase().replace(/\s+/g, '_') === slug);
+  const terrName = terrRec?.name || slug.replace(/_/g, ' ');
+```
+
+```js
+// AFTER:
+for (const [slug, status] of activeTerrs) {
+  const resolvedSlug = resolveTerrId(slug) || slug;
+  const terrRec = terrList.find(t => t.slug === resolvedSlug || t.name?.toLowerCase().replace(/\s+/g, '_') === resolvedSlug);
+  const terrName = terrRec?.name || resolvedSlug.replace(/_/g, ' ');
+```
+
+**What each line does:**
+- `resolveTerrId(slug)` — if `slug` is an ObjectID, returns the canonical slug;
+  if `slug` is already a slug, returns `null` (no match by `_id`)
+- `|| slug` — fallback: keeps the original value if it was already a slug
+- The existing `terrList.find(...)` logic is unchanged — it now runs against the
+  resolved slug instead of the raw ObjectID
+
+**The "Also feeding" peer filter** at lines 8619–8621 and 8644–8646 uses `slug`
+(the raw ObjectID key) to match against `r.feedTerrs?.[slug]`. This is correct
+— both sides are ObjectID keys, so the comparison works. Do NOT change it.
+
+---
+
+## Acceptance criteria
+
+- [ ] Tegan Groves (Rote Action feed) in DT 4: TERRITORIES row shows territory name, not ObjectID
+- [ ] Aleksei Romanov (main feed) in DT 4: TERRITORIES row shows territory name, not ObjectID
+- [ ] Rights / Poaching / Resident badge renders correctly alongside the name
+- [ ] "Also feeding" peer list still appears for shared territories
+- [ ] Ambience label and Regent badge in `_terrRow` now display correctly for
+  feeding rows (previously silently omitted when `terrRec` was undefined)
+
+---
+
+## Guardrails
+
+- Only `public/js/admin/downtime-views.js` changes. No other files.
+- No schema change. `resolveTerrId` is module-scoped and already available in
+  `_renderSnapshotFeedingPanel` — no import or parameter change needed.
+- Do NOT change the "Also feeding" peer filter (`r.feedTerrs?.[slug]`) — it
+  correctly uses the raw ObjectID key for map lookup.
+- Do NOT change `_entryTerritories()` — it already uses `resolveTerrId`
+  correctly.
+- The fix is additive: if a key was already a slug (legacy data), `resolveTerrId`
+  returns `null`, the fallback `|| slug` preserves it, and the existing lookup
+  continues to work.
+
+---
+
+## Dev Agent Record
+
+### Files changed
+
+- `public/js/admin/downtime-views.js` — T1: added `resolveTerrId(slug) || slug` before territory lookup in both the rote-feed and regular-feed branches of `_renderSnapshotFeedingPanel()` (lines 8610–8612 and 8635–8637)
+- `tests/fix-733-feeding-territory-name.spec.js` — 5 Playwright tests, all passing
+
+### Completion notes
+
+One-line addition in each of the two parallel loops inside `_renderSnapshotFeedingPanel()`. Both loops now call `resolveTerrId(slug)` first to convert any ObjectID key to its canonical slug before the `terrList.find()` lookup. If the key was already a slug, `resolveTerrId` returns `null` and the `|| slug` fallback preserves it — no regression for legacy data. The "Also feeding" peer filter retains the raw ObjectID key throughout (correct — both sides of that comparison are ObjectIDs). 5/5 Playwright tests passing: ObjectID→name for regular feed, Rights badge, rote feed, legacy slug (no regression), multiple territories.

--- a/tests/fix-733-feeding-territory-name.spec.js
+++ b/tests/fix-733-feeding-territory-name.spec.js
@@ -1,0 +1,298 @@
+/**
+ * Regression tests for fix #733 — DT Processing Feeding Intelligence shows
+ * raw MongoDB ObjectID instead of territory name.
+ *
+ * Root cause: `_renderSnapshotFeedingPanel()` resolved territory keys via
+ * `terrList.find(t => t.slug === slug)`, but DT4+ submissions store ObjectID
+ * strings as keys in `feeding_territories`. Added `resolveTerrId(slug) || slug`
+ * before the lookup in both the rote-feed and regular-feed branches.
+ *
+ * AC-1: Regular feed — territory name shown (not ObjectID)
+ * AC-2: Regular feed — Rights/Poaching/Resident badge renders alongside name
+ * AC-3: Rote feed (rote project slot) — territory name shown (not ObjectID)
+ * AC-4: Legacy slug key — still resolves correctly (no regression)
+ * AC-5: Multiple territories — all names shown
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const ST_USER = {
+  id: '123000733', username: 'test_st_733', global_name: 'Test ST 733',
+  avatar: null, role: 'st', player_id: 'p-733', character_ids: [], is_dual_role: false,
+};
+
+// Territory with a realistic ObjectID-style _id.
+const TERR_ACADEMY = {
+  _id: '69d9e54c00815d471503bea9',
+  slug: 'the_academy',
+  name: 'The Academy',
+  ambience: 'Scholarly',
+  regent_id: null,
+};
+
+const TERR_HARBOUR = {
+  _id: '69d9e54c00815d471503bea8',
+  slug: 'harbour',
+  name: 'The Harbour',
+  ambience: '',
+  regent_id: null,
+};
+
+const ALL_TERRS = [TERR_ACADEMY, TERR_HARBOUR];
+
+function mkChar(id, name) {
+  return {
+    _id: id, name, moniker: null, honorific: null,
+    clan: 'Daeva', covenant: 'Invictus', player: 'Test Player',
+    blood_potency: 2, humanity: 6, humanity_base: 7, court_title: null, retired: false,
+    status: { city: 1, clan: 1, covenant: { 'Carthian Movement': 0, 'Circle of the Crone': 0, 'Invictus': 1, 'Lancea et Sanctum': 0, 'Ordo Dracul': 0 } },
+    attributes: {
+      Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+      Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+      Presence: { dots: 3, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+    },
+    skills: { Persuasion: { dots: 3, bonus: 0, specs: [], nine_again: false } },
+    disciplines: { Majesty: { dots: 2 } },
+    merits: [], powers: [], ordeals: [],
+  };
+}
+
+const CHAR_TEGAN  = mkChar('char-733-tegan',  'Tegan Groves');
+const CHAR_ALEKSEI = mkChar('char-733-aleksei', 'Aleksei Romanov');
+const ALL_CHARS = [CHAR_TEGAN, CHAR_ALEKSEI];
+
+const TEST_CYCLE = {
+  _id: 'cycle-733', cycle_number: 4, status: 'active',
+  confirmed_ambience: {}, narrative_notes: '',
+};
+
+// Regular feed — key is ObjectID string, status is feeding_rights.
+const SUB_REGULAR_FEED = {
+  _id: 'sub-733-regular',
+  cycle_id: 'cycle-733',
+  character_name: 'Aleksei Romanov',
+  character_id: 'char-733-aleksei',
+  player_name: 'Test Player',
+  submitted_at: '2026-06-15T00:00:00Z',
+  _raw: {
+    feeding: { method: 'seduction', description: 'Seduction' },
+    projects: [],
+    sphere_actions: [],
+    contact_actions: { requests: [] },
+    retainer_actions: { actions: [] },
+  },
+  responses: {
+    feeding_method: 'seduction',
+    feeding_description: 'Seduction',
+    // ObjectID key — the bug scenario
+    feeding_territories: JSON.stringify({ '69d9e54c00815d471503bea9': 'feeding_rights' }),
+  },
+  projects_resolved: [],
+  feeding_review: { pool_status: 'not_set' },
+  merit_actions_resolved: [],
+  st_review: { territory_overrides: {} },
+};
+
+// Rote feed — project action_type = 'rote'; territory also keyed by ObjectID.
+// feeding entry uses poaching status for AC-2 variation.
+const SUB_ROTE_FEED = {
+  _id: 'sub-733-rote',
+  cycle_id: 'cycle-733',
+  character_name: 'Tegan Groves',
+  character_id: 'char-733-tegan',
+  player_name: 'Test Player',
+  submitted_at: '2026-06-15T00:00:00Z',
+  _raw: {
+    feeding: { method: 'seduction', description: 'Rote Seduction' },
+    projects: [
+      {
+        action_type: 'rote',
+        desired_outcome: 'Rote feed',
+        detail: 'Rote seduction feeding.',
+        primary_pool: { expression: 'Presence 3 + Persuasion 3 = 6' },
+      },
+    ],
+    sphere_actions: [],
+    contact_actions: { requests: [] },
+    retainer_actions: { actions: [] },
+  },
+  responses: {
+    feeding_method: 'seduction',
+    feeding_description: 'Rote Seduction',
+    // ObjectID key — the bug scenario
+    feeding_territories: JSON.stringify({ '69d9e54c00815d471503bea9': 'poaching' }),
+    project_1_action: 'rote',
+    project_1_description: 'Rote seduction feeding.',
+    project_1_pool_expr: 'Presence 3 + Persuasion 3 = 6',
+  },
+  projects_resolved: [
+    { pool_status: 'not_set' },
+  ],
+  feeding_review: { pool_status: 'not_set' },
+  merit_actions_resolved: [],
+  st_review: { territory_overrides: {} },
+};
+
+// Legacy slug key — should still resolve (no regression).
+const SUB_SLUG_KEY = {
+  _id: 'sub-733-slug',
+  cycle_id: 'cycle-733',
+  character_name: 'Aleksei Romanov',
+  character_id: 'char-733-aleksei',
+  player_name: 'Test Player',
+  submitted_at: '2026-06-15T00:00:00Z',
+  _raw: {
+    feeding: { method: 'seduction', description: 'Seduction' },
+    projects: [],
+    sphere_actions: [],
+    contact_actions: { requests: [] },
+    retainer_actions: { actions: [] },
+  },
+  responses: {
+    feeding_method: 'seduction',
+    feeding_description: 'Seduction',
+    // Slug key — legacy format
+    feeding_territories: JSON.stringify({ the_academy: 'feeding_rights' }),
+  },
+  projects_resolved: [],
+  feeding_review: { pool_status: 'not_set' },
+  merit_actions_resolved: [],
+  st_review: { territory_overrides: {} },
+};
+
+// Multiple territory keys — both ObjectIDs.
+const SUB_MULTI_TERR = {
+  _id: 'sub-733-multi',
+  cycle_id: 'cycle-733',
+  character_name: 'Aleksei Romanov',
+  character_id: 'char-733-aleksei',
+  player_name: 'Test Player',
+  submitted_at: '2026-06-15T00:00:00Z',
+  _raw: {
+    feeding: { method: 'seduction', description: 'Seduction' },
+    projects: [],
+    sphere_actions: [],
+    contact_actions: { requests: [] },
+    retainer_actions: { actions: [] },
+  },
+  responses: {
+    feeding_method: 'seduction',
+    feeding_description: 'Seduction',
+    feeding_territories: JSON.stringify({
+      '69d9e54c00815d471503bea9': 'feeding_rights',
+      '69d9e54c00815d471503bea8': 'poaching',
+    }),
+  },
+  projects_resolved: [],
+  feeding_review: { pool_status: 'not_set' },
+  merit_actions_resolved: [],
+  st_review: { territory_overrides: {} },
+};
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+
+async function setup(page, submissions) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'local-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url = route.request().url();
+    const method = route.request().method();
+    const ok = body => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+    if (['PUT', 'PATCH', 'POST'].includes(method)) return ok({ ok: true });
+    if (url.includes('/api/downtime_submissions')) return ok(submissions);
+    if (url.includes('/api/downtime_cycles'))      return ok([TEST_CYCLE]);
+    if (url.includes('/api/territories'))          return ok(ALL_TERRS);
+    if (url.includes('/api/characters/names'))     return ok(ALL_CHARS.map(c => ({ _id: c._id, name: c.name, moniker: c.moniker, honorific: c.honorific })));
+    if (url.includes('/api/characters'))           return ok(ALL_CHARS);
+    return ok([]);
+  });
+
+  await page.goto('/admin.html');
+  await page.waitForSelector('#admin-app', { state: 'visible', timeout: 10000 });
+  await page.click('[data-domain="downtime"]');
+  await page.waitForTimeout(1000);
+}
+
+async function openFeedingCard(page, charName) {
+  await page.waitForSelector('.proc-action-row', { timeout: 8000 });
+  const row = page.locator('.proc-action-row', { hasText: charName }).first();
+  await row.click();
+  await page.waitForSelector('.proc-snapshot-panel', { timeout: 8000 });
+}
+
+const feedingPanel = page => page.locator('.proc-snapshot-panel').first();
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('fix.733: feeding territory ObjectID resolved to name in snapshot panel', () => {
+
+  // AC-1 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-1: regular feed — territory name shown instead of ObjectID', async ({ page }) => {
+    await setup(page, [SUB_REGULAR_FEED]);
+    await openFeedingCard(page, 'Aleksei Romanov');
+
+    const panel = feedingPanel(page);
+    // Territory name must appear.
+    await expect(panel).toContainText('The Academy');
+    // Raw ObjectID must not appear.
+    await expect(panel).not.toContainText('69d9e54c00815d471503bea9');
+  });
+
+  // AC-2 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-2: regular feed — Rights badge renders alongside territory name', async ({ page }) => {
+    await setup(page, [SUB_REGULAR_FEED]);
+    await openFeedingCard(page, 'Aleksei Romanov');
+
+    const panel = feedingPanel(page);
+    await expect(panel).toContainText('The Academy');
+    await expect(panel.locator('.proc-snap-terr-status')).toContainText('Rights');
+  });
+
+  // AC-3 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-3: rote feed — territory name shown instead of ObjectID', async ({ page }) => {
+    await setup(page, [SUB_ROTE_FEED]);
+    // The feeding card (not the rote project card) shows the feeding snapshot.
+    await openFeedingCard(page, 'Tegan Groves');
+
+    const panel = feedingPanel(page);
+    await expect(panel).toContainText('The Academy');
+    await expect(panel).not.toContainText('69d9e54c00815d471503bea9');
+    // Poaching badge
+    await expect(panel.locator('.proc-snap-terr-status')).toContainText('Poaching');
+  });
+
+  // AC-4 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-4: legacy slug key — still resolves to territory name (no regression)', async ({ page }) => {
+    await setup(page, [SUB_SLUG_KEY]);
+    await openFeedingCard(page, 'Aleksei Romanov');
+
+    const panel = feedingPanel(page);
+    await expect(panel).toContainText('The Academy');
+    // Neither the slug nor the OID should appear raw.
+    await expect(panel).not.toContainText('69d9e54c00815d471503bea9');
+  });
+
+  // AC-5 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-5: multiple territory ObjectID keys — all resolved to names', async ({ page }) => {
+    await setup(page, [SUB_MULTI_TERR]);
+    await openFeedingCard(page, 'Aleksei Romanov');
+
+    const panel = feedingPanel(page);
+    await expect(panel).toContainText('The Academy');
+    await expect(panel).toContainText('The Harbour');
+    await expect(panel).not.toContainText('69d9e54c00815d471503bea9');
+    await expect(panel).not.toContainText('69d9e54c00815d471503bea8');
+  });
+
+});


### PR DESCRIPTION
## Summary

- Feeding Intelligence snapshot panel showed raw MongoDB ObjectID strings (e.g. \`69D9E54C00815D471503BEA9\`) instead of territory names in DT4 for all characters with ObjectID-keyed \`feeding_territories\`
- Root cause: \`_renderSnapshotFeedingPanel()\` matched keys against \`t.slug\`, but DT4+ submissions store ObjectID strings as keys — \`resolveTerrId()\` already existed to handle this conversion but wasn't called here
- Fix: one-line \`resolveTerrId(slug) || slug\` added before the territory lookup in both the rote-feed and regular-feed branches; the slug/name fallback is unchanged so legacy data has no regression

## Closes

- Closes #733

## Story

- specs/stories/fix.733.dt-proc-feeding-territory-name.story.md

## Test plan

- [x] 5 Playwright tests passing: ObjectID→name (regular), Rights badge, rote feed, legacy slug (regression guard), multiple territories
- [ ] CI green
- [ ] Manual: open DT 4 Processing, expand Tegan Groves (Rote Action) and Aleksei Romanov — TERRITORIES row should show territory names, not ObjectIDs

## Branch flow

- From: \`ms/issue-733-feeding-territory-name\`
- Into: \`dev\`