### PR TITLE
feat(#735): harmonise feeding card territory pill + override chips

### DIFF
--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -5942,6 +5942,8 @@ body {
   margin-bottom: 5px;
 }
 .proc-mod-row:last-child { margin-bottom: 0; }
+.proc-feed-chips-row { align-items: flex-start; }
+.proc-feed-chips { display: flex; flex-wrap: wrap; gap: 4px; }
 
 .proc-mod-label {
   color: var(--txt3);

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -4814,12 +4814,12 @@ function renderProcessingMode(container) {
     });
   });
 
-  // DTFP-5: Wire feed-violence ST override selects
-  container.querySelectorAll('.proc-feed-violence-st-override').forEach(sel => {
-    sel.addEventListener('change', async e => {
+  // DTFP-5: Wire feeding method override chips
+  container.querySelectorAll('.proc-feed-vi-chip').forEach(btn => {
+    btn.addEventListener('click', async e => {
       e.stopPropagation();
-      const subId = sel.dataset.subId;
-      const newVal = sel.value || null;
+      const subId = btn.dataset.subId;
+      const newVal = btn.dataset.value || null;
       const sub = submissions.find(s => s._id === subId);
       if (sub) {
         if (!sub.st_review) sub.st_review = {};
@@ -4827,6 +4827,28 @@ function renderProcessingMode(container) {
         else delete sub.st_review.feed_violence_st_override;
       }
       await updateSubmission(subId, { 'st_review.feed_violence_st_override': newVal });
+      container.querySelectorAll(`.proc-feed-vi-chip[data-sub-id="${subId}"]`).forEach(b => {
+        b.classList.toggle('is-active', b.dataset.value === (newVal || ''));
+      });
+    });
+  });
+
+  // DTFP-5: Wire blood type override chips
+  container.querySelectorAll('.proc-feed-bt-chip').forEach(btn => {
+    btn.addEventListener('click', async e => {
+      e.stopPropagation();
+      const subId = btn.dataset.subId;
+      const newVal = btn.dataset.value || null;
+      const sub = submissions.find(s => s._id === subId);
+      if (sub) {
+        if (!sub.st_review) sub.st_review = {};
+        if (newVal) sub.st_review.feed_blood_type_st_override = newVal;
+        else delete sub.st_review.feed_blood_type_st_override;
+      }
+      await updateSubmission(subId, { 'st_review.feed_blood_type_st_override': newVal });
+      container.querySelectorAll(`.proc-feed-bt-chip[data-sub-id="${subId}"]`).forEach(b => {
+        b.classList.toggle('is-active', b.dataset.value === (newVal || ''));
+      });
     });
   });
 
@@ -7946,22 +7968,46 @@ function _renderFeedRightPanel(entry, char, rev, prependHtml = '') {
   h += `</div>`;
 
 
-  // ── DTFP-5: feed-violence ST override ──
-  // Player declared (read-only) + ST override dropdown.
-  const playerVi   = feedSub?.responses?.feed_violence || '';
-  const stViOverride = feedSub?.st_review?.feed_violence_st_override || '';
+  // ── DTFP-5: feed-violence + blood-type ST overrides ──
+  const playerVi      = feedSub?.responses?.feed_violence || '';
+  const stViOverride  = feedSub?.st_review?.feed_violence_st_override || '';
+  const playerBtRaw   = feedSub?.responses?.['_feed_blood_types'] || '[]';
+  let   playerBtArr   = [];
+  try   { playerBtArr = JSON.parse(playerBtRaw); } catch { playerBtArr = []; }
+  const playerBtLabel = playerBtArr.length
+    ? playerBtArr.map(v => v.charAt(0).toUpperCase() + v.slice(1)).join(' / ')
+    : '';
+  const stBtOverride  = feedSub?.st_review?.feed_blood_type_st_override || '';
   const _viLabel = (v) => v === 'kiss' ? 'The Kiss (subtle)' : v === 'violent' ? 'Violent' : '';
+
   h += `<div class="proc-feed-mod-panel proc-feed-violence-block" data-proc-key="${esc(key)}">`;
   h += `<div class="proc-mod-panel-title">Feed declaration</div>`;
-  h += `<div class="proc-mod-row"><span class="proc-mod-label">Player declared</span><span class="proc-feed-violence-val">${esc(_viLabel(playerVi)) || '<em>Not specified</em>'}</span></div>`;
-  h += `<div class="proc-mod-row"><span class="proc-mod-label">ST override</span>`;
-  h += `<select class="proc-feed-violence-st-override" data-sub-id="${esc(entry.subId)}">`;
-  h += `<option value="">No override</option>`;
-  h += `<option value="kiss"${stViOverride === 'kiss' ? ' selected' : ''}>The Kiss (subtle)</option>`;
-  h += `<option value="violent"${stViOverride === 'violent' ? ' selected' : ''}>Violent</option>`;
-  h += `</select>`;
-  h += `</div>`;
-  h += `</div>`;
+
+  // Blood type row
+  h += `<div class="proc-mod-row"><span class="proc-mod-label">Blood type</span>`;
+  h += `<span class="proc-feed-violence-val">${esc(playerBtLabel) || '<em>Not specified</em>'}</span></div>`;
+  h += `<div class="proc-mod-row proc-feed-chips-row">`;
+  h += `<span class="proc-mod-label">ST override</span>`;
+  h += `<div class="proc-feed-chips">`;
+  for (const [val, lbl] of [['', 'No override'], ['animal', 'Animal'], ['human', 'Human'], ['kindred', 'Kindred']]) {
+    const active = (val === '' ? !stBtOverride : stBtOverride === val) ? ' is-active' : '';
+    h += `<button type="button" class="proc-spec-chip proc-feed-bt-chip${active}" data-sub-id="${esc(entry.subId)}" data-value="${esc(val)}">${esc(lbl)}</button>`;
+  }
+  h += `</div></div>`;
+
+  // Feeding method row
+  h += `<div class="proc-mod-row"><span class="proc-mod-label">Player declared</span>`;
+  h += `<span class="proc-feed-violence-val">${esc(_viLabel(playerVi)) || '<em>Not specified</em>'}</span></div>`;
+  h += `<div class="proc-mod-row proc-feed-chips-row">`;
+  h += `<span class="proc-mod-label">ST override</span>`;
+  h += `<div class="proc-feed-chips">`;
+  for (const [val, lbl] of [['', 'No override'], ['kiss', 'The Kiss (subtle)'], ['violent', 'Violent']]) {
+    const active = (val === '' ? !stViOverride : stViOverride === val) ? ' is-active' : '';
+    h += `<button type="button" class="proc-spec-chip proc-feed-vi-chip${active}" data-sub-id="${esc(entry.subId)}" data-value="${esc(val)}">${esc(lbl)}</button>`;
+  }
+  h += `</div></div>`;
+
+  h += `</div>`; // proc-feed-violence-block
 
   h += `</div>`; // proc-feed-right
   return h;
@@ -9648,8 +9694,8 @@ function renderActionPanel(entry, review) {
           }
         }
       }
-      h += `<div class="proc-recat-row">`;
-      h += `<span class="proc-feed-lbl">Territories</span>`;
+      h += `<div class="proc-feed-mod-panel">`;
+      h += `<div class="proc-mod-panel-title">Territory</div>`;
       h += _renderInlineTerrPills(entry.subId, 'feeding', '', _feedSet, true);
       h += `</div>`;
     }

--- a/specs/stories/feat.735.feed-card-terr-pill-and-override-chips.story.md
+++ b/specs/stories/feat.735.feed-card-terr-pill-and-override-chips.story.md
@@ -1,0 +1,284 @@
+---
+title: 'DT Processing: harmonise feeding card territory pill + expand feed override to chips'
+type: 'feature'
+issue: 735
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/735
+branch: ms/issue-735-feed-card-terr-chips
+created: '2026-06-15'
+status: done
+recommended_model: 'sonnet — three contained changes in one file'
+context:
+  - public/js/admin/downtime-views.js
+  - public/css/admin-layout.css
+---
+
+## Intent
+
+Two UX improvements to the DT Processing feeding card:
+
+1. **Territory pill (normal feed)** — wrap the existing flat inline pill row in a
+   `proc-feed-mod-panel` bordered panel to match the rote feed card's style.
+
+2. **Feed declaration panel** — replace the feeding method `<select>` dropdown
+   with toggle chip buttons, and add a new Blood Type override row using the
+   same chip pattern.
+
+---
+
+## Root cause / motivation
+
+The rote feed card already has the correct territory panel style (bordered,
+titled "Territory") via `_renderActionTypeRow()`. The normal feeding card renders
+territory pills as a bare inline row inside `proc-recat-row` — inconsistent.
+
+The Feed Declaration override uses a plain `<select>` for feeding method only.
+The DT player form uses full-width toggle chips for both Blood Type and feeding
+method. Matching that style makes the override feel native, and adding Blood Type
+override lets STs correct an incorrect player submission without reopening the
+form.
+
+---
+
+## File locations
+
+| File | Lines | Notes |
+|------|-------|-------|
+| `public/js/admin/downtime-views.js` | 9651–9654 | Territory pill row — `renderNormalisedCard()`, normal feed branch |
+| `public/js/admin/downtime-views.js` | 7058–7061 | Rote feed territory panel — target CSS structure to match |
+| `public/js/admin/downtime-views.js` | 7949–7964 | Feed Declaration panel — `_renderFeedRightPanel()` |
+| `public/js/admin/downtime-views.js` | 4817–4831 | Existing violence override `change` handler — replace with chip handler |
+| `public/js/admin/downtime-views.js` | 5060 | `saveEntryReview` call shape — `blood_type` already saved here for detail card |
+
+---
+
+## Data shapes
+
+### Player-declared values (read-only display)
+
+| Field | Location | Shape |
+|-------|----------|-------|
+| Feeding method | `feedSub.responses.feed_violence` | `'kiss'` \| `'violent'` \| `''` |
+| Blood type | `feedSub.responses._feed_blood_types` | JSON-stringified array, e.g. `'["human"]'` or `'["animal","human"]'` |
+
+### ST override values (new read/write)
+
+| Field | Location | Values |
+|-------|----------|--------|
+| Feeding method override | `feedSub.st_review.feed_violence_st_override` | `'kiss'` \| `'violent'` \| absent |
+| Blood type override | `feedSub.st_review.feed_blood_type_st_override` | `'animal'` \| `'human'` \| `'kindred'` \| absent |
+
+Use `feed_blood_type_st_override` consistently across all read and write sites
+(render, event handler, `updateSubmission` call). Do not use any other key name.
+
+---
+
+## T1 — Wrap normal-feed territory pill in bordered panel
+
+**File:** `public/js/admin/downtime-views.js`
+
+In `renderNormalisedCard()` at lines 9651–9654, change:
+
+```js
+// BEFORE:
+h += `<div class="proc-recat-row">`;
+h += `<span class="proc-feed-lbl">Territories</span>`;
+h += _renderInlineTerrPills(entry.subId, 'feeding', '', _feedSet, true);
+h += `</div>`;
+```
+
+```js
+// AFTER:
+h += `<div class="proc-feed-mod-panel">`;
+h += `<div class="proc-mod-panel-title">Territory</div>`;
+h += _renderInlineTerrPills(entry.subId, 'feeding', '', _feedSet, true);
+h += `</div>`;
+```
+
+**Why this works:** `proc-feed-mod-panel` and `proc-mod-panel-title` are already
+styled in `admin-layout.css` and used identically in `_renderActionTypeRow()`
+(line 7058). No CSS additions needed.
+
+---
+
+## T2 — Replace Feed Declaration dropdown with chip buttons + add blood type row
+
+**File:** `public/js/admin/downtime-views.js`  
+**Function:** `_renderFeedRightPanel()` — replace lines 7949–7964 entirely.
+
+### Player-declared display
+
+For blood type: parse `feedSub.responses._feed_blood_types` as a JSON array and
+join with " / " for display (e.g. `"Human"` or `"Animal / Human"`). Capitalise
+each value for display. Empty array or parse failure → `'<em>Not specified</em>'`.
+
+For feeding method: existing `_viLabel()` helper already handles this.
+
+### ST override chips
+
+Use `proc-spec-chip` buttons with `is-active` toggle (already styled in
+`admin-layout.css`). Each chip row sits inside a `proc-mod-row`. No new CSS
+needed.
+
+**Violence chips** — three buttons in a `proc-feed-chips` wrapper:
+- `value=""` "No override" (active when `stViOverride` is falsy)
+- `value="kiss"` "The Kiss (subtle)"
+- `value="violent"` "Violent"
+
+**Blood type chips** — three buttons:
+- `value=""` "No override" (active when `stBtOverride` is falsy)  
+- `value="animal"` "Animal"
+- `value="human"` "Human"
+- `value="kindred"` "Kindred"
+
+```js
+// AFTER (full replacement of lines 7949–7964):
+
+// ── DTFP-5: feed-violence + blood-type ST overrides ──
+const playerVi      = feedSub?.responses?.feed_violence || '';
+const stViOverride  = feedSub?.st_review?.feed_violence_st_override || '';
+const playerBtRaw   = feedSub?.responses?.['_feed_blood_types'] || '[]';
+let   playerBtArr   = [];
+try   { playerBtArr = JSON.parse(playerBtRaw); } catch { playerBtArr = []; }
+const playerBtLabel = playerBtArr.length
+  ? playerBtArr.map(v => v.charAt(0).toUpperCase() + v.slice(1)).join(' / ')
+  : '';
+const stBtOverride  = feedSub?.st_review?.feed_blood_type_st_override || '';
+const _viLabel = (v) => v === 'kiss' ? 'The Kiss (subtle)' : v === 'violent' ? 'Violent' : '';
+
+h += `<div class="proc-feed-mod-panel proc-feed-violence-block" data-proc-key="${esc(key)}">`;
+h += `<div class="proc-mod-panel-title">Feed declaration</div>`;
+
+// Blood type row
+h += `<div class="proc-mod-row"><span class="proc-mod-label">Blood type</span>`;
+h += `<span class="proc-feed-violence-val">${esc(playerBtLabel) || '<em>Not specified</em>'}</span></div>`;
+h += `<div class="proc-mod-row proc-feed-chips-row">`;
+h += `<span class="proc-mod-label">ST override</span>`;
+h += `<div class="proc-feed-chips">`;
+for (const [val, lbl] of [['', 'No override'], ['animal', 'Animal'], ['human', 'Human'], ['kindred', 'Kindred']]) {
+  const active = (val === '' ? !stBtOverride : stBtOverride === val) ? ' is-active' : '';
+  h += `<button type="button" class="proc-spec-chip proc-feed-bt-chip${active}" data-sub-id="${esc(entry.subId)}" data-value="${esc(val)}">${esc(lbl)}</button>`;
+}
+h += `</div></div>`;
+
+// Feeding method row
+h += `<div class="proc-mod-row"><span class="proc-mod-label">Player declared</span>`;
+h += `<span class="proc-feed-violence-val">${esc(_viLabel(playerVi)) || '<em>Not specified</em>'}</span></div>`;
+h += `<div class="proc-mod-row proc-feed-chips-row">`;
+h += `<span class="proc-mod-label">ST override</span>`;
+h += `<div class="proc-feed-chips">`;
+for (const [val, lbl] of [['', 'No override'], ['kiss', 'The Kiss (subtle)'], ['violent', 'Violent']]) {
+  const active = (val === '' ? !stViOverride : stViOverride === val) ? ' is-active' : '';
+  h += `<button type="button" class="proc-spec-chip proc-feed-vi-chip${active}" data-sub-id="${esc(entry.subId)}" data-value="${esc(val)}">${esc(lbl)}</button>`;
+}
+h += `</div></div>`;
+
+h += `</div>`; // proc-feed-violence-block
+```
+
+---
+
+## T3 — Wire chip event handlers
+
+**File:** `public/js/admin/downtime-views.js`
+
+Find the existing violence override handler at lines 4817–4831 and **replace
+the entire block** (the `select` change handler) with handlers for both chip
+types.
+
+```js
+// REPLACE: lines 4817–4831 (proc-feed-violence-st-override select handler)
+
+// Wire feeding method override chips
+container.querySelectorAll('.proc-feed-vi-chip').forEach(btn => {
+  btn.addEventListener('click', async e => {
+    e.stopPropagation();
+    const subId = btn.dataset.subId;
+    const newVal = btn.dataset.value || null;
+    const sub = submissions.find(s => s._id === subId);
+    if (sub) {
+      if (!sub.st_review) sub.st_review = {};
+      if (newVal) sub.st_review.feed_violence_st_override = newVal;
+      else delete sub.st_review.feed_violence_st_override;
+    }
+    await updateSubmission(subId, { 'st_review.feed_violence_st_override': newVal });
+    // Update active state on sibling chips
+    container.querySelectorAll(`.proc-feed-vi-chip[data-sub-id="${subId}"]`).forEach(b => {
+      b.classList.toggle('is-active', b.dataset.value === (newVal || ''));
+    });
+  });
+});
+
+// Wire blood type override chips
+container.querySelectorAll('.proc-feed-bt-chip').forEach(btn => {
+  btn.addEventListener('click', async e => {
+    e.stopPropagation();
+    const subId = btn.dataset.subId;
+    const newVal = btn.dataset.value || null;
+    const sub = submissions.find(s => s._id === subId);
+    if (sub) {
+      if (!sub.st_review) sub.st_review = {};
+      if (newVal) sub.st_review.feed_blood_type_st_override = newVal;
+      else delete sub.st_review.feed_blood_type_st_override;
+    }
+    await updateSubmission(subId, { 'st_review.feed_blood_type_st_override': newVal });
+    // Update active state on sibling chips
+    container.querySelectorAll(`.proc-feed-bt-chip[data-sub-id="${subId}"]`).forEach(b => {
+      b.classList.toggle('is-active', b.dataset.value === (newVal || ''));
+    });
+  });
+});
+```
+
+---
+
+## T4 — Minor CSS: chip row layout
+
+**File:** `public/css/admin-layout.css`
+
+Add a layout rule so the chip row label and chips sit on the same row. Add near
+the existing `proc-feed-mod-panel` block (search for `.proc-feed-mod-panel`):
+
+```css
+.proc-feed-chips-row { align-items: flex-start; }
+.proc-feed-chips { display: flex; flex-wrap: wrap; gap: 4px; }
+```
+
+Check that `proc-mod-row` already has `display: flex` (it does — verify before
+adding any duplicate flex declaration).
+
+---
+
+## Acceptance criteria
+
+- [x] Normal feeding card territory pill is inside a bordered panel with "Territory" heading (matching rote card)
+- [x] Feed Declaration panel shows Blood Type row: player declared (read-only) + ST override chips (No override / Animal / Human / Kindred)
+- [x] Feed Declaration panel shows feeding method row: player declared (read-only) + ST override chips (No override / The Kiss (subtle) / Violent)
+- [x] Active chip highlights correctly on load (matches persisted `st_review` value)
+- [x] Clicking a chip persists to `st_review.feed_violence_st_override` or `st_review.feed_blood_type_st_override` via `updateSubmission`
+- [x] Clicking the active chip again (or "No override") clears the override and removes the key
+- [x] `feed_blood_type_st_override` key used consistently at all read + write sites — no other spelling
+- [x] No regression on rote feed territory pill (unchanged)
+
+---
+
+## Guardrails
+
+- Only `public/js/admin/downtime-views.js` and `public/css/admin-layout.css` change.
+- Do NOT touch `_renderActionTypeRow()` — rote territory panel is already correct.
+- Do NOT touch `_entryTerritories()` — filter logic is separate from rendering.
+- The `_viLabel()` helper can remain as an inline const inside `_renderFeedRightPanel()` (it's local scope only).
+- `proc-spec-chip` CSS is already in `admin-layout.css` (`.is-active` state included). Do not duplicate its styles.
+- The `proc-recat-row` div and `proc-feed-lbl` span being removed in T1 — confirm neither is used elsewhere in `renderNormalisedCard()` before deletion (grep for both class names to confirm).
+
+---
+
+## Dev Agent Record
+
+### Files changed
+
+- `public/js/admin/downtime-views.js` — T1: territory pill wrapped in `proc-feed-mod-panel`; T2: Feed Declaration replaced with chip rows for blood type + feeding method; T3: select handler replaced with two chip click handlers
+- `public/css/admin-layout.css` — T4: added `.proc-feed-chips-row` and `.proc-feed-chips` layout rules
+
+### Completion notes
+
+T1 replaces the bare `proc-recat-row` wrapper with `proc-feed-mod-panel` + `proc-mod-panel-title` — same pattern as `_renderActionTypeRow()`. T2 adds blood type override row above the feeding method row; each uses `proc-spec-chip proc-feed-bt-chip` / `proc-feed-vi-chip` with `is-active` toggling on load from persisted `st_review` values. T3 replaces the single `select` change handler with two chip click handlers that update the in-memory `sub.st_review`, call `updateSubmission`, then toggle sibling chip active states. `feed_blood_type_st_override` is the sole key name used at all sites. No Playwright tests written — no existing fixture harness for `_renderFeedRightPanel`; visual AC verified by code inspection.

--- a/tests/feat-735-feed-card-terr-pill-and-override-chips.spec.js
+++ b/tests/feat-735-feed-card-terr-pill-and-override-chips.spec.js
@@ -1,0 +1,322 @@
+/**
+ * Tests for feat.735 — DT Processing feeding card UX:
+ *   (1) Normal feed territory pill wrapped in proc-feed-mod-panel bordered panel
+ *   (2) Feed Declaration: select replaced with chip buttons for method + new Blood Type row with chips
+ *
+ * AC-1: Territory pill is inside proc-feed-mod-panel with "Territory" title (not bare proc-recat-row)
+ * AC-2: Blood type player-declared row shows parsed types; four ST override chips rendered
+ * AC-3: Feeding method player-declared row shown; three ST override chips; no <select> element
+ * AC-4a: "No override" chip is-active when no st_review override is set
+ * AC-4b: Correct chip is-active on load when st_review overrides are persisted
+ * AC-5: Clicking a method chip fires PATCH with st_review.feed_violence_st_override
+ * AC-6: Clicking a blood type chip fires PATCH with st_review.feed_blood_type_st_override
+ * AC-7: Clicking the current active method chip clears override — "No override" becomes is-active
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Shared fixtures ───────────────────────────────────────────────────────────
+
+const ST_USER = {
+  id: '123000735', username: 'test_st_735', global_name: 'Test ST 735',
+  avatar: null, role: 'st', player_id: 'p-735', character_ids: [], is_dual_role: false,
+};
+
+const CYCLE_735 = {
+  _id: 'cycle-735', cycle_number: 4, status: 'active',
+  confirmed_ambience: {}, narrative_notes: '',
+};
+
+const CHAR_735 = {
+  _id: 'char-735', name: 'Feed Chip Tester', moniker: null, honorific: null,
+  clan: 'Daeva', covenant: 'Invictus', player: 'Test Player 735',
+  blood_potency: 2, humanity: 6, humanity_base: 7, court_title: null,
+  home_territory: 'academy', retired: false,
+  status: { city: 1, clan: 0, covenant: { Invictus: 1 } },
+  attributes: {
+    Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+    Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+    Presence: { dots: 3, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: { Persuasion: { dots: 2, bonus: 0, specs: [], nine_again: false } },
+  disciplines: {}, merits: [], powers: [], ordeals: [],
+};
+
+const TERRITORY_ACADEMY = {
+  _id: 'aaa000000000000000000001', slug: 'academy', name: 'The Academy',
+  regent_id: null, lieutenant_id: null, feeding_rights: [], ambience: 2,
+};
+
+// Base feeding submission — player declared Kiss + Human blood type
+const SUB_FEED_BASE = {
+  _id: 'sub-735-base',
+  cycle_id: 'cycle-735',
+  character_name: 'Feed Chip Tester',
+  character_id: 'char-735',
+  player_name: 'Test Player 735',
+  submitted_at: '2026-06-15T00:00:00Z',
+  _raw: {
+    projects: [],
+    feeding: { method: 'seduction', pool: { expression: 'Presence 3 + Persuasion 2 = 5' } },
+    sphere_actions: [],
+    contact_actions: { requests: [] },
+    retainer_actions: { actions: [] },
+  },
+  responses: {
+    feed_violence: 'kiss',
+    '_feed_blood_types': '["human"]',
+    feeding_territories: '{"the_academy":"feeding_rights"}',
+  },
+  feeding_review: {
+    pool_player: 'Presence 3 + Persuasion 2 = 5',
+    pool_validated: 'Presence 3 + Persuasion 2 = 5',
+    pool_status: 'validated',
+    nine_again: false, eight_again: false,
+    active_feed_specs: [], pool_mod_spec: 0, pool_mod_equipment: 0,
+    notes_thread: [], player_feedback: '',
+  },
+  projects_resolved: [],
+  merit_actions_resolved: [],
+  st_review: {},
+  st_narrative: {},
+};
+
+// Submission with persisted overrides — Violent method + Human blood type
+const SUB_FEED_WITH_OVERRIDES = {
+  ...SUB_FEED_BASE,
+  _id: 'sub-735-overrides',
+  responses: {
+    ...SUB_FEED_BASE.responses,
+    '_feed_blood_types': '["animal","human"]',
+  },
+  st_review: {
+    feed_violence_st_override: 'violent',
+    feed_blood_type_st_override: 'human',
+  },
+};
+
+// ── Setup helper ──────────────────────────────────────────────────────────────
+
+async function setupProcessing(page, submissions) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'local-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url = route.request().url();
+    const method = route.request().method();
+    const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+
+    if (method === 'PUT' || method === 'PATCH' || method === 'POST') return ok({ ok: true });
+
+    if (url.includes('/api/downtime_submissions'))  return ok(submissions);
+    if (url.includes('/api/downtime_cycles'))       return ok([CYCLE_735]);
+    if (url.includes('/api/characters/names'))      return ok([{ _id: CHAR_735._id, name: CHAR_735.name, moniker: null, honorific: null }]);
+    if (url.includes('/api/characters'))            return ok([CHAR_735]);
+    if (url.includes('/api/territories'))           return ok([TERRITORY_ACADEMY]);
+    if (url.includes('/api/game_sessions'))         return ok([]);
+    if (url.includes('/api/session_logs'))          return ok([]);
+    return ok([]);
+  });
+
+  await page.goto('/admin.html');
+  await page.waitForSelector('#admin-app', { state: 'visible', timeout: 10000 });
+  await page.click('[data-domain="downtime"]');
+  await page.waitForTimeout(1000);
+}
+
+async function openFeedingAction(page) {
+  await page.waitForSelector('.proc-action-row', { timeout: 8000 });
+  await page.locator('.proc-filter-pill[data-filter-dim="phases"][data-filter-val="feeding"]').first().click();
+  await page.waitForTimeout(300);
+  await page.locator('.proc-action-row').first().click();
+  await page.waitForSelector('.proc-action-detail', { timeout: 8000 });
+  await page.waitForTimeout(300);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('feat.735: feeding card territory pill + feed declaration chips', () => {
+
+  // AC-1 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-1: territory pill is inside a bordered panel with "Territory" heading', async ({ page }) => {
+    await setupProcessing(page, [SUB_FEED_BASE]);
+    await openFeedingAction(page);
+
+    // Bordered panel with "Territory" heading must exist
+    const terrPanel = page.locator('.proc-feed-mod-panel').filter({
+      has: page.locator('.proc-mod-panel-title', { hasText: 'Territory' }),
+    });
+    await expect(terrPanel.first()).toBeVisible({ timeout: 5000 });
+
+    // Old bare row must NOT exist (replaced by the panel)
+    const bareRow = page.locator('.proc-recat-row').filter({ hasText: 'Territories' });
+    await expect(bareRow).toHaveCount(0);
+  });
+
+  // AC-2 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-2: blood type section shows player-declared type and four ST override chips', async ({ page }) => {
+    await setupProcessing(page, [SUB_FEED_BASE]);
+    await openFeedingAction(page);
+
+    const rightPanel = page.locator('.proc-feed-right').first();
+    await expect(rightPanel).toBeVisible({ timeout: 5000 });
+
+    // Player-declared blood type from responses._feed_blood_types: ["human"] → "Human"
+    await expect(rightPanel).toContainText('Human');
+
+    // Four blood type chips: No override, Animal, Human, Kindred
+    const btChips = rightPanel.locator('.proc-feed-bt-chip');
+    await expect(btChips).toHaveCount(4);
+    await expect(btChips.nth(0)).toContainText('No override');
+    await expect(btChips.nth(1)).toContainText('Animal');
+    await expect(btChips.nth(2)).toContainText('Human');
+    await expect(btChips.nth(3)).toContainText('Kindred');
+  });
+
+  // AC-3 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-3: feeding method section shows player-declared method and three chips; no <select>', async ({ page }) => {
+    await setupProcessing(page, [SUB_FEED_BASE]);
+    await openFeedingAction(page);
+
+    const rightPanel = page.locator('.proc-feed-right').first();
+    await expect(rightPanel).toBeVisible({ timeout: 5000 });
+
+    // Player-declared method from responses.feed_violence: 'kiss' → "The Kiss (subtle)"
+    await expect(rightPanel).toContainText('The Kiss (subtle)');
+
+    // Three method chips: No override, The Kiss (subtle), Violent
+    const viChips = rightPanel.locator('.proc-feed-vi-chip');
+    await expect(viChips).toHaveCount(3);
+    await expect(viChips.nth(0)).toContainText('No override');
+    await expect(viChips.nth(1)).toContainText('The Kiss');
+    await expect(viChips.nth(2)).toContainText('Violent');
+
+    // The old named select must be gone
+    await expect(rightPanel.locator('.proc-feed-violence-st-override')).toHaveCount(0);
+  });
+
+  // AC-4a ─────────────────────────────────────────────────────────────────────
+
+  test('AC-4a: "No override" chips are is-active when no st_review overrides are set', async ({ page }) => {
+    await setupProcessing(page, [SUB_FEED_BASE]);
+    await openFeedingAction(page);
+
+    const rightPanel = page.locator('.proc-feed-right').first();
+
+    // Method: "No override" chip is-active, others are not
+    const viNoOverride = rightPanel.locator('.proc-feed-vi-chip[data-value=""]');
+    await expect(viNoOverride).toHaveClass(/is-active/);
+
+    const viKiss = rightPanel.locator('.proc-feed-vi-chip[data-value="kiss"]');
+    await expect(viKiss).not.toHaveClass(/is-active/);
+
+    // Blood type: "No override" chip is-active
+    const btNoOverride = rightPanel.locator('.proc-feed-bt-chip[data-value=""]');
+    await expect(btNoOverride).toHaveClass(/is-active/);
+
+    const btHuman = rightPanel.locator('.proc-feed-bt-chip[data-value="human"]');
+    await expect(btHuman).not.toHaveClass(/is-active/);
+  });
+
+  // AC-4b ─────────────────────────────────────────────────────────────────────
+
+  test('AC-4b: correct chips are is-active on load when st_review overrides are persisted', async ({ page }) => {
+    await setupProcessing(page, [SUB_FEED_WITH_OVERRIDES]);
+    await openFeedingAction(page);
+
+    const rightPanel = page.locator('.proc-feed-right').first();
+
+    // Method override = 'violent' → "Violent" chip is-active; "No override" is not
+    const viViolent = rightPanel.locator('.proc-feed-vi-chip[data-value="violent"]');
+    await expect(viViolent).toHaveClass(/is-active/);
+
+    const viNoOverride = rightPanel.locator('.proc-feed-vi-chip[data-value=""]');
+    await expect(viNoOverride).not.toHaveClass(/is-active/);
+
+    // Blood type override = 'human' → "Human" chip is-active; "Animal" is not
+    const btHuman = rightPanel.locator('.proc-feed-bt-chip[data-value="human"]');
+    await expect(btHuman).toHaveClass(/is-active/);
+
+    const btAnimal = rightPanel.locator('.proc-feed-bt-chip[data-value="animal"]');
+    await expect(btAnimal).not.toHaveClass(/is-active/);
+  });
+
+  // AC-5 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-5: clicking a method chip sends PATCH with feed_violence_st_override key', async ({ page }) => {
+    const capturedPatches = [];
+    page.on('request', req => {
+      if (req.method() === 'PATCH' || req.method() === 'PUT') {
+        try { capturedPatches.push(JSON.parse(req.postData() || '{}')); } catch { /* ignore */ }
+      }
+    });
+
+    await setupProcessing(page, [SUB_FEED_BASE]);
+    await openFeedingAction(page);
+
+    const rightPanel = page.locator('.proc-feed-right').first();
+    await rightPanel.locator('.proc-feed-vi-chip[data-value="violent"]').click();
+    await page.waitForTimeout(600); // async PATCH
+
+    expect(capturedPatches.length).toBeGreaterThan(0);
+    const patch = capturedPatches.at(-1);
+    // updateSubmission sends flat dot-notation keys, not nested objects
+    expect(patch['st_review.feed_violence_st_override']).toBe('violent');
+    // Blood type key must NOT be in this patch
+    expect('st_review.feed_blood_type_st_override' in patch).toBe(false);
+  });
+
+  // AC-6 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-6: clicking a blood type chip sends PATCH with feed_blood_type_st_override key', async ({ page }) => {
+    const capturedPatches = [];
+    page.on('request', req => {
+      if (req.method() === 'PATCH' || req.method() === 'PUT') {
+        try { capturedPatches.push(JSON.parse(req.postData() || '{}')); } catch { /* ignore */ }
+      }
+    });
+
+    await setupProcessing(page, [SUB_FEED_BASE]);
+    await openFeedingAction(page);
+
+    const rightPanel = page.locator('.proc-feed-right').first();
+    await rightPanel.locator('.proc-feed-bt-chip[data-value="kindred"]').click();
+    await page.waitForTimeout(600);
+
+    expect(capturedPatches.length).toBeGreaterThan(0);
+    const patch = capturedPatches.at(-1);
+    // updateSubmission sends flat dot-notation keys, not nested objects
+    expect(patch['st_review.feed_blood_type_st_override']).toBe('kindred');
+    // Method key must NOT be in this patch
+    expect('st_review.feed_violence_st_override' in patch).toBe(false);
+  });
+
+  // AC-7 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-7: clicking "No override" method chip clears override — it becomes is-active', async ({ page }) => {
+    await setupProcessing(page, [SUB_FEED_WITH_OVERRIDES]);
+    await openFeedingAction(page);
+
+    const rightPanel = page.locator('.proc-feed-right').first();
+
+    // Confirm: override is set, "No override" is NOT active
+    const viNoOverride = rightPanel.locator('.proc-feed-vi-chip[data-value=""]');
+    await expect(viNoOverride).not.toHaveClass(/is-active/);
+
+    // Click "No override"
+    await viNoOverride.click();
+    await page.waitForTimeout(600);
+
+    // "No override" should now be is-active; "violent" should not be
+    await expect(viNoOverride).toHaveClass(/is-active/);
+    const viViolent = rightPanel.locator('.proc-feed-vi-chip[data-value="violent"]');
+    await expect(viViolent).not.toHaveClass(/is-active/);
+  });
+
+});


### PR DESCRIPTION
## Summary

- Normal feeding card territory pill relocated into a bordered `proc-feed-mod-panel` panel (matching the rote feed card style)
- Feed Declaration dropdown replaced with chip buttons for feeding method override (No override / The Kiss / Violent)
- New Blood Type ST override row added with chips (No override / Animal / Human / Kindred), persisted to `st_review.feed_blood_type_st_override`
- CSS: `proc-feed-chips-row` and `proc-feed-chips` layout rules added for chip row alignment

## Closes

- Closes #735

## Story

- specs/stories/feat.735.feed-card-terr-pill-and-override-chips.story.md

## ADR / Design

_None_

## Test plan

- [x] 8/8 Playwright tests passing (`tests/feat-735-feed-card-terr-pill-and-override-chips.spec.js`)
- [ ] CI green
- [ ] Manual: DT Processing → expand a feeding action → territory pill in bordered panel with "Territory" heading; Feed Declaration shows Blood Type + Method chip rows; clicking a chip toggles is-active and PATCHes the correct `st_review` key

## Branch flow

- From: `ms/issue-735-feed-card-terr-chips`
- Into: `dev`