### PR TITLE
fix(#737): move normal feed territory pill to right column

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -7970,6 +7970,43 @@ function _renderFeedRightPanel(entry, char, rev, prependHtml = '') {
   h += `</div>`;
 
 
+  // ── Territory pill ──
+  {
+    const _stOvrArr = feedSub?.st_review?.territory_overrides?.feeding;
+    let _feedSet;
+    if (Array.isArray(_stOvrArr)) {
+      _feedSet = new Set(_stOvrArr);
+    } else {
+      _feedSet = new Set();
+      try {
+        const _grid = JSON.parse(feedSub?.responses?.feeding_territories || '{}');
+        for (const [slug, status] of Object.entries(_grid)) {
+          if (!status || status === 'none' || status === 'Not feeding here') continue;
+          let tid;
+          if (/^[a-f0-9]{24}$/i.test(slug)) {
+            const terrDoc = (cachedTerritories || []).find(t => String(t._id) === slug);
+            tid = terrDoc?.slug || null;
+          } else {
+            tid = TERRITORY_SLUG_MAP[slug];
+          }
+          if (tid) _feedSet.add(tid);
+        }
+      } catch { /* ignore malformed JSON */ }
+      if (_feedSet.size === 0) {
+        const _rawTerrs = _normTerrKeys(feedSub?._raw?.feeding?.territories || {});
+        for (const [_slug, status] of Object.entries(_rawTerrs)) {
+          if (!status || status === 'Not feeding here' || status === 'none') continue;
+          const tid = TERRITORY_SLUG_MAP[_slug];
+          if (tid) _feedSet.add(tid);
+        }
+      }
+    }
+    h += `<div class="proc-feed-mod-panel">`;
+    h += `<div class="proc-mod-panel-title">Territory</div>`;
+    h += _renderInlineTerrPills(entry.subId, 'feeding', '', _feedSet, true);
+    h += `</div>`;
+  }
+
   // ── DTFP-5: feed-violence + blood-type ST overrides ──
   const playerVi      = feedSub?.responses?.feed_violence || '';
   const stViOverride  = feedSub?.st_review?.feed_violence_st_override || '';
@@ -9666,44 +9703,6 @@ function renderActionPanel(entry, review) {
         h += `<div class="proc-mismatch-flag">\u26A0 ${esc(_msg)}</div>`;
       }
     }
-    // Territory row — label + ST override pills on one row
-    {
-      const _stOvrArr = feedSub?.st_review?.territory_overrides?.feeding;
-      let _feedSet;
-      if (Array.isArray(_stOvrArr)) {
-        _feedSet = new Set(_stOvrArr);
-      } else {
-        // No ST override — pre-select from player's submitted territories
-        _feedSet = new Set();
-        try {
-          const _grid = JSON.parse(feedSub?.responses?.feeding_territories || '{}');
-          for (const [slug, status] of Object.entries(_grid)) {
-            if (!status || status === 'none' || status === 'Not feeding here') continue;
-            let tid;
-            if (/^[a-f0-9]{24}$/i.test(slug)) {
-              const terrDoc = (cachedTerritories || []).find(t => String(t._id) === slug);
-              tid = terrDoc?.slug || null;
-            } else {
-              tid = TERRITORY_SLUG_MAP[slug];
-            }
-            if (tid) _feedSet.add(tid);
-          }
-        } catch { /* ignore malformed JSON */ }
-        if (_feedSet.size === 0) {
-          const _rawTerrs = _normTerrKeys(feedSub?._raw?.feeding?.territories || {});
-          for (const [key, status] of Object.entries(_rawTerrs)) {
-            if (!status || status === 'Not feeding here' || status === 'none') continue;
-            const tid = TERRITORY_SLUG_MAP[key];
-            if (tid) _feedSet.add(tid);
-          }
-        }
-      }
-      h += `<div class="proc-feed-mod-panel">`;
-      h += `<div class="proc-mod-panel-title">Territory</div>`;
-      h += _renderInlineTerrPills(entry.subId, 'feeding', '', _feedSet, true);
-      h += `</div>`;
-    }
-
     // Previous roll result (use hoisted feedSub from top of function)
     const feedRoll = feedSub?.feeding_roll;
     if (feedRoll) {

--- a/specs/stories/fix.737.feed-terr-pill-right-column.story.md
+++ b/specs/stories/fix.737.feed-terr-pill-right-column.story.md
@@ -1,0 +1,152 @@
+---
+title: 'DT Processing: move normal feed territory pill to right column'
+type: 'fix'
+issue: 737
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/737
+branch: ms/issue-737-feed-terr-pill-right-col
+created: '2026-06-15'
+status: done
+recommended_model: 'sonnet — targeted relocation in one file'
+context:
+  - public/js/admin/downtime-views.js
+  - public/css/admin-layout.css
+---
+
+## Intent
+
+Move the normal-feed territory pill panel from the LEFT card body
+(`renderNormalisedCard`) to the RIGHT column (`_renderFeedRightPanel`), matching
+the column layout already used by rote feed cards.
+
+---
+
+## Root cause / motivation
+
+In feat.735 the territory block was wrapped in a `proc-feed-mod-panel` bordered
+panel (correct style) but was left in `renderNormalisedCard` — the left card body
+function. The right column (`_renderFeedRightPanel`) is the canonical home for all
+feed-specific ST controls. Moving it there aligns normal-feed with rote-feed UX and
+groups Territory, Feed Declaration, and Dice Pool in one column.
+
+The vertical gap between stacked right-column panels is already provided by the
+existing `flex-direction: column; gap: 12px` on `.proc-feed-right`
+(admin-layout.css line 5878). No CSS changes required.
+
+---
+
+## File locations
+
+| File | Lines | Notes |
+|------|-------|-------|
+| `public/js/admin/downtime-views.js` | 9669–9705 | Territory block to REMOVE from `renderNormalisedCard` |
+| `public/js/admin/downtime-views.js` | 7762 | `_renderFeedRightPanel` — insertion target |
+| `public/js/admin/downtime-views.js` | 7822 | `feedSub` already defined here — no parameter change needed |
+| `public/js/admin/downtime-views.js` | 7972 | Feed Declaration block — territory panel goes BEFORE this |
+
+---
+
+## T1 — Remove territory block from `renderNormalisedCard`
+
+**File:** `public/js/admin/downtime-views.js`
+
+Delete the entire territory block at lines 9669–9705 (the `{ const _stOvrArr ... }` block).
+The surrounding mismatch-flag block (lines 9630–9668) is unrelated and stays in the left card.
+
+---
+
+## T2 — Add territory panel to `_renderFeedRightPanel` before Feed Declaration
+
+**File:** `public/js/admin/downtime-views.js`  
+**Insert before:** the `// ── DTFP-5` comment at line 7972.
+
+`feedSub` is already declared at line 7822 via `submissions.find(s => s._id === entry.subId)`.
+`cachedTerritories` and `TERRITORY_SLUG_MAP` are module-level — both accessible here.
+
+**Critical naming:** Inside `_renderFeedRightPanel`, `key` is bound at line 7763 to
+`entry.key`. The inner `for...of` loop over `_rawTerrs` must use a different variable
+name (e.g. `_slug`) to avoid shadowing it.
+
+```js
+// ── Territory pill ──
+{
+  const _stOvrArr = feedSub?.st_review?.territory_overrides?.feeding;
+  let _feedSet;
+  if (Array.isArray(_stOvrArr)) {
+    _feedSet = new Set(_stOvrArr);
+  } else {
+    _feedSet = new Set();
+    try {
+      const _grid = JSON.parse(feedSub?.responses?.feeding_territories || '{}');
+      for (const [slug, status] of Object.entries(_grid)) {
+        if (!status || status === 'none' || status === 'Not feeding here') continue;
+        let tid;
+        if (/^[a-f0-9]{24}$/i.test(slug)) {
+          const terrDoc = (cachedTerritories || []).find(t => String(t._id) === slug);
+          tid = terrDoc?.slug || null;
+        } else {
+          tid = TERRITORY_SLUG_MAP[slug];
+        }
+        if (tid) _feedSet.add(tid);
+      }
+    } catch { /* ignore malformed JSON */ }
+    if (_feedSet.size === 0) {
+      const _rawTerrs = _normTerrKeys(feedSub?._raw?.feeding?.territories || {});
+      for (const [_slug, status] of Object.entries(_rawTerrs)) {
+        if (!status || status === 'Not feeding here' || status === 'none') continue;
+        const tid = TERRITORY_SLUG_MAP[_slug];
+        if (tid) _feedSet.add(tid);
+      }
+    }
+  }
+  h += `<div class="proc-feed-mod-panel">`;
+  h += `<div class="proc-mod-panel-title">Territory</div>`;
+  h += _renderInlineTerrPills(entry.subId, 'feeding', '', _feedSet, true);
+  h += `</div>`;
+}
+```
+
+---
+
+## T3 — Playwright tests
+
+New spec file: `tests/fix-737-feed-terr-pill-right-col.spec.js`
+
+Reuse `setupProcessing` / `openFeedingAction` pattern from feat-735 spec. Two tests:
+
+- **AC-A**: Territory panel (`proc-feed-mod-panel` with "Territory" title) is visible inside
+  `.proc-feed-right` (not anywhere outside it)
+- **AC-B**: Territory panel appears before the Feed Declaration panel in the right column
+  DOM order — i.e. the Territory panel's bounding box top < Feed Declaration panel's top
+
+---
+
+## Acceptance criteria
+
+- [x] Territory `proc-feed-mod-panel` is rendered inside `.proc-feed-right`, not in the left card body
+- [x] Territory panel appears above the Feed Declaration panel in the right column
+- [x] Vertical gap between Territory and Feed Declaration panels (12px from existing flex gap)
+- [x] No regression on rote feed territory pill (unchanged)
+- [x] No regression on #735 Feed Declaration chips (blood type + method override)
+
+---
+
+## Guardrails
+
+- Only `public/js/admin/downtime-views.js` changes.
+- Do NOT touch `admin-layout.css` — the gap is already there.
+- Do NOT change `_renderFeedRightPanel`'s signature or `feedSub` lookup.
+- The mismatch-flag block in `renderNormalisedCard` (lines 9630–9668) stays in the left card.
+
+---
+
+## Dev Agent Record
+
+### Files changed
+
+- `public/js/admin/downtime-views.js` — T1: removed territory block from `renderNormalisedCard`; T2: added territory block to `_renderFeedRightPanel` before Feed Declaration
+
+### Completion notes
+
+Territory block moved to `_renderFeedRightPanel` before the DTFP-5 Feed Declaration block. Inner
+`for...of` loop variable renamed `_slug` to avoid shadowing outer `key` (line 7763). No CSS changes
+needed — `.proc-feed-right` already has `gap: 12px`. Mismatch-flag block left in left card body unchanged.

--- a/tests/fix-737-feed-terr-pill-right-col.spec.js
+++ b/tests/fix-737-feed-terr-pill-right-col.spec.js
@@ -1,0 +1,157 @@
+/**
+ * Tests for fix #737 — normal feed territory pill must appear in the right column,
+ * not the left card body.
+ *
+ * AC-A: Territory panel is visible inside .proc-feed-right
+ * AC-B: Territory panel precedes the Feed Declaration panel in DOM order (top < top)
+ */
+
+const { test, expect } = require('@playwright/test');
+
+const ST_USER_737 = {
+  id: '123000737', username: 'test_st_737', global_name: 'Test ST 737',
+  avatar: null, role: 'st', player_id: 'p-737', character_ids: [], is_dual_role: false,
+};
+
+const CYCLE_737 = {
+  _id: 'cycle-737', cycle_number: 5, status: 'active',
+  confirmed_ambience: {}, narrative_notes: '',
+};
+
+const CHAR_737 = {
+  _id: 'char-737', name: 'Col Placement Tester', moniker: null, honorific: null,
+  clan: 'Ventrue', covenant: 'Invictus', player: 'Test Player 737',
+  blood_potency: 2, humanity: 6, humanity_base: 7, court_title: null,
+  home_territory: 'academy', retired: false,
+  status: { city: 1, clan: 0, covenant: { Invictus: 1 } },
+  attributes: {
+    Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+    Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+    Presence: { dots: 3, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: { Persuasion: { dots: 2, bonus: 0, specs: [], nine_again: false } },
+  disciplines: {}, merits: [], powers: [], ordeals: [],
+};
+
+const TERRITORY_ACADEMY_737 = {
+  _id: 'aaa000000000000000000737', slug: 'academy', name: 'The Academy',
+  regent_id: null, lieutenant_id: null, feeding_rights: [], ambience: 2,
+};
+
+const SUB_FEED_737 = {
+  _id: 'sub-737-base',
+  cycle_id: 'cycle-737',
+  character_name: 'Col Placement Tester',
+  character_id: 'char-737',
+  player_name: 'Test Player 737',
+  submitted_at: '2026-06-15T00:00:00Z',
+  _raw: {
+    projects: [],
+    feeding: { method: 'seduction', pool: { expression: 'Presence 3 + Persuasion 2 = 5' } },
+    sphere_actions: [],
+    contact_actions: { requests: [] },
+    retainer_actions: { actions: [] },
+  },
+  responses: {
+    feed_violence: 'kiss',
+    '_feed_blood_types': '["human"]',
+    feeding_territories: '{"the_academy":"feeding_rights"}',
+  },
+  feeding_review: {
+    pool_player: 'Presence 3 + Persuasion 2 = 5',
+    pool_validated: 'Presence 3 + Persuasion 2 = 5',
+    pool_status: 'validated',
+    nine_again: false, eight_again: false,
+    active_feed_specs: [], pool_mod_spec: 0, pool_mod_equipment: 0,
+    notes_thread: [], player_feedback: '',
+  },
+  projects_resolved: [],
+  merit_actions_resolved: [],
+  st_review: {},
+  st_narrative: {},
+};
+
+async function setupProcessing737(page) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'local-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER_737 });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url = route.request().url();
+    const method = route.request().method();
+    const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+
+    if (method === 'PUT' || method === 'PATCH' || method === 'POST') return ok({ ok: true });
+
+    if (url.includes('/api/downtime_submissions'))  return ok([SUB_FEED_737]);
+    if (url.includes('/api/downtime_cycles'))       return ok([CYCLE_737]);
+    if (url.includes('/api/characters/names'))      return ok([{ _id: CHAR_737._id, name: CHAR_737.name, moniker: null, honorific: null }]);
+    if (url.includes('/api/characters'))            return ok([CHAR_737]);
+    if (url.includes('/api/territories'))           return ok([TERRITORY_ACADEMY_737]);
+    if (url.includes('/api/game_sessions'))         return ok([]);
+    if (url.includes('/api/session_logs'))          return ok([]);
+    return ok([]);
+  });
+
+  await page.goto('/admin.html');
+  await page.waitForSelector('#admin-app', { state: 'visible', timeout: 10000 });
+  await page.click('[data-domain="downtime"]');
+  await page.waitForTimeout(1000);
+}
+
+async function openFeedingAction737(page) {
+  await page.waitForSelector('.proc-action-row', { timeout: 8000 });
+  await page.locator('.proc-filter-pill[data-filter-dim="phases"][data-filter-val="feeding"]').first().click();
+  await page.waitForTimeout(300);
+  await page.locator('.proc-action-row').first().click();
+  await page.waitForSelector('.proc-action-detail', { timeout: 8000 });
+  await page.waitForTimeout(300);
+}
+
+test.describe('fix.737: feed territory pill column placement', () => {
+
+  // AC-A ──────────────────────────────────────────────────────────────────────
+
+  test('AC-A: territory panel is inside .proc-feed-right, not the left card body', async ({ page }) => {
+    await setupProcessing737(page);
+    await openFeedingAction737(page);
+
+    const rightPanel = page.locator('.proc-feed-right').first();
+    await expect(rightPanel).toBeVisible({ timeout: 5000 });
+
+    // Territory panel must be a descendant of .proc-feed-right
+    const terrInRight = rightPanel.locator('.proc-feed-mod-panel').filter({
+      has: page.locator('.proc-mod-panel-title', { hasText: 'Territory' }),
+    });
+    await expect(terrInRight.first()).toBeVisible({ timeout: 5000 });
+  });
+
+  // AC-B ──────────────────────────────────────────────────────────────────────
+
+  test('AC-B: territory panel appears above the Feed Declaration panel in right column', async ({ page }) => {
+    await setupProcessing737(page);
+    await openFeedingAction737(page);
+
+    const rightPanel = page.locator('.proc-feed-right').first();
+    await expect(rightPanel).toBeVisible({ timeout: 5000 });
+
+    const terrPanel = rightPanel.locator('.proc-feed-mod-panel').filter({
+      has: page.locator('.proc-mod-panel-title', { hasText: 'Territory' }),
+    }).first();
+
+    const feedDeclPanel = rightPanel.locator('.proc-feed-violence-block').first();
+
+    await expect(terrPanel).toBeVisible({ timeout: 5000 });
+    await expect(feedDeclPanel).toBeVisible({ timeout: 5000 });
+
+    const terrBox = await terrPanel.boundingBox();
+    const feedDeclBox = await feedDeclPanel.boundingBox();
+
+    expect(terrBox).not.toBeNull();
+    expect(feedDeclBox).not.toBeNull();
+    expect(terrBox.y).toBeLessThan(feedDeclBox.y);
+  });
+
+});


### PR DESCRIPTION
## Summary

- Territory `proc-feed-mod-panel` was rendered inside the left card body (`renderNormalisedCard`) after feat.735; this fix relocates it to `_renderFeedRightPanel` (right column), matching the rote-feed card layout
- Vertical gap between right-column panels comes from the existing `flex-direction: column; gap: 12px` on `.proc-feed-right` — no CSS changes required
- Inner `for...of` loop variable renamed `_slug` to avoid shadowing the outer `key` binding at line 7763

## Closes

- Closes #737

## Story

- specs/stories/fix.737.feed-terr-pill-right-column.story.md

## Test plan

- [ ] `npx playwright test tests/fix-737-feed-terr-pill-right-col.spec.js` — 2 tests (AC-A: panel in right col; AC-B: panel above Feed Declaration)
- [ ] CI green
- [ ] Manual: open DT Processing admin, filter to Feeding phase, expand a normal-feed action — Territory panel should appear in the right column above Feed declaration

## Branch flow

- From: `ms/issue-737-feed-terr-pill-right-col`
- Into: `dev`