### PR TITLE
feat(#739): add Clear Roll button to discard stale feeding roll result

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -5593,6 +5593,21 @@ function renderProcessingMode(container) {
     });
   });
 
+  // Wire feeding roll clear button
+  container.querySelectorAll('.proc-feed-clear-roll-btn').forEach(btn => {
+    btn.addEventListener('click', async e => {
+      e.stopPropagation();
+      const subId   = btn.dataset.subId;
+      const procKey = btn.dataset.procKey;
+      const entry   = _getQueueEntry(procKey);
+      const sub     = submissions.find(s => s._id === subId);
+      await updateSubmission(subId, { feeding_roll: null, feeding_vitae_tally: null });
+      if (sub) { sub.feeding_roll = null; sub.feeding_vitae_tally = null; }
+      if (entry) await saveEntryReview(entry, { pool_status: 'confirmed' });
+      renderProcessingMode(container);
+    });
+  });
+
   // Wire project 9-Again sidebar toggle
   container.querySelectorAll('.proc-proj-9a').forEach(cb => {
     cb.addEventListener('click', e => e.stopPropagation());
@@ -7780,6 +7795,9 @@ function _renderFeedRightPanel(entry, char, rev, prependHtml = '') {
       canRoll:      _showRollBtn,
       noRollMsg:    'Confirm pool first',
       showConfirm:  _poolStatus === 'pending',
+      clearBtnHtml: _feedRollObj
+        ? `<button class="dt-btn proc-feed-clear-roll-btn" data-sub-id="${esc(entry.subId)}" data-proc-key="${esc(key)}">Clear Roll</button>`
+        : '',
     });
   }
 
@@ -8025,6 +8043,7 @@ function _renderRollCard(key, roll, poolTotal, opts = {}) {
     contestedRoll   = null, // DTR-2: defender roll object (for net calculation)
     showConfirm     = false,
     contestedData   = null, // DTR-2: { isContested, contestedChar, contestedPool, contestedRoll } \u2014 renders toggle+controls inside roll card
+    clearBtnHtml    = '',   // optional button HTML injected after Re-roll (opt-in per call site)
   } = opts;
 
   const poolLabel   = (poolTotal != null && canRoll) ? ` \u2014 ${poolTotal} dice` : '';
@@ -8076,6 +8095,7 @@ function _renderRollCard(key, roll, poolTotal, opts = {}) {
     }
     const btnLabel = roll ? 'Re-roll' : 'Roll Dice Pool';
     h += `<button class="dt-btn ${esc(btnClass)}" data-proc-key="${esc(key)}"${btnDataAttrs}>${btnLabel}</button>`;
+    if (clearBtnHtml) h += clearBtnHtml;
     if (roll) {
       const dStr   = _formatDiceString(roll.dice_string);
       const suc    = roll.successes ?? 0;

--- a/specs/stories/feat.739.dt-proc-clear-roll-button.story.md
+++ b/specs/stories/feat.739.dt-proc-clear-roll-button.story.md
@@ -1,0 +1,183 @@
+---
+title: 'DT Processing: Clear Roll button to discard stale feeding roll result'
+type: 'feature'
+issue: 739
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/739
+branch: ms/issue-739-dt-proc-clear-roll-button
+created: '2026-06-15'
+status: done
+recommended_model: 'sonnet — three small, contained changes in one file'
+context:
+  - public/js/admin/downtime-views.js
+---
+
+## Intent
+
+Add a "Clear Roll" button to the feeding ROLL card that discards the stored
+`feeding_roll` result and returns the card to its pre-rolled state, so the ST
+can re-roll at the correct pool size without a page reload.
+
+---
+
+## Root cause / motivation
+
+After issues #729 and #731 fixed pool builder formula drift, a stored roll result
+can still reflect a stale pool count. The only current option is a full page
+reload. A "Clear Roll" button gives the ST a one-click escape hatch that nulls
+the roll result, resets `pool_status` to `'confirmed'`, and re-renders the card
+showing "Roll Dice Pool" at the current (correct) pool size.
+
+---
+
+## File locations
+
+| File | Lines | Notes |
+|------|-------|-------|
+| `public/js/admin/downtime-views.js` | 8017–8109 | `_renderRollCard(key, roll, poolTotal, opts)` |
+| `public/js/admin/downtime-views.js` | 8018–8028 | opts destructuring — add `clearBtnHtml` here |
+| `public/js/admin/downtime-views.js` | 8077–8078 | Re-roll button render — inject `clearBtnHtml` after this line |
+| `public/js/admin/downtime-views.js` | 7770–7784 | Feeding roll card call site in `_renderFeedRightPanel` |
+| `public/js/admin/downtime-views.js` | 5519 | `.proc-feed-roll-btn` click handler — add sibling handler nearby |
+| `public/js/admin/downtime-views.js` | 5590 | `renderProcessingMode(container)` — the re-render call to follow |
+
+---
+
+## Data shapes
+
+| Field | Path | Effect of clear |
+|-------|------|-----------------|
+| Roll result | `submission.feeding_roll` | Set to `null` via `updateSubmission` |
+| Vitae tally | `submission.feeding_vitae_tally` | Set to `null` via `updateSubmission` |
+| Pool status | `feeding_review.pool_status` | Reset to `'confirmed'` via `saveEntryReview` |
+
+---
+
+## T1 — Add `clearBtnHtml` opt to `_renderRollCard`
+
+**File:** `public/js/admin/downtime-views.js`
+
+In the `opts` destructuring at line 8018, add:
+
+```js
+clearBtnHtml    = '',    // optional button HTML injected after Re-roll
+```
+
+After line 8078 (the Re-roll / Roll Dice Pool button), inject:
+
+```js
+if (clearBtnHtml) h += clearBtnHtml;
+```
+
+This keeps `_renderRollCard` generic — callers opt in per use-site.
+
+---
+
+## T2 — Pass `clearBtnHtml` in the feeding roll card call
+
+**File:** `public/js/admin/downtime-views.js`  
+**Location:** lines 7777–7783 — the `_renderRollCard` call inside `_renderFeedRightPanel`
+
+Add `clearBtnHtml` to the opts:
+
+```js
+h += _renderRollCard(key, _feedRollObj, null, {
+  btnClass:     'proc-feed-roll-btn',
+  btnDataAttrs: ` data-sub-id="${esc(entry.subId)}" data-rote="${_isRote}"`,
+  canRoll:      _showRollBtn,
+  noRollMsg:    'Confirm pool first',
+  showConfirm:  _poolStatus === 'pending',
+  clearBtnHtml: _feedRollObj
+    ? `<button class="dt-btn proc-feed-clear-roll-btn" data-sub-id="${esc(entry.subId)}" data-proc-key="${esc(key)}">Clear Roll</button>`
+    : '',
+});
+```
+
+The button only renders when a roll result exists (`_feedRollObj` is truthy).
+
+---
+
+## T3 — Wire the `.proc-feed-clear-roll-btn` click handler
+
+**File:** `public/js/admin/downtime-views.js`  
+**Location:** Add near the `.proc-feed-roll-btn` handler at line 5519.
+
+```js
+container.querySelectorAll('.proc-feed-clear-roll-btn').forEach(btn => {
+  btn.addEventListener('click', async e => {
+    e.stopPropagation();
+    const subId   = btn.dataset.subId;
+    const procKey = btn.dataset.procKey;
+    const entry   = _getQueueEntry(procKey);
+    const sub     = submissions.find(s => s._id === subId);
+    await updateSubmission(subId, { feeding_roll: null, feeding_vitae_tally: null });
+    if (sub) { sub.feeding_roll = null; sub.feeding_vitae_tally = null; }
+    if (entry) await saveEntryReview(entry, { pool_status: 'confirmed' });
+    renderProcessingMode(container);
+  });
+});
+```
+
+`renderProcessingMode(container)` is the same re-render call used by the
+roll handler (line 5590) — follow that pattern exactly.
+
+---
+
+## T4 — Playwright tests
+
+New spec file: `tests/feat-739-dt-proc-clear-roll-button.spec.js`
+
+Reuse the `setupProcessing` / `openFeedingAction` pattern from
+`tests/feat-735-feed-card-terr-pill-and-override-chips.spec.js`.
+
+Two fixtures:
+- `SUB_WITH_ROLL` — submission where `feeding_roll` is populated (e.g.
+  `{ successes: 1, dice_string: '[1,4,2,3,2,5,1,8]', exceptional: false, pool: 8 }`)
+- `SUB_NO_ROLL` — submission where `feeding_roll` is absent / null
+
+Tests:
+
+- **AC-1**: Clear Roll button is visible in `.proc-feed-right` when `feeding_roll`
+  is set; class `proc-feed-clear-roll-btn` present.
+- **AC-2**: Clear Roll button is NOT present when `feeding_roll` is absent.
+- **AC-3**: Clicking Clear Roll sends a PATCH/PUT with `feeding_roll: null`
+  (capture via `page.on('request', ...)`).
+- **AC-4**: After clicking Clear Roll, `proc-proj-roll-result` div is gone and
+  the Roll button shows label "Roll Dice Pool" (pre-rolled state).
+
+---
+
+## Acceptance criteria
+
+- [x] "Clear Roll" button appears in the feeding ROLL card when and only when a roll result exists
+- [x] Clicking it PATCHes `feeding_roll: null` and `feeding_vitae_tally: null` via `updateSubmission`
+- [x] `pool_status` is reset to `'confirmed'` via `saveEntryReview`
+- [x] Card re-renders to pre-rolled state: result line gone, button label "Roll Dice Pool"
+- [x] Button uses `dt-btn` class — consistent style with Re-roll sibling
+- [x] No regression on project or merit roll cards (`_renderRollCard` change is opt-in via `clearBtnHtml`)
+
+---
+
+## Guardrails
+
+- Only `public/js/admin/downtime-views.js` changes.
+- `_renderRollCard` change is purely additive — `clearBtnHtml` defaults to `''` so all
+  other call sites (project, merit, contested) are unaffected.
+- Do NOT change the `_renderRollCard` signature (positional args `key`, `roll`, `poolTotal`,
+  `opts`) — add `clearBtnHtml` inside the `opts` object only.
+- Do NOT clear `feeding_review` pool builder state — only the roll result fields.
+
+---
+
+## Dev Agent Record
+
+### Files changed
+
+- `public/js/admin/downtime-views.js` — T1: added `clearBtnHtml` opt to `_renderRollCard`; T2: pass Clear Roll button in feeding call site; T3: wired `.proc-feed-clear-roll-btn` handler
+- `tests/feat-739-dt-proc-clear-roll-button.spec.js` — 4 Playwright tests (AC-1 through AC-4)
+
+### Completion notes
+
+`clearBtnHtml` defaults to `''` in `_renderRollCard` so all project/merit/contested call sites
+are unaffected. Feeding call site passes the button only when `_feedRollObj` is truthy.
+Handler nulls `feeding_roll` and `feeding_vitae_tally`, resets `pool_status` to `'confirmed'`
+via `saveEntryReview`, then calls `renderProcessingMode(container)` to re-render. All 4 tests pass.

--- a/tests/feat-739-dt-proc-clear-roll-button.spec.js
+++ b/tests/feat-739-dt-proc-clear-roll-button.spec.js
@@ -1,0 +1,219 @@
+/**
+ * Tests for feat #739 — DT Processing: Clear Roll button on feeding ROLL card
+ *
+ * AC-1: "Clear Roll" button is visible inside .proc-feed-right when feeding_roll is set
+ * AC-2: "Clear Roll" button is absent when feeding_roll is null/absent
+ * AC-3: Clicking Clear Roll sends a PATCH with feeding_roll: null
+ * AC-4: After clicking Clear Roll, the roll result is gone and button label resets to "Roll Dice Pool"
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const ST_USER_739 = {
+  id: '123000739', username: 'test_st_739', global_name: 'Test ST 739',
+  avatar: null, role: 'st', player_id: 'p-739', character_ids: [], is_dual_role: false,
+};
+
+const CYCLE_739 = {
+  _id: 'cycle-739', cycle_number: 5, status: 'active',
+  confirmed_ambience: {}, narrative_notes: '',
+};
+
+const CHAR_739 = {
+  _id: 'char-739', name: 'Clear Roll Tester', moniker: null, honorific: null,
+  clan: 'Daeva', covenant: 'Invictus', player: 'Test Player 739',
+  blood_potency: 2, humanity: 6, humanity_base: 7, court_title: null,
+  home_territory: 'academy', retired: false,
+  status: { city: 1, clan: 0, covenant: { Invictus: 1 } },
+  attributes: {
+    Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+    Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+    Presence: { dots: 3, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: { Persuasion: { dots: 2, bonus: 0, specs: [], nine_again: false } },
+  disciplines: {}, merits: [], powers: [], ordeals: [],
+};
+
+const TERRITORY_ACADEMY_739 = {
+  _id: 'aaa000000000000000000739', slug: 'academy', name: 'The Academy',
+  regent_id: null, lieutenant_id: null, feeding_rights: [], ambience: 2,
+};
+
+const FEED_ROLL_OBJ = {
+  successes: 1,
+  exceptional: false,
+  dice: [1, 4, 2, 3, 2, 5, 1, 8],
+  dice_string: '[1,4,2,3,2,5,1,8]',
+  pool: 8,
+  methodName: 'kiss',
+  rolledAt: '2026-06-15T10:00:00Z',
+};
+
+// Submission WITH a roll result
+const SUB_WITH_ROLL = {
+  _id: 'sub-739-rolled',
+  cycle_id: 'cycle-739',
+  character_name: 'Clear Roll Tester',
+  character_id: 'char-739',
+  player_name: 'Test Player 739',
+  submitted_at: '2026-06-15T00:00:00Z',
+  _raw: {
+    projects: [],
+    feeding: { method: 'seduction', pool: { expression: 'Presence 3 + Persuasion 2 = 5' } },
+    sphere_actions: [],
+    contact_actions: { requests: [] },
+    retainer_actions: { actions: [] },
+  },
+  responses: {
+    feed_violence: 'kiss',
+    '_feed_blood_types': '["human"]',
+    feeding_territories: '{"the_academy":"feeding_rights"}',
+  },
+  feeding_review: {
+    pool_player: 'Presence 3 + Persuasion 2 = 5',
+    pool_validated: 'Presence 3 + Persuasion 2 = 5',
+    pool_status: 'rolled',
+    nine_again: false, eight_again: false,
+    active_feed_specs: [], pool_mod_spec: 0, pool_mod_equipment: 0,
+    notes_thread: [], player_feedback: '',
+  },
+  feeding_roll: FEED_ROLL_OBJ,
+  feeding_vitae_tally: { total: 2 },
+  projects_resolved: [],
+  merit_actions_resolved: [],
+  st_review: {},
+  st_narrative: {},
+};
+
+// Submission WITHOUT a roll result
+const SUB_NO_ROLL = {
+  ...SUB_WITH_ROLL,
+  _id: 'sub-739-no-roll',
+  feeding_review: {
+    ...SUB_WITH_ROLL.feeding_review,
+    pool_status: 'confirmed',
+  },
+  feeding_roll: null,
+  feeding_vitae_tally: null,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function setupProcessing739(page, submissions) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'local-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER_739 });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url = route.request().url();
+    const method = route.request().method();
+    const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+
+    if (method === 'PUT' || method === 'PATCH' || method === 'POST') return ok({ ok: true });
+
+    if (url.includes('/api/downtime_submissions'))  return ok(submissions);
+    if (url.includes('/api/downtime_cycles'))       return ok([CYCLE_739]);
+    if (url.includes('/api/characters/names'))      return ok([{ _id: CHAR_739._id, name: CHAR_739.name, moniker: null, honorific: null }]);
+    if (url.includes('/api/characters'))            return ok([CHAR_739]);
+    if (url.includes('/api/territories'))           return ok([TERRITORY_ACADEMY_739]);
+    if (url.includes('/api/game_sessions'))         return ok([]);
+    if (url.includes('/api/session_logs'))          return ok([]);
+    return ok([]);
+  });
+
+  await page.goto('/admin.html');
+  await page.waitForSelector('#admin-app', { state: 'visible', timeout: 10000 });
+  await page.click('[data-domain="downtime"]');
+  await page.waitForTimeout(1000);
+}
+
+async function openFeedingAction739(page) {
+  await page.waitForSelector('.proc-action-row', { timeout: 8000 });
+  await page.locator('.proc-filter-pill[data-filter-dim="phases"][data-filter-val="feeding"]').first().click();
+  await page.waitForTimeout(300);
+  await page.locator('.proc-action-row').first().click();
+  await page.waitForSelector('.proc-action-detail', { timeout: 8000 });
+  await page.waitForTimeout(300);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('feat.739: Clear Roll button on feeding ROLL card', () => {
+
+  // AC-1 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-1: Clear Roll button is visible in right panel when feeding_roll exists', async ({ page }) => {
+    await setupProcessing739(page, [SUB_WITH_ROLL]);
+    await openFeedingAction739(page);
+
+    const rightPanel = page.locator('.proc-feed-right').first();
+    await expect(rightPanel).toBeVisible({ timeout: 5000 });
+
+    const clearBtn = rightPanel.locator('.proc-feed-clear-roll-btn');
+    await expect(clearBtn).toBeVisible({ timeout: 5000 });
+    await expect(clearBtn).toContainText('Clear Roll');
+  });
+
+  // AC-2 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-2: Clear Roll button is absent when feeding_roll is null', async ({ page }) => {
+    await setupProcessing739(page, [SUB_NO_ROLL]);
+    await openFeedingAction739(page);
+
+    const rightPanel = page.locator('.proc-feed-right').first();
+    await expect(rightPanel).toBeVisible({ timeout: 5000 });
+
+    await expect(rightPanel.locator('.proc-feed-clear-roll-btn')).toHaveCount(0);
+  });
+
+  // AC-3 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-3: clicking Clear Roll sends PATCH with feeding_roll: null', async ({ page }) => {
+    const capturedPatches = [];
+    page.on('request', req => {
+      if (req.method() === 'PATCH' || req.method() === 'PUT') {
+        try { capturedPatches.push(JSON.parse(req.postData() || '{}')); } catch { /* ignore */ }
+      }
+    });
+
+    await setupProcessing739(page, [SUB_WITH_ROLL]);
+    await openFeedingAction739(page);
+
+    const rightPanel = page.locator('.proc-feed-right').first();
+    await rightPanel.locator('.proc-feed-clear-roll-btn').click();
+    await page.waitForTimeout(600);
+
+    expect(capturedPatches.length).toBeGreaterThan(0);
+    const patch = capturedPatches[0];
+    expect(patch.feeding_roll).toBeNull();
+    expect(patch.feeding_vitae_tally).toBeNull();
+  });
+
+  // AC-4 ──────────────────────────────────────────────────────────────────────
+
+  test('AC-4: after Clear Roll, result line gone and button shows "Roll Dice Pool"', async ({ page }) => {
+    await setupProcessing739(page, [SUB_WITH_ROLL]);
+    await openFeedingAction739(page);
+
+    const rightPanel = page.locator('.proc-feed-right').first();
+
+    // Confirm roll result is visible before clearing
+    await expect(rightPanel.locator('.proc-proj-roll-result').first()).toBeVisible({ timeout: 5000 });
+
+    // Click Clear Roll
+    await rightPanel.locator('.proc-feed-clear-roll-btn').click();
+    await page.waitForTimeout(800);
+
+    // Roll result line should be gone
+    await expect(rightPanel.locator('.proc-proj-roll-result')).toHaveCount(0);
+
+    // Roll button should now say "Roll Dice Pool" (not "Re-roll")
+    const rollBtn = rightPanel.locator('.proc-feed-roll-btn');
+    await expect(rollBtn).toContainText('Roll Dice Pool');
+  });
+
+});


### PR DESCRIPTION
## Summary

- Stale roll results persisted in the feeding ROLL card with no way to discard them without a page reload; this adds a one-click escape hatch
- "Clear Roll" button appears in the ROLL section only when a roll result exists; absent when the card is in pre-rolled state
- Clicking clears `feeding_roll` and `feeding_vitae_tally`, resets `pool_status` to `'confirmed'`, and re-renders the card ready for a fresh roll at the current pool size
- `_renderRollCard` extended with an opt-in `clearBtnHtml` parameter (defaults to `''`) so project/merit/contested call sites are unaffected

## Closes

- Closes #739

## Story

- specs/stories/feat.739.dt-proc-clear-roll-button.story.md

## Test plan

- [ ] `npx playwright test tests/feat-739-dt-proc-clear-roll-button.spec.js` — 4 tests (AC-1: button visible with roll; AC-2: absent without roll; AC-3: PATCH nulls feeding_roll; AC-4: card returns to pre-rolled state)
- [ ] CI green
- [ ] Manual: open DT Processing admin, expand a feeding action with a stored roll result — "Clear Roll" button should appear alongside "Re-roll"; clicking it should discard the result and show "Roll Dice Pool"

## Branch flow

- From: `ms/issue-739-dt-proc-clear-roll-button`
- Into: `dev`