### PR TITLE
fix(equipment): server-side catalogue_id validation + catalogue parity test (#753, #754)

### DIFF
--- a/server/routes/characters.js
+++ b/server/routes/characters.js
@@ -10,6 +10,10 @@ import { normalizeMeritsMiddleware, normalizeCharacterMerits, validateWhiteAntsT
 // SUBSET ITSELF (mci + bloodline + retainer) is preserved verbatim per
 // Concern #1 Rev 2 — divergence with the client's mci-only subset stays.
 import { freeOf, resolveSharingScope } from '../../public/js/data/rules-helpers.js';
+// #753: POST /equipment must reject catalogue_ids that aren't in the catalogue
+// (type/presence is checked inline; existence is checked against this Set).
+import { EQUIPMENT_CATALOGUE } from '../data/equipment-catalogue.js';
+const _CATALOGUE_IDS = new Set(EQUIPMENT_CATALOGUE.map(e => e.id));
 
 const router = Router();
 const col = () => getCollection('characters');
@@ -817,6 +821,12 @@ router.post('/:id/equipment', requireRole('st'), async (req, res) => {
   }
   if (!item.catalogue_id || typeof item.catalogue_id !== 'string') {
     return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'catalogue_id is required' });
+  }
+  // #753: existence check against the catalogue. Without this the client-side
+  // fallback (`entry.name || item.catalogue_id`) silently renders the raw slug
+  // instead of a real name — a clearly broken sheet that no test was catching.
+  if (!_CATALOGUE_IDS.has(item.catalogue_id)) {
+    return res.status(400).json({ error: 'VALIDATION_ERROR', message: `Unknown catalogue_id: ${item.catalogue_id}` });
   }
   if (!VALID_STATES.includes(item.state)) {
     return res.status(400).json({ error: 'VALIDATION_ERROR', message: `state must be one of: ${VALID_STATES.join(', ')}` });

--- a/server/tests/equipment-catalogue-parity.test.js
+++ b/server/tests/equipment-catalogue-parity.test.js
@@ -1,0 +1,76 @@
+/**
+ * Equipment catalogue parity test (issue #754).
+ *
+ * Compares the two EQUIPMENT_CATALOGUE exports — client at
+ * `public/js/data/equipment-data.js` and server at
+ * `server/data/equipment-catalogue.js` — and fails fast when they drift.
+ *
+ * Why a parity test instead of a single shared module: the root
+ * `package.json` is `"type": "commonjs"` while `server/` is
+ * `"type": "module"`. A neutral shared module needs restructuring beyond
+ * the scope of this story. This test catches drift at PR time at
+ * near-zero cost (sub-millisecond — pure compute, no DB).
+ *
+ * Fields compared per entry:
+ *   bucket, name, availability, skill_domain, bonus_dice, damage_mod,
+ *   damage_type, weapon_type, armour_value, defence_penalty.
+ *   Plus length parity + id-set parity.
+ *
+ * Intentionally NOT compared:
+ *   description — long-form text; drift here is cosmetic, not functional.
+ *   tags — arrays; order-insensitive comparison would add cost without
+ *          functional value (tags aren't used for any server-side gate).
+ *
+ * If drift surfaces, the test names the offending id and the divergent
+ * field, so the fix is mechanical: align the two files in the same commit.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { EQUIPMENT_CATALOGUE as CLIENT } from '../../public/js/data/equipment-data.js';
+import { EQUIPMENT_CATALOGUE as SERVER } from '../data/equipment-catalogue.js';
+
+const COMPARED_FIELDS = [
+  'bucket', 'name', 'availability',
+  'skill_domain', 'bonus_dice',
+  'damage_mod', 'damage_type', 'weapon_type',
+  'armour_value', 'defence_penalty',
+];
+
+describe('Equipment catalogue parity (client ↔ server)', () => {
+  it('both catalogues are non-empty arrays', () => {
+    expect(Array.isArray(CLIENT)).toBe(true);
+    expect(Array.isArray(SERVER)).toBe(true);
+    expect(CLIENT.length).toBeGreaterThan(0);
+    expect(SERVER.length).toBeGreaterThan(0);
+  });
+
+  it('same length', () => {
+    expect(CLIENT).toHaveLength(SERVER.length);
+  });
+
+  it('same id set (no missing or extra entries on either side)', () => {
+    const clientIds = new Set(CLIENT.map(e => e.id));
+    const serverIds = new Set(SERVER.map(e => e.id));
+    const onlyInClient = [...clientIds].filter(id => !serverIds.has(id));
+    const onlyInServer = [...serverIds].filter(id => !clientIds.has(id));
+    expect(onlyInClient, `Client has entries the server is missing: ${onlyInClient.join(', ')}`).toEqual([]);
+    expect(onlyInServer, `Server has entries the client is missing: ${onlyInServer.join(', ')}`).toEqual([]);
+  });
+
+  it('every compared field matches per id', () => {
+    // Per-id deep compare on the functional fields. Build a per-id diff
+    // report so the failure message names the offending entry + field.
+    const serverById = new Map(SERVER.map(e => [e.id, e]));
+    const diffs = [];
+    for (const c of CLIENT) {
+      const s = serverById.get(c.id);
+      if (!s) continue; // id-set parity test reports this case
+      for (const f of COMPARED_FIELDS) {
+        if (c[f] !== s[f]) {
+          diffs.push(`  ${c.id}.${f}: client=${JSON.stringify(c[f])}, server=${JSON.stringify(s[f])}`);
+        }
+      }
+    }
+    expect(diffs, `Catalogue drift detected on ${diffs.length} field(s):\n${diffs.join('\n')}`).toEqual([]);
+  });
+});

--- a/server/tests/equipment.test.js
+++ b/server/tests/equipment.test.js
@@ -183,6 +183,21 @@ describe('POST /api/characters/:id/equipment', () => {
     expect(res.status).toBe(200);
     expect(res.body.equipment[0].acquired_cycle).toBe(0);
   });
+
+  // #753 — catalogue_id existence check
+  it('400 with VALIDATION_ERROR when catalogue_id is not in the catalogue', async () => {
+    const char4 = await seedChar({ name: 'EQ BadCat' });
+    const res = await request(app)
+      .post(`/api/characters/${char4.id}/equipment`)
+      .set('X-Test-User', stUser())
+      .send({ catalogue_id: 'definitely-not-a-real-item-slug', state: 'carried', acquired_cycle: 1 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('VALIDATION_ERROR');
+    expect(res.body.message).toMatch(/Unknown catalogue_id/);
+    // No write occurred — the equipment array stays empty.
+    const fresh = await getCollection('characters').findOne({ _id: char4._id }, { projection: { equipment: 1 } });
+    expect(fresh.equipment || []).toHaveLength(0);
+  });
 });
 
 // ── DELETE /:id/equipment/:itemIndex ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

**PR-α (server hygiene)** per Khepri's bundling — closes #753 (POST catalogue_id existence check) and #754 (client/server catalogue parity test) in one PR.

## #753 — catalogue_id existence check

The POST `/api/characters/:id/equipment` route validated `catalogue_id` for type + presence but didn't check whether the slug actually existed in the catalogue. Combined with the client-side fallback at `sheet.js:1779/1799/1817` (`entry.name || item.catalogue_id`), an unknown slug was accepted by the server and silently rendered as the raw slug on the sheet — broken-looking output that no test caught.

Adds an `EQUIPMENT_CATALOGUE` import + `Set` check at the route top, then an inline guard between the type-check and the state-validation. Single new test in `equipment.test.js` asserts the 400 + that no partial write occurred. The positive baseline (knife / flashlight / rope) is already covered by the existing tests.

## #754 — Catalogue parity test

`public/js/data/equipment-data.js` (879 lines, full form) and `server/data/equipment-catalogue.js` (110 lines, compact form) hold the same 74 catalogue entries. The header comment on the server file acknowledges the manual-sync burden but there's no automation. One forgetful PR away from drift.

New `server/tests/equipment-catalogue-parity.test.js` imports both exports and asserts:
- both non-empty arrays
- same length
- same id set (no missing/extra on either side)
- per-id field parity on the 10 functional fields: `bucket`, `name`, `availability`, `skill_domain`, `bonus_dice`, `damage_mod`, `damage_type`, `weapon_type`, `armour_value`, `defence_penalty`

`description` and `tags` deliberately NOT compared — drift there is cosmetic, not functional.

On drift the failure names the offending id and field so the fix is mechanical (align the two files in the same commit).

### Why a test, not a single shared module

Root `package.json` is `"type":"commonjs"`; `server/` is `"type":"module"`. A neutral shared module needs restructuring beyond this story's scope (per the issue body).

## Tests

- 26 cases pass across `equipment.test.js` + the new parity file in isolation.
- Full regression: **1418/1418 individual tests pass.** Same four pre-existing test-FILE failures (#675 archive-import family + #706 HoS relative-path) carry forward.

## Test plan
- [ ] After merge, try a `POST /api/characters/<id>/equipment` with `catalogue_id: 'definitely-not-real'` — 400 with `VALIDATION_ERROR: Unknown catalogue_id`.
- [ ] Existing equipment edits still work via the editor.
- [ ] Add a new entry to one catalogue file but not the other → parity test fails with the offending id + field named.

Closes #753
Closes #754