### PR TITLE
fix(equipment): acquired_cycle pre-fill + active-state in roll eligibility (#751, #752)

### DIFF
--- a/public/js/admin/city-views.js
+++ b/public/js/admin/city-views.js
@@ -5,6 +5,9 @@
  */
 
 import { apiGet, apiPut, apiPost } from '../data/api.js';
+// #751: writes state.activeCycleNum when the active cycle resolves so the
+// editor's Add Equipment / Add Asset rows pre-fill acquired_cycle correctly.
+import state from '../data/state.js';
 import { calcTotalInfluence } from '../editor/domain.js';
 import { applyDerivedMerits } from '../editor/mci.js';
 import { displayName, cardName, dropdownName, sortName, clanIcon, covIcon } from '../data/helpers.js';
@@ -58,7 +61,10 @@ export async function initCityView() {
     const cycles = await apiGet('/api/downtime_cycles');
     const sorted = cycles.sort((a, b) => (b.created_at || '').localeCompare(a.created_at || ''));
     _activeCycle = sorted.find(c => c.status === 'active') || null;
-  } catch { _activeCycle = null; }
+    // #751: plumb the cycle number into shared state for the editor's
+    // Add Equipment / Add Asset pre-fill (read in sheet.js + edit.js).
+    state.activeCycleNum = (_activeCycle && _activeCycle.cycle_number) ?? null;
+  } catch { _activeCycle = null; state.activeCycleNum = null; }
 
   try {
     const sessions = await apiGet('/api/game_sessions');

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -4,6 +4,9 @@
  */
 
 import { apiGet, apiPost, apiPut, apiDelete } from '../data/api.js';
+// #751: writes state.activeCycleNum when the active cycle resolves so the
+// editor's Add Equipment / Add Asset rows pre-fill acquired_cycle correctly.
+import state from '../data/state.js';
 import { parseDowntimeCSV } from '../downtime/parser.js';
 import { getCycles, getActiveCycle, createCycle, updateCycle, closeCycle, openGamePhase, getSubmissionsForCycle, upsertCycle, updateSubmission, mapRawToResponses, signoffPhase, setManualOpen, DTUX_PHASES } from '../downtime/db.js';
 import { TERRITORY_DATA, AMBIENCE_FEEDING_TOLERANCE, AMBIENCE_ENTROPY, AMBIENCE_THRESHOLDS, AMBIENCE_MODS, FEEDING_TERRITORIES, FEED_METHODS as FEED_METHODS_DATA, MAINTENANCE_MERITS, normaliseSorceryTargets } from '../tabs/downtime-data.js';
@@ -1193,6 +1196,9 @@ async function loadAllCycles() {
 
   // Auto-select active cycle
   activeCycle = allCycles.find(c => c.status === 'active') || null;
+  // #751: plumb the cycle number into shared state for the editor's
+  // Add Equipment / Add Asset pre-fill.
+  state.activeCycleNum = (activeCycle && activeCycle.cycle_number) ?? null;
   if (activeCycle) {
     selectedCycleId = activeCycle._id;
     sel.value = activeCycle._id;

--- a/public/js/suite/roll.js
+++ b/public/js/suite/roll.js
@@ -138,10 +138,13 @@ export function updPool() {
     const rc = state.rollChar;
     const equip = (rc.equipment || []).filter(item => {
       const entry = getCatalogueEntry(item.catalogue_id);
+      // #752: 'active' is the strongest in-use state — treat it identically
+      // to carried/worn for chip eligibility (Khepri's option (a) — preserves
+      // 'active' as a semantically-stronger marker an ST may have already used).
       return entry && entry.bucket === 'equipment' &&
              entry.bonus_dice > 0 &&
              entry.skill_domain === pi.skill &&
-             (item.state === 'carried' || item.state === 'worn');
+             (item.state === 'carried' || item.state === 'worn' || item.state === 'active');
     });
     if (equip.length) {
       html += '<div class="effpool-specs">' + equip.map(item => {
@@ -225,9 +228,11 @@ export function updWeaponRef() {
     return;
   }
   const weapons = (state.rollChar.equipment || []).filter(item => {
+    // #752: 'active' is the strongest in-use state — include it in weapon-ref
+    // eligibility (matches the chip predicate above).
     const entry = getCatalogueEntry(item.catalogue_id);
     return entry && entry.bucket === 'weapon' &&
-           (item.state === 'carried' || item.state === 'worn');
+           (item.state === 'carried' || item.state === 'worn' || item.state === 'active');
   });
   if (!weapons.length) {
     panel.style.display = 'none';

--- a/server/tests/equipment-client-fixes.test.js
+++ b/server/tests/equipment-client-fixes.test.js
@@ -1,0 +1,83 @@
+/**
+ * Static-analysis tests for the EQ-1..EQ-4 client follow-ups #751 + #752.
+ *
+ * The relevant code paths (admin app boot loaders in city-views.js +
+ * downtime-views.js; the suite roll.js equipment-chip + weapon-ref
+ * predicates) all live behind browser-only module boundaries (apiGet
+ * fetches at module-load, DOM globals, state-machine singletons) that make
+ * direct unit-import expensive.
+ *
+ * Mirrors the precedent of `feature.691.hos-city-status-power.test.js` —
+ * read the source file as text and assert the load-bearing string is
+ * present where it must be. Cheap, fast, catches regressions where a
+ * future refactor removes the wiring or reverts the predicate change.
+ *
+ * Path resolution: uses `import.meta.url` + `path.resolve` so the test
+ * works regardless of the cwd vitest was invoked from (the existing
+ * #706-tracked PR #700 test uses a brittle relative path that fails when
+ * cwd is `server/`; this file deliberately avoids that trap).
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+function read(rel) {
+  return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #751 — state.activeCycleNum wired at both admin loader sites
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#751 — state.activeCycleNum wiring', () => {
+  it('city-views.js writes state.activeCycleNum from the resolved active cycle', () => {
+    const src = read('public/js/admin/city-views.js');
+    // Source must import the state module + write the cycle_number near
+    // the _activeCycle resolution. Two complementary checks so a future
+    // rename of either side still trips the test.
+    expect(src).toMatch(/import\s+state\s+from\s+['"]\.\.\/data\/state\.js['"]/);
+    expect(src).toMatch(/state\.activeCycleNum\s*=\s*\(?\s*_activeCycle\s*&&\s*_activeCycle\.cycle_number/);
+  });
+
+  it('downtime-views.js writes state.activeCycleNum from the resolved active cycle', () => {
+    const src = read('public/js/admin/downtime-views.js');
+    expect(src).toMatch(/import\s+state\s+from\s+['"]\.\.\/data\/state\.js['"]/);
+    expect(src).toMatch(/state\.activeCycleNum\s*=\s*\(?\s*activeCycle\s*&&\s*activeCycle\.cycle_number/);
+  });
+
+  it("state.js still ships activeCycleNum so the editor's read sites stay aligned", () => {
+    const src = read('public/js/data/state.js');
+    expect(src).toMatch(/activeCycleNum/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #752 — 'active' included in roll.js predicates (option a per Khepri)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#752 — roll.js predicates include the active state', () => {
+  it('equipment-chip filter accepts state === active', () => {
+    const src = read('public/js/suite/roll.js');
+    // The predicate block: any line with `item.state === 'active'` near a
+    // `bucket === 'equipment'` filter clause counts. We confirm BOTH the
+    // 'equipment' filter and the 'active' check coexist within a small
+    // window so a future predicate rewrite doesn't silently drop 'active'.
+    expect(src).toMatch(/bucket === 'equipment'[\s\S]{0,400}item\.state === 'active'/);
+  });
+
+  it('weapon-reference filter accepts state === active', () => {
+    const src = read('public/js/suite/roll.js');
+    expect(src).toMatch(/bucket === 'weapon'[\s\S]{0,400}item\.state === 'active'/);
+  });
+
+  it('the legacy carried + worn states still appear in the same predicates (no accidental swap)', () => {
+    const src = read('public/js/suite/roll.js');
+    // Sanity guard: 'active' is an addition, not a replacement.
+    expect(src).toMatch(/'carried'\s*\|\|\s*item\.state === 'worn'/);
+  });
+});


### PR DESCRIPTION
## Summary

**PR-β (client UX/bug)** per Khepri's bundling — closes #751 (acquired_cycle pre-fill from active cycle) and #752 (include `'active'` state in roll eligibility). Both touch editor/roll behaviour; complementary one-line semantic fixes.

## #751 — `state.activeCycleNum` was never written

`state.activeCycleNum` is read by `sheet.js:1852` and `edit.js:1099` / `1062` as the default value for the Add Equipment / Add Asset `acquired_cycle` input, but no module ever wrote to it. Every new entry added by an ST defaulted to `0` ("Pre-campaign") regardless of the cycle currently active in the admin app. Failed an EQ-4 AC.

Two write sites added (both gain a `state` import + a single-line assignment after the active-cycle resolution):
- `public/js/admin/city-views.js` — near `_activeCycle = sorted.find(...)`.
- `public/js/admin/downtime-views.js` — near `activeCycle = allCycles.find(...)`.

Field name `cycle_number` confirmed by existing usage at `downtime-views.js:7744`.

## #752 — `'active'` excluded from chip + weapon-ref predicates

Schema, route, and the editor's Add Equipment dropdown all accept `'active'`. But `roll.js:144` (equipment chips) and `roll.js:230` (weapon ref) filtered only for `'carried'` or `'worn'`. Marking a weapon "Active" (which a player reads as *"in use right now"*) made it disappear from the bonus chips and the weapon reference panel.

**Going with Khepri's option (a)** — include `'active'` in both predicates. Preserves the state for future semantic differentiation (option (b)'s "remove from enum" would lose the state STs may have already used). `STATE_LABELS` already labels it `'Active'` — no doc/tooltip change needed.

Both predicates now: `'carried' || 'worn' || 'active'`.

## Tests

`server/tests/equipment-client-fixes.test.js` — 6 static-analysis cases:

- **#751 (3):** city-views.js + downtime-views.js each import `state` AND write the cycle number; `state.js` still ships `activeCycleNum`.
- **#752 (3):** equipment-chip filter and weapon-ref filter both accept `state === 'active'`; sanity guard that `carried` + `worn` are still present (no accidental swap).

Static-analysis pattern mirrors the precedent of `feature.691.hos-city-status-power.test.js`, but uses `import.meta.url` + `path.resolve` so the test works regardless of the cwd vitest is invoked from — deliberately avoiding the relative-path trap that file is tracked under #706 for.

**Full regression: 1419/1419 individual tests pass.** Same four pre-existing test-FILE failures (#675 archive-import family + #706 HoS relative-path) carry forward — none caused here.

## Test plan
- [ ] Open an admin downtime cycle in `dt` view → switch to the Player tab → Add Equipment on a character → cycle input pre-fills with the active cycle's number.
- [ ] Same on the City tab path (city-views also resolves `_activeCycle`).
- [ ] Mark a weapon `'Active'` in the editor → switch to the suite, roll a combat skill → weapon appears in the weapon-ref panel; equipment chips list includes any matching-skill active items.
- [ ] Existing `'carried'` / `'worn'` paths still render chips (no regression).

Closes #751
Closes #752