### PR TITLE
feat(mnec): N-8 Mandragora prereq amendment + Necropolis attached_to option (#761)

### DIFF
--- a/public/js/editor/domain.js
+++ b/public/js/editor/domain.js
@@ -91,19 +91,31 @@ function domMeritTotalSingle(c, m) {
 }
 
 /**
- * Cap for Haven / Mandragora Garden: effective rating of the attached Safe Place instance.
- * Returns 0 if no attached_to set or Safe Place not found.
+ * Cap for Haven / Mandragora Garden: effective rating of the attached anchor.
+ *
+ * Haven anchors to a Safe Place only. Mandragora Garden anchors to either a
+ * Safe Place or — per N-8 (issue #761, Peter decision B 2026-06-15) — a
+ * Necropolis Sepulcher merit instance. Returns 0 if no anchor set or anchor
+ * not found.
  */
 function _havenCap(c, m) {
   // N-1 (Concern #11): every read of m.attached_to goes through the normaliser.
-  // Single anchor (Haven / Mandragora Garden) → `.destination` carries the Safe Place key.
+  // Single anchor (Haven / Mandragora Garden) → `.destination` carries the anchor key.
   const at = normaliseAttachedTo(m.attached_to);
   if (!at) return 0;
-  const sp = (c.merits || []).find(sp2 =>
-    sp2.category === 'domain' && sp2.name === 'Safe Place' && domKey(sp2) === at.destination
-  );
-  if (!sp) return 0;
-  return domMeritTotalSingle(c, sp);
+  const isMandragora = m.name === 'Mandragora Garden';
+  const anchor = (c.merits || []).find(sp2 => {
+    // Safe Place is the legacy anchor for both Haven and Mandragora.
+    if (sp2.category === 'domain' && sp2.name === 'Safe Place' && domKey(sp2) === at.destination) return true;
+    // N-8: Mandragora can additionally anchor to Necropolis Sepulcher. The
+    // permissive `sp2.name` check (no category constraint) mirrors the
+    // picker filter at sheet.js — Sepulcher could be in any category on
+    // the character; matching by name is the canonical lookup.
+    if (isMandragora && sp2.name === 'Necropolis Sepulcher' && domKey(sp2) === at.destination) return true;
+    return false;
+  });
+  if (!anchor) return 0;
+  return domMeritTotalSingle(c, anchor);
 }
 
 /**

--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -1018,15 +1018,26 @@ export function shRenderDomainMerits(c, editMode) {
       }
       // Attached-to selector for Haven / Mandragora Garden
       if (_isCapped) {
-        const _spInstances = (c.merits || []).filter(sp => sp.category === 'domain' && sp.name === 'Safe Place');
-        const _spOpts = ['<option value="">(select Safe Place)</option>']
+        // N-8 (issue #761, Peter decision B 2026-06-15): Mandragora Garden's
+        // attached_to picker accepts Necropolis Sepulcher as an alternative
+        // destination alongside Safe Place. Single-picker option-set \u2014 NOT
+        // dual-anchor (Sepulcher's purchase prereq carries the clan check;
+        // there's no second anchor field to populate). Haven stays
+        // Safe-Place-only \u2014 only Mandragora gets the expansion.
+        const _isMandragora = m.name === 'Mandragora Garden';
+        const _spInstances = (c.merits || []).filter(sp =>
+          (sp.category === 'domain' && sp.name === 'Safe Place')
+          || (_isMandragora && sp.name === 'Necropolis Sepulcher')
+        );
+        const _placeholderLabel = _isMandragora ? '(select Safe Place or Sepulcher)' : '(select Safe Place)';
+        const _spOpts = ['<option value="">' + _placeholderLabel + '</option>']
           .concat(_spInstances.map(sp => { const k = domKey(sp); const _at = normaliseAttachedTo(m.attached_to); return '<option value="' + esc(k) + '"' + (_at && _at.destination === k ? ' selected' : '') + '>' + esc(k) + '</option>'; }))
           .join('');
         h += '<div class="dom-attach-row"><label class="dom-attach-lbl">Attached to:</label><select class="dom-attach-sel" onchange="shEditDomMerit(' + di + ',\'attached_to\',this.value||null)">' + _spOpts + '</select></div>';
         if (!normaliseAttachedTo(m.attached_to) || _spInstances.length === 0) {
-          h += '<div class="dom-cap-warn">\u26A0 Needs an attached Safe Place \u2014 contributes 0 dots until linked.</div>';
+          h += '<div class="dom-cap-warn">\u26A0 Needs an attached ' + (_isMandragora ? 'Safe Place or Sepulcher' : 'Safe Place') + ' \u2014 contributes 0 dots until linked.</div>';
         } else if (_capStored > _capEff) {
-          h += '<div class="dom-cap-warn">\u26A0 Capped at ' + _capEff + ' (attached Safe Place is ' + _capEff + ' \u2014 ' + (_capStored - _capEff) + ' dot' + (_capStored - _capEff !== 1 ? 's' : '') + ' over-allocated, will count if Safe Place upgraded)</div>';
+          h += '<div class="dom-cap-warn">\u26A0 Capped at ' + _capEff + ' (attached ' + (_isMandragora ? 'anchor' : 'Safe Place') + ' is ' + _capEff + ' \u2014 ' + (_capStored - _capEff) + ' dot' + (_capStored - _capEff !== 1 ? 's' : '') + ' over-allocated, will count if upgraded)</div>';
         }
       }
       const _isLKMerit = m.name === 'Herd' || m.name === 'Retainer'; const _isINVMerit = m.name === 'Herd'; const _isVMMerit = m.name === 'Herd';

--- a/server/scripts/update-mandragora-prereq.js
+++ b/server/scripts/update-mandragora-prereq.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+
+/**
+ * N-8 (issue #761, Peter decisions C + D 2026-06-15) — Mandragora Garden
+ * prereq amendment.
+ *
+ * Replaces the `mandragora-garden` rule's `prereq` block in the
+ * `purchasable_powers` collection with the new OR-of-AND structure that
+ * accepts:
+ *
+ *   - Either a Safe Place OR a Necropolis Sepulcher at the same dot level
+ *     ("same level" qualifier on both branches — Sepulcher's dot count
+ *     gates Mandragora the same way Safe Place does)
+ *   - Either Crúac discipline 1+ OR Fucking Thief merit (permissive — any
+ *     qualifier state; FT-purchased merits enter via dedicated
+ *     buildFThiefOptions, so the general dropdown filter doesn't need a
+ *     FT carve-out)
+ *
+ * Idempotent — re-running matches the same doc and writes the same prereq.
+ * --dry-run default, --apply to write. Mirrors the N-3 / STM-13 / N-2
+ * seeder pattern.
+ *
+ * Usage:
+ *   node server/scripts/update-mandragora-prereq.js               # dry-run preview
+ *   node server/scripts/update-mandragora-prereq.js --apply       # write
+ *   MONGODB_DB=tm_suite_test node server/scripts/update-mandragora-prereq.js --apply
+ *
+ * Locally, run from `server/` so cwd-relative `dotenv/config` picks up
+ * `server/.env`. On Render env vars are pre-set (no-op).
+ */
+
+import 'dotenv/config';
+import { MongoClient } from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+const DRY_RUN = !APPLY;
+const MONGODB_URI = process.env.MONGODB_URI;
+const DB_NAME = process.env.MONGODB_DB || 'tm_suite';
+
+if (!MONGODB_URI) {
+  console.error('MONGODB_URI not set. Ensure server/.env is present and run from server/.');
+  process.exit(1);
+}
+
+// 'Crúac' carries U+00FA — preserved verbatim per existing codebase usage
+// (downtime-data.js, print/layout.js); prereq.js:56 has an accent-normalised
+// fallback so 'Cruac' (ASCII) would also match if needed.
+export const MANDRAGORA_PREREQ = {
+  all: [
+    {
+      any: [
+        { type: 'merit', name: 'Safe Place',           dots: 1, qualifier: 'same level' },
+        { type: 'merit', name: 'Necropolis Sepulcher', dots: 1, qualifier: 'same level' },
+      ],
+    },
+    {
+      any: [
+        { type: 'discipline', name: 'Crúac', dots: 1 },
+        { type: 'merit',      name: 'Fucking Thief' },
+      ],
+    },
+  ],
+};
+
+async function main() {
+  console.log(`Mode: ${APPLY ? 'APPLY (will write)' : 'DRY RUN (read only; pass --apply to write)'}`);
+  console.log(`Target DB: ${DB_NAME}\n`);
+
+  const client = new MongoClient(MONGODB_URI, { serverSelectionTimeoutMS: 10000, tls: true });
+  try {
+    await client.connect();
+    const col = client.db(DB_NAME).collection('purchasable_powers');
+
+    const existing = await col.findOne({ key: 'mandragora-garden' });
+    if (!existing) {
+      console.error('mandragora-garden rule doc not found in purchasable_powers. Aborting.');
+      process.exit(2);
+    }
+
+    const same = JSON.stringify(existing.prereq) === JSON.stringify(MANDRAGORA_PREREQ);
+    if (same) {
+      console.log('mandragora-garden prereq already matches the target shape. No-op.');
+      return;
+    }
+
+    console.log('Current prereq:');
+    console.log(JSON.stringify(existing.prereq, null, 2));
+    console.log('\nTarget prereq:');
+    console.log(JSON.stringify(MANDRAGORA_PREREQ, null, 2));
+
+    if (DRY_RUN) {
+      console.log('\n[DRY RUN] Would replace prereq with the target shape. Pass --apply to write.');
+      return;
+    }
+
+    await col.updateOne({ key: 'mandragora-garden' }, { $set: { prereq: MANDRAGORA_PREREQ } });
+    console.log('\nWrote new prereq. Idempotency check: re-run with no flag and confirm "already matches".');
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch(err => { console.error(err); process.exit(1); });

--- a/server/tests/n8-mandragora-prereq.test.js
+++ b/server/tests/n8-mandragora-prereq.test.js
@@ -1,0 +1,206 @@
+/**
+ * N-8 (issue #761) — Mandragora Garden prereq amendment + Necropolis attached_to
+ * option.
+ *
+ * The prereq DSL is the load-bearing surface — verified directly against
+ * `meetsPrereq` (`public/js/data/prereq.js`) without spinning up the route or
+ * the editor. The seeder script's idempotency and the picker-filter behaviour
+ * are covered by adjacent static-analysis cases (mirroring the precedent set
+ * by equipment-client-fixes from PR #758).
+ */
+
+// Browser shims (must run before the prereq import — prereq.js transitively
+// pulls in api.js which references `location` at module top).
+// Pattern mirrored from compile-push-outcome-joint.test.js: shim at file-top,
+// dynamic-import the browser-only module inside beforeAll so the shim is in
+// scope when the import chain evaluates. Static `import` statements would
+// hoist past the shim and fail at module-link time.
+globalThis.location = {
+  origin: 'http://localhost:8080',
+  hostname: 'localhost',
+  href: 'http://localhost:8080/admin',
+};
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { MANDRAGORA_PREREQ } from '../scripts/update-mandragora-prereq.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+function read(rel) { return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8'); }
+
+// Dynamically imported in beforeAll so the browser shim is in place when
+// prereq.js → accessors.js → api.js evaluates.
+let meetsPrereq;
+beforeAll(async () => {
+  const url = pathToFileURL(path.resolve(__dirname, '..', '..', 'public', 'js', 'data', 'prereq.js')).href;
+  ({ meetsPrereq } = await import(url));
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prereq DSL — meetsPrereq against the new block
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-8 — Mandragora Garden prereq', () => {
+  // `domTotal` is the callback that resolves a shared-domain merit's total
+  // across a character (mirrors what the editor passes). For the prereq tests
+  // we just need it to return cp+xp on the named merit when the leaf names a
+  // domain-class merit; the "same level" semantic in meetsPrereq pivots on
+  // the dots floor against rating, not on the domTotal callback for non-
+  // domain merits. Returning 0 is a safe identity for these tests since we
+  // verify against `m.rating` directly via meetsPrereq's merit-leaf path.
+  const opts = { domTotal: () => 0 };
+
+  // Helpers to build a minimal character shape. meetsPrereq reads only
+  // .merits[], .disciplines, .clan, .status, .humanity for these branches.
+  const mkChar = (overrides = {}) => ({
+    clan: 'Mekhet',
+    merits: [],
+    disciplines: {},
+    status: { city: 0, clan: 0, covenant: {} },
+    humanity: 7,
+    ...overrides,
+  });
+
+  it('passes for Safe Place + Crúac (existing path — regression)', () => {
+    const c = mkChar({
+      merits: [{ name: 'Safe Place', rating: 2, cp: 2, xp: 0, qualifier: 'Penthouse', category: 'domain' }],
+      disciplines: { 'Crúac': { dots: 1 } },
+    });
+    expect(meetsPrereq(c, MANDRAGORA_PREREQ, opts)).toBe(true);
+  });
+
+  it('passes for Necropolis Sepulcher + Crúac (new Sepulcher branch)', () => {
+    const c = mkChar({
+      clan: 'Nosferatu',
+      merits: [{ name: 'Necropolis Sepulcher', rating: 2, cp: 2, xp: 0 }],
+      disciplines: { 'Crúac': { dots: 1 } },
+    });
+    expect(meetsPrereq(c, MANDRAGORA_PREREQ, opts)).toBe(true);
+  });
+
+  it('passes for Safe Place + Fucking Thief (permissive FT, Khepri decision D)', () => {
+    const c = mkChar({
+      merits: [
+        { name: 'Safe Place', rating: 1, cp: 1, xp: 0, qualifier: 'Brothels', category: 'domain' },
+        { name: 'Fucking Thief', rating: 3, cp: 3, xp: 0 },
+      ],
+    });
+    expect(meetsPrereq(c, MANDRAGORA_PREREQ, opts)).toBe(true);
+  });
+
+  it('passes for Necropolis Sepulcher + Fucking Thief (both new branches at once)', () => {
+    const c = mkChar({
+      clan: 'Nosferatu',
+      merits: [
+        { name: 'Necropolis Sepulcher', rating: 1, cp: 1, xp: 0 },
+        { name: 'Fucking Thief', rating: 2, cp: 2, xp: 0 },
+      ],
+    });
+    expect(meetsPrereq(c, MANDRAGORA_PREREQ, opts)).toBe(true);
+  });
+
+  it('fails when first AND-branch is missing (no Safe Place, no Sepulcher)', () => {
+    const c = mkChar({
+      disciplines: { 'Crúac': { dots: 2 } },
+    });
+    expect(meetsPrereq(c, MANDRAGORA_PREREQ, opts)).toBe(false);
+  });
+
+  it('fails when second AND-branch is missing (no Crúac, no Fucking Thief)', () => {
+    const c = mkChar({
+      merits: [{ name: 'Safe Place', rating: 2, cp: 2, xp: 0, qualifier: 'X', category: 'domain' }],
+    });
+    expect(meetsPrereq(c, MANDRAGORA_PREREQ, opts)).toBe(false);
+  });
+
+  it('fails with neither AND-branch satisfied', () => {
+    const c = mkChar();
+    expect(meetsPrereq(c, MANDRAGORA_PREREQ, opts)).toBe(false);
+  });
+
+  it('"same level" sentinel matches at the merit\'s rating floor (Sepulcher branch)', () => {
+    // The "same level" sentinel in meetsPrereq compares the prereq merit's
+    // rating against the dots floor (1 in this prereq block). A rating-0
+    // Sepulcher should NOT satisfy; rating-1+ should.
+    const c0 = mkChar({
+      clan: 'Nosferatu',
+      merits: [{ name: 'Necropolis Sepulcher', rating: 0, cp: 0, xp: 0 }],
+      disciplines: { 'Crúac': { dots: 1 } },
+    });
+    expect(meetsPrereq(c0, MANDRAGORA_PREREQ, opts)).toBe(false);
+
+    const c1 = mkChar({
+      clan: 'Nosferatu',
+      merits: [{ name: 'Necropolis Sepulcher', rating: 1, cp: 1, xp: 0 }],
+      disciplines: { 'Crúac': { dots: 1 } },
+    });
+    expect(meetsPrereq(c1, MANDRAGORA_PREREQ, opts)).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Picker filter — Mandragora gains Sepulcher as a destination option
+// (Static analysis; the actual picker is a sheet.js inline-onchange surface
+// that's expensive to import in isolation.)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-8 — sheet.js Mandragora picker filter', () => {
+  it('Mandragora adds Necropolis Sepulcher to the attached_to option set', () => {
+    const src = read('public/js/editor/sheet.js');
+    // The expanded filter must include a Sepulcher branch gated on the
+    // Mandragora-only flag. Catches future "simplifications" that revert
+    // the filter to Safe-Place-only.
+    expect(src).toMatch(/_isMandragora.*=.*m\.name === 'Mandragora Garden'/);
+    expect(src).toMatch(/sp\.name === 'Necropolis Sepulcher'/);
+    expect(src).toMatch(/_isMandragora && sp\.name === 'Necropolis Sepulcher'/);
+  });
+
+  it('Haven path is NOT broadened — sticks to Safe Place only', () => {
+    // Sanity guard: the filter expansion is gated on _isMandragora, so a
+    // non-Mandragora capped merit (Haven) only sees Safe Place options.
+    const src = read('public/js/editor/sheet.js');
+    expect(src).toMatch(/sp\.category === 'domain' && sp\.name === 'Safe Place'/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// _havenCap — looks up Sepulcher when Mandragora is anchored to one
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-8 — _havenCap looks up Sepulcher anchor on Mandragora', () => {
+  it('domain.js _havenCap has a Mandragora-scoped Sepulcher branch', () => {
+    const src = read('public/js/editor/domain.js');
+    expect(src).toMatch(/isMandragora.*=.*m\.name === 'Mandragora Garden'/);
+    expect(src).toMatch(/isMandragora && sp2\.name === 'Necropolis Sepulcher'/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Seeder shape sanity
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-8 — MANDRAGORA_PREREQ block structure', () => {
+  it('top-level all has exactly two any-of branches', () => {
+    expect(MANDRAGORA_PREREQ.all).toHaveLength(2);
+    expect(MANDRAGORA_PREREQ.all[0].any).toBeDefined();
+    expect(MANDRAGORA_PREREQ.all[1].any).toBeDefined();
+  });
+
+  it('first branch carries the "same level" qualifier on BOTH Safe Place and Sepulcher leaves', () => {
+    const [anchorBranch] = MANDRAGORA_PREREQ.all;
+    for (const leaf of anchorBranch.any) {
+      expect(leaf.qualifier).toBe('same level');
+    }
+  });
+
+  it('second branch is Crúac-OR-Fucking-Thief (permissive FT — no qualifier)', () => {
+    const [, disciplineBranch] = MANDRAGORA_PREREQ.all;
+    expect(disciplineBranch.any).toEqual([
+      { type: 'discipline', name: 'Crúac', dots: 1 },
+      { type: 'merit', name: 'Fucking Thief' },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Two Mandragora Garden changes per Imhotep PR #759 §2 + Peter's locked decisions B/C/D (2026-06-15).

## What ships

### Prereq amendment (`server/scripts/update-mandragora-prereq.js`)

Idempotent seeder mirroring N-3 / STM-13 / N-2 pattern (`--dry-run` default, `--apply` to write, dotenv-first). Replaces the `mandragora-garden` rule's `prereq` with:

```js
{ all: [
  { any: [
    { type: 'merit', name: 'Safe Place',           dots: 1, qualifier: 'same level' },
    { type: 'merit', name: 'Necropolis Sepulcher', dots: 1, qualifier: 'same level' },
  ]},
  { any: [
    { type: 'discipline', name: 'Crúac', dots: 1 },
    { type: 'merit',      name: 'Fucking Thief' },
  ]},
]}
```

- **Decision C** — `"same level"` sentinel on BOTH anchor branches. Sepulcher's dot count gates Mandragora the same way Safe Place does.
- **Decision D** — Permissive Fucking Thief. No new `merit_qualifier` DSL primitive. Slot exclusivity is enforced by the existing FT mechanism; the general dropdown filter doesn't need a FT carve-out (FT-purchased merits enter via `buildFThiefOptions`).

Exports `MANDRAGORA_PREREQ` so tests verify the shape directly.

### Picker filter expansion (`public/js/editor/sheet.js:1021`)

**Decision B** — Mandragora-scoped: when `m.name === 'Mandragora Garden'`, the attached_to picker accepts Necropolis Sepulcher alongside Safe Place. **Single-picker option-set; NOT dual-anchor.** Haven stays Safe-Place-only.

Placeholder + warning copy adjust for Mandragora ("Safe Place or Sepulcher" / "anchor").

### `_havenCap` Sepulcher lookup branch (`public/js/editor/domain.js`)

Mandragora-scoped: when the destination resolves to a Sepulcher merit on the same character, `_havenCap` returns Sepulcher's effective rating. Haven cap path unchanged.

Permissive name-only match for Sepulcher (no category constraint) — works whether Sepulcher was added to `domain` or `general` on the character.

## Tests — 14 cases

- **`meetsPrereq` against the new block**:
  - Safe Place + Crúac (regression on existing path)
  - Sepulcher + Crúac (new Sepulcher branch)
  - Safe Place + FT (permissive FT)
  - Sepulcher + FT (both new branches simultaneously)
  - None / anchor-only / discipline-only → false
  - `"same level"` sentinel at the rating floor (rating 0 → false; rating 1+ → true on the Sepulcher branch)
- **Static-analysis** on `sheet.js` picker filter (catches future reverts to Safe-Place-only) + Haven sanity guard.
- **Static-analysis** on `_havenCap`'s Mandragora-scoped branch.
- **MANDRAGORA_PREREQ structure** sanity (block shape, qualifier on both anchor leaves, permissive FT leaf).

Dynamic-import + `globalThis.location` shim pattern (mirroring `compile-push-outcome-joint.test.js`) since `prereq.js` transitively pulls `api.js`'s `location` reference at module top.

**Full regression: 1438/1438 individual tests pass.** Same four pre-existing test-FILE failures (#675 archive-import family + #706 HoS relative-path) carry forward — none caused here.

## Test plan
- [ ] After merge, run `cd server && node scripts/update-mandragora-prereq.js` (dry-run) then `--apply` against `tm_suite`. Idempotent re-run reports "already matches".
- [ ] In the editor, attach a Mandragora to a Necropolis Sepulcher → cap derives from Sepulcher's effective rating.
- [ ] Haven attachment still picks from Safe Places only.
- [ ] A non-Sepulcher, non-Carthian character with Safe Place + Crúac can still buy Mandragora (regression).
- [ ] A Nosferatu with Sepulcher + Crúac can buy Mandragora at level ≤ Sepulcher dots.
- [ ] Any FT-carrying character with Safe Place can buy Mandragora regardless of FT qualifier state.

Closes #761