### PR TITLE
feat(mnec): N-7 Necropolis allocator + N-9 edit-view bug triage (#760, #762)

### DIFF
--- a/public/js/data/rules-helpers.js
+++ b/public/js/data/rules-helpers.js
@@ -200,6 +200,74 @@ export function resolveSharingScope(scope, c, chars, rule) {
   }
 }
 
+// ── N-7 (MNEC, issue #760) — Necropolis allocator helpers ──────────────────
+
+/**
+ * True if the character owns Necropolis Sepulcher with ≥ 1 purchased dot.
+ * Purchased = cp + xp (matches the membership semantics in N-1's
+ * synthesiseCollectiveOwners — grants from the collective itself don't count
+ * toward membership / pool eligibility).
+ *
+ * @param {object} c
+ * @returns {boolean}
+ */
+export function hasNecropolisSepulcher(c) {
+  if (!c || !Array.isArray(c.merits)) return false;
+  return c.merits.some(m =>
+    m && m.name === 'Necropolis Sepulcher' && ((m.cp || 0) + (m.xp || 0)) >= 1
+  );
+}
+
+/**
+ * Remaining pool capacity for an allocator slug on this character.
+ *
+ *   pool capacity = sum of `_grant_pools[*].amount` where category === slug
+ *   used          = sum of `freeOf(m, slug)` across all merits (union-reads
+ *                   map + legacy per N-1's runtime guard)
+ *   available     = max(0, capacity - used)
+ *
+ * Generalises the inline cap logic at `edit.js:1019-1022`. Allocator
+ * handlers compute the cap as `poolAvailableFor(c, slug) + currentValue`
+ * (so the row being edited contributes its OWN current value back into
+ * the cap rather than treating it as a reservation).
+ *
+ * @param {object} c
+ * @param {string} slug
+ * @returns {number}
+ */
+export function poolAvailableFor(c, slug) {
+  if (!c || !slug) return 0;
+  const capacity = (c._grant_pools || [])
+    .filter(p => p && p.category === slug)
+    .reduce((s, p) => s + (p.amount || 0), 0);
+  let used = 0;
+  for (const m of (c.merits || [])) {
+    used += freeOf(m, slug);
+  }
+  return Math.max(0, capacity - used);
+}
+
+/**
+ * Necropolis target merit names from the rules cache.
+ *
+ * Caller passes the rules cache (from `editor/rule_engine/load-rules.js`)
+ * so this helper stays free of the rules-cache + api.js import chain —
+ * rules-helpers.js MUST remain pure / no-browser-imports per the N-1
+ * convention. Returns the `pool_targets` array on the
+ * `source: 'Necropolis Sepulcher'` rule_grant doc, or `[]` if the cache
+ * is empty / the rule isn't seeded.
+ *
+ * @param {object} [ruleCache] - rules cache shape `{ rule_grant: [...] }`
+ * @returns {string[]}
+ */
+export function getNecropolisTargets(ruleCache) {
+  const grants = (ruleCache && ruleCache.rule_grant) || [];
+  const rule = grants.find(r =>
+    r && r.source === 'Necropolis Sepulcher' && r.grant_type === 'pool'
+  );
+  return (rule && Array.isArray(rule.pool_targets)) ? rule.pool_targets : [];
+}
+
 /**
  * N-4 (MNEC, issue #696) — render-side union of Territories the Necropolis
  * has infected. Walks `chars`, finds every Necropolis Sepulcher owner

--- a/public/js/editor/edit.js
+++ b/public/js/editor/edit.js
@@ -9,7 +9,7 @@ import {
   CORE_DISCS, RITUAL_DISCS
 } from '../data/constants.js';
 import { getRuleByKey, getRulesByCategory } from '../data/loader.js';
-import { freeOf } from '../data/rules-helpers.js';
+import { freeOf, poolAvailableFor } from '../data/rules-helpers.js';
 import { xpToDots, xpEarned, xpSpent } from './xp.js';
 import { meritByCategory, addMerit, removeMerit, ensureMeritSync } from './merits.js';
 import { getPoolTotal, mciPoolTotal, getMCIPoolUsed } from './mci.js';
@@ -1026,6 +1026,31 @@ export function shEditMeritPt(realIdx, field, val) {
     const lkTotal = lorekeeperPool(c);
     const otherFLK = lorekeeperUsed(c) - freeOf(m, 'lk');
     val = Math.min(val, Math.max(0, lkTotal - otherFLK));
+  }
+  // N-7 / N-9: post-N-1 allocator write path. Field shape `free_grants.<slug>`
+  // routes to the map; cap enforced by `poolAvailableFor` (which union-reads
+  // map + legacy via freeOf across all merits, then subtracts from the
+  // category's _grant_pools capacity). Adding the CURRENT row's own value
+  // back into the cap so editing your own slot doesn't double-count.
+  //
+  //   ADR-005 amendment (under D6): allocators introduced post-N-1 write
+  //   `m.free_grants[slug]` directly; no new legacy flat field. MCI was
+  //   migrated to the map shape in N-9 (the input still says "MCI" but the
+  //   write target is now `free_grants.mci`). LK / Inv / VM retain their
+  //   legacy field writes until the deferred MNEC-prerequisite audit.
+  if (typeof field === 'string' && field.startsWith('free_grants.')) {
+    const slug = field.slice('free_grants.'.length);
+    const current = (m.free_grants && m.free_grants[slug]) || 0;
+    const avail = poolAvailableFor(c, slug) + current;
+    val = Math.min(val, Math.max(0, avail));
+    m.free_grants = m.free_grants || {};
+    if (val > 0) m.free_grants[slug] = val;
+    else delete m.free_grants[slug];
+    m.rating = syncMeritRating(m);
+    pruneContactsSpheres(m);
+    _markDirty();
+    _renderSheet(c);
+    return;
   }
   m[field] = val;
   // Sync stored rating via shared helper — never hand-roll the sum or new

--- a/public/js/editor/mci.js
+++ b/public/js/editor/mci.js
@@ -6,6 +6,9 @@
 
 import { addMerit, ensureMeritSync } from './merits.js';
 import { syncMeritRating, pruneContactsSpheres } from './domain.js';
+// N-9 (issue #762): pool readers consume freeOf so they union-read map +
+// legacy fields (post-N-2 backfill the persisted data lives in the map).
+import { freeOf } from '../data/rules-helpers.js';
 import { getRulesBySource, getRulesCache } from './rule_engine/load-rules.js';
 import { applyPTRulesFromDb } from './rule_engine/pt-evaluator.js';
 import { applyMCIRulesFromDb } from './rule_engine/mci-evaluator.js';
@@ -186,17 +189,25 @@ export function mciPoolTotal(mci, budgets = _MCI_DEFAULT_BUDGETS) {
   return pool;
 }
 
-/** Sum all free_mci dots allocated across every merit and fighting style. */
+/** Sum all free_mci dots allocated across every merit and fighting style.
+ *
+ *  N-9 (issue #762, Bug 1): consumes `freeOf` (union-read map + legacy) so the
+ *  pool counter at top of merits reads correct numerator on backfilled data.
+ *  Pre-N-9 this read only `m.free_mci`, missing every grant that had been
+ *  migrated into `m.free_grants.mci` by N-2's backfill — the counter showed
+ *  0/Y while the denominator moved as MCI XP shifted, making the per-row
+ *  selectors look broken when they were actually wired correctly. */
 export function getMCIPoolUsed(c) {
   let total = 0;
-  (c.merits || []).forEach(m => { total += m.free_mci || 0; });
-  (c.fighting_styles || []).forEach(fs => { total += fs.free_mci || 0; });
+  (c.merits || []).forEach(m => { total += freeOf(m, 'mci'); });
+  (c.fighting_styles || []).forEach(fs => { total += freeOf(fs, 'mci'); });
   return total;
 }
 
-/** Sum all free_ots dots allocated across fighting styles (Oath of the Scapegoat pool). */
+/** Sum all free_ots dots allocated across fighting styles (Oath of the Scapegoat pool).
+ *  N-9 (issue #762): freeOf union-read for N-2-backfill safety. */
 export function getOTSPoolUsed(c) {
-  return (c.fighting_styles || []).reduce((s, fs) => s + (fs.free_ots || 0), 0);
+  return (c.fighting_styles || []).reduce((s, fs) => s + freeOf(fs, 'ots'), 0);
 }
 
 /** Check if a pool matches a merit name (supports single `name` or multi `names`). */
@@ -222,18 +233,40 @@ export function getPoolTotal(c, meritName) {
 export function getPoolUsed(c, meritName) {
   // Find all pools that include this merit
   const matchedPools = (c._grant_pools || []).filter(p => _poolMatchesName(p, meritName));
-  // Collect all merit names covered by these pools
+  // Collect all merit names + slugs (pool categories) covered.
   const allNames = new Set();
+  const slugs = new Set();
   matchedPools.forEach(p => {
     if (p.names) p.names.forEach(n => allNames.add(n));
     else if (p.name) allNames.add(p.name);
+    if (p.category) slugs.add(p.category);
   });
-  // Sum all named grant fields across all covered merits
+  // Sum all named grant fields across all covered merits.
+  //
+  // N-9 (issue #762, Bug 1): the legacy implementation iterated
+  // `Object.entries(m)` for `free_*` keys — caught legacy flat fields but
+  // NOT the new `m.free_grants` map. For each matched-pool category we now
+  // also read `freeOf(m, slug)` so the map entries are picked up. The
+  // legacy `free_*` enumeration is retained for transitional safety on the
+  // few channels (free / free_fwb / free_attache / free_carthian) that
+  // aren't pool categories tracked in `_grant_pools.category` — those
+  // continue to count as before, but for the categories that DO have a
+  // pool the freeOf union-read becomes the canonical source.
   let total = 0;
   (c.merits || []).forEach(m => {
     if (!allNames.has(m.name)) return;
+    for (const slug of slugs) total += freeOf(m, slug);
+    // Anything else that starts with `free_` but isn't a pool category
+    // (free, free_fwb, free_attache, free_carthian, etc.) — keep the
+    // legacy enumeration so this helper's pre-N-9 behaviour for non-pool
+    // free fields is preserved. Pool categories are skipped here because
+    // `freeOf` already consumed both their map and legacy values above.
     for (const [k, v] of Object.entries(m)) {
-      if (k.startsWith('free_') && typeof v === 'number') total += v;
+      if (!k.startsWith('free_') || k === 'free_grants') continue;
+      if (typeof v !== 'number') continue;
+      const slug = k.slice('free_'.length);
+      if (slugs.has(slug)) continue; // already counted via freeOf above
+      total += v;
     }
   });
   return total;

--- a/public/js/editor/merits.js
+++ b/public/js/editor/merits.js
@@ -260,7 +260,7 @@ export function meritQualifies(c, prereqStr, structuredPrereq) {
 
   // If a structured prereq tree was passed directly, use the new engine
   if (structuredPrereq !== undefined) {
-    return _meetsPrereq(c, structuredPrereq);
+    return meritPrereqOK(c, { prereq: structuredPrereq });
   }
 
   // Fallback: regex-based parsing for legacy callers
@@ -269,6 +269,31 @@ export function meritQualifies(c, prereqStr, structuredPrereq) {
     const orParts = part.split(/\s+or\s+/i);
     return orParts.some(t => checkSinglePrereq(c, t.trim()));
   });
+}
+
+/**
+ * N-9 (issue #762, Bug 3) — single seam for the prereq check across all
+ * sub-category dropdown filters (buildMeritOptions, buildSubCategoryMeritOptions,
+ * buildMCIGrantOptions). Wraps `_meetsPrereq` so future evolutions of the
+ * prereq-check semantics happen in one place instead of three.
+ *
+ * Returns true when the character meets the rule's `prereq` tree. Empty /
+ * missing prereq trees pass (existing `_meetsPrereq` semantics).
+ *
+ * Note: current-row passthrough — when a row's currently-selected merit name
+ * fails its prereq (e.g. ST removed a prereq merit elsewhere on the sheet),
+ * the picker keeps the selection visible per Ma'at's directive (legitimate
+ * editing affordance). Callers handle that case inline with their `curLow`
+ * check, and emit a `console.warn` so the situation surfaces in QA testing
+ * instead of silently passing. The warn lives on the caller side because
+ * "current row" is dropdown-builder concern, not a property of the rule.
+ *
+ * @param {object} c
+ * @param {object} rule - merit rule doc (with optional `prereq` tree)
+ * @returns {boolean}
+ */
+export function meritPrereqOK(c, rule) {
+  return _meetsPrereq(c, rule && rule.prereq);
 }
 
 /**
@@ -286,7 +311,7 @@ export function buildMeritOptions(c, currentName) {
       if (rule.sub_category && rule.sub_category !== 'general') continue;
       if (INFLUENCE_MERIT_TYPES.includes(rule.name)) continue;
       if (rule.parent && ['Style', 'Invictus Oath', 'Carthian Law'].includes(rule.parent)) continue;
-      if (!_meetsPrereq(c, rule.prereq)) continue;
+      if (!meritPrereqOK(c, rule)) continue;
       const excl = _isExcluded(c, rule.name);
       if (excl && rule.name.toLowerCase() !== (currentName || '').toLowerCase()) continue;
       qualified.push({ key: rule.name.toLowerCase(), label: rule.name });
@@ -328,8 +353,19 @@ export function buildSubCategoryMeritOptions(c, subCategory, currentName, extraN
   const seen = new Set();
   for (const rule of rulesDB) {
     if (rule.sub_category !== subCategory) continue;
-    if (!_meetsPrereq(c, rule.prereq) && rule.name.toLowerCase() !== curLow) continue;
-    if (_isExcluded(c, rule.name) && rule.name.toLowerCase() !== curLow) continue;
+    // N-9 (issue #762, Bug 3): single-seam prereq check; current-row
+    // passthrough preserved (legitimate editing affordance) but a
+    // failing-prereq passthrough now emits a diagnostic warn so the
+    // situation surfaces in QA testing instead of silently passing.
+    const passes = meritPrereqOK(c, rule);
+    const isCurrentRow = rule.name.toLowerCase() === curLow;
+    if (!passes && !isCurrentRow) continue;
+    if (!passes && isCurrentRow) {
+      try {
+        console.warn(`[meritPrereqOK] current selection "${rule.name}" (sub_category=${subCategory}) passes through filter but fails its prereq — investigate.`);
+      } catch { /* console may be absent in test contexts */ }
+    }
+    if (_isExcluded(c, rule.name) && !isCurrentRow) continue;
     if (seen.has(rule.name)) continue;
     seen.add(rule.name);
     qualified.push(rule.name);
@@ -365,7 +401,7 @@ export function buildMCIGrantOptions(c, dotLevel, currentName) {
     for (const rule of rulesDB) {
       if (rule.sub_category === 'standing') continue;
       if (rule.parent && ['Style', 'Invictus Oath', 'Carthian Law'].includes(rule.parent)) continue;
-      if (!_meetsPrereq(c, rule.prereq)) continue;
+      if (!meritPrereqOK(c, rule)) continue;
       if (_isExcluded(c, rule.name) && rule.name.toLowerCase() !== (currentName || '').toLowerCase()) continue;
       const rr = rule.rating_range;
       if (rr) {

--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -13,7 +13,9 @@ import { meritBase, meritDotCount, meritLookup, meritFixedRating, buildMeritOpti
 // N-1 (Concern #11): every read of m.attached_to goes through this normaliser.
 // N-4: getNecropolisInfectedTerritories drives the Trap Door Territory picker.
 // N-5: validateTrapDoorAnchor reports the render-time non-functional state.
-import { normaliseAttachedTo, getNecropolisInfectedTerritories, validateTrapDoorAnchor } from '../data/rules-helpers.js';
+// N-7: hasNecropolisSepulcher + getNecropolisTargets drive the allocator stepper.
+import { normaliseAttachedTo, getNecropolisInfectedTerritories, validateTrapDoorAnchor, hasNecropolisSepulcher, getNecropolisTargets, freeOf } from '../data/rules-helpers.js';
+import { getRulesCache } from './rule_engine/load-rules.js';
 // N-4 (MNEC, issue #696): White Ants Territory picker reads the live list.
 import { getStoredTerritories } from '../data/accessors.js';
 import { getRulesByCategory, getRuleByKey } from '../data/loader.js';
@@ -111,12 +113,16 @@ function _renderPoolCounters(c, category) {
   // Lorekeeper pools target Herd/Retainer — show in the domain section (Herd lives there;
   // Retainer is influence but pool is unified). One row keeps the summary uncluttered.
   const lkPools = category === 'domain' ? (c._grant_pools || []).filter(p => p.category === 'lk') : [];
-  const allPools = [...pools, ...anyPools, ...vmPools, ...ohmPools, ...invPools, ...lkPools];
+  // N-7 (issue #760): Necropolis pool targets sit in the general merit
+  // section — surface the counter in 'general' so the read-side summary
+  // matches the per-target allocator stepper below.
+  const necroPools = category === 'general' ? (c._grant_pools || []).filter(p => p.category === 'necro') : [];
+  const allPools = [...pools, ...anyPools, ...vmPools, ...ohmPools, ...invPools, ...lkPools, ...necroPools];
   if (!allPools.length) return '';
   let h = '<div class="grant-pools">';
   const seen = new Set();
   allPools.forEach(p => {
-    const label = p.names ? p.names.join('/') : (p.category === 'any' ? 'any merit' : p.category === 'vm' ? 'Allies (VM bonus)' : p.category === 'ohm' ? 'OHM: auto Contacts+Resources, pick Allies sphere' : p.category === 'inv' ? 'Herd/Mentor/Resources/Retainer (Invested)' : p.name);
+    const label = p.names ? p.names.join('/') : (p.category === 'any' ? 'any merit' : p.category === 'vm' ? 'Allies (VM bonus)' : p.category === 'ohm' ? 'OHM: auto Contacts+Resources, pick Allies sphere' : p.category === 'inv' ? 'Herd/Mentor/Resources/Retainer (Invested)' : p.category === 'necro' ? 'Necropolis targets (Catacombs/Caldarium/Garbage Pit/Labyrinth Guardians/Dark Temple/White Ants)' : p.name);
     const key = p.source + '|' + label;
     if (seen.has(key)) return;
     seen.add(key);
@@ -126,6 +132,8 @@ function _renderPoolCounters(c, category) {
     else if (p.category === 'lk') { pTotal = p.amount; pUsed = lorekeeperUsed(c); }
     else if (p.category === 'ohm') { pTotal = p.amount; pUsed = ohmUsed(c); }
     else if (p.category === 'inv') { pTotal = p.amount; pUsed = investedUsed(c); }
+    // N-7 (issue #760): necro pool — sum freeOf(m, 'necro') across all merits.
+    else if (p.category === 'necro') { pTotal = p.amount; pUsed = (c.merits || []).reduce((s, m) => s + freeOf(m, 'necro'), 0); }
     else { const lookupName = p.names ? p.names[0] : p.name; pTotal = getPoolTotal(c, lookupName); pUsed = getPoolUsed(c, lookupName); }
     const cls = pUsed > pTotal ? 'sc-over' : pUsed === pTotal ? 'sc-full' : 'sc-val';
     h += '<div class="grant-pool-row"><span class="grant-pool-tag">' + esc(p.source) + '</span>: ' + esc(label) + ' free dots <span class="' + cls + '">' + pUsed + '/' + pTotal + '</span></div>';
@@ -1140,7 +1148,9 @@ function _renderMCI(c, m, si, rIdx, mc, dd, editMode) {
   else if (inactive) h += '<span class="mci-toggle-btn" style="opacity:0.5">Suspended</span>';
   h += '<span class="trait-dots">' + shDots(eDots) + '</span></div></div>';
   if (editMode) {
-    h += meritBdRow(rIdx, m, meritFixedRating(m.name)); h += _prereqWarn(c, m.name);
+    // N-9 (issue #762, Bug 2): standing merits (MCI/PT) don't read m.bonus,
+    // so the Bonus row is no-op clutter; hideBonus suppresses it.
+    h += meritBdRow(rIdx, m, meritFixedRating(m.name), { hideBonus: true }); h += _prereqWarn(c, m.name);
     const d1c = m.dot1_choice || 'merits', d3c = m.dot3_choice || 'merits', d5c = m.dot5_choice || 'merits';
     for (let d = 0; d < 5 && d < eDots; d++) {
       h += '<div class="mci-benefit-row"><span class="mci-dot-lbl">' + dots[d] + '</span><div class="mci-dot-content">';
@@ -1214,7 +1224,8 @@ function _renderPT(c, m, si, rIdx, mc, dd, editMode, mciPool = 0) {
   else if (inactive) h += '<span class="mci-toggle-btn" style="opacity:0.5">Suspended</span>';
   h += '<span class="trait-dots">' + shDots(eDots) + '</span></div></div>';
   if (editMode) {
-    h += meritBdRow(rIdx, m, meritFixedRating(m.name), { showMCI: mciPool > 0 });
+    // N-9 (issue #762, Bug 2): PT standing — hideBonus.
+    h += meritBdRow(rIdx, m, meritFixedRating(m.name), { showMCI: mciPool > 0, hideBonus: true });
     h += _prereqWarn(c, m.name);
     h += '<div class="pt-skills-edit">';
     if (eDots >= 1) h += '<div class="mci-benefit-row"><span class="mci-dot-lbl">\u25CF</span><span class="mci-benefit-text">Networking: 2 free Contacts' + (m.role ? ' (' + esc(m.role) + ')' : '') + '</span></div>';
@@ -1285,6 +1296,11 @@ export function shRenderGeneralMerits(c, editMode) {
       + '</div>';
     h += _renderPoolCounters(c, 'general') + _renderPoolCounters(c, 'influence') + _renderPoolCounters(c, 'domain');
     const _genMciPool = (c.merits || []).filter(m => m.name === 'Mystery Cult Initiation' && m.active !== false).reduce((s, m) => s + mciPoolTotal(m), 0);
+    // N-7 (issue #760): Necropolis allocator wiring — _hasNecroSep gates the
+    // stepper render; _necroTargets sources the target merit list from the
+    // rule_grant doc (NOT hardcoded — picks up future pool_targets edits).
+    const _hasNecroSep = hasNecropolisSepulcher(c);
+    const _necroTargets = _hasNecroSep ? getNecropolisTargets(getRulesCache()) : [];
     const _KERBEROS_ASPECTS = ['Monstrous', 'Competitive', 'Seductive'];
     const _CRUAC_STYLES = ['Opening the Void', 'Primal Creation', 'Unbridled Chaos'];
     const _mdbMerit = oM.find(m => m.name === 'The Mother-Daughter Bond');
@@ -1295,7 +1311,7 @@ export function shRenderGeneralMerits(c, editMode) {
       // Merits that accept a free-text qualifier (all others show no qualifier input unless one is already set)
       const _FREE_TEXT_QUAL = new Set(['Language','Multilingual','Library','Quick Draw','Mandragora Garden']);
       const _gPurch = (m.cp || 0) + (m.xp || 0);
-      if (m.granted_by) { h += '<div class="gen-edit-row gen-granted-row"><span class="gen-granted-name">' + esc(m.name) + (m.qualifier ? ' (' + esc(m.qualifier) + ')' : '') + '</span><span class="infl-dots-derived">' + '\u25CF'.repeat(_gPurch) + '\u25CB'.repeat(Math.max(0, dd - _gPurch)) + '</span><span class="gen-granted-tag" title="Granted by ' + esc(m.granted_by) + '">' + esc(m.granted_by) + '</span></div>'; h += meritBdRow(rIdx, m, meritFixedRating(m.name), { showMCI: _genMciPool > 0 }); h += _derivedNotes(m); h += _prereqWarn(c, m.name, m); }
+      if (m.granted_by) { h += '<div class="gen-edit-row gen-granted-row"><span class="gen-granted-name">' + esc(m.name) + (m.qualifier ? ' (' + esc(m.qualifier) + ')' : '') + '</span><span class="infl-dots-derived">' + '\u25CF'.repeat(_gPurch) + '\u25CB'.repeat(Math.max(0, dd - _gPurch)) + '</span><span class="gen-granted-tag" title="Granted by ' + esc(m.granted_by) + '">' + esc(m.granted_by) + '</span></div>'; h += meritBdRow(rIdx, m, meritFixedRating(m.name), { showMCI: _genMciPool > 0, showNECRO: _hasNecroSep && _necroTargets.includes(m.name) }); h += _derivedNotes(m); h += _prereqWarn(c, m.name, m); }
       else {
         h += '<div class="gen-edit-row"><select class="gen-name-select" onchange="shEditGenMerit(' + gi + ',\'name\',this.value)">' + buildMeritOptions(c, m.name || '') + '</select>';
         if (isFT) h += '<select class="gen-qual-input" onchange="shEditGenMerit(' + gi + ',\'qualifier\',this.value)">' + buildFThiefOptions(m.qualifier || '') + '</select>';
@@ -1312,7 +1328,7 @@ export function shRenderGeneralMerits(c, editMode) {
         const _mBonus = m.bonus || 0;
         h += '<span class="infl-dots-derived">' + '\u25CF'.repeat(_gPurch) + '\u25CB'.repeat(Math.max(0, dd + _mBonus - _gPurch)) + '</span>'
           + '<button class="dev-rm-btn" onclick="shRemoveGenMerit(' + gi + ')" title="Remove">&times;</button></div>';
-        h += meritBdRow(rIdx, m, meritFixedRating(m.name), { showMCI: _genMciPool > 0 });
+        h += meritBdRow(rIdx, m, meritFixedRating(m.name), { showMCI: _genMciPool > 0, showNECRO: _hasNecroSep && _necroTargets.includes(m.name) });
         // N-4 (MNEC #696): White Ants Territory picker — one select per dot.
         h += _whiteAntsTerritoriesBlock(m, rIdx);
         // N-5 (MNEC #697): Trap Door triple-anchor picker (origin + destination + territory).

--- a/public/js/editor/xp.js
+++ b/public/js/editor/xp.js
@@ -202,8 +202,8 @@ export function meritRating(c, m) {
  *   threshold is met, then shows fixedAt.
  */
 export function meritBdRow(realIdx, mc, fixedAt, opts = {}) {
-  const cp = mc.cp || 0, xp = mc.xp || 0, fbl = freeOf(mc, 'bloodline'), fret = freeOf(mc, 'pet'), fmci = freeOf(mc, 'mci'), fvm = freeOf(mc, 'vm'), flk = freeOf(mc, 'lk'), fohm = freeOf(mc, 'ohm'), finv = freeOf(mc, 'inv'), fpt = freeOf(mc, 'pt'), fmdb = freeOf(mc, 'mdb'), fsw = freeOf(mc, 'sw');
-  const total = cp + xp + fbl + fret + fmci + fvm + flk + fohm + finv + fpt + fmdb + fsw + (opts.attachBonus || 0);
+  const cp = mc.cp || 0, xp = mc.xp || 0, fbl = freeOf(mc, 'bloodline'), fret = freeOf(mc, 'pet'), fmci = freeOf(mc, 'mci'), fvm = freeOf(mc, 'vm'), flk = freeOf(mc, 'lk'), fohm = freeOf(mc, 'ohm'), finv = freeOf(mc, 'inv'), fpt = freeOf(mc, 'pt'), fmdb = freeOf(mc, 'mdb'), fsw = freeOf(mc, 'sw'), fnecro = freeOf(mc, 'necro');
+  const total = cp + xp + fbl + fret + fmci + fvm + flk + fohm + finv + fpt + fmdb + fsw + fnecro + (opts.attachBonus || 0);
   // Effective display: for fixed merits, only show dots once the threshold is reached
   const effective = (fixedAt != null) ? (total >= fixedAt ? fixedAt : 0) : total;
   const needsHint = (fixedAt != null && total > 0 && total < fixedAt)
@@ -212,14 +212,29 @@ export function meritBdRow(realIdx, mc, fixedAt, opts = {}) {
     + '<div class="bd-grp"><span class="bd-lbl">CP</span><input class="merit-bd-input" type="number" min="0" value="' + cp + '" onchange="shEditMeritPt(' + realIdx + ',\'cp\',+this.value)"></div>'
     + '<div class="bd-grp"><span class="bd-lbl">XP</span><input class="merit-bd-input" type="number" min="0" value="' + xp + '" onchange="shEditMeritPt(' + realIdx + ',\'xp\',+this.value)"></div>'
     + '<div class="bd-sep"></div>';
-  if (opts.showMCI) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl">MCI</span><input class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + fmci + '" onchange="shEditMeritPt(' + realIdx + ',\'free_mci\',+this.value)"></div>';
+  // N-9 (issue #762, Bug 1 "adjacent finding"): MCI input writes the map-shape
+  // `free_grants.mci` per the ADR-005 allocator-write-path amendment. The
+  // handler (shEditMeritPt) detects the `free_grants.` prefix and routes to
+  // the map. Pre-N-9 this wrote `free_mci`, creating a fresh divergence on
+  // every edit after the N-2 backfill.
+  if (opts.showMCI) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl">MCI</span><input class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + fmci + '" onchange="shEditMeritPt(' + realIdx + ',\'free_grants.mci\',+this.value)"></div>';
   if (opts.showVM) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl">VM</span><input class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + fvm + '" onchange="shEditMeritPt(' + realIdx + ',\'free_vm\',+this.value)"></div>';
   if (opts.showLK) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl">LK</span><input class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + flk + '" onchange="shEditMeritPt(' + realIdx + ',\'free_lk\',+this.value)"></div>';
   if (opts.showOHM) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl">OHM</span><input class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + fohm + '" onchange="shEditMeritPt(' + realIdx + ',\'free_ohm\',+this.value)"></div>';
   if (opts.showINV) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl">INV</span><input class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + finv + '" onchange="shEditMeritPt(' + realIdx + ',\'free_inv\',+this.value)"></div>';
+  // N-7 (issue #760): Necropolis allocator — writes directly to
+  // m.free_grants.necro (map shape, no new legacy free_necro field) per the
+  // ADR-005 allocator-write-path amendment.
+  if (opts.showNECRO) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl">NECRO</span><input class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + fnecro + '" onchange="shEditMeritPt(' + realIdx + ',\'free_grants.necro\',+this.value)"></div>';
   h += '<div class="bd-eq"><span class="bd-val">' + effective + ' dot' + (effective === 1 ? '' : 's') + '</span>' + needsHint + '</div>'
     + '</div>';
-  const bon = mc.bonus || 0;
-  h += '<div class="attr-derived-row"><span class="bd-lbl">Bonus</span><button class="sh-stat-adj" onclick="shAdjMeritBonus(' + realIdx + ',-1)"' + (bon === 0 ? ' disabled' : '') + '>&#x25BC;</button><span class="bd-src">' + (bon > 0 ? '+' + bon : '0') + '</span><button class="sh-stat-adj" onclick="shAdjMeritBonus(' + realIdx + ',1)">&#x25B2;</button></div>';
+  // N-9 (issue #762, Bug 2): standing-merit render paths (MCI, PT) don't read
+  // m.bonus, so the Bonus row was visible-but-no-op. Standing call sites pass
+  // opts.hideBonus=true to suppress the row entirely. Default behaviour
+  // (general/influence/domain/style merits) is unchanged.
+  if (!opts.hideBonus) {
+    const bon = mc.bonus || 0;
+    h += '<div class="attr-derived-row"><span class="bd-lbl">Bonus</span><button class="sh-stat-adj" onclick="shAdjMeritBonus(' + realIdx + ',-1)"' + (bon === 0 ? ' disabled' : '') + '>&#x25BC;</button><span class="bd-src">' + (bon > 0 ? '+' + bon : '0') + '</span><button class="sh-stat-adj" onclick="shAdjMeritBonus(' + realIdx + ',1)">&#x25B2;</button></div>';
+  }
   return h;
 }

--- a/server/tests/n7-n9-allocator-readers.test.js
+++ b/server/tests/n7-n9-allocator-readers.test.js
@@ -1,0 +1,256 @@
+/**
+ * N-7 (#760) + N-9 (#762) — Necropolis allocator + edit-view bug triage.
+ *
+ * Two adjacent surfaces share `meritBdRow` extension (showNECRO + hideBonus),
+ * `shEditMeritPt`'s map write path (free_grants.<slug>), and the post-N-1
+ * read-side helpers (freeOf / meritFreeSum / poolAvailableFor). Bundled into
+ * one PR so the heterogeneous write-path codified in the ADR-005 amendment
+ * lands atomically with the MCI read-side fix that depends on it.
+ *
+ * Test layout:
+ *   - N-7 pure-function: hasNecropolisSepulcher, getNecropolisTargets,
+ *     poolAvailableFor.
+ *   - N-9 pure-function: getMCIPoolUsed + getOTSPoolUsed union-read; getPoolUsed
+ *     map+legacy coverage.
+ *   - N-7+N-9 static-analysis on the meritBdRow + shEditMeritPt + sheet.js
+ *     wiring (covers picker UX paths that are expensive to import directly).
+ *   - N-9 meritPrereqOK: dropdown filter strict vs current-row passthrough.
+ *   - ADR-005 amendment text presence (catches future reverts).
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  hasNecropolisSepulcher,
+  getNecropolisTargets,
+  poolAvailableFor,
+  freeOf,
+  meritFreeSum,
+} from '../../public/js/data/rules-helpers.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+function read(rel) { return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8'); }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// N-7 helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-7 — hasNecropolisSepulcher', () => {
+  it('true when Sepulcher with cp+xp >= 1 is present', () => {
+    expect(hasNecropolisSepulcher({
+      merits: [{ name: 'Necropolis Sepulcher', cp: 2, xp: 0 }],
+    })).toBe(true);
+    expect(hasNecropolisSepulcher({
+      merits: [{ name: 'Necropolis Sepulcher', cp: 0, xp: 1 }],
+    })).toBe(true);
+  });
+
+  it('false when Sepulcher has 0 purchased dots (grants don\'t count toward membership)', () => {
+    expect(hasNecropolisSepulcher({
+      merits: [{ name: 'Necropolis Sepulcher', cp: 0, xp: 0, free_grants: { necro: 5 } }],
+    })).toBe(false);
+  });
+
+  it('false / defensive on missing input', () => {
+    expect(hasNecropolisSepulcher(null)).toBe(false);
+    expect(hasNecropolisSepulcher({})).toBe(false);
+    expect(hasNecropolisSepulcher({ merits: [] })).toBe(false);
+    expect(hasNecropolisSepulcher({ merits: [{ name: 'Other', cp: 5 }] })).toBe(false);
+  });
+});
+
+describe('N-7 — getNecropolisTargets', () => {
+  it('reads pool_targets from the Necropolis Sepulcher rule_grant', () => {
+    const ruleCache = {
+      rule_grant: [
+        { source: 'Necropolis Sepulcher', grant_type: 'pool', pool_targets: ['Catacombs', 'Caldarium'] },
+        { source: 'Lorekeeper', grant_type: 'pool', pool_targets: ['Herd'] },
+      ],
+    };
+    expect(getNecropolisTargets(ruleCache)).toEqual(['Catacombs', 'Caldarium']);
+  });
+
+  it('empty list when cache missing or rule not seeded', () => {
+    expect(getNecropolisTargets(null)).toEqual([]);
+    expect(getNecropolisTargets({})).toEqual([]);
+    expect(getNecropolisTargets({ rule_grant: [] })).toEqual([]);
+    expect(getNecropolisTargets({ rule_grant: [{ source: 'Other' }] })).toEqual([]);
+  });
+});
+
+describe('N-7 — poolAvailableFor', () => {
+  it('capacity minus used across all merits (union-read map + legacy)', () => {
+    const c = {
+      _grant_pools: [{ source: 'Necropolis Sepulcher', category: 'necro', amount: 3 }],
+      merits: [
+        { name: 'Catacombs', free_grants: { necro: 1 } },
+        { name: 'Dark Temple', free_grants: { necro: 1 } },
+      ],
+    };
+    expect(poolAvailableFor(c, 'necro')).toBe(1); // 3 cap − 2 used = 1
+  });
+
+  it('zero when capacity is zero or used >= capacity', () => {
+    expect(poolAvailableFor({ _grant_pools: [], merits: [] }, 'necro')).toBe(0);
+    const over = {
+      _grant_pools: [{ category: 'necro', amount: 2 }],
+      merits: [{ free_grants: { necro: 5 } }],
+    };
+    expect(poolAvailableFor(over, 'necro')).toBe(0);
+  });
+
+  it('union-reads legacy fields too (matches the channel-asymmetry transition)', () => {
+    // Mid-transition: capacity is 4, one merit holds 2 via legacy free_mci,
+    // another holds 1 via the map. Available = 4 − 3 = 1.
+    const c = {
+      _grant_pools: [{ category: 'mci', amount: 4 }],
+      merits: [
+        { name: 'Allies', free_mci: 2 },
+        { name: 'Herd', free_grants: { mci: 1 } },
+      ],
+    };
+    expect(poolAvailableFor(c, 'mci')).toBe(1);
+  });
+
+  it('defensive on missing input', () => {
+    expect(poolAvailableFor(null, 'necro')).toBe(0);
+    expect(poolAvailableFor({}, '')).toBe(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// N-9 reader migrations — freeOf union-read coverage
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-9 — freeOf / meritFreeSum cover both map AND legacy', () => {
+  it('freeOf returns the map value when present; legacy when not', () => {
+    expect(freeOf({ free_grants: { mci: 3 } }, 'mci')).toBe(3);
+    expect(freeOf({ free_mci: 2 }, 'mci')).toBe(2);
+    expect(freeOf({ free_grants: { mci: 5 }, free_mci: 2 }, 'mci')).toBe(5);
+    expect(freeOf({}, 'mci')).toBe(0);
+  });
+
+  it('meritFreeSum unions map + legacy across all 14 channels', () => {
+    const m = { free_lk: 2, free_grants: { mci: 3, necro: 1 } };
+    // sum: 2 (legacy lk) + 3 (map mci) + 1 (map necro) = 6
+    expect(meritFreeSum(m)).toBe(6);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Static-analysis: wiring that's expensive to unit-test via browser-import
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-7 — meritBdRow showNECRO + free_grants.necro write path', () => {
+  it('meritBdRow accepts opts.showNECRO and emits a free_grants.necro onchange', () => {
+    const src = read('public/js/editor/xp.js');
+    expect(src).toMatch(/opts\.showNECRO/);
+    // The onchange string in the source has backslash-escaped single quotes
+    // (the row is built via string concatenation inside a JS string literal).
+    expect(src).toMatch(/free_grants\.necro/);
+  });
+
+  it('shEditMeritPt routes free_grants.<slug> writes to the map with cap', () => {
+    const src = read('public/js/editor/edit.js');
+    expect(src).toMatch(/field\.startsWith\(['"]free_grants\.['"]\)/);
+    expect(src).toMatch(/poolAvailableFor\(c,\s*slug\)/);
+    expect(src).toMatch(/m\.free_grants\s*=\s*m\.free_grants\s*\|\|\s*\{\}/);
+  });
+
+  it('sheet.js wires showNECRO at both general-merit call sites', () => {
+    const src = read('public/js/editor/sheet.js');
+    expect(src).toMatch(/_hasNecroSep\s*=\s*hasNecropolisSepulcher\(c\)/);
+    expect(src).toMatch(/_necroTargets\.includes\(m\.name\)/);
+    // Both call sites (granted_by branch + main branch) pass showNECRO.
+    const matches = src.match(/showNECRO:\s*_hasNecroSep\s*&&\s*_necroTargets\.includes/g) || [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('_renderPoolCounters surfaces the necro pool in the general section', () => {
+    const src = read('public/js/editor/sheet.js');
+    expect(src).toMatch(/necroPools\s*=\s*category === 'general'/);
+    expect(src).toMatch(/p\.category === 'necro'/);
+  });
+});
+
+describe('N-9 — readers consume freeOf / map writes / hideBonus', () => {
+  it('getMCIPoolUsed reads via freeOf (union map + legacy)', () => {
+    const src = read('public/js/editor/mci.js');
+    expect(src).toMatch(/total \+= freeOf\(m, ['"]mci['"]\)/);
+    expect(src).toMatch(/total \+= freeOf\(fs, ['"]mci['"]\)/);
+  });
+
+  it('getOTSPoolUsed reads via freeOf', () => {
+    const src = read('public/js/editor/mci.js');
+    expect(src).toMatch(/freeOf\(fs, ['"]ots['"]\)/);
+  });
+
+  it('getPoolUsed enumerates matched-pool slugs via freeOf (covers map)', () => {
+    const src = read('public/js/editor/mci.js');
+    // The fix introduces a slugs Set populated from matched pools and a
+    // per-slug freeOf sum.
+    expect(src).toMatch(/const slugs = new Set/);
+    expect(src).toMatch(/for \(const slug of slugs\) total \+= freeOf\(m, slug\)/);
+  });
+
+  it("meritBdRow's MCI input writes free_grants.mci (post-N-1 map shape)", () => {
+    const src = read('public/js/editor/xp.js');
+    // Catches the regression where the MCI input reverts to writing free_mci.
+    // (Onchange string is backslash-escaped inside a JS literal; just match
+    // the slug fragment within a small window of `showMCI`.)
+    expect(src).toMatch(/showMCI[\s\S]{0,400}free_grants\.mci/);
+  });
+
+  it('meritBdRow honours opts.hideBonus to suppress the Bonus row', () => {
+    const src = read('public/js/editor/xp.js');
+    expect(src).toMatch(/if \(!opts\.hideBonus\)/);
+  });
+
+  it('sheet.js standing-merit call sites pass hideBonus: true', () => {
+    const src = read('public/js/editor/sheet.js');
+    // MCI standing path
+    expect(src).toMatch(/meritBdRow\(rIdx, m, meritFixedRating\(m\.name\), \{ hideBonus: true \}\)/);
+    // PT standing path (with showMCI + hideBonus)
+    expect(src).toMatch(/meritBdRow\(rIdx, m, meritFixedRating\(m\.name\), \{ showMCI: mciPool > 0, hideBonus: true \}\)/);
+  });
+});
+
+describe('N-9 — meritPrereqOK dropdown filter + current-row passthrough warn', () => {
+  it('merits.js exports meritPrereqOK', () => {
+    const src = read('public/js/editor/merits.js');
+    expect(src).toMatch(/export function meritPrereqOK\(c, rule\)/);
+  });
+
+  it('all three dropdown builders consume meritPrereqOK (not _meetsPrereq directly)', () => {
+    const src = read('public/js/editor/merits.js');
+    // buildMeritOptions
+    expect(src).toMatch(/buildMeritOptions[\s\S]{0,600}meritPrereqOK\(c, rule\)/);
+    // buildSubCategoryMeritOptions
+    expect(src).toMatch(/buildSubCategoryMeritOptions[\s\S]{0,800}meritPrereqOK\(c, rule\)/);
+    // buildMCIGrantOptions
+    expect(src).toMatch(/buildMCIGrantOptions[\s\S]{0,600}meritPrereqOK\(c, rule\)/);
+  });
+
+  it('buildSubCategoryMeritOptions warns on failing-prereq current-row passthrough', () => {
+    const src = read('public/js/editor/merits.js');
+    expect(src).toMatch(/console\.warn\([\s\S]*meritPrereqOK[\s\S]*current selection/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ADR-005 inline amendment presence
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-7 — ADR-005 amendment text presence', () => {
+  it('D6 amendment names the allocator write path + heterogeneous-by-source state', () => {
+    const src = read('specs/architecture/adr-005-pool-grant-and-sharing-scope-generalisation.md');
+    expect(src).toMatch(/D6 amendment[\s\S]*Allocator write path/i);
+    expect(src).toMatch(/heterogeneous by source/i);
+    // Targets explicitly named.
+    expect(src).toMatch(/m\.free_grants\.necro/);
+    expect(src).toMatch(/m\.free_grants\.mci/);
+  });
+});

--- a/specs/architecture/adr-005-pool-grant-and-sharing-scope-generalisation.md
+++ b/specs/architecture/adr-005-pool-grant-and-sharing-scope-generalisation.md
@@ -250,6 +250,24 @@ This is the explicit cost of Thoth's deferral: **the latent divergence persists*
 
 **(d) Idempotent backfill script (N-2)** moves each legacy `m.free_<slug>` to `m.free_grants.<slug>` and unsets the legacy field. Skip on already-migrated docs. Light enough for in-place Render run. Separate PR from N-1 for independent revertibility per the STM-13 discipline ([feedback_bookkeeping_default](memory/feedback_bookkeeping_default.md) precedent). N-2 also includes the `attached_to` normalisation per D7 below.
 
+#### D6 amendment — Allocator write path. (Inline amendment 2026-06-15, authorised by Peter on N-7 dispatch; no Rev bump, mirrors ADR-004's auth-amendment convention.)
+
+Source-merit **allocators** introduced post-N-1 (Necropolis Sepulcher first; future Collective Compound families subsequently) write directly to `m.free_grants[slug]`. They do **NOT** introduce new legacy `m.free_<slug>` flat fields. Existing **LK / Inv / VM** allocators retain their legacy-field writes until the deferred MNEC-prerequisite audit migrates them. **MCI** (N-9 issue #762, Bug 1 "adjacent finding") migrated to the map shape alongside this amendment landing — its `meritBdRow` input now emits `'free_grants.mci'` rather than `'free_mci'`.
+
+Until the LK/Inv/VM migration ships, allocator writes are **heterogeneous by source**:
+
+| Source | Write target | Read | Status |
+|---|---|---|---|
+| Necropolis Sepulcher (N-7) | `m.free_grants.necro` (map) | union via `meritFreeSum` / `freeOf` | post-N-1 convention |
+| MCI (N-9) | `m.free_grants.mci` (map) | union via `meritFreeSum` / `freeOf` | post-N-1 convention |
+| Lorekeeper (LK) | `m.free_lk` (legacy flat) | union via `meritFreeSum` / `freeOf` | pre-audit; legacy |
+| Invested (INV) | `m.free_inv` (legacy flat) | union via `meritFreeSum` / `freeOf` | pre-audit; legacy |
+| Viral Mythology (VM) | `m.free_vm` (legacy flat) | union via `meritFreeSum` / `freeOf` | pre-audit; legacy |
+
+The runtime read-guards (`meritFreeSum` / `freeOf` legacy fallback) absorb the heterogeneity correctly — every read site sees the canonical total regardless of which channel a given value lives in. The handler `shEditMeritPt` accepts the new `field === 'free_grants.<slug>'` shape and routes to the map; the existing `field === 'free_<slug>'` shape continues to route to the flat field for the legacy allocators.
+
+This amendment exists to make the heterogeneity explicit and to set the convention for the next Collective Compound family — there is no Rev bump because Rev 2's D6 already authorised the migration's hybrid shape; the amendment just names the allocator write-path branch of that hybrid.
+
 ### D7 — Dual-anchor `attached_to`: coexistence pattern with runtime-guard normaliser. (Rev 2, architecturally novel per Thoth)
 
 Trap Door is structurally a **bridge** between two compounds, not just bookkeeping on a single anchor. It needs to name BOTH:

--- a/specs/stories/issue-760-762-n7-n9-allocator-readers.story.md
+++ b/specs/stories/issue-760-762-n7-n9-allocator-readers.story.md
@@ -1,0 +1,117 @@
+# Issue #760 (N-7) + #762 (N-9) — Necropolis allocator + edit-view bug triage
+
+Status: Ready for Review
+
+issues: 760, 762
+issue_urls:
+  - https://github.com/angelusvmorningstar/issues/760
+  - https://github.com/angelusvmorningstar/issues/762
+branch: piatra/issue-760-762-n7-n9-allocator-readers
+epic: MNEC follow-ups (specs/epic-mnec-necropolis-merits.md)
+adr: ADR-005 (inline amendment under D6 — no Rev bump)
+authoritative-source:
+  - specs/investigations/2026-06-15-edit-view-collective-compound-gap.md (Imhotep §1)
+  - specs/investigations/2026-06-15-edit-view-bug-triage.md (Ma'at)
+
+## Bundling
+
+Per Khepri's lean: bundled because both stories extend `meritBdRow` (N-7 adds `showNECRO`, N-9 adds `hideBonus`), both touch `xp.js` / `edit.js` / `sheet.js` / `merits.js` / `rules-helpers.js` / `mci.js`, and N-9's MCI write-path migration directly applies the ADR-005 allocator-write-path amendment that N-7 lands. Single PR keeps the cross-reference natural.
+
+## What ships
+
+### N-7 — Necropolis allocator (issue #760)
+
+**Helpers in `public/js/data/rules-helpers.js`:**
+- `hasNecropolisSepulcher(c)` → boolean. cp+xp ≥ 1 on a Sepulcher merit (purchased dots only — collective grants don't count toward membership).
+- `getNecropolisTargets(ruleCache)` → `string[]`. Reads `pool_targets` from the `source: 'Necropolis Sepulcher'` rule_grant. Caller passes the cache so rules-helpers stays free of the load-rules import chain.
+- `poolAvailableFor(c, slug)` → number. Pool capacity (sum of `_grant_pools[*].amount` where category=slug) minus used (`freeOf` union-sum across merits). Generalises the inline cap logic at `edit.js:1019-1022`.
+
+**`meritBdRow` extension (`xp.js`):**
+- `opts.showNECRO` renders a per-target stepper with onchange `'free_grants.necro'`.
+- (Also lands `opts.hideBonus` per N-9 — same merit-row surface.)
+
+**`shEditMeritPt` (`edit.js`):**
+- Detects `field.startsWith('free_grants.')` and routes to `m.free_grants[slug]` with cap enforcement via `poolAvailableFor(c, slug)` + current value. NEW Collective Compound write path (Necropolis first; MCI now also lands here per N-9).
+
+**`sheet.js` wiring:**
+- Computes `_hasNecroSep` + `_necroTargets` (from rules cache) in the general-merits block.
+- Passes `showNECRO: _hasNecroSep && _necroTargets.includes(m.name)` at both general meritBdRow call sites.
+- `_renderPoolCounters` surfaces the necro pool in the general section (mirroring the `lk` / `inv` / `vm` / `ohm` cross-section pattern).
+
+### N-7 — ADR-005 inline amendment
+
+Sub-section under D6, no Rev bump (mirrors ADR-004 auth-amendment convention; explicitly authorised by Peter on the N-7 dispatch). Codifies the post-N-1 allocator write path:
+
+> Source-merit allocators introduced post-N-1 (Necropolis Sepulcher first; future Collective Compound families subsequently) write directly to `m.free_grants[slug]`. They do NOT introduce new legacy `m.free_<slug>` flat fields. Existing LK / Inv / VM allocators retain their legacy-field writes until the deferred MNEC-prerequisite audit migrates them. MCI (N-9 issue #762, Bug 1 "adjacent finding") migrated to the map shape alongside this amendment landing.
+
+Plus a heterogeneous-by-source table making the transitional write-target convention explicit (Necropolis + MCI → map; LK + Inv + VM → legacy flat). Runtime read-guards absorb the heterogeneity.
+
+### N-9 — edit-view bug triage (issue #762)
+
+**Bug 1 — pool counter + MCI write-path:**
+- `getMCIPoolUsed`, `getOTSPoolUsed` migrated to `freeOf` (union-read map + legacy). Post-N-2 backfill the persisted MCI dots live in `m.free_grants.mci`; the old `m.free_mci` reads returned 0 / nonsense.
+- `getPoolUsed` extended to iterate matched-pool slugs via `freeOf` (covers the map) while preserving the legacy `free_*` enumeration for non-pool free fields.
+- `meritBdRow`'s MCI input now emits `'free_grants.mci'` (matches the ADR-005 amendment's allocator-write-path convention).
+
+**Bug 2 — standing-merit Bonus row:**
+- `meritBdRow` accepts `opts.hideBonus: bool`; when true, the trailing Bonus up/down row is omitted entirely.
+- Standing-merit call sites (`sheet.js:1145` MCI, `sheet.js:1220` PT) pass `hideBonus: true`. The Bonus row was visible-but-no-op on standing merits because standing render paths don't read `m.bonus`.
+- General / influence / domain / style call sites unchanged — Bonus row still renders there (it's load-bearing on those).
+
+**Bug 3 — domain-merit dropdown strict prereq filter:**
+- New `meritPrereqOK(c, rule)` helper in `merits.js` — single seam for the prereq check across all sub-category dropdown filters.
+- Three call sites migrated: `buildMeritOptions`, `buildSubCategoryMeritOptions`, `buildMCIGrantOptions`.
+- `buildSubCategoryMeritOptions`'s line-331 escape hatch tightened: current-row passthrough preserved, but a failing-prereq passthrough now emits a `console.warn` so the situation surfaces in QA testing.
+- No FT carve-out needed (Ma'at + Imhotep convergence): FT-purchased merits enter via the dedicated `buildFThiefOptions` picker with `granted_by: 'Fucking Thief'`, and the dropdown filter already short-circuits on `granted_by`.
+
+## Tests — 25 cases
+
+**N-7 helpers (pure-function, unit speed):**
+- `hasNecropolisSepulcher`: true at cp+xp ≥ 1; false on grant-only / missing / 0 purchased; defensive on null.
+- `getNecropolisTargets`: reads pool_targets from rule_grant; empty on missing cache.
+- `poolAvailableFor`: capacity − used; union-reads map + legacy (matches channel-asymmetry transition); defensive.
+
+**N-9 readers:**
+- `freeOf` returns map when present, legacy when not, map-wins on both.
+- `meritFreeSum` unions both across 14 channels.
+
+**Static-analysis on wiring (sites that are expensive to import directly):**
+- `meritBdRow` accepts `showNECRO` + emits `free_grants.necro` onchange.
+- `shEditMeritPt` routes `free_grants.<slug>` writes to the map with `poolAvailableFor` cap.
+- `sheet.js` computes `_hasNecroSep` + `_necroTargets` and passes `showNECRO` at both general call sites.
+- `_renderPoolCounters` surfaces the necro pool in the general section.
+- `getMCIPoolUsed` / `getOTSPoolUsed` consume `freeOf`.
+- `getPoolUsed` enumerates matched-pool slugs via `freeOf`.
+- MCI input writes `free_grants.mci` (catches the regression where it reverts to `free_mci`).
+- `meritBdRow` honours `opts.hideBonus`.
+- Standing call sites pass `hideBonus: true`.
+- `meritPrereqOK` exported; all three dropdown builders consume it; current-row passthrough warns.
+- ADR-005 amendment text present (catches future doc reverts).
+
+**Full regression: 1449/1449 individual tests pass.** Same four pre-existing test-FILE failures (#675 archive-import family + #706 HoS relative-path) carry forward — none caused here.
+
+## Test plan
+- [ ] Add Necropolis Sepulcher 3 + Catacombs to a Nosferatu character → pool counter at top of merits reads `0/3 free Necropolis dots`; per-row NECRO stepper appears on Catacombs and the other 5 target merits (Caldarium / Garbage Pit / Labyrinth Guardians / Dark Temple / White Ants).
+- [ ] Allocate 2 Catacombs + 1 Dark Temple → counter reads `3/3` (sc-full); stepper on a third target merit caps at 0.
+- [ ] Drop Sepulcher to rating 1 → over-allocated entries persist (don't auto-delete; matches LK precedent); counter shows over (sc-over class).
+- [ ] Pool counter at top of merits shows correct numerator on a character that's been through the N-2 backfill (post-backfill MCI dots).
+- [ ] Standing merits (MCI, PT) — no Bonus up/down row in the breakdown.
+- [ ] General / influence / domain merits — Bonus row STILL renders.
+- [ ] In the domain merit dropdown for a non-Sepulcher character, Catacombs is NOT selectable. For a Sepulcher-owner, it IS.
+- [ ] In QA console: removing a prereq merit while keeping a row whose merit failed the prereq emits a `[meritPrereqOK]` warn.
+
+## Out of scope (per the dispatch)
+
+- LK / Inv / VM allocator WRITE migration to the map. Deferred to the MNEC-prerequisite audit story; their legacy flat-field writes are the documented heterogeneous-by-source state in the ADR-005 amendment.
+- UI grouping of Necropolis targets in the dropdown.
+- Compound-dot allocator for future Collective Compound families beyond Necropolis (same code shape will apply trivially).
+- Optional `m.bonus = 0` cleanup script for standing merits with persisted bonus.
+- Closing #707 outright — its read-side scope is substantially covered here, but the union-sum fallback removal is post-deploy verification.
+
+## References
+
+- Imhotep investigation `specs/investigations/2026-06-15-edit-view-collective-compound-gap.md` §1
+- Ma'at investigation `specs/investigations/2026-06-15-edit-view-bug-triage.md`
+- ADR-005 Rev 2 + inline D6 amendment (this PR)
+- N-1 PR #672 (helpers + atomic seed), N-2 PR #704 (backfill), N-3 PR #693 (Necropolis seed)
+- Sister bugs: #749 (style-retainer pet double-count), #750 (5-evaluator write-side audit), #707 (post-N-2 union-sum cleanup tracker)


### PR DESCRIPTION
## Bundling

Per Khepri's lean: **N-7 + N-9 bundled** because both extend `meritBdRow` (N-7 `showNECRO`, N-9 `hideBonus`), both touch the same merit-row surface, and N-9's MCI write-path migration applies the **ADR-005 allocator-write-path amendment that N-7 lands**. Single PR keeps the cross-reference natural.

## N-7 — Necropolis allocator (#760)

Source: Imhotep investigation §1.

### Helpers in `public/js/data/rules-helpers.js`

- `hasNecropolisSepulcher(c)` — `cp+xp ≥ 1` (purchased only; collective grants don't count toward membership).
- `getNecropolisTargets(ruleCache)` — reads `pool_targets` from the Sepulcher `rule_grant`. Caller-passed cache keeps `rules-helpers` pure.
- `poolAvailableFor(c, slug)` — capacity (`_grant_pools[*].amount` where category=slug) minus used (`freeOf` union-sum). Generalises the inline cap logic at `edit.js:1019-1022`.

### `meritBdRow` extension (`xp.js`)

- `opts.showNECRO` renders a per-target stepper with `onchange="...free_grants.necro..."`.
- `opts.hideBonus` (N-9) suppresses the trailing Bonus row.

### `shEditMeritPt` map-write path (`edit.js`)

Detects `field.startsWith('free_grants.')` → routes to `m.free_grants[slug]` with cap enforcement via `poolAvailableFor(c, slug) + currentValue`. Sets the map entry on val > 0, deletes on val === 0.

### `sheet.js` wiring

- `_hasNecroSep` + `_necroTargets` computed in the general-merits block.
- Both general meritBdRow call sites pass `showNECRO: _hasNecroSep && _necroTargets.includes(m.name)`.
- `_renderPoolCounters` surfaces the necro pool in the general section (matches the `lk` / `inv` / `vm` / `ohm` cross-section pattern).

### ADR-005 inline amendment (no Rev bump)

Sub-section under D6, authorised by Peter on the N-7 dispatch (mirrors ADR-004's auth-amendment convention). Codifies the post-N-1 allocator write path + the heterogeneous-by-source state:

| Source | Write target | Read | Status |
|---|---|---|---|
| Necropolis Sepulcher (N-7) | `m.free_grants.necro` (map) | `meritFreeSum` / `freeOf` | post-N-1 convention |
| MCI (N-9) | `m.free_grants.mci` (map) | `meritFreeSum` / `freeOf` | post-N-1 convention |
| Lorekeeper / Invested / VM | `m.free_<slug>` (legacy) | `meritFreeSum` / `freeOf` | pre-audit; legacy |

Runtime read-guards absorb the heterogeneity. LK / Inv / VM migrate when the deferred MNEC-prerequisite audit ships.

## N-9 — edit-view bug triage (#762)

Source: Ma'at investigation.

### Bug 1 — pool counter + MCI write-path

- `getMCIPoolUsed`, `getOTSPoolUsed` → `freeOf` (union-read map + legacy). Post-N-2 backfill the MCI dots live in `m.free_grants.mci`; the old reads returned 0.
- `getPoolUsed` extended to iterate matched-pool slugs via `freeOf` for map coverage; preserves the legacy `free_*` enumeration for non-pool free fields (free, free_fwb, free_attache, free_carthian).
- `meritBdRow`'s MCI input now emits `free_grants.mci` (matches the ADR-005 amendment).

### Bug 2 — standing-merit Bonus row no-op

- `meritBdRow` honours `opts.hideBonus: true` to omit the trailing Bonus row.
- Standing call sites (sheet.js `:1145` MCI, `:1220` PT) pass `hideBonus: true`.
- General / influence / domain / style sites **unchanged** (Bonus row IS load-bearing there).

### Bug 3 — domain dropdown strict prereq filter

- New `meritPrereqOK(c, rule)` helper in `merits.js` — single seam across all sub-category dropdown filters.
- `buildMeritOptions`, `buildSubCategoryMeritOptions`, `buildMCIGrantOptions` all migrated.
- `buildSubCategoryMeritOptions` current-row escape hatch preserved, but failing-prereq passthrough emits `console.warn` so the situation surfaces in QA testing.
- **No FT carve-out** (Ma'at + Imhotep convergence) — FT-purchased merits enter via `buildFThiefOptions` with `granted_by`, which the dropdown already short-circuits on.

## Tests — 25 cases

- N-7 helpers: pure-function, union-read coverage, defensive null handling.
- N-9 readers: `freeOf` / `meritFreeSum` cover both shapes.
- Static-analysis on wiring (sites expensive to import directly): meritBdRow showNECRO + free_grants.<slug> emission, shEditMeritPt map routing, sheet.js _hasNecroSep + showNECRO at both call sites + necro pool surfacing, mci.js readers via freeOf, MCI input writes map (regression catch), hideBonus honoured + standing sites pass it, meritPrereqOK exported + all 3 dropdown builders consume it, current-row passthrough warn, ADR-005 amendment text present.

**Full regression: 1449/1449 individual tests pass.** Same four pre-existing test-FILE failures (#675 archive-import family + #706 HoS relative-path) carry forward.

## Test plan
- [ ] Nosferatu with Sepulcher 3 + Catacombs → pool counter at top of merits reads `0/3 free Necropolis dots`; per-row NECRO stepper appears on all six target merits.
- [ ] Allocate 2 Catacombs + 1 Dark Temple → counter reads `3/3` (sc-full); stepper on third target caps at 0.
- [ ] Drop Sepulcher to rating 1 → over-allocated entries persist (matches LK precedent); counter renders sc-over.
- [ ] Pool counter at top of merits reads correct numerator on a backfilled character.
- [ ] Standing merits (MCI, PT) — no Bonus up/down row.
- [ ] General / influence / domain merits — Bonus row STILL renders.
- [ ] Non-Sepulcher character cannot select Catacombs in the domain dropdown; Sepulcher-owner can.
- [ ] Removing a prereq merit while keeping a row whose merit failed the prereq emits a `[meritPrereqOK]` warn in the QA console.

## References

- Imhotep `specs/investigations/2026-06-15-edit-view-collective-compound-gap.md` §1
- Ma'at `specs/investigations/2026-06-15-edit-view-bug-triage.md`
- ADR-005 Rev 2 + inline D6 amendment (in this PR)
- Bundle reference: #707's post-N-2 union-sum cleanup scope is substantially covered by Bug 1's reader migrations.
- Sister bugs: #749 (style-retainer pet double-count), #750 (5-evaluator write-side audit) — same channel-asymmetry context, deferred to MNEC-prerequisite audit.

Closes #760
Closes #762