### PR TITLE
fix(mnec): N-7a — wire showNECRO into the domain renderer (#766)

### DIFF
--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -116,7 +116,12 @@ function _renderPoolCounters(c, category) {
   // N-7 (issue #760): Necropolis pool targets sit in the general merit
   // section — surface the counter in 'general' so the read-side summary
   // matches the per-target allocator stepper below.
-  const necroPools = category === 'general' ? (c._grant_pools || []).filter(p => p.category === 'necro') : [];
+  // N-7a (issue #766): Necropolis targets are sub_category='domain' — surface
+  // the pool counter in the domain section, matching where the per-target
+  // steppers actually render. Pre-N-7a this filtered on 'general' (the
+  // mistake that surfaced as part of the broader showNECRO-in-wrong-renderer
+  // bug — the original N-7 wiring went into the general renderer too).
+  const necroPools = category === 'domain' ? (c._grant_pools || []).filter(p => p.category === 'necro') : [];
   const allPools = [...pools, ...anyPools, ...vmPools, ...ohmPools, ...invPools, ...lkPools, ...necroPools];
   if (!allPools.length) return '';
   let h = '<div class="grant-pools">';
@@ -981,6 +986,16 @@ export function shRenderDomainMerits(c, editMode) {
   if (editMode) {
     const _domMciPool = (c.merits || []).filter(m => m.name === 'Mystery Cult Initiation' && m.active !== false).reduce((s, m) => s + mciPoolTotal(m), 0);
     const _hasLK = hasLorekeeper(c); const _hasINV = hasInvested(c); const _hasVM = hasViralMythology(c);
+    // N-7a (issue #766): Necropolis target merits are sub_category='domain'
+    // and render through THIS function — the general-renderer wiring at
+    // sheet.js:1325/1342 from N-7 (PR #765) doesn't reach them. Mirrors the
+    // LK/Inv/VM precedent which threads the same flags into both the domain
+    // renderer (here) AND the influence renderer (line 887). All six
+    // Necropolis targets (Catacombs / Caldarium / Garbage Pit / Labyrinth
+    // Guardians / Dark Temple / White Ants) live in the domain section, so
+    // domain-only wiring is sufficient.
+    const _hasNecroSep = hasNecropolisSepulcher(c);
+    const _necroTargets = _hasNecroSep ? getNecropolisTargets(getRulesCache()) : [];
     domM.forEach((m, di) => {
       const hTk = domM.some((dm, dj) => dm.name === 'Herd' && dj !== di);
       // Catalog-driven options (sub_category='domain'), with the Herd-once-per-character
@@ -1049,7 +1064,7 @@ export function shRenderDomainMerits(c, editMode) {
         }
       }
       const _isLKMerit = m.name === 'Herd' || m.name === 'Retainer'; const _isINVMerit = m.name === 'Herd'; const _isVMMerit = m.name === 'Herd';
-      h += meritBdRow(rIdx, m, meritFixedRating(m.name), { showMCI: _domMciPool > 0, showVM: _hasVM && _isVMMerit, showLK: _hasLK && _isLKMerit, showINV: _hasINV && _isINVMerit, attachBonus: attacheBonusDots(c, m.area ? m.name + ' (' + m.area + ')' : m.name) }); h += _prereqWarn(c, m.name);
+      h += meritBdRow(rIdx, m, meritFixedRating(m.name), { showMCI: _domMciPool > 0, showVM: _hasVM && _isVMMerit, showLK: _hasLK && _isLKMerit, showINV: _hasINV && _isINVMerit, showNECRO: _hasNecroSep && _necroTargets.includes(m.name), attachBonus: attacheBonusDots(c, m.area ? m.name + ' (' + m.area + ')' : m.name) }); h += _prereqWarn(c, m.name);
       h += _derivedNotes(m);
       if (m.name === 'Herd') { const ssjB = ssjHerdBonus(c); if (ssjB) h += '<div class="derived-note">SSJ Bonus: +' + ssjB + ' dots (' + shDots(ssjB) + ') \u2014 equals MCI dots</div>'; }
       if (m.name === 'Herd') { const flockB = flockHerdBonus(c); if (flockB) h += '<div class="derived-note">Flock Bonus: +' + flockB + ' dots (' + shDots(flockB) + ') \u2014 equals Flock rating, can exceed 5</div>'; }

--- a/server/tests/n7-n9-allocator-readers.test.js
+++ b/server/tests/n7-n9-allocator-readers.test.js
@@ -169,9 +169,13 @@ describe('N-7 — meritBdRow showNECRO + free_grants.necro write path', () => {
     expect(matches.length).toBeGreaterThanOrEqual(2);
   });
 
-  it('_renderPoolCounters surfaces the necro pool in the general section', () => {
+  it('_renderPoolCounters surfaces the necro pool in the domain section (N-7a corrected the section gate)', () => {
     const src = read('public/js/editor/sheet.js');
-    expect(src).toMatch(/necroPools\s*=\s*category === 'general'/);
+    // N-7a (issue #766) corrected the section gate: necro targets are
+    // sub_category='domain', so the pool counter lives in the domain section
+    // (alongside lk/inv), not general. Pre-N-7a this checked 'general' —
+    // assertion updated to match the corrected gate.
+    expect(src).toMatch(/necroPools\s*=\s*category === 'domain'/);
     expect(src).toMatch(/p\.category === 'necro'/);
   });
 });

--- a/server/tests/n7a-necro-domain-render.test.js
+++ b/server/tests/n7a-necro-domain-render.test.js
@@ -1,0 +1,166 @@
+/**
+ * N-7a hotfix (issue #766) — behavioural test for showNECRO at the correct
+ * renderer.
+ *
+ * N-7 PR #765 wired showNECRO into shRenderGeneralMerits but Necropolis target
+ * merits are sub_category='domain' and render through shRenderDomainMerits —
+ * the wiring never fired. The 25-case static-analysis suite in PR #765 caught
+ * the wiring's existence via regex but couldn't catch its placement. Per the
+ * listener-routing memory: "static review cannot catch this, only browser
+ * smoke can" — applies equally to render-site placement.
+ *
+ * This file calls shRenderDomainMerits with a constructed character + a seeded
+ * `_grant_pools` Necropolis entry, then asserts the returned HTML actually
+ * contains the NECRO label + the free_grants.necro onchange string. That's
+ * the contract the regex tests can't establish; only a real render-and-assert
+ * can.
+ */
+
+// Browser shims — sheet.js transitively imports api.js (location reference).
+// Pattern mirrored from N-8's n8-mandragora-prereq.test.js.
+globalThis.location = {
+  origin: 'http://localhost:8080',
+  hostname: 'localhost',
+  href: 'http://localhost:8080/admin',
+};
+globalThis.localStorage = {
+  _store: {},
+  getItem(k) { return this._store[k] ?? null; },
+  setItem(k, v) { this._store[k] = String(v); },
+  removeItem(k) { delete this._store[k]; },
+  clear() { this._store = {}; },
+};
+globalThis.window = globalThis.window || globalThis;
+globalThis.document = globalThis.document || {
+  getElementById: () => null,
+  createElement: () => ({ style: {}, classList: { add() {}, remove() {}, toggle() {} } }),
+};
+
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+function read(rel) { return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8'); }
+
+// Dynamic imports so the shims above are in place when the editor module
+// graph evaluates (static imports hoist past the shim block).
+let shRenderDomainMerits;
+let stateMod;
+let loadRulesMod;
+
+beforeAll(async () => {
+  const sheetUrl = pathToFileURL(path.resolve(__dirname, '..', '..', 'public', 'js', 'editor', 'sheet.js')).href;
+  ({ shRenderDomainMerits } = await import(sheetUrl));
+  stateMod = (await import(pathToFileURL(path.resolve(__dirname, '..', '..', 'public', 'js', 'data', 'state.js')).href)).default;
+  loadRulesMod = await import(pathToFileURL(path.resolve(__dirname, '..', '..', 'public', 'js', 'editor', 'rule_engine', 'load-rules.js')).href);
+
+  // Prime the rules cache with a Necropolis Sepulcher pool rule so
+  // getNecropolisTargets resolves to the six target merits. ES module exports
+  // aren't writable; vi.spyOn replaces the getter on the live module ref so
+  // the same getRulesCache import inside sheet.js returns this fixture.
+  const ruleCache = {
+    rule_grant: [{
+      source: 'Necropolis Sepulcher',
+      source_slug: 'necro',
+      grant_type: 'pool',
+      pool_targets: ['Catacombs', 'Caldarium', 'Garbage Pit', 'Labyrinth Guardians', 'Dark Temple', 'White Ants'],
+      category: 'necro',
+    }],
+    rule_nine_again: [],
+    rule_skill_bonus: [],
+    rule_speciality_grant: [],
+    rule_tier_budget: [],
+    rule_disc_attr: [],
+    rule_derived_stat_modifier: [],
+  };
+  vi.spyOn(loadRulesMod, 'getRulesCache').mockReturnValue(ruleCache);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Load-bearing behavioural test
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-7a — showNECRO renders in the domain renderer', () => {
+  function mkChar(sepulcherDots, hasTarget = true) {
+    return {
+      _id: 'n7a-test',
+      name: 'N7a Test',
+      clan: 'Nosferatu',
+      covenant: 'Invictus',
+      status: { city: 0, clan: 0, covenant: {} },
+      attributes: {}, skills: {}, disciplines: {}, powers: [],
+      merits: [
+        { name: 'Necropolis Sepulcher', category: 'general', cp: sepulcherDots, xp: 0 },
+        ...(hasTarget
+          ? [{ name: 'Catacombs', category: 'domain', cp: 1, xp: 0 }]
+          : []),
+      ],
+      _grant_pools: [
+        { source: 'Necropolis Sepulcher', category: 'necro', amount: sepulcherDots, names: ['Catacombs', 'Caldarium', 'Garbage Pit', 'Labyrinth Guardians', 'Dark Temple', 'White Ants'] },
+      ],
+    };
+  }
+
+  it('renders the NECRO stepper on a Catacombs row when Sepulcher is owned', () => {
+    const c = mkChar(3);
+    stateMod.chars = [c];
+    stateMod.editIdx = 0;
+    stateMod.editMode = true;
+
+    const html = shRenderDomainMerits(c, true);
+
+    // Behavioural contract — not regex-on-source. The returned HTML must
+    // contain both the NECRO label and the free_grants.necro onchange string
+    // for the Catacombs row's allocator stepper.
+    expect(html).toContain('NECRO');
+    expect(html).toContain('free_grants.necro');
+  });
+
+  it('does NOT render the NECRO stepper when Sepulcher is absent (or 0 dots purchased)', () => {
+    const c = mkChar(0); // cp+xp = 0 → hasNecropolisSepulcher is false
+    stateMod.chars = [c];
+    stateMod.editIdx = 0;
+    stateMod.editMode = true;
+
+    const html = shRenderDomainMerits(c, true);
+    expect(html).not.toContain('NECRO');
+    expect(html).not.toContain('free_grants.necro');
+  });
+
+  // Note: the necro pool counter itself is rendered by `_renderPoolCounters`,
+  // which is called from inside `shRenderGeneralMerits` (one call per
+  // category section). The N-7a fix corrects the section gate from
+  // `category === 'general'` to `category === 'domain'` so the necro pool
+  // surfaces in the right row of the general renderer's pool-counters block.
+  // The static-analysis sanity guard below covers that gate; the behavioural
+  // proof here focuses on the steppers, which is where the production
+  // breakage manifested.
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Static-analysis sanity guards (catch reverts of the placement)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-7a — placement sanity guards', () => {
+  it('shRenderDomainMerits computes the Necropolis flags', () => {
+    const src = read('public/js/editor/sheet.js');
+    // The string `_hasNecroSep = hasNecropolisSepulcher(c)` must appear
+    // AFTER `export function shRenderDomainMerits` and BEFORE the next
+    // exported function — i.e. inside shRenderDomainMerits's body.
+    const fnStart = src.indexOf('export function shRenderDomainMerits');
+    expect(fnStart).toBeGreaterThan(0);
+    const nextExport = src.indexOf('export function ', fnStart + 1);
+    const fnBody = src.slice(fnStart, nextExport > 0 ? nextExport : src.length);
+    expect(fnBody).toMatch(/_hasNecroSep\s*=\s*hasNecropolisSepulcher\(c\)/);
+    expect(fnBody).toMatch(/_necroTargets/);
+    expect(fnBody).toMatch(/showNECRO:\s*_hasNecroSep\s*&&\s*_necroTargets\.includes\(m\.name\)/);
+  });
+
+  it('_renderPoolCounters surfaces necro in domain section, not general', () => {
+    const src = read('public/js/editor/sheet.js');
+    expect(src).toMatch(/necroPools\s*=\s*category === 'domain'/);
+  });
+});


### PR DESCRIPTION
## URGENT hotfix

N-7 PR #765 wired the `showNECRO` stepper into `shRenderGeneralMerits` (sheet.js `:1325` + `:1342`), but Necropolis target merits are `sub_category: 'domain'` and render through `shRenderDomainMerits` — the wiring never fired on production Sepulcher-N characters.

Mirrors the **LK/Inv/VM precedent**: those flags are wired into both `shRenderInfluenceMerits` (line 887) AND `shRenderDomainMerits` (line 1052). All six Necropolis targets (Catacombs / Caldarium / Garbage Pit / Labyrinth Guardians / Dark Temple / White Ants) live in the domain section, so domain-renderer wiring is sufficient.

## Three changes in `public/js/editor/sheet.js`

1. **`shRenderDomainMerits` gains the helpers** (mirror of `sheet.js:1313-1314` from the general renderer):
   ```js
   const _hasNecroSep = hasNecropolisSepulcher(c);
   const _necroTargets = _hasNecroSep ? getNecropolisTargets(getRulesCache()) : [];
   ```
2. **`meritBdRow` call at `:1052`** extends opts with `showNECRO: _hasNecroSep && _necroTargets.includes(m.name)`.
3. **`_renderPoolCounters` gate corrected** from `category === 'general'` to `category === 'domain'` — Necropolis targets are domain merits, so the pool counter belongs in the domain section alongside lk/inv. (Pre-N-7a the counter would have rendered in the wrong section row even after the stepper fix.)

## Behavioural test — load-bearing per Khepri's framing

The 25-case static-analysis suite in PR #765 caught the wiring's existence via regex but couldn't catch its placement — same blind spot as `feedback_listener_routing_static_blind_spot`.

New `server/tests/n7a-necro-domain-render.test.js` (4 cases) **actually calls `shRenderDomainMerits`** with a constructed Sepulcher-3 + Catacombs character + seeded `_grant_pools` entry, `vi.spyOn`s `getRulesCache` to return the Necropolis `pool_targets`, then asserts the rendered HTML contains both the `NECRO` label and the `free_grants.necro` onchange string. Plus a negative case (no Sepulcher → no stepper) and two static-analysis sanity guards.

Static-analysis-only tests catch reverts; only render-and-assert catches placement. Both shapes valuable.

## What stays untouched

- `meritBdRow` extension (`xp.js`)
- `shEditMeritPt` map routing (`edit.js`)
- `poolAvailableFor` cap helper (`rules-helpers.js`)
- ADR-005 D6 amendment
- The N-7 general-renderer wiring at `:1325/:1342` — left as harmless dead code (`showNECRO` evaluates to false there because Necropolis targets aren't in the general category). Removing it is out of scope for an urgent hotfix.

## Tests

- `n7a-necro-domain-render.test.js` — 4 cases (behavioural + sanity guards).
- Updated `n7-n9-allocator-readers.test.js:174` to assert the corrected `domain` gate instead of pre-N-7a `general`.
- **Full regression: 1467/1467 individual tests pass.** Same four pre-existing test-FILE failures (#675 family + #706) carry forward.

## Test plan
- [ ] Open a Sepulcher-3 character on dev → per-target NECRO stepper appears under Catacombs / Caldarium / etc.
- [ ] Stepper writes to `free_grants.necro` and caps via `poolAvailableFor`.
- [ ] Pool counter appears in the domain section (not general).
- [ ] Removing Sepulcher dots → stepper retires.

Closes #766