### PR TITLE
fix(mnec): N-7b — suppress CP/XP/MCI/Bonus inputs on Necropolis target rows (#768)

### DIFF
--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -995,7 +995,13 @@ export function shRenderDomainMerits(c, editMode) {
     // Guardians / Dark Temple / White Ants) live in the domain section, so
     // domain-only wiring is sufficient.
     const _hasNecroSep = hasNecropolisSepulcher(c);
-    const _necroTargets = _hasNecroSep ? getNecropolisTargets(getRulesCache()) : [];
+    // N-7b (issue #768): _necroTargets must populate UNCONDITIONALLY — option 3
+    // suppression is "categorically by merit name, regardless of Sepulcher
+    // ownership." The stepper render is still gated on _hasNecroSep below
+    // (showNECRO: _hasNecroSep && _isNecroTarget), but the hide-* flags fire
+    // even for non-Sepulcher characters who somehow have a Necropolis target
+    // merit on their sheet.
+    const _necroTargets = getNecropolisTargets(getRulesCache());
     domM.forEach((m, di) => {
       const hTk = domM.some((dm, dj) => dm.name === 'Herd' && dj !== di);
       // Catalog-driven options (sub_category='domain'), with the Herd-once-per-character
@@ -1064,7 +1070,13 @@ export function shRenderDomainMerits(c, editMode) {
         }
       }
       const _isLKMerit = m.name === 'Herd' || m.name === 'Retainer'; const _isINVMerit = m.name === 'Herd'; const _isVMMerit = m.name === 'Herd';
-      h += meritBdRow(rIdx, m, meritFixedRating(m.name), { showMCI: _domMciPool > 0, showVM: _hasVM && _isVMMerit, showLK: _hasLK && _isLKMerit, showINV: _hasINV && _isINVMerit, showNECRO: _hasNecroSep && _necroTargets.includes(m.name), attachBonus: attacheBonusDots(c, m.area ? m.name + ' (' + m.area + ')' : m.name) }); h += _prereqWarn(c, m.name);
+      // N-7b (issue #768, Peter decision option 3, 2026-06-16): Necropolis
+      // target merits are pool-funded only. Suppress CP / XP / MCI / Bonus
+      // categorically by merit name (regardless of Sepulcher ownership —
+      // the row exists because the merit is on the sheet, but it must NEVER
+      // be hand-funded). The NECRO stepper is the only allocation surface.
+      const _isNecroTarget = _necroTargets.includes(m.name);
+      h += meritBdRow(rIdx, m, meritFixedRating(m.name), { showMCI: _domMciPool > 0 && !_isNecroTarget, showVM: _hasVM && _isVMMerit, showLK: _hasLK && _isLKMerit, showINV: _hasINV && _isINVMerit, showNECRO: _hasNecroSep && _isNecroTarget, hideCP: _isNecroTarget, hideXP: _isNecroTarget, hideMCI: _isNecroTarget, hideBonus: _isNecroTarget, attachBonus: attacheBonusDots(c, m.area ? m.name + ' (' + m.area + ')' : m.name) }); h += _prereqWarn(c, m.name);
       h += _derivedNotes(m);
       if (m.name === 'Herd') { const ssjB = ssjHerdBonus(c); if (ssjB) h += '<div class="derived-note">SSJ Bonus: +' + ssjB + ' dots (' + shDots(ssjB) + ') \u2014 equals MCI dots</div>'; }
       if (m.name === 'Herd') { const flockB = flockHerdBonus(c); if (flockB) h += '<div class="derived-note">Flock Bonus: +' + flockB + ' dots (' + shDots(flockB) + ') \u2014 equals Flock rating, can exceed 5</div>'; }

--- a/public/js/editor/xp.js
+++ b/public/js/editor/xp.js
@@ -208,16 +208,25 @@ export function meritBdRow(realIdx, mc, fixedAt, opts = {}) {
   const effective = (fixedAt != null) ? (total >= fixedAt ? fixedAt : 0) : total;
   const needsHint = (fixedAt != null && total > 0 && total < fixedAt)
     ? '<span class="bd-needs-hint">' + total + ' / ' + fixedAt + ' needed</span>' : '';
-  let h = '<div class="merit-bd-row">'
-    + '<div class="bd-grp"><span class="bd-lbl">CP</span><input class="merit-bd-input" type="number" min="0" value="' + cp + '" onchange="shEditMeritPt(' + realIdx + ',\'cp\',+this.value)"></div>'
-    + '<div class="bd-grp"><span class="bd-lbl">XP</span><input class="merit-bd-input" type="number" min="0" value="' + xp + '" onchange="shEditMeritPt(' + realIdx + ',\'xp\',+this.value)"></div>'
-    + '<div class="bd-sep"></div>';
+  // N-7b (issue #768): Necropolis target merits are pool-funded only — the
+  // domain-renderer call site suppresses CP / XP / MCI / Bonus on these rows
+  // via opts.hideCP / opts.hideXP / opts.hideMCI (this block) + opts.hideBonus
+  // (below). Same opts-flag pattern as N-9's hideBonus on standing merits.
+  // The pre-N-7b shape rendered CP + XP + sep unconditionally; the guards
+  // here are defaults-false so existing call sites that don't pass the
+  // hide-flags get the legacy behaviour unchanged.
+  let h = '<div class="merit-bd-row">';
+  if (!opts.hideCP) h += '<div class="bd-grp"><span class="bd-lbl">CP</span><input class="merit-bd-input" type="number" min="0" value="' + cp + '" onchange="shEditMeritPt(' + realIdx + ',\'cp\',+this.value)"></div>';
+  if (!opts.hideXP) h += '<div class="bd-grp"><span class="bd-lbl">XP</span><input class="merit-bd-input" type="number" min="0" value="' + xp + '" onchange="shEditMeritPt(' + realIdx + ',\'xp\',+this.value)"></div>';
+  if (!opts.hideCP || !opts.hideXP) h += '<div class="bd-sep"></div>';
   // N-9 (issue #762, Bug 1 "adjacent finding"): MCI input writes the map-shape
   // `free_grants.mci` per the ADR-005 allocator-write-path amendment. The
   // handler (shEditMeritPt) detects the `free_grants.` prefix and routes to
   // the map. Pre-N-9 this wrote `free_mci`, creating a fresh divergence on
   // every edit after the N-2 backfill.
-  if (opts.showMCI) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl">MCI</span><input class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + fmci + '" onchange="shEditMeritPt(' + realIdx + ',\'free_grants.mci\',+this.value)"></div>';
+  // N-7b: showMCI is AND'd with !hideMCI at the call site so Necropolis
+  // targets don't surface the MCI allocator even when there's pool capacity.
+  if (opts.showMCI && !opts.hideMCI) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl">MCI</span><input class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + fmci + '" onchange="shEditMeritPt(' + realIdx + ',\'free_grants.mci\',+this.value)"></div>';
   if (opts.showVM) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl">VM</span><input class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + fvm + '" onchange="shEditMeritPt(' + realIdx + ',\'free_vm\',+this.value)"></div>';
   if (opts.showLK) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl">LK</span><input class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + flk + '" onchange="shEditMeritPt(' + realIdx + ',\'free_lk\',+this.value)"></div>';
   if (opts.showOHM) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl">OHM</span><input class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + fohm + '" onchange="shEditMeritPt(' + realIdx + ',\'free_ohm\',+this.value)"></div>';

--- a/server/tests/n7a-necro-domain-render.test.js
+++ b/server/tests/n7a-necro-domain-render.test.js
@@ -156,7 +156,11 @@ describe('N-7a — placement sanity guards', () => {
     const fnBody = src.slice(fnStart, nextExport > 0 ? nextExport : src.length);
     expect(fnBody).toMatch(/_hasNecroSep\s*=\s*hasNecropolisSepulcher\(c\)/);
     expect(fnBody).toMatch(/_necroTargets/);
-    expect(fnBody).toMatch(/showNECRO:\s*_hasNecroSep\s*&&\s*_necroTargets\.includes\(m\.name\)/);
+    // N-7b (issue #768) introduced `_isNecroTarget = _necroTargets.includes(m.name)`
+    // as a local intermediate so the same boolean threads into hideCP/XP/MCI/
+    // Bonus alongside showNECRO. Semantic check stays the same: showNECRO is
+    // gated on Sepulcher ownership AND target-name membership.
+    expect(fnBody).toMatch(/showNECRO:\s*_hasNecroSep\s*&&\s*(_necroTargets\.includes\(m\.name\)|_isNecroTarget)/);
   });
 
   it('_renderPoolCounters surfaces necro in domain section, not general', () => {

--- a/server/tests/n7b-necro-input-suppression.test.js
+++ b/server/tests/n7b-necro-input-suppression.test.js
@@ -1,0 +1,241 @@
+/**
+ * N-7b (issue #768) — Necropolis target merit input suppression.
+ *
+ * Pool-funded-only contract per Peter's 2026-06-16 option 3: rows whose merit
+ * is in `_necroTargets` (Catacombs / Caldarium / Garbage Pit / Labyrinth
+ * Guardians / Dark Temple / White Ants) hide CP / XP / MCI / Bonus inputs
+ * categorically — by merit name, regardless of Sepulcher ownership. The
+ * NECRO stepper is the only allocation surface.
+ *
+ * Tests are behavioural per `feedback_render_wiring_placement` — actually
+ * call `shRenderDomainMerits` and assert what the HTML contains / lacks.
+ * Static-analysis sanity guards at the bottom catch reverts of the call-site
+ * shape; the behavioural cases catch placement / regression.
+ */
+
+// Browser shims — sheet.js transitively pulls api.js's `location` reference.
+globalThis.location = {
+  origin: 'http://localhost:8080',
+  hostname: 'localhost',
+  href: 'http://localhost:8080/admin',
+};
+globalThis.localStorage = {
+  _store: {},
+  getItem(k) { return this._store[k] ?? null; },
+  setItem(k, v) { this._store[k] = String(v); },
+  removeItem(k) { delete this._store[k]; },
+  clear() { this._store = {}; },
+};
+globalThis.window = globalThis.window || globalThis;
+globalThis.document = globalThis.document || {
+  getElementById: () => null,
+  createElement: () => ({ style: {}, classList: { add() {}, remove() {}, toggle() {} } }),
+};
+
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+function read(rel) { return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8'); }
+
+let shRenderDomainMerits;
+let stateMod;
+let loadRulesMod;
+
+beforeAll(async () => {
+  const sheetUrl = pathToFileURL(path.resolve(__dirname, '..', '..', 'public', 'js', 'editor', 'sheet.js')).href;
+  ({ shRenderDomainMerits } = await import(sheetUrl));
+  stateMod = (await import(pathToFileURL(path.resolve(__dirname, '..', '..', 'public', 'js', 'data', 'state.js')).href)).default;
+  loadRulesMod = await import(pathToFileURL(path.resolve(__dirname, '..', '..', 'public', 'js', 'editor', 'rule_engine', 'load-rules.js')).href);
+
+  const ruleCache = {
+    rule_grant: [{
+      source: 'Necropolis Sepulcher',
+      source_slug: 'necro',
+      grant_type: 'pool',
+      pool_targets: ['Catacombs', 'Caldarium', 'Garbage Pit', 'Labyrinth Guardians', 'Dark Temple', 'White Ants'],
+      category: 'necro',
+    }],
+    rule_nine_again: [],
+    rule_skill_bonus: [],
+    rule_speciality_grant: [],
+    rule_tier_budget: [],
+    rule_disc_attr: [],
+    rule_derived_stat_modifier: [],
+  };
+  vi.spyOn(loadRulesMod, 'getRulesCache').mockReturnValue(ruleCache);
+});
+
+function mkChar(overrides = {}) {
+  return {
+    _id: 'n7b-test',
+    name: 'N7b Test',
+    clan: 'Nosferatu',
+    covenant: 'Invictus',
+    status: { city: 0, clan: 0, covenant: {} },
+    attributes: {}, skills: {}, disciplines: {}, powers: [],
+    merits: [],
+    _grant_pools: [],
+    ...overrides,
+  };
+}
+
+// Markers for what we want present / absent in the row's bd-row block. The
+// merit-bd-row container is one HTML chunk per merit so we can slice the
+// returned HTML by the row's data signal (the onchange writing `shEditMeritPt(
+// ${rIdx},` etc.) and assert against just that row.
+function sliceRowFor(html, realIdx) {
+  // The bd-row block for a given realIdx contains onchange="shEditMeritPt(<realIdx>,...".
+  // Anchor on the first occurrence and capture until the closing </div> after
+  // the bd-eq span. Cheap-and-cheerful — sufficient for assertion granularity.
+  const start = html.indexOf('class="merit-bd-row"');
+  if (start === -1) return '';
+  // Use the next `<div class="merit-list">` or `<div class="dom-edit-block"` as the loose end-marker.
+  // For our purposes the row will always include the bd-row + the bd-eq closer.
+  // To keep the implementation simple, scope on the FIRST bd-row in the
+  // returned HTML — tests construct chars with one Necropolis target each,
+  // so there's no ambiguity.
+  void realIdx;
+  const endHint = html.indexOf('attr-derived-row', start);
+  const stop = endHint === -1 ? html.indexOf('</div></div>', start) : endHint;
+  return html.slice(start, stop + 'attr-derived-row'.length);
+}
+
+describe('N-7b — Necropolis target input suppression (behavioural)', () => {
+  it('Catacombs row hides CP / XP / MCI / Bonus and keeps only NECRO', () => {
+    const c = mkChar({
+      merits: [
+        { name: 'Necropolis Sepulcher', category: 'general', cp: 3, xp: 0 },
+        { name: 'Catacombs', category: 'domain', cp: 0, xp: 0, free_grants: { necro: 1 } },
+      ],
+      _grant_pools: [{ source: 'Necropolis Sepulcher', category: 'necro', amount: 3, names: ['Catacombs', 'Caldarium', 'Garbage Pit', 'Labyrinth Guardians', 'Dark Temple', 'White Ants'] }],
+    });
+    stateMod.chars = [c];
+    stateMod.editIdx = 0;
+    stateMod.editMode = true;
+
+    const html = shRenderDomainMerits(c, true);
+
+    // Positive — NECRO stepper present + writes to the map.
+    expect(html).toContain('NECRO');
+    expect(html).toContain('free_grants.necro');
+
+    // Negative — CP / XP inputs and Bonus row are absent on the Catacombs
+    // row. shEditMeritPt(0,'cp',...) and shEditMeritPt(0,'xp',...) would
+    // appear if the inputs rendered (realIdx 1 is Catacombs; we check the
+    // row's specific input strings).
+    expect(html).not.toContain("shEditMeritPt(1,'cp'");
+    expect(html).not.toContain("shEditMeritPt(1,'xp'");
+    // The Bonus row's onchange string identifies it uniquely.
+    expect(html).not.toContain("shAdjMeritBonus(1,");
+    // MCI input on this row is suppressed too. The MCI onchange uses
+    // free_grants.mci as the write path — that string must NOT appear
+    // alongside the Catacombs row's idx. Since shRenderDomainMerits returns
+    // only domain merits and the only one here is Catacombs, the entire
+    // returned HTML must not contain a free_grants.mci.
+    expect(html).not.toContain('free_grants.mci');
+  });
+
+  it('regression — Haven row still shows CP / XP / Bonus (suppression only fires on Necropolis targets)', () => {
+    const c = mkChar({
+      merits: [
+        { name: 'Safe Place', category: 'domain', cp: 1, xp: 0, qualifier: 'Penthouse' },
+        { name: 'Haven', category: 'domain', cp: 1, xp: 0, attached_to: 'Safe Place (Penthouse)' },
+      ],
+    });
+    stateMod.chars = [c];
+    stateMod.editIdx = 0;
+    stateMod.editMode = true;
+
+    const html = shRenderDomainMerits(c, true);
+    // Haven is NOT a Necropolis target — CP / XP / Bonus must still render.
+    expect(html).toContain("shEditMeritPt(1,'cp'");
+    expect(html).toContain("shEditMeritPt(1,'xp'");
+    expect(html).toContain('shAdjMeritBonus(1');
+    // And no NECRO stepper on Haven (it's a non-Necropolis domain merit
+    // even if the character lacked Sepulcher entirely).
+    expect(html).not.toContain('NECRO');
+  });
+
+  it('non-Sepulcher character with a stray Catacombs merit STILL hides CP / XP (option 3 categorical)', () => {
+    // Edge: an ST somehow ended up with a Catacombs row on a character with
+    // no Sepulcher (e.g. legacy import). Suppression is by merit name, not
+    // gated on Sepulcher ownership — per Peter's option 3.
+    const c = mkChar({
+      merits: [
+        { name: 'Catacombs', category: 'domain', cp: 0, xp: 0 },
+      ],
+      _grant_pools: [],
+    });
+    stateMod.chars = [c];
+    stateMod.editIdx = 0;
+    stateMod.editMode = true;
+
+    const html = shRenderDomainMerits(c, true);
+    expect(html).not.toContain("shEditMeritPt(0,'cp'");
+    expect(html).not.toContain("shEditMeritPt(0,'xp'");
+    // No NECRO stepper either (no Sepulcher → showNECRO is false).
+    expect(html).not.toContain('NECRO');
+  });
+
+  it('all six Necropolis target names trigger suppression', () => {
+    // Spot-check: every name in pool_targets gets the hide treatment.
+    const targets = ['Catacombs', 'Caldarium', 'Garbage Pit', 'Labyrinth Guardians', 'Dark Temple', 'White Ants'];
+    for (const name of targets) {
+      const c = mkChar({
+        merits: [
+          { name: 'Necropolis Sepulcher', category: 'general', cp: 3, xp: 0 },
+          { name, category: 'domain', cp: 0, xp: 0 },
+        ],
+        _grant_pools: [{ source: 'Necropolis Sepulcher', category: 'necro', amount: 3 }],
+      });
+      stateMod.chars = [c];
+      stateMod.editIdx = 0;
+      stateMod.editMode = true;
+      const html = shRenderDomainMerits(c, true);
+      expect(html, `${name} should hide cp`).not.toContain("shEditMeritPt(1,'cp'");
+      expect(html, `${name} should hide xp`).not.toContain("shEditMeritPt(1,'xp'");
+      expect(html, `${name} should show NECRO`).toContain('NECRO');
+    }
+  });
+});
+
+describe('N-7b — meritBdRow hide-flag plumbing (static-analysis sanity)', () => {
+  it('meritBdRow gates CP / XP renders on opts.hideCP / opts.hideXP', () => {
+    const src = read('public/js/editor/xp.js');
+    // Class attributes in the source are backslash-escaped inside the JS
+    // string literal — match a narrower window of `opts.hideCP` near the
+    // label "CP" rather than the full quoted attribute.
+    expect(src).toMatch(/if \(!opts\.hideCP\)[\s\S]{0,200}>CP</);
+    expect(src).toMatch(/if \(!opts\.hideXP\)[\s\S]{0,200}>XP</);
+  });
+
+  it('meritBdRow AND-s opts.showMCI with !opts.hideMCI', () => {
+    const src = read('public/js/editor/xp.js');
+    expect(src).toMatch(/if \(opts\.showMCI && !opts\.hideMCI\)/);
+  });
+
+  it('domain-renderer call site computes _isNecroTarget and threads all four hide-flags + AND-s showMCI', () => {
+    const src = read('public/js/editor/sheet.js');
+    expect(src).toMatch(/_isNecroTarget\s*=\s*_necroTargets\.includes\(m\.name\)/);
+    expect(src).toMatch(/showMCI:\s*_domMciPool > 0 && !_isNecroTarget/);
+    expect(src).toMatch(/hideCP:\s*_isNecroTarget/);
+    expect(src).toMatch(/hideXP:\s*_isNecroTarget/);
+    expect(src).toMatch(/hideMCI:\s*_isNecroTarget/);
+    expect(src).toMatch(/hideBonus:\s*_isNecroTarget/);
+  });
+
+  it('_necroTargets is populated UNCONDITIONALLY (option 3 categorical) in shRenderDomainMerits', () => {
+    const src = read('public/js/editor/sheet.js');
+    const fnStart = src.indexOf('export function shRenderDomainMerits');
+    const nextExport = src.indexOf('export function ', fnStart + 1);
+    const body = src.slice(fnStart, nextExport > 0 ? nextExport : src.length);
+    // The pre-N-7b shape was `_necroTargets = _hasNecroSep ? getNecropolisTargets(...) : []`.
+    // Option 3 requires this to NOT be Sepulcher-gated — must be unconditional.
+    expect(body).toMatch(/_necroTargets\s*=\s*getNecropolisTargets\(getRulesCache\(\)\)/);
+    expect(body).not.toMatch(/_necroTargets\s*=\s*_hasNecroSep\s*\?/);
+  });
+});


### PR DESCRIPTION
## Summary

Per Peter's 2026-06-16 **option 3** decision: Necropolis target merits (Catacombs / Caldarium / Garbage Pit / Labyrinth Guardians / Dark Temple / White Ants) are pool-funded only. The row must render with the NECRO stepper as its sole allocation surface — no CP / XP / MCI / Bonus inputs alongside.

**Suppression is categorical by merit name**, regardless of Sepulcher ownership. An ST somehow ending up with a stray Catacombs row on a non-Sepulcher character still gets the inputs hidden (option 3 framing).

## Three changes

### `public/js/editor/xp.js` (meritBdRow)

- New `opts.hideCP` / `hideXP` / `hideMCI` flags. CP / XP renders gate on `!hideCP` / `!hideXP`. The intra-block separator only renders if at least one of CP / XP is present (no orphan separator on full-hide rows).
- `showMCI` now AND-s with `!hideMCI` so the call site can both have pool capacity AND suppress the input on a specific row.
- Mirrors the N-9 `opts.hideBonus` pattern. Defaults false → existing call sites unchanged.

### `public/js/editor/sheet.js` (shRenderDomainMerits)

- `_necroTargets` now populates **unconditionally** (pre-N-7b shape gated it on `_hasNecroSep` — option 3 requires categorical-by-name suppression regardless of Sepulcher ownership). The stepper render itself still gates on `_hasNecroSep` via the existing `showNECRO` calc.
- `meritBdRow` call site at `:1064` computes `_isNecroTarget` once and threads `hideCP` / `hideXP` / `hideMCI` / `hideBonus` all gated on it, plus AND-s `showMCI` with `!_isNecroTarget`.

## Behavioural test — per the N-7a lesson

`server/tests/n7b-necro-input-suppression.test.js` (8 cases) — actually calls `shRenderDomainMerits` per `feedback_render_wiring_placement`:

- Catacombs row hides CP / XP / Bonus and contains only NECRO.
- **Regression** — Haven row still shows CP / XP / Bonus (suppression only fires on Necropolis targets).
- Non-Sepulcher character with a stray Catacombs row STILL hides CP / XP (option 3 categorical proof).
- All six Necropolis target names trigger suppression.

Plus static-analysis sanity guards: hide-flag gating in `meritBdRow`, `showMCI` AND-ed with `!hideMCI`, call-site threads all four flags, `_necroTargets` populates unconditionally.

Adjusted the pre-existing `n7a-necro-domain-render.test.js` sanity guard to accept the N-7b shape (`showNECRO` via `_isNecroTarget` intermediate local — semantic check unchanged).

**Full regression: 1475/1475 individual tests pass.** Same four pre-existing test-FILE failures (#675 family + #706) carry forward.

## Side-context observation (NOT fixed here per the brief)

Per Khepri's note in the dispatch, this PR does NOT touch the `_collective_shared_with` synthesis path. The ADR-005 D3 collective synthesis should fire correctly post-N-3 seed; if Peter's post-deploy smoke shows it isn't surfacing the aggregate Catacombs total, that's a separate ticket. Flagged here for visibility; no investigation undertaken.

## Test plan
- [ ] Sepulcher-3 character with Catacombs row → only NECRO stepper visible (no CP / XP / MCI / Bonus on that row).
- [ ] Haven row regression — CP / XP / Bonus all still render.
- [ ] Domain-section pool counter still shows `N/3 Necropolis targets` (unchanged from N-7a).
- [ ] All six target merit names trigger the suppression.

Closes #768