### PR TITLE
fix(mnec): N-7c — dispatch Necropolis pool evaluator in applyDerivedMerits (#771)

### DIFF
--- a/public/js/editor/mci.js
+++ b/public/js/editor/mci.js
@@ -111,6 +111,15 @@ export function applyDerivedMerits(c, allChars = []) {
   // ── Lorekeeper grant pool (evaluator reads from rule_grant) ──
   applyPoolRulesFromDb(c, getRulesBySource('Lorekeeper'));
 
+  // ── Necropolis Sepulcher grant pool (N-7c, issue #771): pool=Sepulcher
+  //    rating, distributable across the six Collective Compound targets via
+  //    `free_grants.necro`. Same pool-evaluator dispatch shape as LK/Inv/VM —
+  //    its absence from N-7 left `_grant_pools` empty for necro, which silently
+  //    broke the domain counter render AND clamped the per-target stepper to 0
+  //    via poolAvailableFor. The helpers + write-path landed in N-7; this is
+  //    the producer call that fills the pool. ──
+  applyPoolRulesFromDb(c, getRulesBySource('Necropolis Sepulcher'));
+
   // ── Oath of the Scapegoat: floor on covenant status + 2 free style dots per dot ──
   applyOTSRulesFromDb(c, getRulesBySource('Oath of the Scapegoat'));
 

--- a/public/js/editor/xp.js
+++ b/public/js/editor/xp.js
@@ -234,7 +234,11 @@ export function meritBdRow(realIdx, mc, fixedAt, opts = {}) {
   // N-7 (issue #760): Necropolis allocator — writes directly to
   // m.free_grants.necro (map shape, no new legacy free_necro field) per the
   // ADR-005 allocator-write-path amendment.
-  if (opts.showNECRO) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl">NECRO</span><input class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + fnecro + '" onchange="shEditMeritPt(' + realIdx + ',\'free_grants.necro\',+this.value)"></div>';
+  // N-7c (issue #771): id + aria-label so browsers don't flag "form field
+  // element should have an id or name attribute / No label associated with a
+  // form field". Existing LK/INV/VM/OHM/MCI steppers share the same gap —
+  // filed as separate follow-up to keep N-7c scoped.
+  if (opts.showNECRO) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl" id="bd-necro-lbl-' + realIdx + '">NECRO</span><input id="bd-necro-' + realIdx + '" name="bd-necro-' + realIdx + '" aria-label="Necropolis pool allocation" class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + fnecro + '" onchange="shEditMeritPt(' + realIdx + ',\'free_grants.necro\',+this.value)"></div>';
   h += '<div class="bd-eq"><span class="bd-val">' + effective + ' dot' + (effective === 1 ? '' : 's') + '</span>' + needsHint + '</div>'
     + '</div>';
   // N-9 (issue #762, Bug 2): standing-merit render paths (MCI, PT) don't read

--- a/server/tests/n7c-necro-orchestrator-pipeline.test.js
+++ b/server/tests/n7c-necro-orchestrator-pipeline.test.js
@@ -1,0 +1,240 @@
+/**
+ * N-7c (issue #771) — end-to-end pipeline test for the Necropolis pool grant.
+ *
+ * Per Khepri's lesson extending feedback_render_wiring_placement: the existing
+ * N-7 suites tested the helpers (hasNecropolisSepulcher / getNecropolisTargets /
+ * poolAvailableFor) with manually-seeded `_grant_pools`, which silently bypassed
+ * the producer — the orchestrator dispatch in applyDerivedMerits that fills
+ * _grant_pools from the rule_grant doc. The missing dispatch slipped past the
+ * 25-case behavioural + static suite because the test seam mocked the pool
+ * state directly.
+ *
+ * This file runs the full pipeline:
+ *   1. Build a Sepulcher-3 character with Catacombs.
+ *   2. Run `applyDerivedMerits` against a rules cache containing the N-3
+ *      Necropolis Sepulcher rule_grant doc.
+ *   3. Assert `c._grant_pools` actually received the necro entry.
+ *   4. Call `shRenderDomainMerits` and assert the rendered HTML contains the
+ *      pool counter AND the NECRO stepper.
+ *
+ * If the orchestrator regresses (line removed from mci.js), this test fails
+ * on assertion 3 long before render — catching the producer-level bug at the
+ * producer level. Helper-mocked tests can't do that.
+ */
+
+// Browser shims — sheet.js + applyDerivedMerits's import chain transitively
+// pull api.js's `location` reference.
+globalThis.location = {
+  origin: 'http://localhost:8080',
+  hostname: 'localhost',
+  href: 'http://localhost:8080/admin',
+};
+globalThis.localStorage = {
+  _store: {},
+  getItem(k) { return this._store[k] ?? null; },
+  setItem(k, v) { this._store[k] = String(v); },
+  removeItem(k) { delete this._store[k]; },
+  clear() { this._store = {}; },
+};
+globalThis.window = globalThis.window || globalThis;
+globalThis.document = globalThis.document || {
+  getElementById: () => null,
+  createElement: () => ({ style: {}, classList: { add() {}, remove() {}, toggle() {} } }),
+};
+
+import { describe, it, expect, beforeAll, beforeEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+function read(rel) { return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8'); }
+
+let applyDerivedMerits;
+let shRenderDomainMerits;
+let shRenderGeneralMerits;
+let stateMod;
+let loadRulesMod;
+
+// N-3 rule_grant doc shape — matches what seed-rules-necropolis.js writes.
+// `amount_basis: 'rating_of_source'` makes the pool equal the Sepulcher's own
+// purchased rating (cp+xp). `condition: 'merit_present'` is the gate the
+// pool-evaluator uses to pick up this rule.
+const NECRO_GRANT = {
+  source: 'Necropolis Sepulcher',
+  source_slug: 'necro',
+  grant_type: 'pool',
+  condition: 'merit_present',
+  amount_basis: 'rating_of_source',
+  category: 'necro',
+  pool_targets: [
+    'Catacombs', 'Caldarium', 'Garbage Pit',
+    'Labyrinth Guardians', 'Dark Temple', 'White Ants',
+  ],
+};
+
+function mkRulesCache() {
+  return {
+    rule_grant: [NECRO_GRANT],
+    rule_nine_again: [],
+    rule_skill_bonus: [],
+    rule_speciality_grant: [],
+    rule_tier_budget: [],
+    rule_disc_attr: [],
+    rule_derived_stat_modifier: [],
+  };
+}
+
+beforeAll(async () => {
+  const mciUrl = pathToFileURL(path.resolve(REPO_ROOT, 'public', 'js', 'editor', 'mci.js')).href;
+  ({ applyDerivedMerits } = await import(mciUrl));
+
+  const sheetUrl = pathToFileURL(path.resolve(REPO_ROOT, 'public', 'js', 'editor', 'sheet.js')).href;
+  ({ shRenderDomainMerits, shRenderGeneralMerits } = await import(sheetUrl));
+
+  stateMod = (await import(pathToFileURL(path.resolve(REPO_ROOT, 'public', 'js', 'data', 'state.js')).href)).default;
+  loadRulesMod = await import(pathToFileURL(path.resolve(REPO_ROOT, 'public', 'js', 'editor', 'rule_engine', 'load-rules.js')).href);
+});
+
+beforeEach(() => {
+  const cache = mkRulesCache();
+  vi.spyOn(loadRulesMod, 'getRulesCache').mockReturnValue(cache);
+  // getRulesBySource is what the orchestrator's per-source dispatch calls.
+  // Real shape mirrors load-rules.js:50-58 — filter by source across each
+  // family. Most families are empty for this test so we just return the
+  // grants for the requested source.
+  vi.spyOn(loadRulesMod, 'getRulesBySource').mockImplementation((source) => ({
+    grants:           (cache.rule_grant            || []).filter(r => r.source === source),
+    nineAgain:        (cache.rule_nine_again       || []).filter(r => r.source === source),
+    skillBonus:       (cache.rule_skill_bonus      || []).filter(r => r.source === source),
+    specialityGrants: (cache.rule_speciality_grant || []).filter(r => r.source === source),
+    tierBudget:       (cache.rule_tier_budget      || []).find(r => r.source === source) || null,
+  }));
+});
+
+function mkYusufLike(catacombsCp = 0, catacombsFreeNecro = 0) {
+  return {
+    _id: 'n7c-yusuf',
+    name: 'N7c Yusuf',
+    clan: 'Nosferatu',
+    covenant: 'Invictus',
+    status: { city: 0, clan: 0, covenant: {} },
+    attributes: {}, skills: {}, disciplines: {}, powers: [],
+    merits: [
+      { name: 'Necropolis Sepulcher', category: 'general', cp: 3, xp: 0 },
+      { name: 'Catacombs', category: 'domain', cp: catacombsCp, xp: 0,
+        free_grants: catacombsFreeNecro ? { necro: catacombsFreeNecro } : {} },
+    ],
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Producer-level: orchestrator fills _grant_pools
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-7c — applyDerivedMerits dispatches Necropolis pool evaluator', () => {
+  it('fills c._grant_pools with the necro entry after applyDerivedMerits runs', () => {
+    const c = mkYusufLike();
+    applyDerivedMerits(c, []);
+
+    const necroEntry = (c._grant_pools || []).find(p => p.category === 'necro');
+    expect(necroEntry, 'Necropolis pool entry must be present in _grant_pools after orchestrator runs').toBeDefined();
+    expect(necroEntry.source).toBe('Necropolis Sepulcher');
+    expect(necroEntry.amount).toBe(3); // rating_of_source: Sepulcher cp=3 xp=0
+    expect(necroEntry.names).toEqual(expect.arrayContaining(['Catacombs', 'Caldarium', 'White Ants']));
+  });
+
+  it('emits no necro pool entry when Sepulcher is absent', () => {
+    const c = {
+      _id: 'n7c-no-sep', name: 'N7c No Sepulcher',
+      clan: 'Nosferatu', covenant: 'Invictus',
+      status: { city: 0, clan: 0, covenant: {} },
+      attributes: {}, skills: {}, disciplines: {}, powers: [],
+      merits: [{ name: 'Catacombs', category: 'domain', cp: 0, xp: 0 }],
+    };
+    applyDerivedMerits(c, []);
+    const necroEntry = (c._grant_pools || []).find(p => p.category === 'necro');
+    expect(necroEntry).toBeUndefined();
+  });
+
+  it('pool amount tracks Sepulcher purchased rating (cp + xp)', () => {
+    const c = mkYusufLike();
+    c.merits[0].cp = 1;
+    c.merits[0].xp = 4; // total 5
+    applyDerivedMerits(c, []);
+    const necroEntry = (c._grant_pools || []).find(p => p.category === 'necro');
+    expect(necroEntry.amount).toBe(5);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// End-to-end: orchestrator → render produces the pool counter + stepper
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-7c — full pipeline: applyDerivedMerits → shRenderDomainMerits', () => {
+  it('renders the Necropolis pool counter in the domain section', () => {
+    const c = mkYusufLike();
+    applyDerivedMerits(c, []);
+
+    stateMod.chars = [c];
+    stateMod.editIdx = 0;
+    stateMod.editMode = true;
+
+    // Pool counters for all three categories are rendered by _renderPoolCounters
+    // calls that live inside shRenderGeneralMerits (sheet.js:1335) — the domain
+    // section's counter surfaces from the general renderer, not the domain one.
+    // Production wiring assembles general + influence + domain blocks together,
+    // so the counter renders for users; this test calls the general renderer
+    // directly to surface the counter assertion in isolation.
+    const html = shRenderGeneralMerits(c, true);
+    expect(html).toContain('Necropolis Sepulcher');
+    expect(html).toMatch(/0\s*\/\s*3/); // 0 used / 3 available
+  });
+
+  it('renders the NECRO stepper with cap 3 on a fresh Catacombs row', () => {
+    const c = mkYusufLike(0, 0);
+    applyDerivedMerits(c, []);
+
+    stateMod.chars = [c];
+    stateMod.editIdx = 0;
+    stateMod.editMode = true;
+
+    const html = shRenderDomainMerits(c, true);
+    expect(html).toContain('NECRO');
+    expect(html).toContain('free_grants.necro');
+    // a11y additions per N-7c secondary fix — id + aria-label so browsers
+    // don't flag the form-field warning.
+    expect(html).toMatch(/id="bd-necro-\d+"/);
+    expect(html).toContain('aria-label="Necropolis pool allocation"');
+  });
+
+  it('pool counter reflects spent dots when free_grants.necro is set', () => {
+    const c = mkYusufLike(0, 2); // Catacombs has 2 necro dots allocated
+    applyDerivedMerits(c, []);
+
+    stateMod.chars = [c];
+    stateMod.editIdx = 0;
+    stateMod.editMode = true;
+
+    const html = shRenderGeneralMerits(c, true);
+    expect(html).toMatch(/2\s*\/\s*3/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Static-analysis sanity guard — orchestrator dispatch present at the right place
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-7c — orchestrator dispatch sanity guard', () => {
+  it('applyDerivedMerits contains the Necropolis Sepulcher pool dispatch', () => {
+    const src = read('public/js/editor/mci.js');
+    expect(src).toMatch(/applyPoolRulesFromDb\(c,\s*getRulesBySource\(['"]Necropolis Sepulcher['"]\)\)/);
+  });
+
+  it('NECRO stepper has id + aria-label for accessibility', () => {
+    const src = read('public/js/editor/xp.js');
+    expect(src).toMatch(/id="bd-necro-/);
+    expect(src).toMatch(/aria-label="Necropolis pool allocation"/);
+  });
+});


### PR DESCRIPTION
## Summary

URGENT fix for #771. N-7 wired everything except the one orchestrator line in `mci.js`'s `applyDerivedMerits` that actually fills `c._grant_pools` with the necro entry. Both production symptoms (missing pool counter + clamped-to-zero stepper) collapse to that single missing dispatch.

## Changes

**`public/js/editor/mci.js`** — added one orchestrator dispatch:
```js
applyPoolRulesFromDb(c, getRulesBySource('Necropolis Sepulcher'));
```
Grouped with the other pool-grant calls right after Lorekeeper. Same shape as LK / Inv / VM.

**`public/js/editor/xp.js`** — NECRO stepper a11y. Added `id` + `aria-label` + matching `<span id=...>` so browsers no longer flag "form field element should have an id or name attribute". The existing LK / INV / VM / OHM / MCI steppers (lines 229-233) share the same a11y gap — flagged for separate follow-up per the dispatch's scope guard.

**`server/tests/n7c-necro-orchestrator-pipeline.test.js`** (new, 8 cases) — closes the helpers-and-UI-but-not-pipeline test seam that let N-7/N-7a/N-7b slip past their suites. Pattern:

1. **Producer-level (3 cases):** build char → run real `applyDerivedMerits` → assert `c._grant_pools` actually receives the necro entry. Test #1 catches an orchestrator-dispatch regression at the producer level — before any render.
2. **End-to-end pipeline (3 cases):** orchestrator → `shRenderGeneralMerits` → assert pool counter HTML; orchestrator → `shRenderDomainMerits` → assert NECRO stepper HTML + a11y attributes; spent-dot counter math.
3. **Static-analysis sanity guards (2 cases):** orchestrator dispatch line present in mci.js; a11y attributes present in xp.js.

Test pattern uses `vi.spyOn` on the real `load-rules.js` exports so the orchestrator's `getRulesBySource('Necropolis Sepulcher')` call returns the controlled rule_grant doc with `amount_basis: 'rating_of_source'`. Browser shims + dynamic imports per the established N-7a/N-7b pattern (sheet.js transitively pulls api.js `location`).

## Lesson extending [`feedback_render_wiring_placement`](https://github.com/angelusvmorningstar/TerraMortis/blob/main/.claude/memory/feedback_render_wiring_placement.md)

> N-7a was 'wrong renderer'. N-7b was 'inputs not hidden'. N-7c is 'orchestrator never fires'.

Three N-7 follow-ups all trace to the original suite mocking `_grant_pools` directly — confirming the consumer works without ever proving the producer runs. For any future allocator family: at least one test must run `applyDerivedMerits` end-to-end and assert against actual rendered output. Helper-level mocks confirm the consumer; pipeline-level tests confirm the producer.

## Acceptance criteria

- [x] `applyDerivedMerits` orchestrator dispatches Necropolis pool grant
- [x] After dispatch fires for Sepulcher-3 character, `c._grant_pools` contains `{ source: 'Necropolis Sepulcher', category: 'necro', amount: 3, names: [...] }`
- [x] Pool counter "Necropolis X/Y" renders in the domain section (verified via `shRenderGeneralMerits` test — counters are composed inside that renderer per sheet.js:1335)
- [x] NECRO stepper renders + writes to `m.free_grants.necro` (verified via `shRenderDomainMerits` test)
- [x] **Pipeline test** present (8 cases — producer + end-to-end + static guards)
- [x] Stepper input has `id` + `aria-label`
- [x] No regression on existing tests (485 individual tests pass, 0 failures — 76 file-level setup failures are MongoDB ECONNREFUSED, unrelated)

## Smoke test path (post-deploy)

Per the issue body:
1. Yusuf Kalusicj (Sepulcher 3, no targets yet)
2. Add Catacombs → NECRO stepper, cap 3
3. Set Catacombs NECRO=2 → counter '2/3', other targets see cap=1

## Out of scope

- LK / INV / VM / OHM / MCI stepper a11y gap (same `id`/`aria-label` missing) — separate follow-up
- `_collective_shared_with` aggregate-display verification across multi-Sepulcher characters — separate downstream once pool actually populates per ADR-005 D3

## Test status

- `n7c-necro-orchestrator-pipeline.test.js` — 8/8 pass
- Full vitest run: 485 individual tests pass, 984 skipped, 0 failed
- 76 file-level setup failures — all `ECONNREFUSED 127.0.0.1:27017` (MongoDB not running on local box; unrelated to this change). CI will exercise the DB-dependent suites.

Closes #771