### PR TITLE
fix(mnec): N-4a + #782 — picker placement + shared_with suppression (#781, #782)

### DIFF
--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -1086,26 +1086,52 @@ export function shRenderDomainMerits(c, editMode) {
       // be hand-funded). The NECRO stepper is the only allocation surface.
       const _isNecroTarget = _necroTargets.includes(m.name);
       h += meritBdRow(rIdx, m, meritFixedRating(m.name), { showMCI: _domMciPool > 0 && !_isNecroTarget, showVM: _hasVM && _isVMMerit, showLK: _hasLK && _isLKMerit, showINV: _hasINV && _isINVMerit, showNECRO: _hasNecroSep && _isNecroTarget, hideCP: _isNecroTarget, hideXP: _isNecroTarget, hideMCI: _isNecroTarget, hideBonus: _isNecroTarget, attachBonus: attacheBonusDots(c, m.area ? m.name + ' (' + m.area + ')' : m.name) }); h += _prereqWarn(c, m.name);
+      // N-4a (issue #781): White Ants Territory picker + Trap Door triple-anchor
+      // picker. Both target merits are sub_category='domain', so the pickers
+      // must render in the domain loop here — not in shRenderGeneralMerits.
+      // The N-4 / N-5 wiring originally lifted the integration point from a
+      // general-merit precedent; same blind spot as N-7a (NECRO stepper in
+      // wrong renderer) and N-7c (orchestrator dispatch missing). Production
+      // symptom pre-fix: ST cannot pick territories → save fails 400.
+      h += _whiteAntsTerritoriesBlock(m, rIdx);
+      h += _trapDoorAnchorBlock(c, m, rIdx);
       h += _derivedNotes(m);
       if (m.name === 'Herd') { const ssjB = ssjHerdBonus(c); if (ssjB) h += '<div class="derived-note">SSJ Bonus: +' + ssjB + ' dots (' + shDots(ssjB) + ') \u2014 equals MCI dots</div>'; }
       if (m.name === 'Herd') { const flockB = flockHerdBonus(c); if (flockB) h += '<div class="derived-note">Flock Bonus: +' + flockB + ' dots (' + shDots(flockB) + ') \u2014 equals Flock rating, can exceed 5</div>'; }
-      // Issue #160 (2026-05-08): Mandragora Garden gains the shared quality
-      // per published errata — direct partner sharing on the Mandragora
-      // instance, semantically identical to Safe Place's existing treatment.
-      // Removed from _noShare here. The attached-to-Safe-Place cap stays
-      // (CAP_DOMAIN in editor/domain.js); per-instance shared_with sums
-      // partner contributions through the existing domMeritShareable path.
-      // Issue #313 (2026-05-15): Haven also gains direct shared quality --
-      // same mechanism as Mandragora Garden above.
-      const _noShare = ['Herd', 'Feeding Grounds'];
-      if (!_noShare.includes(m.name) && parts.length) { h += '<div class="dom-partners-row">'; parts.forEach(pN => { const p = chars.find(ch => ch.name === pN), pD = p ? domMeritShareable(p, m.name) : 0; h += '<span class="dom-partner-tag">' + esc(pN) + (pD ? ' ' + shDots(pD) : ' \u25CB') + '<button class="dom-partner-rm" onclick="shRemoveDomainPartner(' + di + ',\'' + pN.replace(/'/g, "\\'") + '\')">\u00D7</button></span>'; }); h += '</div>'; }
-      if (!_noShare.includes(m.name) && avP.length) h += '<div class="dom-add-partner-row"><select class="dom-partner-sel" onchange="if(this.value){shAddDomainPartner(' + di + ',this.value);this.value=\'\';}"><option value="">+ Add shared partner\u2026</option>' + avP.map(p => '<option value="' + esc(p.name) + '">' + esc(dropdownName(p)) + '</option>').join('') + '</select></div>';
+      // Issue #782 (Peter decision (a), 2026-06-16): partner_explicit shared_with
+      // picker is restricted to Safe Place and Haven only. Inverted from the
+      // previous negative `_noShare` exclusion (['Herd', 'Feeding Grounds']) to
+      // a positive include list — every other domain merit (Mandragora Garden,
+      // Necropolis Sepulcher, all 6 Necropolis targets, Trap Door, future
+      // additions) defaults to NOT shareable via this picker.
+      //
+      // Audit trail of prior decisions reversed/preserved:
+      // - Issue #160 (2026-05-08): added Mandragora Garden to shareable per
+      //   published errata. REVERSED by #782 — Peter's framing returns the
+      //   game to "only Safe Place and Haven share".
+      // - Issue #313 (2026-05-15): added Haven to shareable. PRESERVED.
+      // - Necropolis family auto-shares via _collective_shared_with synthesis
+      //   (ADR-005 Rev 2 §D3) — that's the correct mechanism, orthogonal to
+      //   this partner_explicit picker UI.
+      //
+      // Existing `m.shared_with` data on non-shareable merits is preserved in
+      // the DB as inert (no destructive migration in this scope); the gate
+      // below suppresses display + add-partner UI on the editor surface.
+      const _canShare = ['Safe Place', 'Haven'];
+      if (_canShare.includes(m.name) && parts.length) { h += '<div class="dom-partners-row">'; parts.forEach(pN => { const p = chars.find(ch => ch.name === pN), pD = p ? domMeritShareable(p, m.name) : 0; h += '<span class="dom-partner-tag">' + esc(pN) + (pD ? ' ' + shDots(pD) : ' \u25CB') + '<button class="dom-partner-rm" onclick="shRemoveDomainPartner(' + di + ',\'' + pN.replace(/'/g, "\\'") + '\')">\u00D7</button></span>'; }); h += '</div>'; }
+      if (_canShare.includes(m.name) && avP.length) h += '<div class="dom-add-partner-row"><select class="dom-partner-sel" onchange="if(this.value){shAddDomainPartner(' + di + ',this.value);this.value=\'\';}"><option value="">+ Add shared partner\u2026</option>' + avP.map(p => '<option value="' + esc(p.name) + '">' + esc(dropdownName(p)) + '</option>').join('') + '</select></div>';
       h += '</div>';
     });
     h += '<div class="dev-add-row"><button class="dev-add-btn" onclick="shAddDomMerit()">+ Add Domain Merit</button></div>';
   } else {
+    // Issue #782: read-only view shares the same partner-display gate as the
+    // editor surface — only Safe Place and Haven render the "Shared · ..." line.
+    // Stored `m.shared_with` on other merits is treated as inert data and
+    // suppressed from display (no destructive migration; future cleanup is a
+    // separate story).
+    const _canShareView = ['Safe Place', 'Haven'];
     domM.slice().sort((a, b) => (a.name || '').localeCompare(b.name || '')).forEach(m => {
-      const dp = m.shared_with && m.shared_with.length ? m.shared_with : null;
+      const dp = _canShareView.includes(m.name) && m.shared_with && m.shared_with.length ? m.shared_with : null;
       // de: per-instance effective rating (handles cap for Haven/MG, multi-instance for SP/FG)
       const de = meritEffectiveRating(c, m);
       const mBon = m.bonus || 0;
@@ -1377,10 +1403,10 @@ export function shRenderGeneralMerits(c, editMode) {
         h += '<span class="infl-dots-derived">' + '\u25CF'.repeat(_gPurch) + '\u25CB'.repeat(Math.max(0, dd + _mBonus - _gPurch)) + '</span>'
           + '<button class="dev-rm-btn" onclick="shRemoveGenMerit(' + gi + ')" title="Remove">&times;</button></div>';
         h += meritBdRow(rIdx, m, meritFixedRating(m.name), { showMCI: _genMciPool > 0, showNECRO: _hasNecroSep && _necroTargets.includes(m.name) });
-        // N-4 (MNEC #696): White Ants Territory picker — one select per dot.
-        h += _whiteAntsTerritoriesBlock(m, rIdx);
-        // N-5 (MNEC #697): Trap Door triple-anchor picker (origin + destination + territory).
-        h += _trapDoorAnchorBlock(c, m, rIdx);
+        // N-4a (issue #781): White Ants + Trap Door pickers moved to
+        // shRenderDomainMerits (their merits are sub_category='domain').
+        // Calls removed here — would never have fired in the general renderer
+        // since both merits route to the domain branch by sub_category.
         h += _derivedNotes(m);
         h += _prereqWarn(c, m.name, m);
       }

--- a/server/tests/n4a-picker-renderer-placement.test.js
+++ b/server/tests/n4a-picker-renderer-placement.test.js
@@ -1,0 +1,263 @@
+/**
+ * N-4a (issue #781) + #782 — picker-placement + shared_with-suppression
+ * behavioural tests.
+ *
+ * N-4a fix: `_whiteAntsTerritoriesBlock` and `_trapDoorAnchorBlock` were
+ * wired inside `shRenderGeneralMerits` (sheet.js:1381, :1383 pre-fix) but
+ * both target merits are sub_category='domain'. The pickers never rendered
+ * during a real edit, save failed server-side with 400. Third instance of
+ * the wiring-placement blind spot from `feedback_render_wiring_placement`
+ * (after N-7a stepper + N-7c orchestrator). Behavioural render-and-assert
+ * tests are the only mechanism that catches placement bugs — regex tests
+ * confirm the wiring exists in the file, not its execution path.
+ *
+ * #782 fix: shared_with partner_explicit picker suppression. Inverted the
+ * `_noShare` exclusion list to a positive `_canShare = ['Safe Place',
+ * 'Haven']` include list per Peter's 2026-06-16 decision (a). Reverses
+ * #160 (Mandragora shareable). Necropolis family auto-shares via
+ * `_collective_shared_with` synthesis — orthogonal to this picker UI.
+ */
+
+// Browser shims — sheet.js transitively imports api.js's `location` reference.
+globalThis.location = {
+  origin: 'http://localhost:8080',
+  hostname: 'localhost',
+  href: 'http://localhost:8080/admin',
+};
+globalThis.localStorage = {
+  _store: {},
+  getItem(k) { return this._store[k] ?? null; },
+  setItem(k, v) { this._store[k] = String(v); },
+  removeItem(k) { delete this._store[k]; },
+  clear() { this._store = {}; },
+};
+globalThis.window = globalThis.window || globalThis;
+globalThis.document = globalThis.document || {
+  getElementById: () => null,
+  createElement: () => ({ style: {}, classList: { add() {}, remove() {}, toggle() {} } }),
+};
+
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+function read(rel) { return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8'); }
+
+let shRenderDomainMerits;
+let shRenderGeneralMerits;
+let stateMod;
+let loadRulesMod;
+
+const NECRO_GRANT = {
+  source: 'Necropolis Sepulcher',
+  source_slug: 'necro',
+  grant_type: 'pool',
+  condition: 'merit_present',
+  amount_basis: 'rating_of_source',
+  category: 'necro',
+  pool_targets: ['Catacombs', 'Caldarium', 'Garbage Pit', 'Labyrinth Guardians', 'Dark Temple', 'White Ants'],
+};
+
+beforeAll(async () => {
+  const sheetUrl = pathToFileURL(path.resolve(REPO_ROOT, 'public', 'js', 'editor', 'sheet.js')).href;
+  ({ shRenderDomainMerits, shRenderGeneralMerits } = await import(sheetUrl));
+  stateMod = (await import(pathToFileURL(path.resolve(REPO_ROOT, 'public', 'js', 'data', 'state.js')).href)).default;
+  loadRulesMod = await import(pathToFileURL(path.resolve(REPO_ROOT, 'public', 'js', 'editor', 'rule_engine', 'load-rules.js')).href);
+
+  vi.spyOn(loadRulesMod, 'getRulesCache').mockReturnValue({
+    rule_grant: [NECRO_GRANT],
+    rule_nine_again: [], rule_skill_bonus: [], rule_speciality_grant: [],
+    rule_tier_budget: [], rule_disc_attr: [], rule_derived_stat_modifier: [],
+  });
+});
+
+function mkChar(merits) {
+  return {
+    _id: 'n4a-test', name: 'N4a Test',
+    clan: 'Nosferatu', covenant: 'Invictus',
+    status: { city: 0, clan: 0, covenant: {} },
+    attributes: {}, skills: {}, disciplines: {}, powers: [],
+    merits,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// N-4a — picker placement in the domain renderer (production bug)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-4a — White Ants Territory picker renders in shRenderDomainMerits', () => {
+  it('renders the White Ants picker block when a Sepulcher owner has White Ants', () => {
+    const c = mkChar([
+      { name: 'Necropolis Sepulcher', category: 'general', cp: 3, xp: 0 },
+      { name: 'White Ants', category: 'domain', cp: 2, xp: 0, territories: [] },
+    ]);
+    stateMod.chars = [c]; stateMod.editIdx = 0; stateMod.editMode = true;
+
+    const html = shRenderDomainMerits(c, true);
+    // wa-picker-block is the class marker the White Ants block always emits
+    // (with a "Loading territories…" placeholder when getStoredTerritories
+    // returns empty — that's the render-time fallback). Production bug
+    // pre-N-4a: this marker was missing from the domain HTML entirely.
+    expect(html).toContain('wa-picker-block');
+    expect(html).toContain('White Ants');
+  });
+
+  it('does NOT render the White Ants picker block in shRenderGeneralMerits', () => {
+    // Regression sentinel — White Ants is sub_category='domain' so the
+    // general renderer must NEVER render the picker. Pre-N-4a the picker
+    // was wired here and was inert; we've removed the call entirely.
+    const c = mkChar([
+      { name: 'Necropolis Sepulcher', category: 'general', cp: 3, xp: 0 },
+      { name: 'White Ants', category: 'general', cp: 2, xp: 0 }, // contrived: even if mis-categorised, picker should not appear
+    ]);
+    stateMod.chars = [c]; stateMod.editIdx = 0; stateMod.editMode = true;
+
+    const html = shRenderGeneralMerits(c, true);
+    expect(html).not.toContain('wa-picker-block');
+  });
+});
+
+describe('N-4a — Trap Door anchor picker renders in shRenderDomainMerits', () => {
+  it('renders the Trap Door anchor block when a Sepulcher owner has Trap Door', () => {
+    const c = mkChar([
+      { name: 'Necropolis Sepulcher', category: 'general', cp: 3, xp: 0 },
+      { name: 'Safe Place', category: 'domain', cp: 2, xp: 0, qualifier: 'Penthouse' },
+      { name: 'Trap Door', category: 'domain', cp: 1, xp: 0 },
+    ]);
+    stateMod.chars = [c]; stateMod.editIdx = 0; stateMod.editMode = true;
+
+    const html = shRenderDomainMerits(c, true);
+    expect(html).toContain('td-anchor-block');
+  });
+
+  it('does NOT render the Trap Door anchor block in shRenderGeneralMerits', () => {
+    const c = mkChar([
+      { name: 'Necropolis Sepulcher', category: 'general', cp: 3, xp: 0 },
+      { name: 'Trap Door', category: 'general', cp: 1, xp: 0 }, // contrived
+    ]);
+    stateMod.chars = [c]; stateMod.editIdx = 0; stateMod.editMode = true;
+
+    const html = shRenderGeneralMerits(c, true);
+    expect(html).not.toContain('td-anchor-block');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #782 — shared_with picker suppression (only Safe Place + Haven)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#782 — shared_with picker include-list (Safe Place + Haven only)', () => {
+  it('Safe Place renders the partner picker (with candidate partner in state.chars)', () => {
+    // dom-add-partner-row only emits when avP.length > 0 (i.e. there's at
+    // least one other character to share with). Seed a partner.
+    const c = mkChar([{ name: 'Safe Place', category: 'domain', cp: 2, xp: 0, qualifier: 'Penthouse' }]);
+    const partner = { _id: 'partner', name: 'Partner Char', merits: [{ name: 'Safe Place', category: 'domain', cp: 1, xp: 0 }] };
+    stateMod.chars = [c, partner]; stateMod.editIdx = 0; stateMod.editMode = true;
+    const html = shRenderDomainMerits(c, true);
+    expect(html).toContain('dom-add-partner-row');
+  });
+
+  it('Haven renders the partner picker (with candidate partner in state.chars)', () => {
+    const c = mkChar([
+      { name: 'Safe Place', category: 'domain', cp: 2, xp: 0, qualifier: 'Penthouse' },
+      { name: 'Haven', category: 'domain', cp: 1, xp: 0, attached_to: 'Safe Place (Penthouse)' },
+    ]);
+    const partner = { _id: 'partner', name: 'Partner Char', merits: [{ name: 'Haven', category: 'domain', cp: 1, xp: 0 }] };
+    stateMod.chars = [c, partner]; stateMod.editIdx = 0; stateMod.editMode = true;
+    const html = shRenderDomainMerits(c, true);
+    // Expect TWO picker rows: one for Safe Place, one for Haven. The
+    // suppression sentinel tests below assert non-shareable merits would
+    // give only one (or zero) picker.
+    const pickerCount = (html.match(/dom-add-partner-row/g) || []).length;
+    expect(pickerCount).toBe(2);
+  });
+
+  it('Necropolis Sepulcher does NOT render the partner picker', () => {
+    const c = mkChar([{ name: 'Necropolis Sepulcher', category: 'domain', cp: 3, xp: 0 }]);
+    stateMod.chars = [c, { _id: 'other', name: 'Other Char', merits: [{ name: 'Necropolis Sepulcher', category: 'domain', cp: 2, xp: 0 }] }];
+    stateMod.editIdx = 0; stateMod.editMode = true;
+    const html = shRenderDomainMerits(c, true);
+    // Even with a candidate partner in state.chars, Necropolis Sepulcher must
+    // NOT surface the add-partner picker — auto-sharing is via
+    // _collective_shared_with (ADR-005 D3), not partner_explicit.
+    expect(html).not.toContain('dom-add-partner-row');
+  });
+
+  it('Necropolis targets (Catacombs/etc) do NOT render the partner picker', () => {
+    const targets = ['Catacombs', 'Caldarium', 'Garbage Pit', 'Labyrinth Guardians', 'Dark Temple', 'White Ants'];
+    for (const name of targets) {
+      const c = mkChar([
+        { name: 'Necropolis Sepulcher', category: 'domain', cp: 3, xp: 0 },
+        { name, category: 'domain', cp: 0, xp: 0 },
+      ]);
+      stateMod.chars = [c, { _id: 'other', name: 'Other Char', merits: [{ name, category: 'domain', cp: 1, xp: 0 }] }];
+      stateMod.editIdx = 0; stateMod.editMode = true;
+      const html = shRenderDomainMerits(c, true);
+      expect(html, `${name} should not render partner picker`).not.toContain('dom-add-partner-row');
+    }
+  });
+
+  it('Mandragora Garden does NOT render the partner picker (reverses #160 per Peter 2026-06-16 decision (a))', () => {
+    const c = mkChar([
+      { name: 'Safe Place', category: 'domain', cp: 2, xp: 0, qualifier: 'Penthouse' },
+      { name: 'Mandragora Garden', category: 'domain', cp: 1, xp: 0, attached_to: 'Safe Place (Penthouse)' },
+    ]);
+    stateMod.chars = [c, { _id: 'other', name: 'Other Char', merits: [{ name: 'Mandragora Garden', category: 'domain', cp: 1, xp: 0 }] }];
+    stateMod.editIdx = 0; stateMod.editMode = true;
+    const html = shRenderDomainMerits(c, true);
+    // Mandragora row must not surface the picker. Safe Place does — assert
+    // overall picker count is one (only Safe Place's), not two.
+    const pickerCount = (html.match(/dom-add-partner-row/g) || []).length;
+    expect(pickerCount).toBe(1);
+  });
+
+  it('Trap Door does NOT render the partner picker', () => {
+    const c = mkChar([
+      { name: 'Safe Place', category: 'domain', cp: 2, xp: 0, qualifier: 'Penthouse' },
+      { name: 'Trap Door', category: 'domain', cp: 1, xp: 0 },
+    ]);
+    stateMod.chars = [c, { _id: 'other', name: 'Other Char', merits: [{ name: 'Trap Door', category: 'domain', cp: 1, xp: 0 }] }];
+    stateMod.editIdx = 0; stateMod.editMode = true;
+    const html = shRenderDomainMerits(c, true);
+    // Safe Place gets one picker; Trap Door must not add a second.
+    const pickerCount = (html.match(/dom-add-partner-row/g) || []).length;
+    expect(pickerCount).toBe(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Static-analysis sanity guards
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('N-4a + #782 — placement sanity guards', () => {
+  it('White Ants + Trap Door blocks called inside shRenderDomainMerits', () => {
+    const src = read('public/js/editor/sheet.js');
+    const fnStart = src.indexOf('export function shRenderDomainMerits');
+    const nextExport = src.indexOf('export function ', fnStart + 1);
+    const body = src.slice(fnStart, nextExport > 0 ? nextExport : src.length);
+    expect(body).toMatch(/_whiteAntsTerritoriesBlock\(m,\s*rIdx\)/);
+    expect(body).toMatch(/_trapDoorAnchorBlock\(c,\s*m,\s*rIdx\)/);
+  });
+
+  it('White Ants + Trap Door blocks NOT called inside shRenderGeneralMerits', () => {
+    const src = read('public/js/editor/sheet.js');
+    const fnStart = src.indexOf('export function shRenderGeneralMerits');
+    const nextExport = src.indexOf('export function ', fnStart + 1);
+    const body = src.slice(fnStart, nextExport > 0 ? nextExport : src.length);
+    expect(body).not.toMatch(/_whiteAntsTerritoriesBlock\(/);
+    expect(body).not.toMatch(/_trapDoorAnchorBlock\(/);
+  });
+
+  it('shared_with gate inverted to positive _canShare include list', () => {
+    const src = read('public/js/editor/sheet.js');
+    expect(src).toMatch(/const _canShare = \['Safe Place', 'Haven'\]/);
+    expect(src).toMatch(/const _canShareView = \['Safe Place', 'Haven'\]/);
+    // No remaining executable `_noShare` reference (mention in audit comment is fine)
+    const codeOnly = src.split('\n').filter(l => !l.trim().startsWith('//')).join('\n');
+    expect(codeOnly).not.toMatch(/_noShare\.includes/);
+    expect(codeOnly).not.toMatch(/const _noShare =/);
+  });
+});


### PR DESCRIPTION
## Summary

Bundled two related domain-renderer fixes touching `shRenderDomainMerits`:

- **#781 (URGENT — N-4a):** White Ants + Trap Door pickers wired into wrong renderer. Save fails server-side with 400.
- **#782:** shared_with picker suppression per Peter's 2026-06-16 decision (a) — only Safe Place + Haven keep the partner picker.

## N-4a — picker placement (the URGENT half)

`_whiteAntsTerritoriesBlock` and `_trapDoorAnchorBlock` were wired inside `shRenderGeneralMerits` (sheet.js:1381, :1383). Both target merits are `sub_category='domain'` — pickers never rendered during real edits. Lifted both calls into `shRenderDomainMerits`'s per-merit loop after `meritBdRow`; removed the inert calls from the general renderer.

Third instance of the `feedback_render_wiring_placement` blind spot (after N-7a stepper, N-7c orchestrator). The memory postdated N-4 but now covers this exact case.

## #782 — shared_with picker include-list

`sheet.js:1100` inverted from negative `_noShare = ['Herd', 'Feeding Grounds']` to positive `_canShare = ['Safe Place', 'Haven']`. Read-only view at sheet.js:1108 gated symmetrically with `_canShareView`.

Reverses #160 (Mandragora Garden shareable, 2026-05-08) per Peter's framing. Necropolis family auto-shares via `_collective_shared_with` synthesis (ADR-005 D3) — that's the correct mechanism, orthogonal to this picker UI. Existing `shared_with` data on non-shareable merits preserved in DB as inert.

## Tests

`server/tests/n4a-picker-renderer-placement.test.js` — **13 cases** (behavioural-first per the memory):

**N-4a placement (4):**
- White Ants picker renders in `shRenderDomainMerits` ✓
- White Ants picker does NOT render in `shRenderGeneralMerits` ✓
- Trap Door picker renders in `shRenderDomainMerits` ✓
- Trap Door picker does NOT render in `shRenderGeneralMerits` ✓

**#782 include-list (6):**
- Safe Place + Haven: picker present (with candidate partner in state.chars) ✓
- Necropolis Sepulcher: no picker ✓
- All 6 Necropolis targets: no picker (loop assertion) ✓
- Mandragora Garden: no picker (asserts picker count = 1 — only Safe Place's) ✓
- Trap Door: no picker (asserts picker count = 1) ✓

**Static-analysis sanity guards (3):**
- Block calls present in domain renderer, absent in general renderer
- `_canShare` + `_canShareView` include list shape
- No residual executable `_noShare` references (comments OK for audit trail)

Counting picker occurrences (not just presence/absence) catches regressions where the gate forgets one merit name.

## Regression

- Targeted file: 13/13 pass
- Related sheet.js suites (n7a / n7b / n7c / feeding-grounds): 29/29 pass — no regression on closely-related domain renderer paths
- Mongo not running locally; DB-dependent test files skip at setup with ECONNREFUSED (unrelated)

## Smoke test path (post-deploy)

1. Yusuf (Sepulcher 3, White Ants 2) — save no longer 400s; territory picker visible on the domain row
2. Trap Door anchor picker surfaces on the domain row (was missing pre-fix)
3. Necropolis Sepulcher row: no "Add shared partner..." dropdown
4. Catacombs / Caldarium / etc rows: no "Add shared partner..." dropdown
5. Mandragora Garden row: no "Add shared partner..." dropdown (reverses #160)
6. Safe Place + Haven rows: "Add shared partner..." dropdown still present

## Scope notes

- **In scope:** picker placement lift + include-list inversion + behavioural tests
- **Out of scope:** retroactive cleanup of `shared_with` data on Mandragora characters (separate migration if desired)
- **Out of scope:** broader audit of other N-4 / N-5 / N-7 wiring placement

Closes #781
Closes #782