### PR TITLE
fix(mnec): #770 + #775 — preserve sub_category in seed; bridge category from source_slug

### DIFF
--- a/public/js/editor/rule_engine/pool-evaluator.js
+++ b/public/js/editor/rule_engine/pool-evaluator.js
@@ -30,7 +30,14 @@ export function applyPoolRulesFromDb(c, { grants = [] } = {}) {
     c._grant_pools.push({
       source: rule.source,
       names: rule.pool_targets,
-      category: rule.category,
+      // Issue #775: bridge rule_grant docs that use `source_slug` (N-1
+      // convention) without an explicit `category` field. Older docs set
+      // only `category`; N-3-era and post-MNEC docs may set only
+      // `source_slug`. Fall back so consumers downstream (sheet.js:124
+      // `_renderPoolCounters` filters, poolAvailableFor cap math) always
+      // see a non-undefined category. Belt-and-braces with the seed which
+      // writes both fields explicitly.
+      category: rule.category ?? rule.source_slug,
       amount,
     });
   }

--- a/server/scripts/seed-rules-necropolis.js
+++ b/server/scripts/seed-rules-necropolis.js
@@ -97,6 +97,7 @@ const MERITS = [
     key: 'necropolis-sepulcher',
     name: 'Necropolis Sepulcher',
     rating_range: [1, 5],
+    sub_category: 'domain',
     prereq: PREREQ_CLAN,
     description:
       "Prerequisites: Nosferatu Status •\n\n" +
@@ -110,6 +111,7 @@ const MERITS = [
     key: 'catacombs',
     name: 'Catacombs',
     rating_range: [1, 5],
+    sub_category: 'domain',
     prereq: PREREQ_FAMILY,
     description:
       "Navigating the tunnels necessitates an extended Wits + Investigation roll, with ten successes required. " +
@@ -125,6 +127,7 @@ const MERITS = [
     key: 'caldarium',
     name: 'Caldarium',
     rating_range: [1, 3],
+    sub_category: 'domain',
     prereq: PREREQ_FAMILY,
     description:
       "The Caldaria is the one location in the Necropolis that strangers may be allowed to visit, it is, in a way, a Nosferatu Elysium: one shall not bring violence here.\n\n" +
@@ -139,6 +142,7 @@ const MERITS = [
     key: 'garbage-pit',
     name: 'Garbage Pit',
     rating_range: [1, 3],
+    sub_category: 'domain',
     prereq: PREREQ_FAMILY,
     description:
       "The Garbage Pit provides 2 distinct benefits that Haunts have learnt not to look too closely at: " +
@@ -153,6 +157,7 @@ const MERITS = [
     key: 'labyrinth-guardians',
     name: 'Labyrinth Guardians',
     rating_range: [1, 5],
+    sub_category: 'domain',
     prereq: PREREQ_FAMILY,
     description:
       "Guardian Swarms are packs or hordes of mutant animals that live in the Warren. " +
@@ -168,6 +173,7 @@ const MERITS = [
     name: 'Dark Temple',
     rating_range: [2, 2],
     xp_fixed: 2,
+    sub_category: 'domain',
     prereq: PREREQ_FAMILY,
     description:
       "A Haunt spending time in the Dark Temple has their Beast quietened; they take the Sated Condition (+1 on Frenzy checks) and are considered to have meditated (+1 on Breakpoint checks). " +
@@ -180,6 +186,7 @@ const MERITS = [
     key: 'white-ants',
     name: 'White Ants',
     rating_range: [1, 5],
+    sub_category: 'domain',
     prereq: PREREQ_FAMILY,
     description:
       "The Necropolis sprawls and opens into Territories far beyond what is reasonable. " +
@@ -196,6 +203,7 @@ const MERITS = [
     name: 'Trap Door',
     rating_range: [1, 1],
     xp_fixed: 1,
+    sub_category: 'domain',
     prereq: PREREQ_FAMILY,
     description:
       // VERBATIM TYPOS PRESERVED ("a entrance" → "an entrance"; "above group" → "above ground") per Peter 2026-06-10 ack.
@@ -211,6 +219,7 @@ const MERITS = [
     name: 'True Worm',
     rating_range: [2, 2],
     xp_fixed: 2,
+    sub_category: 'general',
     prereq: PREREQ_CLAN,
     description:
       "So used to the dark, the Nosferatu no longer feels the draw of day sleep when in the tunnels of the Necropolis that lay more than 10 meters below the earth where there is no possibility of sunlight. " +
@@ -228,6 +237,13 @@ const MERITS = [
 const NECRO_RULE_GRANT = {
   source: 'Necropolis Sepulcher',
   source_slug: 'necro',
+  // Issue #775: belt-and-braces — write both `category` (N-1 convention,
+  // read directly by _renderPoolCounters filters at sheet.js:124) and
+  // `source_slug` (legacy field). Pool-evaluator now bridges both at write
+  // time via `rule.category ?? rule.source_slug` so future rule_grant docs
+  // don't need this dual field, but keeping it explicit here matches the
+  // shape consumers expect and survives a re-seed without surprise.
+  category: 'necro',
   grant_type: 'pool',
   condition: 'merit_present',
   amount_basis: 'rating_of_source',

--- a/server/tests/n7c-necro-orchestrator-pipeline.test.js
+++ b/server/tests/n7c-necro-orchestrator-pipeline.test.js
@@ -143,6 +143,14 @@ describe('N-7c — applyDerivedMerits dispatches Necropolis pool evaluator', () 
     expect(necroEntry.source).toBe('Necropolis Sepulcher');
     expect(necroEntry.amount).toBe(3); // rating_of_source: Sepulcher cp=3 xp=0
     expect(necroEntry.names).toEqual(expect.arrayContaining(['Catacombs', 'Caldarium', 'White Ants']));
+    // Issue #775: assert on the full entry SHAPE, not just presence. category
+    // must always be set — pre-#775 a rule_grant doc that omits `category`
+    // (using only `source_slug`) silently pushed an entry with
+    // `category: undefined`, breaking downstream filters at sheet.js:124
+    // (_renderPoolCounters) and the poolAvailableFor cap math. The
+    // pool-evaluator now bridges via `rule.category ?? rule.source_slug`;
+    // this assertion catches a regression of that bridge.
+    expect(necroEntry.category).toBe('necro');
   });
 
   it('emits no necro pool entry when Sepulcher is absent', () => {

--- a/server/tests/seed-770-775-hygiene.test.js
+++ b/server/tests/seed-770-775-hygiene.test.js
@@ -1,0 +1,156 @@
+/**
+ * Issue #770 + #775 — seed sub_category preservation + pool-evaluator
+ * source_slug bridge.
+ *
+ * #770: `seed-rules-necropolis.js` `_baseDoc()` defaults `sub_category: null`
+ * and pre-fix none of the 9 merit overrides set it. Every `--apply` run
+ * silently stripped `sub_category: 'domain'` from prod docs (had to be
+ * restored twice on 2026-06-16). The fix sets sub_category explicitly on
+ * each merit override; this test asserts the source-of-truth so the
+ * regression cannot recur.
+ *
+ * #775: `pool-evaluator.js:33` pushed `category: rule.category` directly.
+ * A rule_grant doc using only `source_slug` (N-1 convention) would push
+ * `category: undefined`, breaking downstream filters. The fix bridges
+ * via `rule.category ?? rule.source_slug`. The seed now also writes both
+ * fields explicitly (belt-and-braces).
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+function read(rel) { return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8'); }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #770 — seed preserves sub_category on every merit
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Decisions baked in per Peter 2026-06-16:
+//   - 8 merits get 'domain': sepulcher / catacombs / caldarium / garbage pit /
+//     labyrinth guardians / dark temple / white ants / trap door
+//   - True Worm gets 'general' (per-character drawback, no sharing, no
+//     Sepulcher prereq)
+const EXPECTED_SUB_CATEGORY = {
+  'necropolis-sepulcher': 'domain',
+  'catacombs': 'domain',
+  'caldarium': 'domain',
+  'garbage-pit': 'domain',
+  'labyrinth-guardians': 'domain',
+  'dark-temple': 'domain',
+  'white-ants': 'domain',
+  'trap-door': 'domain',
+  'true-worm': 'general',
+};
+
+describe('#770 — seed-rules-necropolis.js preserves sub_category on every merit', () => {
+  it('every merit override in MERITS sets sub_category explicitly', () => {
+    const src = read('server/scripts/seed-rules-necropolis.js');
+
+    // Extract the MERITS = [ ... ]; block. Match from `const MERITS = [` to
+    // the matching closing `];` at column-0 (the seed file uses a single
+    // top-level array, so a balanced-bracket parser isn't required).
+    const start = src.indexOf('const MERITS = [');
+    expect(start, 'MERITS array must exist in seed').toBeGreaterThan(0);
+    const end = src.indexOf('\n];', start);
+    expect(end, 'MERITS array must close with `\\n];`').toBeGreaterThan(start);
+    const block = src.slice(start, end);
+
+    // For each expected key, find its _baseDoc({...}) call and assert the
+    // sub_category line is present with the expected value. Order-of-fields
+    // within the call is not constrained by the test.
+    for (const [key, expectedSub] of Object.entries(EXPECTED_SUB_CATEGORY)) {
+      const keyIdx = block.indexOf(`key: '${key}'`);
+      expect(keyIdx, `merit '${key}' must appear in MERITS`).toBeGreaterThan(0);
+
+      // Slice the surrounding _baseDoc call body — from the preceding
+      // `_baseDoc({` to the matching `})`. Cheap-and-cheerful: take the
+      // next ~30 lines after the key match (largest merit description is
+      // well under that). Sufficient for assertion granularity.
+      const sliceEnd = block.indexOf('}),', keyIdx);
+      const body = block.slice(keyIdx, sliceEnd > keyIdx ? sliceEnd : keyIdx + 2000);
+
+      const subCatMatch = body.match(/sub_category:\s*'([^']+)'/);
+      expect(subCatMatch, `merit '${key}' must set sub_category explicitly (pre-#770 bug: _baseDoc default null silently stripped prod state)`).not.toBeNull();
+      expect(subCatMatch[1]).toBe(expectedSub);
+    }
+  });
+
+  it('_baseDoc default of sub_category: null is preserved as a safety net (NOT removed)', () => {
+    // We keep the default at null intentionally — it means an over-ride
+    // forgetting sub_category will write null and the per-merit assertion
+    // above will fail, catching the omission. Removing the default and
+    // requiring an explicit field would also work but is more invasive.
+    const src = read('server/scripts/seed-rules-necropolis.js');
+    expect(src).toMatch(/sub_category:\s*null,?\s*\n\s*cult:/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #775 — pool-evaluator bridges category from source_slug when absent
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#775 — pool-evaluator.js bridges category ?? source_slug', () => {
+  it('pushes category from source_slug when category is undefined', async () => {
+    // Mock minimal character + rule shape — only `category` is omitted on the
+    // rule (source_slug provides the slug). The evaluator must fall back.
+    const { applyPoolRulesFromDb } = await import('../../public/js/editor/rule_engine/pool-evaluator.js');
+    const c = {
+      _grant_pools: [],
+      merits: [{ name: 'Test Source', cp: 3, xp: 0 }],
+    };
+    applyPoolRulesFromDb(c, {
+      grants: [{
+        source: 'Test Source',
+        source_slug: 'test_slug',
+        grant_type: 'pool',
+        condition: 'merit_present',
+        amount_basis: 'rating_of_source',
+        pool_targets: ['Target A', 'Target B'],
+        // NOTE: category intentionally omitted — the bridge must fall back to source_slug.
+      }],
+    });
+    expect(c._grant_pools).toHaveLength(1);
+    expect(c._grant_pools[0].category).toBe('test_slug');
+    expect(c._grant_pools[0].source).toBe('Test Source');
+    expect(c._grant_pools[0].amount).toBe(3);
+  });
+
+  it('prefers explicit category over source_slug when both are present', async () => {
+    const { applyPoolRulesFromDb } = await import('../../public/js/editor/rule_engine/pool-evaluator.js');
+    const c = {
+      _grant_pools: [],
+      merits: [{ name: 'Test Source', cp: 3, xp: 0 }],
+    };
+    applyPoolRulesFromDb(c, {
+      grants: [{
+        source: 'Test Source',
+        source_slug: 'should_be_ignored',
+        category: 'explicit_category',
+        grant_type: 'pool',
+        condition: 'merit_present',
+        amount_basis: 'rating_of_source',
+        pool_targets: ['Target'],
+      }],
+    });
+    expect(c._grant_pools[0].category).toBe('explicit_category');
+  });
+
+  it('seed-rules-necropolis.js NECRO_RULE_GRANT writes both category and source_slug (belt-and-braces)', () => {
+    const src = read('server/scripts/seed-rules-necropolis.js');
+    const start = src.indexOf('const NECRO_RULE_GRANT = {');
+    expect(start).toBeGreaterThan(0);
+    const end = src.indexOf('};', start);
+    const block = src.slice(start, end);
+    expect(block).toMatch(/source_slug:\s*'necro'/);
+    expect(block).toMatch(/category:\s*'necro'/);
+  });
+
+  it('pool-evaluator source confirms the bridge expression', () => {
+    const src = read('public/js/editor/rule_engine/pool-evaluator.js');
+    expect(src).toMatch(/category:\s*rule\.category\s*\?\?\s*rule\.source_slug/);
+  });
+});


### PR DESCRIPTION
## Summary

Bundled two related seed/evaluator hygiene fixes — both touch `server/scripts/seed-rules-necropolis.js` and address re-seed regressions Peter hit twice on 2026-06-16.

## #770 — preserve sub_category on every merit doc

`_baseDoc()` at line 83 defaults `sub_category: null` and pre-fix none of the 9 merit overrides set it. Every `--apply` silently stripped `sub_category: 'domain'` from prod docs → Peter's domain merit dropdown lost Catacombs/etc → manual restore via `restore-necro-sub-category.js` twice on the same day.

Per Peter 2026-06-16:
- **8 merits → 'domain'**: Sepulcher / Catacombs / Caldarium / Garbage Pit / Labyrinth Guardians / Dark Temple / White Ants / Trap Door
- **True Worm → 'general'** (per-character drawback, no sharing, no Sepulcher prereq)

`_baseDoc()` default kept at `null` as a safety net — a future merit forgetting `sub_category` fires the per-key assertion immediately rather than silently writing null.

## #775 — pool-evaluator bridges category from source_slug

`pool-evaluator.js:33` pre-fix pushed `category: rule.category` directly. Docs using only `source_slug` (N-1 convention) silently pushed `category: undefined`, breaking downstream filters at `sheet.js:124` (`_renderPoolCounters`) and `poolAvailableFor` cap math.

**Fix (one line):**
```js
category: rule.category ?? rule.source_slug,
```

**Seed belt-and-braces:** `NECRO_RULE_GRANT` now writes both `category: 'necro'` and `source_slug: 'necro'` explicitly. Compatible with legacy field readers; survives a re-seed without surprise.

**N-7c pipeline test extended:** asserts `necroEntry.category === 'necro'` (shape, not just presence) so a regression of the bridge fails at the producer level.

## Tests

`server/tests/seed-770-775-hygiene.test.js` — **6 cases**:

**#770:**
- Every merit in MERITS sets sub_category explicitly with the expected per-key value
- `_baseDoc()` default `null` preserved as safety net

**#775:**
- Pool-evaluator falls back to `source_slug` when `category` absent
- Pool-evaluator prefers explicit `category` over `source_slug` when both present
- Seed `NECRO_RULE_GRANT` writes both fields
- Pool-evaluator source contains the bridge expression (`category: rule.category ?? rule.source_slug`)

**N-7c test updated:** new shape assertion on `necroEntry.category`.

## Regression

- Targeted: 6/6 pass on new file; 14/14 across seed-hygiene + n7c; 26/26 across seed-hygiene + n7a/b/c
- No regression on closely-related domain renderer paths
- Mongo not running locally; DB-dependent test files skip at setup with ECONNREFUSED (unrelated)

## Sequencing relative to PR-A (#783)

PR-A (#783, N-4a + #782) lands first — it's the URGENT save-broken fix. This PR (#770 + #775) is the seed/evaluator hygiene pass; recommend shipping soon because the next person who runs the N-3 seed (you, me, automation) will regress prod again until #770 lands. Either merge order works — no overlap with PR-A's touched files (sheet.js + new test only).

Closes #770
Closes #775