### PR TITLE
fix(mnec): #790 + #774 — meritFreeSum Necropolis-target gate + sibling stepper a11y

### DIFF
--- a/public/js/editor/domain.js
+++ b/public/js/editor/domain.js
@@ -219,7 +219,28 @@ export function domMeritTotal(c, name) {
  * contributions for shared domain merits). Those are summed in by
  * meritEffectiveRating, not by this helper.
  */
+// Issue #790: Necropolis target merit names — pool-funded only. meritFreeSum
+// must categorically ignore m.free + every legacy flat free_<slug> + every
+// non-necro entry in free_grants for these rows. The only legitimate funding
+// channel is m.free_grants.necro. Same categorical-by-name pattern as N-7b's
+// input suppression; static set is acceptable for v1 since the targets are
+// stable from N-3 (matches N-7b's static set at sheet.js _necroTargets).
+const NECRO_TARGETS_FOR_SUM = new Set([
+  'Catacombs', 'Caldarium', 'Garbage Pit',
+  'Labyrinth Guardians', 'Dark Temple', 'White Ants',
+]);
+
 export function meritFreeSum(m) {
+  // Issue #790: Necropolis-target categorical exclusion. Without this gate,
+  // any stray write to m.free or any legacy m.free_<slug> field on a target
+  // merit silently double-counts on top of the legitimate pool allocation.
+  // Yusuf hit this 2026-06-16 — 4 merits showed +1 too high because of legacy
+  // m.free=1 contamination of unknown origin (no current main code path
+  // writes m.free positive on these rows, but the cleanup script was one-shot
+  // and the class needs a permanent gate).
+  if (m && NECRO_TARGETS_FOR_SUM.has(m.name)) {
+    return (m.free_grants && m.free_grants.necro) || 0;
+  }
   // N-1 / ADR-005 Rev 2: delegate to the shared helper which sums BOTH the
   // new `m.free_grants` map AND every legacy `m.free_<slug>` field. The
   // shared helper EXCLUDES `m.free` (the unprefixed player-allocated channel)
@@ -294,9 +315,13 @@ export function meritEffectiveRating(c, m) {
       return domMeritTotal(c, m.name);
     }
   }
-  // N-1: delegate the 14-channel enumeration to the shared helper. `m.free`
-  // (unprefixed) added separately per the meritFreeSum public contract.
-  const sum = (m.cp || 0) + (m.xp || 0) + (m.free || 0) + _meritFreeSumHelper(m);
+  // Issue #790: route through meritFreeSum so the Necropolis-target
+  // categorical exclusion applies here too (it would otherwise be bypassed by
+  // the inline 14-channel sum). Pre-#790 this was hand-rolled as
+  // `(m.cp||0) + (m.xp||0) + (m.free||0) + _meritFreeSumHelper(m)` — a
+  // duplicate of meritFreeSum's body plus cp+xp — and silently summed every
+  // free channel even on Necropolis target rows.
+  const sum = (m.cp || 0) + (m.xp || 0) + meritFreeSum(m);
   if (m.name === 'Herd') {
     return sum + ssjHerdBonus(c) + flockHerdBonus(c);
   }

--- a/public/js/editor/xp.js
+++ b/public/js/editor/xp.js
@@ -226,18 +226,23 @@ export function meritBdRow(realIdx, mc, fixedAt, opts = {}) {
   // every edit after the N-2 backfill.
   // N-7b: showMCI is AND'd with !hideMCI at the call site so Necropolis
   // targets don't surface the MCI allocator even when there's pool capacity.
-  if (opts.showMCI && !opts.hideMCI) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl">MCI</span><input class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + fmci + '" onchange="shEditMeritPt(' + realIdx + ',\'free_grants.mci\',+this.value)"></div>';
-  if (opts.showVM) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl">VM</span><input class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + fvm + '" onchange="shEditMeritPt(' + realIdx + ',\'free_vm\',+this.value)"></div>';
-  if (opts.showLK) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl">LK</span><input class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + flk + '" onchange="shEditMeritPt(' + realIdx + ',\'free_lk\',+this.value)"></div>';
-  if (opts.showOHM) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl">OHM</span><input class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + fohm + '" onchange="shEditMeritPt(' + realIdx + ',\'free_ohm\',+this.value)"></div>';
-  if (opts.showINV) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl">INV</span><input class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + finv + '" onchange="shEditMeritPt(' + realIdx + ',\'free_inv\',+this.value)"></div>';
+  // Issue #774: a11y — every stepper input carries id + name + aria-label
+  // matching the NECRO precedent at line 241 (added by N-7c #771). Same
+  // browser warning ("form field element should have an id or name
+  // attribute / No label associated with a form field") was firing on
+  // these 5 sibling steppers. Single-line additions per stepper.
+  if (opts.showMCI && !opts.hideMCI) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl" id="bd-mci-lbl-' + realIdx + '">MCI</span><input id="bd-mci-' + realIdx + '" name="bd-mci-' + realIdx + '" aria-label="Mystery Cult Initiation pool allocation" class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + fmci + '" onchange="shEditMeritPt(' + realIdx + ',\'free_grants.mci\',+this.value)"></div>';
+  if (opts.showVM) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl" id="bd-vm-lbl-' + realIdx + '">VM</span><input id="bd-vm-' + realIdx + '" name="bd-vm-' + realIdx + '" aria-label="Viral Mythology pool allocation" class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + fvm + '" onchange="shEditMeritPt(' + realIdx + ',\'free_vm\',+this.value)"></div>';
+  if (opts.showLK) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl" id="bd-lk-lbl-' + realIdx + '">LK</span><input id="bd-lk-' + realIdx + '" name="bd-lk-' + realIdx + '" aria-label="Lorekeeper pool allocation" class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + flk + '" onchange="shEditMeritPt(' + realIdx + ',\'free_lk\',+this.value)"></div>';
+  if (opts.showOHM) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl" id="bd-ohm-lbl-' + realIdx + '">OHM</span><input id="bd-ohm-' + realIdx + '" name="bd-ohm-' + realIdx + '" aria-label="Oath of the Hard Motherfucker pool allocation" class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + fohm + '" onchange="shEditMeritPt(' + realIdx + ',\'free_ohm\',+this.value)"></div>';
+  if (opts.showINV) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl" id="bd-inv-lbl-' + realIdx + '">INV</span><input id="bd-inv-' + realIdx + '" name="bd-inv-' + realIdx + '" aria-label="Invested pool allocation" class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + finv + '" onchange="shEditMeritPt(' + realIdx + ',\'free_inv\',+this.value)"></div>';
   // N-7 (issue #760): Necropolis allocator — writes directly to
   // m.free_grants.necro (map shape, no new legacy free_necro field) per the
   // ADR-005 allocator-write-path amendment.
   // N-7c (issue #771): id + aria-label so browsers don't flag "form field
   // element should have an id or name attribute / No label associated with a
-  // form field". Existing LK/INV/VM/OHM/MCI steppers share the same gap —
-  // filed as separate follow-up to keep N-7c scoped.
+  // form field". The 5 sibling steppers (LK/INV/VM/OHM/MCI) got the same
+  // treatment in #774 — see lines above.
   if (opts.showNECRO) h += '<div class="bd-grp"><span class="bd-lbl bd-bonus-lbl" id="bd-necro-lbl-' + realIdx + '">NECRO</span><input id="bd-necro-' + realIdx + '" name="bd-necro-' + realIdx + '" aria-label="Necropolis pool allocation" class="merit-bd-input bd-bonus-input" type="number" min="0" value="' + fnecro + '" onchange="shEditMeritPt(' + realIdx + ',\'free_grants.necro\',+this.value)"></div>';
   h += '<div class="bd-eq"><span class="bd-val">' + effective + ' dot' + (effective === 1 ? '' : 's') + '</span>' + needsHint + '</div>'
     + '</div>';

--- a/server/tests/n7d-meritfreesum-necro-gate.test.js
+++ b/server/tests/n7d-meritfreesum-necro-gate.test.js
@@ -1,0 +1,263 @@
+/**
+ * Issue #790 + #774 — meritFreeSum categorical exclusion + stepper a11y.
+ *
+ * #790 (URGENT): meritFreeSum now categorically returns ONLY
+ * m.free_grants.necro for Necropolis target merit names. Pre-fix any stray
+ * write to m.free or any legacy m.free_<slug> on a target row would silently
+ * double-count on top of the pool allocation. Yusuf hit this 2026-06-16
+ * (4 merits with m.free=1 contamination, origin untraceable in current main).
+ *
+ * #774: 5 sibling steppers (MCI/VM/LK/OHM/INV) get id + name + aria-label
+ * matching the NECRO precedent from N-7c #771.
+ *
+ * Behavioural-first per the feedback_render_wiring_placement chain:
+ * - #790 calls real meritFreeSum + meritEffectiveRating + syncMeritRating
+ *   on constructed characters with multi-channel contamination; assertions
+ *   compare the returned numbers, not the source.
+ * - #774 calls real meritBdRow with each opts.show* and asserts the
+ *   rendered HTML carries the a11y attributes.
+ */
+
+// Browser shims — domain.js transitively imports api.js's `location` reference.
+globalThis.location = {
+  origin: 'http://localhost:8080',
+  hostname: 'localhost',
+  href: 'http://localhost:8080/admin',
+};
+globalThis.localStorage = {
+  _store: {},
+  getItem(k) { return this._store[k] ?? null; },
+  setItem(k, v) { this._store[k] = String(v); },
+  removeItem(k) { delete this._store[k]; },
+  clear() { this._store = {}; },
+};
+globalThis.window = globalThis.window || globalThis;
+globalThis.document = globalThis.document || {
+  getElementById: () => null,
+  createElement: () => ({ style: {}, classList: { add() {}, remove() {}, toggle() {} } }),
+};
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+function read(rel) { return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8'); }
+
+let meritFreeSum, meritEffectiveRating, syncMeritRating, meritBdRow;
+
+beforeAll(async () => {
+  const domainUrl = pathToFileURL(path.resolve(REPO_ROOT, 'public', 'js', 'editor', 'domain.js')).href;
+  ({ meritFreeSum, meritEffectiveRating, syncMeritRating } = await import(domainUrl));
+  const xpUrl = pathToFileURL(path.resolve(REPO_ROOT, 'public', 'js', 'editor', 'xp.js')).href;
+  ({ meritBdRow } = await import(xpUrl));
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #790 — meritFreeSum returns only m.free_grants.necro on Necropolis targets
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#790 — meritFreeSum categorical exclusion on Necropolis targets', () => {
+  const NECRO_TARGETS = ['Catacombs', 'Caldarium', 'Garbage Pit', 'Labyrinth Guardians', 'Dark Temple', 'White Ants'];
+
+  it.each(NECRO_TARGETS)('%s: meritFreeSum returns ONLY free_grants.necro despite contamination on other channels', (name) => {
+    const m = {
+      name,
+      category: 'domain',
+      cp: 0,
+      xp: 0,
+      free: 5,              // legacy contamination (Yusuf's exact symptom)
+      free_mci: 3,          // any other channel write
+      free_vm: 2,           // any other channel write
+      free_lk: 4,           // any other channel write
+      free_grants: { necro: 2, mci: 7 }, // necro is the only one that counts; map.mci is ignored too
+    };
+    // Pre-#790: 5 (m.free) + 3 (free_mci) + 2 (free_vm) + 4 (free_lk) + 2 (map.necro) + 7 (map.mci) = 23
+    // Post-#790: 2 (map.necro only)
+    expect(meritFreeSum(m)).toBe(2);
+  });
+
+  it('returns 0 when free_grants.necro is unset and other channels are contaminated', () => {
+    const m = {
+      name: 'Catacombs',
+      category: 'domain',
+      cp: 0, xp: 0,
+      free: 1,
+      free_mci: 2,
+      free_grants: {},
+    };
+    expect(meritFreeSum(m)).toBe(0);
+  });
+
+  it('non-Necropolis domain merit: meritFreeSum sums all channels normally (regression sentinel)', () => {
+    const m = {
+      name: 'Safe Place',
+      category: 'domain',
+      cp: 0, xp: 0,
+      free: 5,
+      free_mci: 3,
+      free_vm: 2,
+      free_grants: { lk: 1 },
+    };
+    // 5 (m.free) + 3 (free_mci) + 2 (free_vm) + 1 (map.lk) = 11
+    expect(meritFreeSum(m)).toBe(11);
+  });
+
+  it('Necropolis Sepulcher (the SOURCE merit, not a target): sums normally (only targets gate, not Sepulcher itself)', () => {
+    const m = {
+      name: 'Necropolis Sepulcher',
+      category: 'domain',
+      cp: 3, xp: 0,
+      free: 1, // hypothetical contamination
+      free_grants: {},
+    };
+    // Sepulcher is the source, not a target — gate doesn't apply.
+    // 1 (m.free) + 0 (no other channels) = 1
+    expect(meritFreeSum(m)).toBe(1);
+  });
+
+  it('Trap Door (per-character bridge, NOT a Necropolis target): sums normally', () => {
+    const m = {
+      name: 'Trap Door',
+      category: 'domain',
+      cp: 1, xp: 0,
+      free: 2,
+      free_grants: { mci: 1 },
+    };
+    // Trap Door is NOT in the categorical exclusion set (it's per-character,
+    // not collective-shared). Sums normally.
+    // 2 (m.free) + 1 (map.mci) = 3
+    expect(meritFreeSum(m)).toBe(3);
+  });
+
+  it('syncMeritRating inherits the Necropolis exclusion (consumes meritFreeSum)', () => {
+    const m = {
+      name: 'Catacombs',
+      category: 'domain',
+      cp: 0, xp: 0,
+      free: 5, // contamination
+      free_grants: { necro: 2 },
+    };
+    // Pre-#790: 0 + 0 + 5 + ... = inflated
+    // Post-#790: cp(0) + xp(0) + meritFreeSum(m)=2  →  2
+    expect(syncMeritRating(m)).toBe(2);
+  });
+
+  it('meritEffectiveRating inherits the Necropolis exclusion (refactored to use meritFreeSum)', () => {
+    const c = {
+      _id: 'n7d-test',
+      merits: [{
+        name: 'Catacombs',
+        category: 'domain',
+        cp: 0, xp: 0,
+        free: 5, // contamination
+        free_grants: { necro: 2 },
+      }],
+    };
+    // Pre-#790: line 299 inline sum would include m.free + every flat channel
+    // Post-#790: routes through meritFreeSum → exclusion applies
+    expect(meritEffectiveRating(c, c.merits[0])).toBe(2);
+  });
+
+  it('class-of-bug regression sentinel: Yusuf-shape (free=1, no other channels)', () => {
+    // The exact contamination shape Peter hit on 2026-06-16.
+    for (const name of NECRO_TARGETS) {
+      const m = { name, category: 'domain', cp: 0, xp: 0, free: 1, free_grants: { necro: 1 } };
+      // Pre-#790: 1 (m.free) + 1 (map.necro) = 2 → +1 dot too high
+      // Post-#790: 1 (map.necro only)
+      expect(meritFreeSum(m), `${name}: m.free=1 contamination must not double-count`).toBe(1);
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #774 — sibling steppers carry id + name + aria-label
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#774 — sibling stepper a11y (id + name + aria-label)', () => {
+  // Construct a merit instance that surfaces every stepper when opts are set.
+  // realIdx is arbitrary (used in the id/name suffix).
+  const fixture = (overrides = {}) => ({
+    name: 'Mentor', category: 'general', cp: 0, xp: 0, free_grants: {},
+    ...overrides,
+  });
+
+  it('MCI stepper carries id, name, and aria-label', () => {
+    const html = meritBdRow(7, fixture(), null, { showMCI: true });
+    expect(html).toContain('id="bd-mci-7"');
+    expect(html).toContain('name="bd-mci-7"');
+    expect(html).toContain('aria-label="Mystery Cult Initiation pool allocation"');
+  });
+
+  it('VM stepper carries id, name, and aria-label', () => {
+    const html = meritBdRow(3, fixture(), null, { showVM: true });
+    expect(html).toContain('id="bd-vm-3"');
+    expect(html).toContain('name="bd-vm-3"');
+    expect(html).toContain('aria-label="Viral Mythology pool allocation"');
+  });
+
+  it('LK stepper carries id, name, and aria-label', () => {
+    const html = meritBdRow(5, fixture(), null, { showLK: true });
+    expect(html).toContain('id="bd-lk-5"');
+    expect(html).toContain('name="bd-lk-5"');
+    expect(html).toContain('aria-label="Lorekeeper pool allocation"');
+  });
+
+  it('OHM stepper carries id, name, and aria-label', () => {
+    const html = meritBdRow(2, fixture(), null, { showOHM: true });
+    expect(html).toContain('id="bd-ohm-2"');
+    expect(html).toContain('name="bd-ohm-2"');
+    expect(html).toContain('aria-label="Oath of the Hard Motherfucker pool allocation"');
+  });
+
+  it('INV stepper carries id, name, and aria-label', () => {
+    const html = meritBdRow(9, fixture(), null, { showINV: true });
+    expect(html).toContain('id="bd-inv-9"');
+    expect(html).toContain('name="bd-inv-9"');
+    expect(html).toContain('aria-label="Invested pool allocation"');
+  });
+
+  it('NECRO stepper a11y preserved from N-7c', () => {
+    // Regression sentinel — N-7c's a11y wiring must remain intact across the
+    // #774 sibling pass.
+    const html = meritBdRow(1, fixture({ free_grants: {} }), null, { showNECRO: true });
+    expect(html).toContain('id="bd-necro-1"');
+    expect(html).toContain('aria-label="Necropolis pool allocation"');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Static-analysis sanity guards
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#790 + #774 — placement sanity guards', () => {
+  it('NECRO_TARGETS_FOR_SUM gate present in domain.js meritFreeSum', () => {
+    const src = read('public/js/editor/domain.js');
+    expect(src).toMatch(/NECRO_TARGETS_FOR_SUM = new Set\(/);
+    expect(src).toMatch(/NECRO_TARGETS_FOR_SUM\.has\(m\.name\)/);
+    expect(src).toMatch(/m\.free_grants && m\.free_grants\.necro/);
+  });
+
+  it('meritEffectiveRating routes through meritFreeSum (inherits exclusion)', () => {
+    const src = read('public/js/editor/domain.js');
+    const fnStart = src.indexOf('export function meritEffectiveRating');
+    const nextExport = src.indexOf('export function ', fnStart + 1);
+    const body = src.slice(fnStart, nextExport > 0 ? nextExport : src.length);
+    // Must call meritFreeSum directly (not the helper) so the gate applies.
+    expect(body).toMatch(/\+\s*meritFreeSum\(m\)/);
+    // Sanity: the pre-#790 inline pattern is gone from this function.
+    expect(body).not.toMatch(/\(m\.free \|\| 0\)\s*\+\s*_meritFreeSumHelper\(m\)/);
+  });
+
+  it('all 5 sibling stepper labels carry their aria-label', () => {
+    const src = read('public/js/editor/xp.js');
+    expect(src).toContain('aria-label="Mystery Cult Initiation pool allocation"');
+    expect(src).toContain('aria-label="Viral Mythology pool allocation"');
+    expect(src).toContain('aria-label="Lorekeeper pool allocation"');
+    expect(src).toContain('aria-label="Oath of the Hard Motherfucker pool allocation"');
+    expect(src).toContain('aria-label="Invested pool allocation"');
+    expect(src).toContain('aria-label="Necropolis pool allocation"');
+  });
+});


### PR DESCRIPTION
## Summary

Bundled two related editor-surface fixes — both touch the post-N-7c chain. Peter pre-authorised main-merge cascade for this delivery.

## #790 (URGENT) — meritFreeSum categorical exclusion

Necropolis target merits are categorically pool-funded only (N-7b suppresses all manual inputs). The single legitimate funding channel is `m.free_grants.necro`. But `meritFreeSum` at `domain.js:230` summed every channel — any stray write to `m.free` or any legacy `m.free_<slug>` silently double-counted on top of the pool allocation.

**Yusuf 2026-06-16:** 4 merits with `m.free=1` contamination of unknown origin (no current main code path writes m.free positive on these rows — treated as legacy contamination). One-shot cleanup ran on prod; this fix adds the permanent gate.

**Implementation:**
- `NECRO_TARGETS_FOR_SUM` static Set (matches N-7b's `_necroTargets` pattern; v1 hardcoded is acceptable since the targets are stable from N-3)
- `meritFreeSum` returns ONLY `m.free_grants.necro` for any merit whose name is in the set
- `meritEffectiveRating` line 299 refactored from inline 14-channel sum to route through `meritFreeSum` (single source of truth) so the exclusion applies there too
- `syncMeritRating` already consumed `meritFreeSum` — inherits naturally

## #774 — sibling stepper a11y

5 sibling steppers (MCI/VM/LK/OHM/INV) at `xp.js:227-233` got the same `id` + `name` + `aria-label` treatment as the NECRO stepper added in N-7c #771. Browsers no longer flag the form-field warnings on any stepper.

Per-source aria-labels:
- MCI: "Mystery Cult Initiation pool allocation"
- VM: "Viral Mythology pool allocation"
- LK: "Lorekeeper pool allocation"
- OHM: "Oath of the Hard Motherfucker pool allocation"
- INV: "Invested pool allocation"

## Tests

`server/tests/n7d-meritfreesum-necro-gate.test.js` — **22 cases**:

**#790 (8, behavioural):**
- `it.each` over all 6 Necropolis target names — multi-channel contamination (m.free=5, free_mci=3, free_vm=2, free_lk=4, map.necro=2, map.mci=7); pre-#790 sum = 23, post-#790 = 2 (necro only)
- Empty free_grants returns 0
- Non-Necropolis merit (Safe Place) sums all channels normally — regression sentinel
- Necropolis Sepulcher (the source, not a target) sums normally — gate scope sanity
- Trap Door (per-character bridge, NOT in collective set) sums normally
- syncMeritRating + meritEffectiveRating both inherit the exclusion
- Yusuf-shape regression sentinel (m.free=1 contamination across all 6 targets)

**#774 (6, render-and-assert):**
- MCI / VM / LK / OHM / INV steppers each carry id + name + aria-label matching realIdx
- NECRO stepper a11y preserved from N-7c (regression sentinel)

**Static-analysis sanity (3):**
- NECRO_TARGETS_FOR_SUM gate present in domain.js
- meritEffectiveRating routes through meritFreeSum (NOT inline helper)
- All 6 aria-labels present in xp.js source

## Regression

- Targeted file: 22/22 pass
- Across all touched-function tests (n7d + n7-n9-allocator-readers + feeding-grounds-double-free + applyDerivedMerits-null-cache-guard + n7a/b/c + n4a): **95/95 pass**
- No regression on closely-related domain renderer paths
- Mongo not running locally; DB-dependent test files skip at setup with ECONNREFUSED (unrelated)

## Smoke test path (post-deploy)

1. Yusuf (now clean post-script-run) — Catacombs/Caldarium/Garbage Pit/White Ants render at correct dot count
2. Any test character with deliberate m.free contamination on a Necropolis target: only the necro pool counts
3. Browser DevTools accessibility audit: no form-field warnings on any pool stepper

## Scope notes

- **In scope:** the categorical exclusion + a11y siblings + behavioural tests
- **Out of scope:** tracing origin of m.free writes (don't reproduce in current main; legacy contamination)
- **Out of scope:** data-driven NECRO_TARGETS_FOR_SUM via `getNecropolisTargets(getRulesCache())` — static set is fine for v1; matches N-7b precedent. Generalisation to future Collective Compound families would lift to data-driven.

Closes #790
Closes #774