### PR TITLE
fix(editor): #811 — sumChannels missing free_grants (root cause); bundled cleanup script

### DIFF
--- a/server/lib/normalize-character.js
+++ b/server/lib/normalize-character.js
@@ -63,6 +63,21 @@ function backfillChannel(merit) {
 function sumChannels(merit) {
   let s = 0;
   for (const ch of MERIT_CHANNELS) s += (merit[ch] || 0);
+  // Issue #811 (root-cause fix): sum the post-N-1 `free_grants` map too.
+  // Pre-fix this iterated only the legacy flat channels, so a merit whose
+  // free dots had been backfilled to the map (post-N-2) looked like sum=0
+  // and triggered the `if (sum === 0 && rating > 0)` backfill branch on
+  // every save — writing `m.free = rating` AND leaving the map populated.
+  // The two channels then read additively (client `meritFreeSum` union-
+  // sums both), doubling the dot display. Mechanism documented in
+  // specs/investigations/2026-06-16-free-channel-contamination.md. The
+  // same file's `_effectiveMeritRating` (~line 242) already sums the map
+  // — proving the canonical formula was known; sumChannels just wasn't
+  // updated when N-1 landed. Adding it here aligns with the client
+  // syncMeritRating / meritFreeSum shape too.
+  if (merit.free_grants && typeof merit.free_grants === 'object') {
+    for (const v of Object.values(merit.free_grants)) s += (v || 0);
+  }
   return s;
 }
 

--- a/server/scripts/cleanup-free-channel-contamination.js
+++ b/server/scripts/cleanup-free-channel-contamination.js
@@ -1,0 +1,176 @@
+#!/usr/bin/env node
+
+/**
+ * Issue #811 — Phase 2: cleanup of free-channel contamination from the
+ * pre-Phase-1 sumChannels bug.
+ *
+ * Mechanism (see specs/investigations/2026-06-16-free-channel-contamination.md):
+ * pre-Phase-1, `server/lib/normalize-character.js` `sumChannels` summed only
+ * the legacy flat channels and ignored `m.free_grants`. Post-N-2 backfill, a
+ * merit with map-only data looked like sum=0 to the normalizer; the
+ * `sum === 0 && rating > 0` branch fired and backfilled `m.free = rating`
+ * (or `m.free_<slug>` via `granted_by`) on EVERY save. The map then
+ * coexisted with the populated legacy field — client `meritFreeSum` union-
+ * sums both, doubling the displayed dot count.
+ *
+ * Patterns covered:
+ *
+ *   Pattern A — `m.free` populated AND any `m.free_grants.<slug>` populated.
+ *     Cause: backfill via `backfillChannel` defaulting to `'free'` when no
+ *     `granted_by` is set. Fix: zero `m.free`.
+ *
+ *   Pattern B — `m.free_<slug>` populated AND `m.free_grants.<slug>`
+ *     populated (same slug). Cause: backfill via `backfillChannel` resolving
+ *     `granted_by` to a specific slug channel. Fix: zero the legacy flat
+ *     field `m.free_<slug>`.
+ *
+ *   Pattern C (ambiguous, NOT cleaned by this script) — `m.free` populated
+ *     and NO `m.free_grants.*` populated. Could be a legitimate ST-granted
+ *     "bonus dots" allocation, or pre-N-1 contamination that was never
+ *     mirrored to the map. The script leaves these untouched; manual audit
+ *     required if a specific case surfaces.
+ *
+ * Idempotent: re-running with `--apply` after a clean pass touches 0 docs.
+ * Default mode is `--dry-run` (no writes). Pass `--apply` to commit.
+ *
+ * Usage:
+ *   cd server && node scripts/cleanup-free-channel-contamination.js
+ *   cd server && node scripts/cleanup-free-channel-contamination.js --apply
+ *
+ * dotenv path note: must be run from `server/` so `dotenv/config` picks up
+ * `server/.env`. See memory [[feedback_server_scripts_dotenv_path]].
+ */
+
+import 'dotenv/config';
+import { MongoClient } from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+const DRY_RUN = !APPLY;
+const DB_NAME = process.env.MONGODB_DB || 'tm_suite';
+
+// 14 legacy free_<slug> fields (matches LEGACY_FREE_SLUGS in
+// public/js/data/rules-helpers.js — kept in parallel until Phase 4
+// consolidates channel enumeration).
+const LEGACY_FREE_SLUGS = [
+  'attache', 'bloodline', 'carthian', 'fwb', 'inv', 'lk', 'mci', 'mdb',
+  'ohm', 'pet', 'pt', 'retainer', 'sw', 'vm',
+];
+
+/**
+ * Classify and clean a single merit. Mutates in place. Returns a diagnostics
+ * object describing what changed (or null if no change).
+ */
+export function cleanupMerit(merit) {
+  if (!merit || typeof merit !== 'object') return null;
+  const fg = (merit.free_grants && typeof merit.free_grants === 'object') ? merit.free_grants : null;
+  const mapSlugs = fg ? Object.keys(fg).filter(k => (fg[k] || 0) > 0) : [];
+  const hasMapData = mapSlugs.length > 0;
+
+  const changes = [];
+
+  // Pattern A: m.free > 0 AND map populated. Zero m.free.
+  if ((merit.free || 0) > 0 && hasMapData) {
+    changes.push({ pattern: 'A', field: 'free', before: merit.free, after: 0 });
+    merit.free = 0;
+  }
+
+  // Pattern B: m.free_<slug> > 0 AND m.free_grants[<slug>] > 0 (same slug).
+  // Zero the legacy flat field.
+  if (fg) {
+    for (const slug of LEGACY_FREE_SLUGS) {
+      const flat = 'free_' + slug;
+      const flatVal = merit[flat] || 0;
+      const mapVal = fg[slug] || 0;
+      if (flatVal > 0 && mapVal > 0) {
+        changes.push({ pattern: 'B', field: flat, slug, before: flatVal, after: 0 });
+        merit[flat] = 0;
+      }
+    }
+  }
+
+  if (!changes.length) return null;
+  return {
+    name: merit.name || '(unnamed)',
+    category: merit.category || null,
+    qualifier: merit.qualifier || merit.area || null,
+    changes,
+  };
+}
+
+async function main() {
+  const MONGODB_URI = process.env.MONGODB_URI;
+  if (!MONGODB_URI) {
+    console.error('MONGODB_URI not set. Ensure server/.env is present and the script is run from server/.');
+    process.exit(1);
+  }
+  const client = new MongoClient(MONGODB_URI);
+  await client.connect();
+  try {
+    const db = client.db(DB_NAME);
+    const characters = db.collection('characters');
+    const cursor = characters.find({}, { projection: { _id: 1, name: 1, merits: 1 } });
+
+    let charsTouched = 0;
+    let meritsTouched = 0;
+    let patternA = 0;
+    let patternB = 0;
+
+    console.log(`\n${DRY_RUN ? '[DRY RUN]' : '[APPLY]'} cleanup-free-channel-contamination.js`);
+    console.log(`Database: ${DB_NAME}`);
+    console.log('');
+
+    for await (const doc of cursor) {
+      if (!Array.isArray(doc.merits)) continue;
+      const charChanges = [];
+      let charDirty = false;
+      for (const m of doc.merits) {
+        const r = cleanupMerit(m);
+        if (r) {
+          charDirty = true;
+          meritsTouched++;
+          for (const ch of r.changes) {
+            if (ch.pattern === 'A') patternA++;
+            else if (ch.pattern === 'B') patternB++;
+          }
+          charChanges.push(r);
+        }
+      }
+      if (charDirty) {
+        charsTouched++;
+        const charLabel = `${doc.name || '(unnamed)'} [${doc._id}]`;
+        console.log(`  ${charLabel}`);
+        for (const meritChange of charChanges) {
+          const meritLabel = meritChange.qualifier
+            ? `${meritChange.name} (${meritChange.qualifier})`
+            : meritChange.name;
+          for (const ch of meritChange.changes) {
+            const fieldLabel = ch.slug ? `${ch.field} (slug: ${ch.slug})` : ch.field;
+            console.log(`    ${meritLabel.padEnd(40)} Pattern ${ch.pattern}  ${fieldLabel.padEnd(20)} ${ch.before} → ${ch.after}`);
+          }
+        }
+        if (!DRY_RUN) {
+          await characters.replaceOne({ _id: doc._id }, doc);
+        }
+      }
+    }
+
+    console.log('');
+    console.log(`Summary: ${charsTouched} character${charsTouched === 1 ? '' : 's'}, ${meritsTouched} merit${meritsTouched === 1 ? '' : 's'} affected.`);
+    console.log(`  Pattern A (m.free + map populated): ${patternA}`);
+    console.log(`  Pattern B (m.free_<slug> + map populated): ${patternB}`);
+    console.log(`  Pattern C ambiguous (m.free alone, no map): NOT cleaned by this script.`);
+    if (DRY_RUN) {
+      console.log('\n[DRY RUN] Re-run with --apply to write.');
+    } else {
+      console.log('\n[APPLY] Idempotency check: re-run with no flag (dry-run) and confirm "0 characters, 0 merits affected".');
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+// Run main() only when invoked directly. Importable for tests.
+const _invokedDirectly = import.meta.url === `file://${process.argv[1]}`;
+if (_invokedDirectly) {
+  main().catch(err => { console.error(err); process.exit(1); });
+}

--- a/server/tests/issue-811-sumchannels-rootcause.test.js
+++ b/server/tests/issue-811-sumchannels-rootcause.test.js
@@ -1,0 +1,197 @@
+/**
+ * Issue #811 — root-cause fix + cleanup script tests.
+ *
+ * Phase 1: server `sumChannels` in `server/lib/normalize-character.js` must
+ * sum `m.free_grants` map values. Pre-fix it iterated only the 14 legacy
+ * flat channels, so map-only merits returned sum=0 → triggered the
+ * `if (sum === 0 && rating > 0)` backfill branch on every save → wrote
+ * `m.free = rating` while leaving the map populated. Client union-read then
+ * doubled the displayed dot count.
+ *
+ * Phase 2: `server/scripts/cleanup-free-channel-contamination.js` exposes a
+ * pure `cleanupMerit(merit)` helper. Patterns:
+ *   - A: m.free > 0 AND map populated → zero m.free
+ *   - B: m.free_<slug> > 0 AND m.free_grants.<slug> > 0 → zero legacy flat
+ *   - C: m.free > 0 alone (no map) → ambiguous, NOT cleaned
+ *
+ * Both phases ship together — fix-without-cleanup leaves stale data,
+ * cleanup-without-fix gets re-polluted on next save.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { normalizeMerit } from '../lib/normalize-character.js';
+import { cleanupMerit } from '../scripts/cleanup-free-channel-contamination.js';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase 1 — sumChannels via normalizeMerit (sumChannels is private; assert
+// via the public normalizer's observable behaviour)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#811 Phase 1 — normalizeMerit no longer backfills m.free when map is populated', () => {
+  it('Yusuf-shape reproducer: map-only merit at rating > 0 → m.free stays 0', () => {
+    // Pre-#811: sumChannels returned 0 (ignored map), branch fired, m.free=1.
+    // Post-#811: sumChannels returns 1 (map summed), sum===rating, no backfill.
+    const m = { name: 'Catacombs', category: 'domain', cp: 0, xp: 0, free: 0, free_grants: { necro: 1 }, rating: 1 };
+    const r = normalizeMerit(m);
+    expect(m.free).toBe(0);
+    expect(m.free_grants.necro).toBe(1);
+    // No backfill — either no change (sum === rating) or just a rating sync.
+    expect(r.changed === false || r.reason === 'synced').toBe(true);
+  });
+
+  it('map-only Allies with free_grants.mci=3 at rating=3 → no m.free backfill', () => {
+    const m = { name: 'Allies', category: 'influence', cp: 0, xp: 0, free_grants: { mci: 3 }, rating: 3 };
+    normalizeMerit(m);
+    expect(m.free || 0).toBe(0);
+    expect(m.free_mci || 0).toBe(0); // backfill via granted_by would have written here
+    expect(m.free_grants.mci).toBe(3);
+  });
+
+  it('legacy + map both populated: sumChannels returns total, no spurious backfill', () => {
+    // Pattern B contaminated input arriving at the normalizer. The fix
+    // means rating gets synced to the actual sum (4+3 = 7), but m.free
+    // stays 0 — no backfill into legacy fields. Cleanup script handles
+    // the pre-existing contamination separately.
+    const m = { name: 'Mentor', category: 'general', cp: 0, xp: 0, free: 0, free_mci: 4, free_grants: { mci: 3 }, rating: 7 };
+    const r = normalizeMerit(m);
+    expect(m.free || 0).toBe(0);
+    expect(r.changed === false || r.reason !== 'backfilled').toBe(true);
+  });
+
+  it('truly empty merit at rating > 0 still triggers backfill (Pattern C / legitimate ST grant)', () => {
+    // Regression sentinel: a merit with no map AND no flat channels populated
+    // but rating > 0 should still backfill (this is the only sensible repair
+    // when no other source explains the rating).
+    const m = { name: 'Resources', category: 'influence', cp: 0, xp: 0, free: 0, rating: 2 };
+    const r = normalizeMerit(m);
+    expect(r.reason).toBe('backfilled');
+    expect(m.free).toBe(2);
+  });
+
+  it('granted_by Mentor with map-only data → no spurious free_mci backfill', () => {
+    // Pre-#811: backfillChannel resolved 'Mentor' → 'free_mci' and wrote
+    // m.free_mci = rating on top of the map. The fix prevents this.
+    const m = { name: 'Allies', category: 'influence', granted_by: 'Mentor', cp: 0, xp: 0, free_grants: { mci: 2 }, rating: 2 };
+    normalizeMerit(m);
+    expect(m.free_mci || 0).toBe(0);
+    expect(m.free_grants.mci).toBe(2);
+  });
+
+  it('rating gets synced when channels sum to a different total (regression — sync path still works)', () => {
+    // Sanity: the rating-sync branch (sum !== rating) must still fire so
+    // mis-rated merits get corrected. Pre and post-#811 behaviour the same.
+    const m = { name: 'Library', category: 'domain', cp: 2, xp: 1, free_grants: { lk: 1 }, rating: 99 };
+    const r = normalizeMerit(m);
+    expect(m.rating).toBe(4); // 2 + 1 + 1
+    expect(r.reason).toBe('synced');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase 2 — cleanupMerit helper
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#811 Phase 2 — cleanupMerit removes Pattern A + Pattern B contamination', () => {
+  it('Pattern A: m.free > 0 AND map populated → zeroes m.free, preserves map', () => {
+    const m = { name: 'Catacombs', category: 'domain', free: 1, free_grants: { necro: 1 } };
+    const r = cleanupMerit(m);
+    expect(r).not.toBeNull();
+    expect(m.free).toBe(0);
+    expect(m.free_grants.necro).toBe(1);
+    expect(r.changes[0].pattern).toBe('A');
+    expect(r.changes[0].before).toBe(1);
+  });
+
+  it('Pattern B: m.free_<slug> > 0 AND m.free_grants.<slug> > 0 → zeroes legacy flat', () => {
+    const m = { name: 'Allies', category: 'influence', free_mci: 3, free_grants: { mci: 3 } };
+    const r = cleanupMerit(m);
+    expect(r).not.toBeNull();
+    expect(m.free_mci).toBe(0);
+    expect(m.free_grants.mci).toBe(3);
+    expect(r.changes[0].pattern).toBe('B');
+    expect(r.changes[0].slug).toBe('mci');
+  });
+
+  it('Pattern A + B together: both legacy fields zeroed in one pass', () => {
+    const m = { name: 'Mentor', category: 'general', free: 2, free_lk: 1, free_grants: { lk: 1, mci: 1 } };
+    cleanupMerit(m);
+    expect(m.free).toBe(0);
+    expect(m.free_lk).toBe(0);
+    expect(m.free_grants.lk).toBe(1);
+    expect(m.free_grants.mci).toBe(1);
+  });
+
+  it('Pattern C (m.free alone, no map): NOT cleaned (ambiguous — possibly legitimate ST grant)', () => {
+    const m = { name: 'Resources', category: 'influence', free: 2 };
+    const r = cleanupMerit(m);
+    expect(r).toBeNull();
+    expect(m.free).toBe(2);
+  });
+
+  it('Pattern C variant: free_mci alone with no map → NOT cleaned (legitimate pre-N-1 data)', () => {
+    const m = { name: 'Allies', category: 'influence', free_mci: 1 };
+    const r = cleanupMerit(m);
+    expect(r).toBeNull();
+    expect(m.free_mci).toBe(1);
+  });
+
+  it('all zeros: NOT cleaned (no-op)', () => {
+    const m = { name: 'Allies', category: 'influence', cp: 0, xp: 0, free: 0, free_grants: {} };
+    const r = cleanupMerit(m);
+    expect(r).toBeNull();
+  });
+
+  it('idempotent: re-cleaning a cleaned merit yields no further changes', () => {
+    const m = { name: 'Catacombs', category: 'domain', free: 1, free_grants: { necro: 1 } };
+    const r1 = cleanupMerit(m);
+    expect(r1).not.toBeNull();
+    const r2 = cleanupMerit(m);
+    expect(r2).toBeNull();
+  });
+
+  it('bridges with normalizeMerit: cleanup then normalize leaves merit clean', () => {
+    // End-to-end: contaminated merit → cleanup zeroes contamination →
+    // normalize syncs rating against the now-clean map. No re-pollution.
+    const m = { name: 'Allies', category: 'influence', cp: 0, xp: 0, free: 0, free_mci: 3, free_grants: { mci: 3 }, rating: 3 };
+    cleanupMerit(m);
+    expect(m.free_mci).toBe(0);
+    expect(m.free_grants.mci).toBe(3);
+    const r = normalizeMerit(m);
+    expect(m.free || 0).toBe(0);
+    expect(m.free_mci || 0).toBe(0);
+    expect(m.free_grants.mci).toBe(3);
+    expect(r.changed === false || r.reason === 'synced').toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Static-analysis sanity guards
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#811 — placement sanity guards', () => {
+  it('sumChannels source includes the free_grants map iteration', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const __dirname = path.dirname(new URL(import.meta.url).pathname);
+    const REPO_ROOT = path.resolve(__dirname, '..', '..');
+    const src = fs.readFileSync(path.join(REPO_ROOT, 'server/lib/normalize-character.js'), 'utf8');
+    // Anchor the assertion inside the sumChannels function body.
+    const fnStart = src.indexOf('function sumChannels');
+    const fnEnd = src.indexOf('}', src.indexOf('return s', fnStart));
+    const body = src.slice(fnStart, fnEnd);
+    expect(body).toMatch(/merit\.free_grants\s*&&\s*typeof merit\.free_grants\s*===\s*'object'/);
+    expect(body).toMatch(/Object\.values\(merit\.free_grants\)/);
+  });
+
+  it('cleanup script exports cleanupMerit and main() is not auto-invoked on import', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const __dirname = path.dirname(new URL(import.meta.url).pathname);
+    const REPO_ROOT = path.resolve(__dirname, '..', '..');
+    const src = fs.readFileSync(path.join(REPO_ROOT, 'server/scripts/cleanup-free-channel-contamination.js'), 'utf8');
+    expect(src).toMatch(/export function cleanupMerit/);
+    // Auto-invoke must be guarded by a direct-invocation check so vitest
+    // import doesn't connect to Mongo.
+    expect(src).toMatch(/import\.meta\.url\s*===\s*`file:\/\/\$\{process\.argv\[1\]\}`/);
+  });
+});


### PR DESCRIPTION
## Summary

ROOT-CAUSE FIX for the widespread display double-counting Ma'at investigated (#808 → #810). Two phases bundled per the dispatch:

- **Phase 1 (3 lines):** `server/lib/normalize-character.js` `sumChannels` now sums `m.free_grants` map values
- **Phase 2 (cleanup script):** `server/scripts/cleanup-free-channel-contamination.js` zeroes Pattern A + Pattern B legacy contamination idempotently

Must ship together — fix-without-cleanup leaves stale data; cleanup-without-fix gets re-polluted on next save.

## Phase 1 — what was broken

Pre-fix `sumChannels` iterated `MERIT_CHANNELS` (cp + xp + free + 14 legacy slugs) but ignored `m.free_grants`. Map-only merits (post-N-2 backfill) looked like sum=0 server-side → the `if (sum === 0 && rating > 0)` branch fired → wrote `m.free = rating` (or `m.free_<slug>` via `granted_by`) while leaving the map populated. Client `meritFreeSum` union-summed both → dot display doubled.

Same file's `_effectiveMeritRating` (line ~242) already summed the map correctly — proves the canonical formula was known; `sumChannels` just wasn't updated when N-1 landed.

**Fix:** 3 lines added to `sumChannels` — iterate `Object.values(free_grants)` and add to the sum. Aligns with `_effectiveMeritRating` + client `syncMeritRating` / `meritFreeSum`.

#790's `NECRO_TARGETS_FOR_SUM` gate is now revealed as a band-aid for this exact bug on Necropolis targets specifically. **Phase 3** (separate story) will remove that gate once Phase 1+2 settle.

## Phase 2 — cleanup script

`server/scripts/cleanup-free-channel-contamination.js`:

| Pattern | Trigger | Action |
|---|---|---|
| **A** | `m.free > 0` AND `m.free_grants.*` populated | zero `m.free` |
| **B** | `m.free_<slug> > 0` AND `m.free_grants.<slug> > 0` (same slug) | zero `m.free_<slug>` |
| **C** | `m.free > 0` alone (no map) | **NOT cleaned** — ambiguous (possibly legitimate ST grant) |

- `--dry-run` default; `--apply` to write
- Idempotent (re-running on cleaned merits yields 0 touches)
- Importable for tests: `main()` is direct-invocation guarded; `MONGODB_URI` check moved inside `main` so the module imports cleanly

## Tests

`server/tests/issue-811-sumchannels-rootcause.test.js` — **16 cases**:

**Phase 1 (6, behavioural via `normalizeMerit`):**
- Yusuf-shape reproducer (`{cp:0, xp:0, free:0, free_grants:{necro:1}, rating:1}` → `m.free` stays 0)
- Map-only Allies (no backfill)
- Legacy + map both populated (no spurious backfill; rating syncs)
- Truly empty merit at rating > 0 **still backfills** (regression sentinel — the legitimate use of the backfill branch)
- `granted_by: Mentor` with map-only data (no `free_mci` backfill via `backfillChannel`)
- Rating-sync path still fires when `sum !== rating` (regression — sync branch must work)

**Phase 2 (8, `cleanupMerit` unit):**
- Pattern A / B / A+B / C ambiguous (Pattern C variant for legacy `free_<slug>` alone)
- All-zero merit no-op
- Idempotency: second pass yields no changes
- End-to-end: cleanup → normalize keeps merit clean

**Static-analysis sanity (2):**
- `sumChannels` source contains the `free_grants` iteration
- Cleanup script exports `cleanupMerit` + `main()` is direct-invocation guarded

## --dry-run snapshot

**Not included** — script requires `MONGODB_URI` which is hook-blocked from this dev environment. Recommend:

```sh
cd server && node scripts/cleanup-free-channel-contamination.js
```

(dry-run default) before `--apply` to produce the audit baseline against `tm_suite`. Expected scope per Ma'at's #810 investigation: **~60 merit instances across ~13 characters**.

## Regression

- Targeted file: 16/16 pass
- Across all closely-related files (sumchannels-rootcause + n7d + n7a/b/c + n4a + collective-1): **92/92 pass**
- No regression on related domain renderer / normalizer paths
- Mongo not running locally; DB-dependent test files skip at setup with ECONNREFUSED (unrelated)

## Smoke test path (post-deploy)

1. Run cleanup `--dry-run` against `tm_suite`, confirm scope matches Ma'at's audit (~60 instances)
2. Run `--apply` to zero Pattern A + B contamination
3. Run dry-run again — expect 0 docs touched (idempotency)
4. Any character edits made through admin: subsequent server normalize doesn't re-pollute
5. Yusuf + Xavier + COLLECTIVE-1 row displays show correct cumulative dots (own + cross-owner)

## Pre-auth

Per the dispatch — **main-merge pre-authorised**. Khepri cascades dev → main on dev merge clear.

## Out of scope (Phase 3+4)

- Remove `NECRO_TARGETS_FOR_SUM` gate from `meritFreeSum` (Phase 3 — small cleanup story after settling period)
- Server imports `LEGACY_FREE_SLUGS` from `public/js/data/rules-helpers.js` to consolidate channel enumeration; closes the dual-view bug class (Phase 4 — architectural cleanup)

Closes #811