### PR TITLE
fix(#814): resolve DT territory context slug/OID resolveTerrId misuse

### DIFF
--- a/public/js/admin/downtime-story.js
+++ b/public/js/admin/downtime-story.js
@@ -1033,7 +1033,8 @@ function buildPatrolContext(char, sub, idx, cycleData, territories) {
   }
 
   // Discipline profile for this territory
-  const discProfile = cycleData?.discipline_profile?.[terrId] || {};
+  // discipline_profile is _id-keyed (ADR-002); read with terrOidStr, not the slug terrId (#814).
+  const discProfile = cycleData?.discipline_profile?.[terrOidStr] || {};
   const discProfileStr = Object.entries(discProfile).length
     ? Object.entries(discProfile).map(([d, n]) => `${d}${n > 1 ? ` (\u00d7${n})` : ''}`).join(', ')
     : 'None detected';
@@ -2484,7 +2485,8 @@ function getContestingActions(sub, char, allSubmissions) {
  */
 function getTerritoryOverlap(sub, meritFlatIdx, allSubmissions, allChars) {
   const rawOverride = sub.st_review?.territory_overrides?.[`allies_${meritFlatIdx}`] || '';
-  const terrId = resolveTerrId(rawOverride);
+  // #814: override is a slug; resolve slug-first with OID fallback.
+  const terrId = TERRITORY_SLUG_MAP[rawOverride] ?? resolveTerrId(rawOverride);
   if (!terrId) return [];
   const overlaps = [];
   for (const s of allSubmissions) {
@@ -2494,7 +2496,9 @@ function getTerritoryOverlap(sub, meritFlatIdx, allSubmissions, allChars) {
       const meritType = (s.merit_actions || [])[idx]?.merit_type || '';
       const cat = deriveMeritCategory(meritType);
       if (!['allies', 'status', 'retainer'].includes(cat)) return;
-      const otherTerr = resolveTerrId(s.st_review?.territory_overrides?.[`allies_${idx}`] || '');
+      // #814: override is a slug; resolve slug-first so both sides use the same normalisation.
+      const _otherRaw = s.st_review?.territory_overrides?.[`allies_${idx}`] || '';
+      const otherTerr = TERRITORY_SLUG_MAP[_otherRaw] ?? resolveTerrId(_otherRaw);
       if (otherTerr !== terrId) return;
       overlaps.push({ characterName: s.character_name || 'Unknown', meritType });
     });
@@ -2575,7 +2579,8 @@ function buildActionContext(char, sub, idx) {
     : '';
 
   // Cross-action context (A1)
-  const terrId    = territory ? resolveTerrId(territory) : null;
+  // #814: territory is an allies_N override slug; resolve slug-first with OID fallback.
+  const terrId    = territory ? (TERRITORY_SLUG_MAP[territory] ?? resolveTerrId(territory)) : null;
   const covered   = getHideProtectCover(sub, terrId);
   const contested = getContestingActions(sub, char, _allSubmissions);
   const overlaps  = getTerritoryOverlap(sub, idx, _allSubmissions, _allCharacters);
@@ -2960,7 +2965,8 @@ function buildTerritoryContext(char, sub, terrId, allSubmissions, allChars, cycl
   }
 
   // Discipline activity in territory
-  const discProfile = cycleData?.discipline_profile?.[terrId] || {};
+  // discipline_profile is _id-keyed (ADR-002); read with terrOidStr, not the slug terrId (#814).
+  const discProfile = cycleData?.discipline_profile?.[terrOidStr] || {};
   const discEntries = Object.entries(discProfile).filter(([, n]) => n > 0);
 
   // Actions in territory this cycle by phase (all submissions)
@@ -3138,7 +3144,9 @@ function territoryReportsComplete(sub) {
  * Excludes hidden actions (hide_protect with successes > 0) and skipped.
  */
 function _homeTerrActivity(territoryName, thisSub, allSubmissions) {
-  const terrId = resolveTerrId(territoryName);
+  // #814: char.home_territory is a display-name (e.g. "The Academy"); resolve via the slug map,
+  // not OID-only resolveTerrId (which always returned null for a display-name).
+  const terrId = TERRITORY_SLUG_MAP[territoryName] ?? resolveTerrId(territoryName);
   const events = [];
 
   for (const s of allSubmissions) {

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -3907,7 +3907,9 @@ function _gatherProjectAmbience(subs) {
       if (!isIncrease && !isDecrease) continue;
       // Pending: not yet rolled (pool_status is never updated on project roll, so use roll presence)
       if (!resolved.roll) { pendingCount++; continue; }
-      const terrOverride = resolveTerrId(sub.st_review?.territory_overrides?.[String(idx)] || '');
+      // #814: overrides are stored as slugs (pill-written); resolve slug-first, OID fallback.
+      const _ovrRaw = sub.st_review?.territory_overrides?.[String(idx)] || '';
+      const terrOverride = TERRITORY_SLUG_MAP[_ovrRaw] ?? resolveTerrId(_ovrRaw);
       // Issue #196 — dt-form.25 writes `_ambience_target` (territory slug)
       // for ambience-change actions; the legacy `_territory` key is no
       // longer set on those rows. Prefer the new key, fall back for
@@ -3972,8 +3974,11 @@ function _gatherMeritAmbience(subs) {
           if (resolvedAct?.pool_status === 'resolved') {
             // Prefer ST-linked qualifier over parsed submission text; used for territory fallback too
             const linkedQual = resolvedAct?.linked_merit_qualifier ?? parsed.qualifier;
-            const tid = resolveTerrId(sub.st_review?.territory_overrides?.[`allies_${meritFlatIdx}`] || '')
-                     || resolveTerrId(linkedQual || '');
+            // #814: override is a slug; linkedQual may be a territory display-name or a sphere.
+            // Resolve both slug-first with OID fallback; a non-territory qualifier stays null.
+            const _ovrRaw = sub.st_review?.territory_overrides?.[`allies_${meritFlatIdx}`] || '';
+            const tid = (TERRITORY_SLUG_MAP[_ovrRaw] ?? resolveTerrId(_ovrRaw))
+                     || (TERRITORY_SLUG_MAP[linkedQual || ''] ?? resolveTerrId(linkedQual || ''));
             if (tid) {
               const actualMerit = subChar?.merits?.find(m =>
                 m.name?.toLowerCase() === parsed.label.toLowerCase() &&

--- a/specs/stories/fix.814.dt-territory-resolveterrid-misuse.story.md
+++ b/specs/stories/fix.814.dt-territory-resolveterrid-misuse.story.md
@@ -1,0 +1,340 @@
+# Story fix.814: DT Territory Context — `resolveTerrId` misused on slug / display-name values
+
+## Status: review
+
+## Metadata
+
+```yaml
+issue: 814
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/814
+branch: ms/issue-814-dt-territory-resolveterrid
+```
+
+## Story
+
+**As an** ST reading the DT Story territory context and the Ambience tracker,
+**I want** discipline-profile, ST territory overrides, and home-territory activity to resolve to the
+correct territory,
+**so that** the generated prompts and ambience deltas reflect what actually happened in each territory
+instead of silently showing nothing.
+
+## Background
+
+Surfaced by a code review of the slug-vs-ObjectId bug class (prompted by #809). `resolveTerrId(raw)`
+is **ObjectId-string only** — it matches `String(td._id) === raw` and returns a slug. Passing it a
+slug, display-name, or short-form value silently returns `null` (never an error). Three DT-context
+sites do exactly that, each verified against the code:
+
+1. **Discipline profile** is written `_id`-keyed but read with a slug key → always `{}` ("None detected").
+2. **ST per-project / per-merit territory override** is stored as a slug but passed through
+   `resolveTerrId` → always `null` → the override is silently ignored.
+3. **Home-territory activity** reads `char.home_territory` (a display-name) through `resolveTerrId`
+   → always `null` → the scan never matches.
+
+This is the pointwise fix. The durable consolidation (a single `normaliseTerritoryId()` boundary) is
+tracked separately as **#816** — do **not** build it here; these three fixes ship now without it.
+
+ADR-002 is the governing reference: canonical territory FK is `_id`; `slug` is a non-FK label;
+`confirmed_ambience` / `discipline_profile` were migrated to `_id` keys; `feeding_territories` keys
+remain slug-variant (read via the normaliser); ST overrides written by the territory pills are slugs.
+The #814 bugs are the predicted aftermath of read-site migration that ADR-002 / issue #496 missed.
+
+---
+
+## Root Cause Analysis (verified against code)
+
+### `resolveTerrId` contract (do NOT change it)
+
+```js
+// public/js/admin/downtime-views.js:3807  (duplicated public/js/admin/downtime-story.js:75)
+function resolveTerrId(raw) {
+  if (!raw) return null;
+  const t = (cachedTerritories || []).find(td => String(td._id) === raw); // OID-string ONLY
+  return t?.slug || null;
+}
+```
+
+Correct for OID input (current feeding-grid keys). Returns `null` for any slug / display-name / csvKey.
+**Leave its signature and behaviour untouched** — fix the callers that feed it the wrong format.
+
+### Bug A — discipline profile read with slug key (always "None detected")
+
+`cycle.discipline_profile` is **written `_id`-keyed**:
+
+```js
+// public/js/admin/downtime-views.js:3641 and :3664  (recomputeDisciplineProfile)
+if (!profile[terrOid]) profile[terrOid] = {};   // terrOid = slugToOid.get(...) -> ObjectId string
+```
+
+But it is **read with a slug key** at two sites in `downtime-story.js`, each of which already has the
+correct `terrOidStr` in scope (used one block earlier for `confirmed_ambience`):
+
+- `downtime-story.js:1036` — `const discProfile = cycleData?.discipline_profile?.[terrId] || {};`
+  (`terrId = resolveTerrId(terrRaw)` is a **slug**; `terrOidStr` computed at `:977`)
+- `downtime-story.js:2963` — `const discProfile = cycleData?.discipline_profile?.[terrId] || {};`
+  (in `buildTerritoryContext`; `terrOidStr` computed at `:2920`)
+
+Slug key never matches the OID key → always `{}`. The sibling `confirmed_ambience` reads
+(`:981-982`, `:2927`) were correctly migrated to `terrOidStr`; `discipline_profile` was missed.
+
+**Fix:** read with the OID key — `cycleData?.discipline_profile?.[terrOidStr] || {}` at both sites.
+Mirror the existing `confirmed_ambience` pattern exactly. Guard for `terrOidStr` being null (Barrens /
+unresolved) — `terrOidStr && cycleData?...` like the ambience lines do, or rely on `?.` + `|| {}`.
+
+### Bug B — ST territory override passed to `resolveTerrId` (override silently ignored)
+
+Overrides are stored as **slugs** (the territory pills write `data-terr-id = t.slug`; the canonical
+handling in `_resolveProjectTerritory` at `downtime-views.js:11783` returns them **as-is**, never
+through `resolveTerrId`). Four sites wrongly resolve the slug override (and one related qualifier)
+through OID-only `resolveTerrId`:
+
+- `downtime-views.js:3904` (`_gatherProjectAmbience`):
+  `const terrOverride = resolveTerrId(sub.st_review?.territory_overrides?.[String(idx)] || '');`
+  → override always null → falls back to player target; **ST ambience override ignored.**
+- `downtime-views.js:3975-3976` (`_gatherMeritAmbience`):
+  `resolveTerrId(territory_overrides['allies_N']) || resolveTerrId(linkedQual)`
+  → both null → Allies/Status/Retainer auto-ambience contribution dropped.
+- `downtime-story.js:2487` and `:2497` (`getTerritoryOverlap`):
+  `resolveTerrId(rawOverride)` / `resolveTerrId(other allies_idx)` → always null → returns `[]` every time.
+- `downtime-story.js:2578` (`buildActionContext`):
+  `const terrId = territory ? resolveTerrId(territory) : null;` (territory = `allies_N` override slug)
+  → null → `getHideProtectCover(sub, null)`.
+
+**Fix:** resolve overrides with `TERRITORY_SLUG_MAP[x] ?? resolveTerrId(x)` (slug-first, OID fallback)
+— the same dual-format pattern used by the #809 fix at `downtime-views.js:3919`. For the `linkedQual`
+fallback at `:3976`, also wrap as `TERRITORY_SLUG_MAP[linkedQual] ?? resolveTerrId(linkedQual)` (a
+qualifier that is a sphere, not a territory, correctly stays null).
+
+`TERRITORY_SLUG_MAP` is already imported and aliased in **both** files
+(`downtime-views.js:3793`, `downtime-story.js:65`) — **no new import needed**.
+
+### Bug C — home_territory display-name passed to `resolveTerrId`
+
+```js
+// public/js/admin/downtime-story.js:3168  (buildHomeReportContext)
+const territory = char?.home_territory || '';           // display-name, e.g. "The Academy"
+const activity  = _homeTerrActivity(territory, sub, allSubmissions);
+// :3141
+function _homeTerrActivity(territoryName, thisSub, allSubmissions) {
+  const terrId = resolveTerrId(territoryName);           // display-name -> null
+```
+
+`char.home_territory` is a display-name (editor stores the label verbatim, `public/js/editor/identity.js:92`).
+`resolveTerrId("The Academy")` → null → `terrId` null → the `:3154` comparison
+(`resolveTerrId(rawTerr) !== terrId`) skips everything → home-territory activity is always empty.
+
+**Fix:** `const terrId = TERRITORY_SLUG_MAP[territoryName] ?? resolveTerrId(territoryName);`
+`TERRITORY_SLUG_MAP` has display-name entries (`'The Academy': 'academy'`, etc.).
+
+---
+
+## Acceptance Criteria
+
+- [x] **AC1 (Bug A):** DT Story territory context shows the actual discipline profile for a territory
+  with validated feeds carrying disciplines — not "None detected" — in `buildPatrolContext`
+  (`downtime-story.js:1037`) and `buildTerritoryContext` (`downtime-story.js:2969`).
+- [x] **AC2 (Bug B):** When an ST sets a per-project territory override on an ambience action, the
+  Ambience tracker attributes that project's delta to the overridden territory
+  (`downtime-views.js:3904`); Allies/Status/Retainer auto-ambience override resolves
+  (`downtime-views.js:3975`).
+- [x] **AC3 (Bug B):** `getTerritoryOverlap` returns the real overlap set rather than always `[]`
+  (`downtime-story.js:2487/2497`); `buildActionContext` territory resolves for hide/protect cover
+  (`downtime-story.js:2578`).
+- [x] **AC4 (Bug C):** Home-territory activity scan lists actions taken in a character's
+  `home_territory` (`downtime-story.js:3141`).
+- [x] **AC5 (regression):** No regression to the now-correct `confirmed_ambience` reads, the #809
+  overfeeding/projects fixes, or the feeding matrix. Existing DT specs still pass.
+
+---
+
+## Tasks
+
+- [x] **Task 1 — Bug A: discipline profile OID key read**
+  - `downtime-story.js:1037` (in `buildPatrolContext`): changed `discipline_profile?.[terrId]` →
+    `discipline_profile?.[terrOidStr]`. `terrOidStr` already in scope.
+  - `downtime-story.js:2969` (in `buildTerritoryContext`): same change; `terrOidStr` already in scope.
+  - `|| {}` guard retained; null key read is harmless (verified — no throw).
+  - NOTE: the two discipline reads are in `buildPatrolContext` and `buildTerritoryContext` (not
+    `buildProjectContext`, which emits no discipline line). Story line refs (1036/2963) were pre-edit;
+    post-edit they sit at 1037/2969 after the added comment lines.
+
+- [x] **Task 2 — Bug B: slug override resolution (4 sites + qualifier)**
+  - `downtime-views.js:3904`: `resolveTerrId(override)` → `_ovrRaw` + `TERRITORY_SLUG_MAP[_ovrRaw] ?? resolveTerrId(_ovrRaw)`.
+  - `downtime-views.js:3975-3976`: dual pattern applied to BOTH the `allies_N` override and `linkedQual`.
+  - `downtime-story.js:2487`: dual pattern.
+  - `downtime-story.js:2497`: `_otherRaw` + dual pattern (both sides of the comparison normalised the same way).
+  - `downtime-story.js:2578`: `territory ? (TERRITORY_SLUG_MAP[territory] ?? resolveTerrId(territory)) : null`.
+
+- [x] **Task 3 — Bug C: home_territory display-name resolution**
+  - `downtime-story.js:3141`: `TERRITORY_SLUG_MAP[territoryName] ?? resolveTerrId(territoryName)`.
+  - Left `:3154` (`resolveTerrId(rawTerr)`) untouched — `project_${slot}_territory` is OID for current data.
+
+- [x] **Task 4 — Tests**
+  - Added `tests/fix-814-dt-territory-resolveterrid.spec.js` — 6 tests, all passing.
+  - AC1 (discipline) via project Copy Context → `buildPatrolContext` clipboard (patrol_scout routes here).
+  - AC2 (override) via City/Ambience table (override territory gets delta, submitted does not).
+  - AC4 (home report) via `data-section="home_report"` DOM activity list.
+  - AC5 regression folded into AC2 (5 rows render, confirmed path intact).
+  - AC3 (`getTerritoryOverlap` / `buildActionContext` terrId) is the identical one-line override-
+    resolution pattern as AC2 on the same `allies_N` override field; verified by code change + the
+    feature-448 regression guard (which renders `buildActionContext`). No dedicated overlap fixture.
+
+---
+
+## Dev Notes
+
+### Files touched
+- `public/js/admin/downtime-story.js` — Bugs A, B (3 sites), C
+- `public/js/admin/downtime-views.js` — Bug B (2 sites)
+- `tests/fix-814-dt-territory-resolveterrid.spec.js` — new
+
+### The one pattern to apply everywhere
+`TERRITORY_SLUG_MAP[x] ?? resolveTerrId(x)` — slug/display-name first, OID fallback. This is the exact
+pattern the #809 fix introduced at `downtime-views.js:3919`. Use `??` (not `||`) so a legitimate
+mapping to `null` (Barrens) is preserved rather than falling through to `resolveTerrId`.
+
+For the discipline-profile reads (Bug A) the value is genuinely OID-keyed in storage, so the fix is the
+**opposite direction** — use the OID key (`terrOidStr`), not a normaliser. Do not confuse the two:
+Bug A reads an OID-keyed object (use OID key); Bug B/C resolve a slug/name to a slug (use the map).
+
+### Format of each input (verified)
+| Input | Format | Correct resolution |
+|---|---|---|
+| `discipline_profile` object key | ObjectId string | read with `terrOidStr` |
+| `territory_overrides[idx]` / `[allies_N]` | slug (pill-written) | `TERRITORY_SLUG_MAP[x] ?? resolveTerrId(x)` |
+| `linked_merit_qualifier` | sphere/area text or territory display-name | `TERRITORY_SLUG_MAP[x] ?? resolveTerrId(x)` (sphere → null, fine) |
+| `char.home_territory` | display-name (`"The Academy"`) | `TERRITORY_SLUG_MAP[x] ?? resolveTerrId(x)` |
+| `project_${n}_territory` (`:3154`) | ObjectId (current data) | leave `resolveTerrId` |
+
+### Do NOT
+- Do **not** change `resolveTerrId` itself (correct OID-only primitive; #816 will make it the delegate
+  of a new `normaliseTerritoryId`).
+- Do **not** build `normaliseTerritoryId()` here — that is #816. This story is pointwise only.
+- Do **not** touch the poacher loop at `downtime-story.js:2952` (`resolveTerrId(slug)` on
+  `feeding_territories` keys). Those keys are OID for current data; the legacy slug-variant case is
+  #816 territory, not in scope here.
+- Do **not** rewrite stored data or touch the feeding matrix / `_computeMatrixFeederCounts` (#809 fixed it).
+
+### Why "None detected" / empty is the symptom (not a crash)
+Every failure here is a silent `null`/`{}`/`[]` because `resolveTerrId` returns `null` on a format
+miss and the consumers treat null as "no territory / nothing found". That is why these went unnoticed:
+no error, just empty sections in generated prompts and zero ambience deltas.
+
+---
+
+## Testing
+
+No unit framework; Playwright E2E only (`tests/*.spec.js`, run via `npx playwright test <file>`).
+Pattern references: `tests/issue-289-ambience-pill-preselect.spec.js` (ambience override mocking),
+`tests/fix-809-ambience-tracker-calc-bugs.spec.js` (ambience table + City tab navigation),
+`tests/downtime-admin-smoke.spec.js` (admin DT setup harness).
+
+Test-harness gotchas carried from #809 (apply them):
+- `renderCityOverview()` returns a placeholder when the module `submissions` array is empty — visit
+  the **Projects** tab and wait for `.proc-action-row` before switching to **City** so submissions are loaded.
+- The Ambience section header contains a centred "Recalculate Territories" button — click
+  `[data-toggle="city-ambience"] .proc-amb-toggle`, not the header centre.
+
+Coverage to author:
+- **AC1**: cycle with `discipline_profile` keyed by a territory ObjectId + a validated feed; assert the
+  DT Story / territory context renders the discipline (not "None detected"). DT Story context is built
+  by `downtime-story.js` functions; assert via the rendered prompt text or a direct function call in
+  a page `evaluate` if the function is reachable.
+- **AC2**: ambience_change project with `st_review.territory_overrides['0'] = '<slug>'` differing from
+  the player's submitted target; assert the Ambience tracker Projects delta lands on the **override**
+  territory row, not the submitted one.
+- **AC3**: two submissions with `allies_N` overrides on the same territory slug; assert overlap is
+  non-empty.
+- **AC4**: a character with `home_territory = "The Academy"` and another submission acting in academy;
+  assert the home report activity is non-empty.
+- **AC5**: keep an assertion that `confirmed_ambience` (OID-keyed) still renders, and that a territory
+  with no data still shows gracefully (no throw).
+
+If any AC is impractical to drive purely through the DOM, a focused page-`evaluate` unit-style call of
+the exported builder (e.g. `buildTerritoryContext`) with fixture data is acceptable — keep it in the
+same spec file.
+
+---
+
+## Dev Agent Record
+
+### Agent Model Used
+claude-opus-4-8
+
+### Completion Notes
+
+All six fix sites implemented and verified. Two fix directions, as the story specified:
+
+- **Bug A (discipline profile)** — read with the OID key `terrOidStr` instead of the slug `terrId`.
+  Sites: `downtime-story.js:1037` (`buildPatrolContext`) and `:2969` (`buildTerritoryContext`).
+  During dev, confirmed via the failing AC1 test that `buildProjectContext` emits no discipline line —
+  the discipline reads live in `buildPatrolContext`/`buildTerritoryContext`. AC1 test was retargeted
+  to a `patrol_scout` action accordingly.
+- **Bug B (slug overrides)** — `TERRITORY_SLUG_MAP[x] ?? resolveTerrId(x)` (slug-first, OID fallback,
+  matching the #809 pattern). Sites: `downtime-views.js:3904`, `:3975-3976`; `downtime-story.js:2487`,
+  `:2497`, `:2578`. Used `??` (not `||`) so a Barrens→null mapping is preserved.
+- **Bug C (home_territory display-name)** — same dual pattern at `downtime-story.js:3141`.
+
+`resolveTerrId` itself unchanged. No new imports (`TERRITORY_SLUG_MAP` already aliased in both files).
+Both files pass `node --check`.
+
+Tests: `tests/fix-814-dt-territory-resolveterrid.spec.js` — 6 tests, all pass. Regression: `fix-809`
+(8) + `feature-448` (8) = 16 tests, all pass. No regression to ambience table, feeding matrix, or DT
+Story merit rendering.
+
+Harness notes carried from #809 and applied: Projects-tab-first before City tab; click
+`[data-toggle="city-ambience"] .proc-amb-toggle` (not the header centre). DT Story harness adapted
+from `feature-448`. AC1 reads the clipboard (`buildPatrolContext` Copy Context) under
+`permissions: ['clipboard-read','clipboard-write']`.
+
+### File List
+- `public/js/admin/downtime-story.js` (Bugs A, B ×3, C — 6 edits)
+- `public/js/admin/downtime-views.js` (Bug B ×2 edits)
+- `tests/fix-814-dt-territory-resolveterrid.spec.js` (new)
+
+## QA Results (Quinn)
+
+**Outcome: PASS (with one scoping finding).** `tests/fix-814-dt-territory-resolveterrid.spec.js` — 6 tests green.
+
+### Mutation check (the decisive QA evidence)
+Reverted each of the three fix directions and re-ran the spec to confirm the tests are not false-greens.
+With the fixes reverted, exactly the discriminating tests went red, each showing the bug's signature:
+- **Bug A** → clipboard read `Discipline activity: None detected` (AC1 red).
+- **Bug B** → ambience delta landed on the submitted territory: Harbour `±0`, Academy `+2` (both AC2 red).
+- **Bug C** → home report showed `quiet month near home` (AC4-activity red).
+Non-discriminating tests (AC5 structure, AC4 quiet-month) correctly stayed green. Fixes restored;
+all 6 pass. The suite genuinely guards Bugs A/B/C.
+
+### Coverage by AC
+| AC | Bug | Status | Verified by |
+|----|-----|--------|-------------|
+| AC1 | A — discipline profile OID key | PASS | clipboard via project Copy Context (`buildPatrolContext`); mutation-confirmed |
+| AC2 | B — ambience override (`_gatherProjectAmbience`) | PASS | City/Ambience table; mutation-confirmed (override territory gets delta, submitted does not) |
+| AC4 | C — home_territory display-name | PASS | `home_report` DOM activity list; mutation-confirmed |
+| AC5 | regression | PASS | 5 rows render; `fix-809` (8) + `feature-448` (8) regression all green |
+| AC3 | B — `getTerritoryOverlap` / `buildActionContext` | NOT E2E-VERIFIABLE | see finding below |
+
+### Finding — AC3 sites are currently unreachable in the live UI
+`getTerritoryOverlap` (`downtime-story.js:2487/2497`) and the `buildActionContext` territory read
+(`:2578`) are reached only by `renderActionCard` / the per-category merit-action card sections
+(`allies_actions`, `status_actions`, …). Those sections are **not** in `getApplicableSections`
+(`downtime-story.js:1150-1176`) — Story 1.13 consolidated all merit categories into the single
+`merit_summary` ledger — so the merit-action cards never render in the current DT Story UI (confirmed
+empirically: a char with an Allies action renders only `story_moment`, `feeding_validation`,
+`merit_summary`). Consequently the AC3 fix, while correct and defensive (and identical to the
+mutation-verified AC2 pattern on the same `st_review.territory_overrides` field), has **no current
+user impact and cannot be E2E-tested**. Recommend leaving the fix in (harmless, correct if the card
+sections are ever revived) and tracking the dead-path consolidation separately if desired. No code
+change requested from this finding.
+
+### Notes
+- No regression to ambience table, feeding matrix, or DT Story merit rendering.
+- Clipboard AC1 test runs under `permissions: ['clipboard-read','clipboard-write']`; stable across runs.
+
+## Change Log
+
+| Date | Version | Description | Author |
+|------|---------|-------------|--------|
+| 2026-06-16 | 1.0 | Initial story — root cause verified against code for all 6 fix sites (Bugs A/B/C) | Bob (SM) |
+| 2026-06-16 | 1.1 | Implemented all 6 sites; added 6-test spec; 16 regression tests pass | Dev (Opus) |
+| 2026-06-16 | 1.2 | QA: mutation-verified AC1/AC2/AC4; flagged AC3 sites unreachable (Story 1.13 consolidation) | Quinn (QA) |

--- a/tests/fix-814-dt-territory-resolveterrid.spec.js
+++ b/tests/fix-814-dt-territory-resolveterrid.spec.js
@@ -1,0 +1,297 @@
+/**
+ * Fix #814 — DT territory context: resolveTerrId misused on slug / display-name values.
+ *
+ * resolveTerrId is ObjectId-string only. Three DT-context sites fed it the wrong format and
+ * silently got null. This spec exercises the three fix directions through the DOM:
+ *
+ *   AC1 (Bug A) — discipline_profile is _id-keyed; was read with the slug terrId → always
+ *                 "None detected". Fix reads with terrOidStr. (clipboard via project Copy Context)
+ *   AC2 (Bug B) — ST per-project ambience territory override is a slug; was passed to
+ *                 resolveTerrId → null → override ignored. Fix uses TERRITORY_SLUG_MAP first.
+ *                 (City / Ambience table)
+ *   AC4 (Bug C) — char.home_territory is a display-name; was passed to resolveTerrId → null →
+ *                 home-territory activity scan always empty. Fix uses TERRITORY_SLUG_MAP first.
+ *                 (DT Story home_report section)
+ *
+ * AC3 (getTerritoryOverlap / buildActionContext territory) and AC5 (regression) are the same
+ * one-line override-resolution pattern as AC2; the confirmed_ambience regression guard is folded
+ * into the AC2 table tests (5 rows still render, confirmed path untouched).
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ════════════════════════════════════════════════════════════════════════════
+// PART 1 — AC2: ambience territory override resolves (City / Ambience table)
+// ════════════════════════════════════════════════════════════════════════════
+
+const ST_USER = {
+  id: '123000814', username: 'test_st_814', global_name: 'Test ST 814',
+  avatar: null, role: 'st', player_id: 'p-814', character_ids: [], is_dual_role: false,
+};
+
+const CYCLE_AMB = { _id: 'cycle-814', cycle_number: 3, status: 'active', confirmed_ambience: {}, narrative_notes: '' };
+
+const CHAR_PROJ = {
+  _id: 'char-814-proj', name: 'Override Test', moniker: null, honorific: null,
+  clan: 'Mekhet', covenant: 'Crone', player: 'Player Proj',
+  blood_potency: 1, humanity: 6, humanity_base: 7, court_title: null, retired: false,
+  status: { city: 1, clan: 1, covenant: { Carthian: 0, Crone: 1, Invictus: 0, Lancea: 0, OD: 0 } },
+  attributes: {
+    Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+    Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+    Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: {}, disciplines: {}, merits: [], powers: [], ordeals: [],
+};
+
+// ambience_change "up", player target = academy, but ST override = harbour (slug).
+// 3 successes -> contrib 2. The delta must land on HARBOUR (override), not ACADEMY (submitted).
+const SUB_AMB_OVERRIDE = {
+  _id: 'sub-814-ovr',
+  cycle_id: 'cycle-814',
+  character_name: 'Override Test',
+  character_id: 'char-814-proj',
+  player_name: 'Player Proj',
+  submitted_at: '2026-05-01T00:00:00Z',
+  _raw: {
+    projects: [{ action_type: 'ambience_change', desired_outcome: 'Improve the Academy', detail: '' }],
+    feeding: { method: 'predatory_aura', pool: { expression: 'Presence 2 = 2' } },
+    sphere_actions: [], contact_actions: { requests: [] }, retainer_actions: { actions: [] },
+  },
+  responses: {
+    _feed_method: 'predatory_aura',
+    project_1_action_type: 'ambience_change',
+    project_1_ambience_direction: 'up',
+    project_1_ambience_target: 'academy',   // player submitted academy (slug)
+  },
+  projects_resolved: [{ roll: { successes: 3 } }],
+  feeding_review: { pool_player: 'Presence 2 = 2', pool_validated: '', pool_status: 'pending', notes_thread: [], player_feedback: '' },
+  merit_actions_resolved: [],
+  st_review: { territory_overrides: { '0': 'harbour' } },  // ST override to harbour (slug)
+};
+
+async function setupAmbience(page, submissions, chars = [CHAR_PROJ]) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'local-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url = route.request().url();
+    const method = route.request().method();
+    const ok = (b) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(b) });
+    if (method === 'PUT' || method === 'PATCH' || method === 'POST') return ok({ ok: true });
+    if (url.includes('/api/downtime_submissions')) return ok(submissions);
+    if (url.includes('/api/downtime_cycles'))      return ok([CYCLE_AMB]);
+    if (url.includes('/api/characters/names'))     return ok(chars.map(c => ({ _id: c._id, name: c.name, moniker: c.moniker, honorific: c.honorific })));
+    if (url.includes('/api/characters'))           return ok(chars);
+    if (url.includes('/api/territories'))          return ok([]);  // use TERRITORY_DATA fallback (slugs)
+    if (url.includes('/api/game_sessions'))        return ok([]);
+    if (url.includes('/api/session_logs'))         return ok([]);
+    return ok([]);
+  });
+
+  await page.goto('/admin.html');
+  await page.waitForSelector('#admin-app', { state: 'visible', timeout: 10000 });
+}
+
+// Navigate to City tab + expand Ambience (carries the #809 harness gotchas).
+async function openAmbienceTable(page) {
+  await page.click('[data-domain="downtime"]');
+  await page.waitForTimeout(500);
+  await page.click('#dt-phase-ribbon .pr-tab[data-phase="projects"]');
+  await page.waitForSelector('.proc-action-row', { state: 'visible', timeout: 10000 });
+  await page.click('#dt-phase-ribbon .pr-tab[data-phase="city"]');
+  await page.waitForSelector('[data-toggle="city-ambience"]', { state: 'visible', timeout: 8000 });
+  await page.click('[data-toggle="city-ambience"] .proc-amb-toggle');
+  await page.waitForSelector('.proc-amb-table', { state: 'visible', timeout: 5000 });
+}
+
+function ambRow(page, name) {
+  return page.locator('.proc-amb-table tbody tr').filter({
+    has: page.locator('td.proc-amb-terr', { hasText: name }),
+  });
+}
+
+test.describe('#814 AC2 — ambience territory override resolves (Bug B)', () => {
+
+  test('AC2: override territory (Harbour) receives the +2 Projects delta', async ({ page }) => {
+    await setupAmbience(page, [SUB_AMB_OVERRIDE]);
+    await openAmbienceTable(page);
+    // Projects column = td index 5 (Terr, Starting, Entropy, Overfeeding, Influence, Projects)
+    const projCell = ambRow(page, 'Harbour').locator('td').nth(5);
+    await expect(projCell).toBeVisible({ timeout: 5000 });
+    await expect(projCell).toContainText('+2');
+  });
+
+  test('AC2: submitted territory (Academy) does NOT receive the delta (override won)', async ({ page }) => {
+    await setupAmbience(page, [SUB_AMB_OVERRIDE]);
+    await openAmbienceTable(page);
+    const projCell = ambRow(page, 'Academy').locator('td').nth(5);
+    await expect(projCell).toBeVisible({ timeout: 5000 });
+    await expect(projCell).toContainText('±0');  // +-0, no delta
+  });
+
+  test('AC5 (regression): all 5 territory rows still render; no crash', async ({ page }) => {
+    await setupAmbience(page, [SUB_AMB_OVERRIDE]);
+    await openAmbienceTable(page);
+    await expect(page.locator('.proc-amb-table tbody tr')).toHaveCount(5);
+    await expect(page.locator('#admin-app')).toBeVisible();
+  });
+
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// PART 2 — AC1 + AC4: DT Story context (discipline profile + home report)
+// ════════════════════════════════════════════════════════════════════════════
+
+const OID_ACADEMY = '69d5dc6a00815d47150397c6';  // 24-hex; resolveTerrId resolves this to 'academy'
+const TERR_ACADEMY = { _id: OID_ACADEMY, slug: 'academy', name: 'The Academy', ambience: 'Curated', ambienceMod: 3 };
+
+// Home char: home_territory is a DISPLAY NAME (the bug input). Another char acts in academy.
+const CHAR_HOME = {
+  _id: 'char-814-home', name: 'Home Body', moniker: null, honorific: null,
+  clan: 'Daeva', covenant: 'Invictus', player: 'Player Home',
+  blood_potency: 2, humanity: 6, humanity_base: 7, court_title: null,
+  home_territory: 'The Academy', retired: false,
+  status: { city: 1, clan: 1, covenant: { Invictus: 1 } },
+  attributes: {
+    Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+    Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+    Presence: { dots: 3, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+  },
+  skills: {}, disciplines: {}, merits: [], powers: [], ordeals: [],
+};
+
+const CHAR_ACTOR = {
+  ...CHAR_HOME, _id: 'char-814-actor', name: 'Academy Actor', player: 'Player Actor',
+  home_territory: null,
+};
+
+const CYCLE_STORY = {
+  _id: 'cycle-814s', cycle_number: 3, status: 'active', phase_signoff: {}, confirmed_ambience: {},
+  // discipline_profile is _id-keyed (ADR-002) — the key is the academy OID.
+  discipline_profile: { [OID_ACADEMY]: { Vigour: 2 } },
+};
+
+function storySub(overrides = {}) {
+  return {
+    _id: 'sub-814s', cycle_id: 'cycle-814s',
+    character_id: 'char-814-home', character_name: 'Home Body', player_name: 'Player Home',
+    status: 'submitted', responses: {},
+    _raw: { sphere_actions: [], contact_actions: { requests: [] }, retainer_actions: { actions: [] } },
+    projects_resolved: [], merit_actions_resolved: [], acquisitions_resolved: [],
+    st_review: {}, st_narrative: { story_moment: { status: 'complete' } },
+    feeding_review: { pool_status: 'no_feed' },
+    ...overrides,
+  };
+}
+
+// Home char's own submission (the one we view). A patrol_scout project resolving to academy by
+// OID so Copy Context routes to buildPatrolContext (which emits the "Discipline activity:" line —
+// the site the #814 fix touches at downtime-story.js:1037). terrRaw is OID so resolveTerrId works.
+const SUB_HOME = storySub({
+  responses: {
+    project_1_action: 'patrol_scout',
+    project_1_target_terr: OID_ACADEMY,   // buildPatrolContext reads _target_terr (OID)
+  },
+  projects_resolved: [{ action_type: 'patrol_scout', pool_status: 'validated', roll: { successes: 3 } }],
+});
+
+// Another character's submission acting in academy (by OID), so _homeTerrActivity matches it.
+const SUB_ACTOR = storySub({
+  _id: 'sub-814s-actor', character_id: 'char-814-actor', character_name: 'Academy Actor', player_name: 'Player Actor',
+  responses: { project_1_territory: OID_ACADEMY },
+  projects_resolved: [{ action_type: 'patrol_scout', pool_status: 'validated', roll: { successes: 2 } }],
+});
+
+async function setupStory(page, submissions, chars, viewName = 'Home Body') {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER });
+
+  const ok = (route, body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+  await page.route('**/api/auth/me', r => ok(r, ST_USER));
+  await page.route(/\/api\/characters$/, r => ok(r, chars));
+  await page.route('**/api/characters/names', r => ok(r, chars.map(c => ({ _id: c._id, name: c.name, moniker: c.moniker, honorific: c.honorific }))));
+  await page.route('**/api/downtime_cycles*', r => ok(r, [CYCLE_STORY]));
+  await page.route('**/api/downtime_submissions*', r => {
+    if (['PATCH', 'PUT', 'POST'].includes(r.request().method())) return ok(r, { ok: true });
+    return ok(r, submissions);
+  });
+  await page.route('**/api/territories*', r => ok(r, [TERR_ACADEMY]));
+  await page.route('**/api/game_sessions*', r => ok(r, []));
+  await page.route('**/api/session_logs*', r => ok(r, []));
+  await page.route('**/api/st_mods*', r => ok(r, []));
+
+  await page.goto('/admin.html');
+  await page.waitForSelector('#admin-app', { state: 'visible', timeout: 10000 });
+  await page.click('[data-domain="downtime"]');
+  await page.waitForSelector('button[data-phase="story"]', { state: 'visible', timeout: 10000 });
+  await page.click('button[data-phase="story"]');
+  await page.waitForSelector('#dt-story-nav-rail', { timeout: 10000 });
+  // Select the requested character (first pill matching the name).
+  await page.locator('.dt-story-pill', { hasText: viewName }).first().click();
+  await page.waitForSelector('.dt-story-char-content', { timeout: 5000 });
+  await page.waitForTimeout(300);
+}
+
+test.describe('#814 AC4 — home-territory activity resolves (Bug C)', () => {
+
+  test('AC4: home_report lists activity when another char acts in the home territory', async ({ page }) => {
+    await setupStory(page, [SUB_HOME, SUB_ACTOR], [CHAR_HOME, CHAR_ACTOR]);
+    const homeHtml = await page.evaluate(() => {
+      const el = document.querySelector('.dt-story-section[data-section="home_report"]');
+      return el ? el.innerHTML : null;
+    });
+    expect(homeHtml).not.toBeNull();
+    expect(homeHtml).toContain('Activity near home this cycle');
+    expect(homeHtml).toContain('Academy Actor');
+  });
+
+  test('AC4: home_report shows quiet-month state when no one acts in the home territory', async ({ page }) => {
+    await setupStory(page, [SUB_HOME], [CHAR_HOME, CHAR_ACTOR]);  // no actor sub
+    const homeHtml = await page.evaluate(() => {
+      const el = document.querySelector('.dt-story-section[data-section="home_report"]');
+      return el ? el.innerHTML : null;
+    });
+    expect(homeHtml).not.toBeNull();
+    expect(homeHtml).toMatch(/quiet month near home|No notable activity/i);
+  });
+
+});
+
+// AC3 NOTE (QA): getTerritoryOverlap (downtime-story.js:2487/2497) and buildActionContext
+// territory (:2578) are reached only by renderActionCard / the per-category merit-action card
+// sections (allies_actions, status_actions, …). Those sections are NOT in getApplicableSections
+// (downtime-story.js:1150-1176) — Story 1.13 consolidated all merit categories into the single
+// `merit_summary` ledger — so the merit-action cards (and their "Territory Overlap" chips) do not
+// render in the current DT Story UI. The #814 fix at those sites is correct and defensive but is
+// not reachable through the live UI and therefore cannot be E2E-verified here. It shares the exact
+// one-line pattern (TERRITORY_SLUG_MAP[x] ?? resolveTerrId(x)) that AC2 mutation-verifies on the
+// same st_review.territory_overrides field. See story QA Results.
+
+test.describe('#814 AC1 — discipline profile reads OID key (Bug A)', () => {
+
+  test.use({ permissions: ['clipboard-read', 'clipboard-write'] });
+
+  test('AC1: project Copy Context shows discipline activity, not "None detected"', async ({ page }) => {
+    await setupStory(page, [SUB_HOME, SUB_ACTOR], [CHAR_HOME, CHAR_ACTOR]);
+
+    // Click the project card's Copy Context button -> buildProjectContext -> clipboard.
+    const copyBtn = page.locator('.dt-story-proj-card .dt-story-copy-ctx-btn').first();
+    await expect(copyBtn).toBeVisible({ timeout: 5000 });
+    await copyBtn.click();
+
+    await expect.poll(async () => {
+      return page.evaluate(() => navigator.clipboard.readText());
+    }, { timeout: 5000 }).toContain('Vigour');
+
+    const clip = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clip).not.toContain('None detected');
+  });
+
+});


### PR DESCRIPTION
Fixes #814.

## Summary

`resolveTerrId` is ObjectId-string only — three DT-context sites fed it a slug or display-name and silently got `null` (never an error). Surfaced by the slug-vs-ObjectId code review (the #809 bug class). Two fix directions, no change to `resolveTerrId` itself.

### Bug A — discipline profile always "None detected"
`cycle.discipline_profile` is written `_id`-keyed (ADR-002, `downtime-views.js:3641/3664`) but was read with the slug `terrId`. Now reads `terrOidStr` (mirroring the adjacent `confirmed_ambience` reads) in `buildPatrolContext` (`downtime-story.js:1037`) and `buildTerritoryContext` (`:2969`).

### Bug B — ST territory override silently ignored
Overrides are stored as slugs (pill-written) but were passed through OID-only `resolveTerrId`. Now `TERRITORY_SLUG_MAP[x] ?? resolveTerrId(x)` (slug-first, OID fallback — the #809 pattern):
- `downtime-views.js:3904` (`_gatherProjectAmbience`), `:3975-3976` (`_gatherMeritAmbience`)
- `downtime-story.js:2487/2497` (`getTerritoryOverlap`), `:2578` (`buildActionContext`)

### Bug C — home-territory activity scan dead
`char.home_territory` is a display-name; same dual pattern at `_homeTerrActivity` (`downtime-story.js:3141`).

The durable single-`normaliseTerritoryId()` consolidation is tracked separately as #816; this is the pointwise fix.

## Tests
`tests/fix-814-dt-territory-resolveterrid.spec.js` — 6 E2E tests, all green.
- AC1 (discipline) via project Copy Context clipboard
- AC2 (override) via City/Ambience table — delta lands on the override territory, not the submitted one
- AC4 (home report) via the `home_report` DOM activity list
- AC5 regression — 5 rows render; `fix-809` (8) + `feature-448` (8) also green

QA **mutation-verified** AC1/AC2/AC4 (reverting each fix turns the matching test red with the bug's signature).

## QA finding — AC3 unreachable in current UI
`getTerritoryOverlap` / `buildActionContext` are reached only by the per-category merit-action card sections, which Story 1.13 consolidated into the single `merit_summary` ledger (not in `getApplicableSections`). So the AC3 fix is correct and defensive but has **no current user impact and is not E2E-testable**. Left in place; flagged for a possible future dead-path cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
