### PR TITLE
feat(editor): sort domain merits and group Necropolis targets

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -6078,3 +6078,14 @@ html:not([data-theme="dark"]) .char-picker__pill { font-weight: 600; }
   font-size: 13px; color: var(--text);
 }
 .dt-conn-dd-item:hover { background: var(--gold-a10); color: var(--gold2); }
+
+.necro-inherited-block {
+  margin: 8px 0 8px 20px;
+  padding: 8px 12px;
+  border-left: 2px solid var(--accent);
+}
+
+.necro-inherited-title {
+  font-weight: 600;
+  margin-bottom: 6px;
+}

--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -984,6 +984,28 @@ function _inflArea(m, idx, isC) {
 
 export function shRenderDomainMerits(c, editMode) {
   const chars = state.chars, domM = (c.merits || []).filter(m => m.category === 'domain');
+
+  const _necroTargets = getNecropolisTargets(getRulesCache());
+    const sortedDomM = [...domM].sort((a, b) =>
+    (a.name || '').localeCompare(b.name || '')
+  );
+
+  const _sepulcher = sortedDomM.find(
+  m => m.name === 'Necropolis Sepulcher'
+);
+
+const _necroMerits = sortedDomM
+  .filter(m => _necroTargets.includes(m.name))
+  .sort((a, b) =>
+    (a.name || '').localeCompare(b.name || '')
+  );
+
+if (!_sepulcher && _necroMerits.length) {
+  console.warn(
+    '[N-793] Necropolis targets found without Necropolis Sepulcher'
+  );
+}
+
   if (!editMode && !domM.length) return '';
   const _domLkPools = (c._grant_pools || []).filter(p => p.category === 'lk');
   const _domInvPools = (c._grant_pools || []).filter(p => p.category === 'inv');
@@ -1010,8 +1032,10 @@ export function shRenderDomainMerits(c, editMode) {
     // (showNECRO: _hasNecroSep && _isNecroTarget), but the hide-* flags fire
     // even for non-Sepulcher characters who somehow have a Necropolis target
     // merit on their sheet.
-    const _necroTargets = getNecropolisTargets(getRulesCache());
-    domM.forEach((m, di) => {
+    sortedDomM.forEach((m, di) => {
+      if (_sepulcher && _necroTargets.includes(m.name)) {
+  return;
+}
       const hTk = domM.some((dm, dj) => dm.name === 'Herd' && dj !== di);
       // Catalog-driven options (sub_category='domain'), with the Herd-once-per-character
       // rule layered on top. Mandragora Garden's prereq is enforced by the helper.
@@ -1121,6 +1145,20 @@ export function shRenderDomainMerits(c, editMode) {
       if (_canShare.includes(m.name) && parts.length) { h += '<div class="dom-partners-row">'; parts.forEach(pN => { const p = chars.find(ch => ch.name === pN), pD = p ? domMeritShareable(p, m.name) : 0; h += '<span class="dom-partner-tag">' + esc(pN) + (pD ? ' ' + shDots(pD) : ' \u25CB') + '<button class="dom-partner-rm" onclick="shRemoveDomainPartner(' + di + ',\'' + pN.replace(/'/g, "\\'") + '\')">\u00D7</button></span>'; }); h += '</div>'; }
       if (_canShare.includes(m.name) && avP.length) h += '<div class="dom-add-partner-row"><select class="dom-partner-sel" onchange="if(this.value){shAddDomainPartner(' + di + ',this.value);this.value=\'\';}"><option value="">+ Add shared partner\u2026</option>' + avP.map(p => '<option value="' + esc(p.name) + '">' + esc(dropdownName(p)) + '</option>').join('') + '</select></div>';
       h += '</div>';
+
+      if (
+  m.name === 'Necropolis Sepulcher' &&
+  _necroMerits.length
+) {
+  h += '<div class="necro-inherited-block">';
+  h += '<div class="necro-inherited-title">Inherited from Necropolis Sepulcher</div>';
+
+  _necroMerits.forEach(nm => {
+    h += '<div class="derived-note">• ' + esc(nm.name) + '</div>';
+  });
+
+  h += '</div>';
+}
     });
     h += '<div class="dev-add-row"><button class="dev-add-btn" onclick="shAddDomMerit()">+ Add Domain Merit</button></div>';
   } else {
@@ -1130,7 +1168,10 @@ export function shRenderDomainMerits(c, editMode) {
     // suppressed from display (no destructive migration; future cleanup is a
     // separate story).
     const _canShareView = ['Safe Place', 'Haven'];
-    domM.slice().sort((a, b) => (a.name || '').localeCompare(b.name || '')).forEach(m => {
+    sortedDomM.slice().sort((a, b) => (a.name || '').localeCompare(b.name || '')).forEach(m => {
+      if (_sepulcher && _necroTargets.includes(m.name)) {
+  return;
+}
       const dp = _canShareView.includes(m.name) && m.shared_with && m.shared_with.length ? m.shared_with : null;
       // de: per-instance effective rating (handles cap for Haven/MG, multi-instance for SP/FG)
       const de = meritEffectiveRating(c, m);
@@ -1173,6 +1214,19 @@ export function shRenderDomainMerits(c, editMode) {
         }
       }
       h += '</div>';
+      if (
+  m.name === 'Necropolis Sepulcher' &&
+  _necroMerits.length
+) {
+  h += '<div class="necro-inherited-block">';
+  h += '<div class="necro-inherited-title">Inherited from Necropolis Sepulcher</div>';
+
+  _necroMerits.forEach(nm => {
+    h += '<div class="derived-note">• ' + esc(nm.name) + '</div>';
+  });
+
+  h += '</div>';
+}
     });
   }
   h += '</div></div>'; return h;

--- a/server/tests/n793-domain-merit-sorting.test.js
+++ b/server/tests/n793-domain-merit-sorting.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+let shRenderDomainMerits;
+
+beforeAll(async () => {
+  const sheetPath = path.resolve('public/js/editor/sheet.js');
+  const sheetUrl = pathToFileURL(sheetPath).href;
+
+  ({ shRenderDomainMerits } = await import(sheetUrl));
+});
+
+describe('N-793 Domain Merit Sorting', () => {
+  it('loads renderer', () => {
+    expect(shRenderDomainMerits).toBeTypeOf('function');
+  });
+});
+
+it('renders Necropolis Sepulcher before inherited card', () => {
+    const c = {
+      name: 'Test',
+      merits: [
+        { category: 'domain', name: 'White Ants' },
+        { category: 'domain', name: 'Catacombs' },
+        { category: 'domain', name: 'Necropolis Sepulcher' }
+      ]
+    };
+  
+    const html = shRenderDomainMerits(c, true);
+  
+    expect(html.includes('Necropolis Sepulcher')).toBe(true);
+    expect(html.includes('Inherited from Necropolis Sepulcher')).toBe(true);
+  });
+
+  it('contains inherited card css class', () => {
+    const c = {
+      name: 'Test',
+      merits: [
+        { category: 'domain', name: 'Necropolis Sepulcher' },
+        { category: 'domain', name: 'White Ants' }
+      ]
+    };
+  
+    const html = shRenderDomainMerits(c, true);
+  
+    expect(html.includes('necro-inherited-block')).toBe(true);
+  });


### PR DESCRIPTION
## Summary

This PR updates the Domain Merits renderer to improve ordering and Necropolis merit presentation.

### Changes
- Sort domain merits alphabetically by merit name in both edit and view modes.
- Render `Necropolis Sepulcher` in its alphabetical position.
- Group Necropolis collective target merits inside an inherited block directly below Sepulcher.
- Sort inherited Necropolis targets alphabetically within the inherited block.
- Skip duplicate rendering of Necropolis targets in the main domain merit list when Sepulcher is present.
- Preserve fallback behavior for legacy data where Necropolis targets exist without Sepulcher.
- Add styling hook for the inherited block (`.necro-inherited-block`).

Closes #793