### PR TITLE
fix(editor): #827 — Haven/MG/White Ants subtitle precedes dots (dots always rightmost)

### DIFF
--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -1102,10 +1102,23 @@ export function shRenderDomainMerits(c, editMode) {
       const _necroCumulative = _isNecroTargetHere ? collectiveNecroDots(chars, m.name) : 0;
       const _necroPartner = Math.max(0, _necroCumulative - _necroOwn);
       const _necroDotsHtml = shDotsMixed(_necroOwn, _necroPartner);
+      // Issue #827: subtitle for Haven / Mandragora Garden / White Ants
+      // renders BEFORE the dots column inside the main row (LHS-justified),
+      // keeping dots rightmost. Pre-#827 these subtitles emitted as sibling
+      // sub-rows AFTER the dot row, breaking the consistent rightmost-dots
+      // rule that every other domain merit follows.
+      let _subtitleInline = '';
+      if (m.name === 'Haven' || m.name === 'Mandragora Garden') {
+        const _viewAt = normaliseAttachedTo(m.attached_to);
+        const _dest = _viewAt && _viewAt.destination ? _viewAt.destination : '(not attached)';
+        _subtitleInline = '<span class="dom-row-subtitle">Attached: ' + esc(_dest) + '</span>';
+      } else if (m.name === 'White Ants' && _necroTerritoryUnion) {
+        _subtitleInline = '<span class="dom-row-subtitle">Territories: ' + esc(_necroTerritoryUnion) + '</span>';
+      }
       if (_isNecroTargetHere) {
-        h += '<div class="dom-edit-block"><div class="infl-edit-row"><select class="infl-type" onchange="shEditDomMerit(' + di + ',\'name\',this.value)">' + tOpts + '</select><span class="dom-contrib-lbl">My dots: ' + '\u25CF'.repeat(_necroOwn) + '</span><span class="dom-total-lbl" title="Cumulative across all Sepulcher-owners (\u25CF own, \u25CB partners)">Total: ' + _necroDotsHtml + '</span><button class="dev-rm-btn" onclick="shRemoveDomMerit(' + di + ')" title="Remove">&times;</button></div>';
+        h += '<div class="dom-edit-block"><div class="infl-edit-row"><select class="infl-type" onchange="shEditDomMerit(' + di + ',\'name\',this.value)">' + tOpts + '</select>' + _subtitleInline + '<span class="dom-contrib-lbl">My dots: ' + '\u25CF'.repeat(_necroOwn) + '</span><span class="dom-total-lbl" title="Cumulative across all Sepulcher-owners (\u25CF own, \u25CB partners)">Total: ' + _necroDotsHtml + '</span><button class="dev-rm-btn" onclick="shRemoveDomMerit(' + di + ')" title="Remove">&times;</button></div>';
       } else {
-        h += '<div class="dom-edit-block"><div class="infl-edit-row"><select class="infl-type" onchange="shEditDomMerit(' + di + ',\'name\',this.value)">' + tOpts + '</select><span class="dom-contrib-lbl">My dots: ' + '\u25CF'.repeat(_dPurch) + '\u25CB'.repeat(Math.max(0, dd + (m.bonus || 0) - _dPurch)) + '</span><span class="dom-total-lbl" title="Total across all contributors (\u25CF own, \u25CB partners)">Total: ' + (_isCapped ? _capTotalDots : _totalDots) + '</span><button class="dev-rm-btn" onclick="shRemoveDomMerit(' + di + ')" title="Remove">&times;</button></div>';
+        h += '<div class="dom-edit-block"><div class="infl-edit-row"><select class="infl-type" onchange="shEditDomMerit(' + di + ',\'name\',this.value)">' + tOpts + '</select>' + _subtitleInline + '<span class="dom-contrib-lbl">My dots: ' + '\u25CF'.repeat(_dPurch) + '\u25CB'.repeat(Math.max(0, dd + (m.bonus || 0) - _dPurch)) + '</span><span class="dom-total-lbl" title="Total across all contributors (\u25CF own, \u25CB partners)">Total: ' + (_isCapped ? _capTotalDots : _totalDots) + '</span><button class="dev-rm-btn" onclick="shRemoveDomMerit(' + di + ')" title="Remove">&times;</button></div>';
       }
       // Qualifier input for Safe Place / Feeding Grounds
       if (['Safe Place', 'Feeding Grounds'].includes(m.name)) {
@@ -1153,13 +1166,13 @@ export function shRenderDomainMerits(c, editMode) {
       // wrong renderer) and N-7c (orchestrator dispatch missing). Production
       // symptom pre-fix: ST cannot pick territories → save fails 400.
       h += _whiteAntsTerritoriesBlock(m, rIdx);
-      // COLLECTIVE-1 (issue #800): flat territory union under the White Ants
-      // row — every Sepulcher-owner's sheet shows the same union. No
-      // attribution per Peter decision (a) 2026-06-16. Renders only on the
-      // owner's own White Ants row (virtual row handles it separately below).
-      if (m.name === 'White Ants' && _necroTerritoryUnion) {
-        h += '<div class="wa-territory-union">Territories: ' + esc(_necroTerritoryUnion) + '</div>';
-      }
+      // Issue #827: territory union no longer rendered here as a sibling
+      // sub-row — moved INLINE into the infl-edit-row above (LHS-justified,
+      // before the dots column). Keeps dots as the rightmost element per
+      // Peter 2026-06-16 ("Dots should be last and rightmost thing in the
+      // row always for all domain merits"). The COLLECTIVE-1 union helper
+      // (_necroTerritoryUnion) still computes the same value; only the
+      // emission site moved.
       h += _trapDoorAnchorBlock(c, m, rIdx);
       h += _derivedNotes(m);
       if (m.name === 'Herd') { const ssjB = ssjHerdBonus(c); if (ssjB) h += '<div class="derived-note">SSJ Bonus: +' + ssjB + ' dots (' + shDots(ssjB) + ') \u2014 equals MCI dots</div>'; }
@@ -1196,9 +1209,14 @@ export function shRenderDomainMerits(c, editMode) {
       const _vOwn = 0;
       const _vDots = shDotsMixed(_vOwn, _vPartner);
       const _vSlug = vName.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+      // Issue #827: territory subtitle inline before the dots (rightmost).
+      const _vSubtitle = (vName === 'White Ants' && _necroTerritoryUnion)
+        ? '<span class="dom-row-subtitle">Territories: ' + esc(_necroTerritoryUnion) + '</span>'
+        : '';
       h += '<div class="dom-edit-block dom-edit-block--virtual">'
         + '<div class="infl-edit-row">'
         + '<span class="infl-type infl-type--virtual" title="Partner-only \u2014 click NECRO to allocate your own dots">' + esc(vName) + '</span>'
+        + _vSubtitle
         + '<span class="dom-contrib-lbl">My dots: </span>'
         + '<span class="dom-total-lbl" title="Cumulative across all Sepulcher-owners (\u25CF own, \u25CB partners)">Total: ' + _vDots + '</span>'
         + '</div>'
@@ -1209,9 +1227,6 @@ export function shRenderDomainMerits(c, editMode) {
         + '</div>'
         + '<div class="bd-eq"><span class="bd-val">' + _vPartner + ' partner dot' + (_vPartner === 1 ? '' : 's') + '</span></div>'
         + '</div>';
-      if (vName === 'White Ants' && _necroTerritoryUnion) {
-        h += '<div class="wa-territory-union">Territories: ' + esc(_necroTerritoryUnion) + '</div>';
-      }
       h += '</div>';
     };
     // Issue #793: sorted iteration with inherited-card grouping.
@@ -1345,37 +1360,47 @@ export function shRenderDomainMerits(c, editMode) {
       const _shHtml      = '<div class="dom-total-view" title="\u25CF inherent, \u25CB bonus, \u25CB\u0332 shared">' + shDotsThreeTier(_sh3Inherent, _sh3Bonus, _sh3Shared) + '</div>';
       // Display name includes qualifier when present
       const _dispName = m.name + (m.qualifier ? ' <span class="trait-qual">(' + esc(m.qualifier) + ')</span>' : '');
-      h += '<div class="merit-plain"><div class="trait-row"><div class="trait-main"><span class="trait-name">' + _dispName + '</span><div class="trait-right">' + (dp ? _shHtml : dotHtml) + '</div></div>' + (dp ? '<div class="trait-sub"><span class="trait-qual dom-shared-lbl">Shared \u00B7 ' + dp.map(n => { const p = chars.find(ch => ch.name === n), pd = p ? domMeritShareable(p, m.name) : 0; return esc(n) + (pd ? ' ' + shDots(pd) : ''); }).join(', ') + '</span></div>' : '') + '</div>';
+      // Issue #827: subtitle inline before dots (rightmost). Haven /
+      // Mandragora "Attached: X" + White Ants "Territories: ..." move from
+      // sibling sub-rows into the main row.
+      let _subtitleInlineView = '';
       if (_isCappedView) {
-        // N-1 (Concern #11): normaliser keeps the rendered "Attached: X" string
-        // correct when `m.attached_to` is the new object form (would otherwise
-        // render [object Object]).
+        const _viewAt = normaliseAttachedTo(m.attached_to);
+        if (_viewAt && _viewAt.destination) {
+          _subtitleInlineView = '<span class="trait-qual dom-row-subtitle">Attached: ' + esc(_viewAt.destination) + '</span>';
+        }
+      } else if (m.name === 'White Ants' && _necroTerritoryUnionView) {
+        _subtitleInlineView = '<span class="trait-qual dom-row-subtitle">Territories: ' + esc(_necroTerritoryUnionView) + '</span>';
+      }
+      h += '<div class="merit-plain"><div class="trait-row"><div class="trait-main"><span class="trait-name">' + _dispName + '</span>' + _subtitleInlineView + '<div class="trait-right">' + (dp ? _shHtml : dotHtml) + '</div></div>' + (dp ? '<div class="trait-sub"><span class="trait-qual dom-shared-lbl">Shared \u00B7 ' + dp.map(n => { const p = chars.find(ch => ch.name === n), pd = p ? domMeritShareable(p, m.name) : 0; return esc(n) + (pd ? ' ' + shDots(pd) : ''); }).join(', ') + '</span></div>' : '') + '</div>';
+      if (_isCappedView) {
+        // The "Needs an attached Safe Place" warning and "Capped at N" notes
+        // remain as derived-note sub-rows (they're warnings, not subtitles).
+        // The "Attached: X" success label moved INLINE above per #827.
         const _viewAt = normaliseAttachedTo(m.attached_to);
         if (!_viewAt) {
           h += '<div class="derived-note dom-cap-warn">Needs an attached Safe Place (0 effective dots)</div>';
-        } else {
-          if (_viewStored > de) h += '<div class="derived-note">Capped at ' + de + ' \u2014 Safe Place limits effective dots</div>';
-          h += '<div class="trait-sub"><span class="trait-qual">Attached: ' + esc(_viewAt.destination) + '</span></div>';
+        } else if (_viewStored > de) {
+          h += '<div class="derived-note">Capped at ' + de + ' \u2014 Safe Place limits effective dots</div>';
         }
       }
-      // COLLECTIVE-1: White Ants row gets the territory union label in view
-      // mode too. No attribution per Peter decision (a) 2026-06-16.
-      if (m.name === 'White Ants' && _necroTerritoryUnionView) {
-        h += '<div class="wa-territory-union">Territories: ' + esc(_necroTerritoryUnionView) + '</div>';
-      }
+      // Issue #827: wa-territory-union sub-row removed \u2014 moved inline above.
       h += '</div>';
     };
     const _emitVirtualViewRow = (vName) => {
       const _vPartner = collectiveNecroDots(chars, vName);
       const _vDots = shDotsMixed(0, _vPartner);
+      // Issue #827: territory subtitle inline before dots on White Ants
+      // virtual row too.
+      const _vSubtitle = (vName === 'White Ants' && _necroTerritoryUnionView)
+        ? '<span class="trait-qual dom-row-subtitle">Territories: ' + esc(_necroTerritoryUnionView) + '</span>'
+        : '';
       h += '<div class="merit-plain merit-plain--virtual">'
         + '<div class="trait-row"><div class="trait-main">'
         + '<span class="trait-name">' + esc(vName) + '</span>'
+        + _vSubtitle
         + '<div class="trait-right">' + _vDots + '</div>'
         + '</div></div>';
-      if (vName === 'White Ants' && _necroTerritoryUnionView) {
-        h += '<div class="wa-territory-union">Territories: ' + esc(_necroTerritoryUnionView) + '</div>';
-      }
       h += '</div>';
     };
     const _virtualNamesView = _collectiveNamesView.filter(n => !_ownedNecroSetView.has(n));

--- a/server/tests/collective-1-virtual-rows.test.js
+++ b/server/tests/collective-1-virtual-rows.test.js
@@ -225,7 +225,10 @@ describe('COLLECTIVE-1 — Yusuf + Xavier render (edit mode)', () => {
   it('White Ants territory union renders on Yusuf with all 4 territory slugs (no attribution)', () => {
     const { yusuf } = setupYusuf();
     const html = shRenderDomainMerits(yusuf, true);
-    expect(html).toContain('wa-territory-union');
+    // Issue #827: subtitle now emitted inline as dom-row-subtitle (was the
+    // standalone wa-territory-union sub-row pre-#827).
+    expect(html).toContain('dom-row-subtitle');
+    expect(html).toContain('Territories:');
     // The territory display uses slugs when name lookup fails (no territories
     // loaded in getStoredTerritories under the test shim). Either form is fine
     // for this assertion — slugs are what's in the fixture.
@@ -282,7 +285,9 @@ describe('COLLECTIVE-1 — Sepulcher boundary + source merit', () => {
     const html = shRenderDomainMerits(nonOwner, true);
     expect(html).not.toContain('dom-edit-block--virtual');
     expect(html).not.toContain('shAllocateNecroVirtual');
-    expect(html).not.toContain('wa-territory-union');
+    // Issue #827: subtitle now uses dom-row-subtitle class. Non-Sepulcher
+    // chars don't surface the territory subtitle (no _necroTerritoryUnion).
+    expect(html).not.toContain('dom-row-subtitle');
   });
 
   it('Sepulcher source merit row uses standard dot display (not cumulative)', () => {
@@ -323,7 +328,10 @@ describe('COLLECTIVE-1 — view mode (read-only) synthesis', () => {
     stateMod.editIdx = 0;
     stateMod.editMode = false;
     const html = shRenderDomainMerits(yusuf, false);
-    expect(html).toContain('wa-territory-union');
+    // Issue #827: subtitle moved from standalone wa-territory-union sub-row
+    // into inline dom-row-subtitle span.
+    expect(html).toContain('dom-row-subtitle');
+    expect(html).toContain('Territories:');
   });
 });
 

--- a/server/tests/issue-827-subtitle-order.test.js
+++ b/server/tests/issue-827-subtitle-order.test.js
@@ -1,0 +1,274 @@
+/**
+ * Issue #827 — domain merit subtitle/label must precede dots in DOM order.
+ *
+ * Three merits are affected:
+ *   - Haven (subtitle: "Attached: <Safe Place>")
+ *   - Mandragora Garden (subtitle: "Attached: <Safe Place or Sepulcher>")
+ *   - White Ants (subtitle: "Territories: <flat union>")
+ *
+ * Pre-#827: subtitles emitted as sibling sub-rows AFTER the dot row → in
+ * DOM order, subtitle followed dots, breaking the consistent rightmost-dots
+ * rule.
+ *
+ * Post-#827: subtitle inline inside the main row (infl-edit-row /
+ * trait-main), placed between the merit name and the dot spans → dots
+ * remain rightmost in every domain merit row.
+ *
+ * Behavioural per feedback_render_wiring_placement — call the real renderer
+ * and assert position of subtitle vs dots in the returned HTML.
+ */
+
+// Browser shims — sheet.js transitively imports api.js (location).
+globalThis.location = {
+  origin: 'http://localhost:8080',
+  hostname: 'localhost',
+  href: 'http://localhost:8080/admin',
+};
+globalThis.localStorage = {
+  _store: {},
+  getItem(k) { return this._store[k] ?? null; },
+  setItem(k, v) { this._store[k] = String(v); },
+  removeItem(k) { delete this._store[k]; },
+  clear() { this._store = {}; },
+};
+globalThis.window = globalThis.window || globalThis;
+globalThis.document = globalThis.document || {
+  getElementById: () => null,
+  createElement: () => ({ style: {}, classList: { add() {}, remove() {}, toggle() {} } }),
+};
+
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+function read(rel) { return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8'); }
+
+let shRenderDomainMerits;
+let stateMod;
+let loadRulesMod;
+
+const NECRO_GRANT = {
+  source: 'Necropolis Sepulcher',
+  source_slug: 'necro',
+  category: 'necro',
+  grant_type: 'pool',
+  condition: 'merit_present',
+  amount_basis: 'rating_of_source',
+  pool_targets: ['Catacombs', 'Caldarium', 'Garbage Pit', 'Labyrinth Guardians', 'Dark Temple', 'White Ants'],
+};
+
+beforeAll(async () => {
+  const sheetUrl = pathToFileURL(path.resolve(REPO_ROOT, 'public', 'js', 'editor', 'sheet.js')).href;
+  ({ shRenderDomainMerits } = await import(sheetUrl));
+  stateMod = (await import(pathToFileURL(path.resolve(REPO_ROOT, 'public', 'js', 'data', 'state.js')).href)).default;
+  loadRulesMod = await import(pathToFileURL(path.resolve(REPO_ROOT, 'public', 'js', 'editor', 'rule_engine', 'load-rules.js')).href);
+  vi.spyOn(loadRulesMod, 'getRulesCache').mockReturnValue({
+    rule_grant: [NECRO_GRANT],
+    rule_nine_again: [], rule_skill_bonus: [], rule_speciality_grant: [],
+    rule_tier_budget: [], rule_disc_attr: [], rule_derived_stat_modifier: [],
+  });
+});
+
+function mkChar(name, merits) {
+  return {
+    _id: 'c-' + name.toLowerCase(),
+    name,
+    clan: 'Nosferatu', covenant: 'Invictus',
+    status: { city: 0, clan: 0, covenant: {} },
+    attributes: {}, skills: {}, disciplines: {}, powers: [],
+    merits,
+  };
+}
+
+// The dots column in the editor's main row is `dom-total-lbl` (Total: ...).
+// In view mode it's the `trait-right` div. Both are reliable anchors that
+// only appear in one place per row.
+
+describe('#827 — subtitle precedes dots in DOM order (edit mode)', () => {
+  it('Haven row: "Attached: X" subtitle appears BEFORE the dots span', () => {
+    const c = mkChar('Yusuf', [
+      { name: 'Safe Place', category: 'domain', cp: 2, xp: 0, qualifier: 'Penthouse' },
+      { name: 'Haven', category: 'domain', cp: 1, xp: 0, attached_to: 'Safe Place (Penthouse)' },
+    ]);
+    stateMod.chars = [c]; stateMod.editIdx = 0; stateMod.editMode = true;
+    const html = shRenderDomainMerits(c, true);
+    // Find Haven's row. Each row's remove-button handler uniquely identifies it.
+    const havenDi = c.merits.findIndex(m => m.name === 'Haven');
+    const removeMarker = `shRemoveDomMerit(${havenDi})`;
+    const removeIdx = html.indexOf(removeMarker);
+    expect(removeIdx).toBeGreaterThan(0);
+    // Slice Haven's infl-edit-row by anchoring on its remove-button position.
+    // The row starts at the previous '<div class="dom-edit-block"' before
+    // removeIdx and ends at the next 'dom-edit-block' or 'dev-add-row'.
+    const blockStart = html.lastIndexOf('<div class="dom-edit-block"', removeIdx);
+    const blockEnd = html.indexOf('<div class="dom-edit-block', blockStart + 1);
+    const rowSlice = html.slice(blockStart, blockEnd > 0 ? blockEnd : html.length);
+    const subtitleIdx = rowSlice.indexOf('Attached:');
+    const totalIdx = rowSlice.indexOf('dom-total-lbl');
+    expect(subtitleIdx).toBeGreaterThan(0);
+    expect(totalIdx).toBeGreaterThan(0);
+    expect(subtitleIdx).toBeLessThan(totalIdx);
+  });
+
+  it('Mandragora Garden row: "Attached: X" subtitle appears BEFORE the dots span', () => {
+    const c = mkChar('Yusuf', [
+      { name: 'Safe Place', category: 'domain', cp: 2, xp: 0, qualifier: 'Penthouse' },
+      { name: 'Mandragora Garden', category: 'domain', cp: 1, xp: 0, attached_to: 'Safe Place (Penthouse)' },
+    ]);
+    stateMod.chars = [c]; stateMod.editIdx = 0; stateMod.editMode = true;
+    const html = shRenderDomainMerits(c, true);
+    const mgDi = c.merits.findIndex(m => m.name === 'Mandragora Garden');
+    const removeIdx = html.indexOf(`shRemoveDomMerit(${mgDi})`);
+    const blockStart = html.lastIndexOf('<div class="dom-edit-block"', removeIdx);
+    const blockEnd = html.indexOf('<div class="dom-edit-block', blockStart + 1);
+    const rowSlice = html.slice(blockStart, blockEnd > 0 ? blockEnd : html.length);
+    const subtitleIdx = rowSlice.indexOf('Attached:');
+    const totalIdx = rowSlice.indexOf('dom-total-lbl');
+    expect(subtitleIdx).toBeGreaterThan(0);
+    expect(subtitleIdx).toBeLessThan(totalIdx);
+  });
+
+  it('White Ants row: "Territories: ..." subtitle appears BEFORE the dots span', () => {
+    const yusuf = mkChar('Yusuf', [
+      { name: 'Necropolis Sepulcher', category: 'domain', cp: 3, xp: 0 },
+      { name: 'White Ants', category: 'domain', cp: 0, xp: 0, free_grants: { necro: 2 }, territories: ['the-shore', 'the-harbour'] },
+    ]);
+    stateMod.chars = [yusuf]; stateMod.editIdx = 0; stateMod.editMode = true;
+    const html = shRenderDomainMerits(yusuf, true);
+    const waDi = yusuf.merits.findIndex(m => m.name === 'White Ants');
+    const removeIdx = html.indexOf(`shRemoveDomMerit(${waDi})`);
+    const blockStart = html.lastIndexOf('<div class="dom-edit-block"', removeIdx);
+    const blockEnd = html.indexOf('<div class="dom-edit-block', blockStart + 1);
+    const rowSlice = html.slice(blockStart, blockEnd > 0 ? blockEnd : html.length);
+    const subtitleIdx = rowSlice.indexOf('Territories:');
+    const totalIdx = rowSlice.indexOf('dom-total-lbl');
+    expect(subtitleIdx).toBeGreaterThan(0);
+    expect(subtitleIdx).toBeLessThan(totalIdx);
+  });
+
+  it('Standalone wa-territory-union sub-row is no longer emitted', () => {
+    const yusuf = mkChar('Yusuf', [
+      { name: 'Necropolis Sepulcher', category: 'domain', cp: 3, xp: 0 },
+      { name: 'White Ants', category: 'domain', cp: 0, xp: 0, free_grants: { necro: 2 }, territories: ['the-shore'] },
+    ]);
+    stateMod.chars = [yusuf]; stateMod.editIdx = 0; stateMod.editMode = true;
+    const html = shRenderDomainMerits(yusuf, true);
+    // The pre-#827 sub-row class `wa-territory-union` no longer appears.
+    expect(html).not.toContain('class="wa-territory-union"');
+    // The new inline subtitle class `dom-row-subtitle` does appear, with the text.
+    expect(html).toContain('dom-row-subtitle');
+    expect(html).toContain('Territories:');
+  });
+
+  it('Haven without attached_to: subtitle shows "(not attached)" placeholder, still before dots', () => {
+    const c = mkChar('Yusuf', [
+      { name: 'Haven', category: 'domain', cp: 1, xp: 0 }, // no attached_to
+    ]);
+    stateMod.chars = [c]; stateMod.editIdx = 0; stateMod.editMode = true;
+    const html = shRenderDomainMerits(c, true);
+    expect(html).toContain('Attached: (not attached)');
+    expect(html.indexOf('Attached:')).toBeLessThan(html.indexOf('dom-total-lbl'));
+  });
+});
+
+describe('#827 — subtitle precedes dots in DOM order (view mode)', () => {
+  it('Haven row: "Attached: X" appears BEFORE trait-right (dots container)', () => {
+    const c = mkChar('Yusuf', [
+      { name: 'Safe Place', category: 'domain', cp: 2, xp: 0, qualifier: 'Penthouse' },
+      { name: 'Haven', category: 'domain', cp: 1, xp: 0, attached_to: 'Safe Place (Penthouse)' },
+    ]);
+    stateMod.chars = [c]; stateMod.editIdx = 0; stateMod.editMode = false;
+    const html = shRenderDomainMerits(c, false);
+    // View mode sorts alphabetically — Haven < Safe Place. Find Haven via its
+    // name text content.
+    const havenIdx = html.indexOf('>Haven<');
+    expect(havenIdx).toBeGreaterThan(0);
+    // Slice Haven's row.
+    const blockStart = html.lastIndexOf('<div class="merit-plain', havenIdx);
+    const blockEnd = html.indexOf('<div class="merit-plain', blockStart + 1);
+    const rowSlice = html.slice(blockStart, blockEnd > 0 ? blockEnd : html.length);
+    const subtitleIdx = rowSlice.indexOf('Attached:');
+    const traitRightIdx = rowSlice.indexOf('trait-right');
+    expect(subtitleIdx).toBeGreaterThan(0);
+    expect(traitRightIdx).toBeGreaterThan(0);
+    expect(subtitleIdx).toBeLessThan(traitRightIdx);
+  });
+
+  it('White Ants row: "Territories: ..." appears BEFORE trait-right', () => {
+    const yusuf = mkChar('Yusuf', [
+      { name: 'Necropolis Sepulcher', category: 'domain', cp: 3, xp: 0 },
+      { name: 'White Ants', category: 'domain', cp: 0, xp: 0, free_grants: { necro: 2 }, territories: ['the-shore'] },
+    ]);
+    stateMod.chars = [yusuf]; stateMod.editIdx = 0; stateMod.editMode = false;
+    const html = shRenderDomainMerits(yusuf, false);
+    // White Ants's row contains "Territories:" — find it.
+    const territoriesIdx = html.indexOf('Territories:');
+    expect(territoriesIdx).toBeGreaterThan(0);
+    // The trait-right for the same row appears AFTER the subtitle.
+    // Slice the row: lastIndexOf('<div class="merit-plain' before
+    // territoriesIdx), nextIndexOf after.
+    const blockStart = html.lastIndexOf('<div class="merit-plain', territoriesIdx);
+    const blockEnd = html.indexOf('<div class="merit-plain', blockStart + 1);
+    const rowSlice = html.slice(blockStart, blockEnd > 0 ? blockEnd : html.length);
+    const subtitleIdx = rowSlice.indexOf('Territories:');
+    const traitRightIdx = rowSlice.indexOf('trait-right');
+    expect(subtitleIdx).toBeLessThan(traitRightIdx);
+  });
+
+  it('Standalone trait-sub "Attached: X" sub-row no longer emitted (replaced by inline)', () => {
+    const c = mkChar('Yusuf', [
+      { name: 'Safe Place', category: 'domain', cp: 2, xp: 0, qualifier: 'Penthouse' },
+      { name: 'Haven', category: 'domain', cp: 1, xp: 0, attached_to: 'Safe Place (Penthouse)' },
+    ]);
+    stateMod.chars = [c]; stateMod.editIdx = 0; stateMod.editMode = false;
+    const html = shRenderDomainMerits(c, false);
+    // The pre-#827 sub-row had `<div class="trait-sub"><span class="trait-qual">Attached:`
+    // — the inline version uses `<span class="trait-qual dom-row-subtitle">Attached:`.
+    expect(html).not.toMatch(/<div class="trait-sub"><span class="trait-qual">Attached:/);
+    expect(html).toMatch(/<span class="trait-qual dom-row-subtitle">Attached:/);
+  });
+});
+
+describe('#827 — non-target merits unaffected (regression sentinel)', () => {
+  it('Safe Place has no dom-row-subtitle (not in the three named merits)', () => {
+    const c = mkChar('Yusuf', [
+      { name: 'Safe Place', category: 'domain', cp: 2, xp: 0, qualifier: 'Penthouse' },
+    ]);
+    stateMod.chars = [c]; stateMod.editIdx = 0; stateMod.editMode = true;
+    const html = shRenderDomainMerits(c, true);
+    expect(html).not.toContain('dom-row-subtitle');
+  });
+
+  it('Feeding Grounds has no dom-row-subtitle (not in the three named merits)', () => {
+    const c = mkChar('Yusuf', [
+      { name: 'Feeding Grounds', category: 'domain', cp: 2, xp: 0, qualifier: 'Docks' },
+    ]);
+    stateMod.chars = [c]; stateMod.editIdx = 0; stateMod.editMode = true;
+    const html = shRenderDomainMerits(c, true);
+    expect(html).not.toContain('dom-row-subtitle');
+  });
+});
+
+describe('#827 — placement sanity guards', () => {
+  it('shRenderDomainMerits source emits dom-row-subtitle for the three named merits', () => {
+    const src = read('public/js/editor/sheet.js');
+    expect(src).toMatch(/m\.name === 'Haven' \|\| m\.name === 'Mandragora Garden'/);
+    expect(src).toMatch(/m\.name === 'White Ants' && _necroTerritoryUnion/);
+    expect(src).toMatch(/dom-row-subtitle/);
+  });
+
+  it('wa-territory-union standalone sub-row removed from edit mode emission', () => {
+    const src = read('public/js/editor/sheet.js');
+    const fnStart = src.indexOf('export function shRenderDomainMerits');
+    const nextExport = src.indexOf('export function ', fnStart + 1);
+    const body = src.slice(fnStart, nextExport > 0 ? nextExport : src.length);
+    // The class attribute `class="wa-territory-union"` no longer appears as an
+    // emitted element string. (The audit-trail comment text references it,
+    // but only inside JS comments — strip comments and confirm.)
+    const codeOnly = body.split('\n').filter(l => !l.trim().startsWith('//')).join('\n');
+    expect(codeOnly).not.toMatch(/class="wa-territory-union"/);
+  });
+});


### PR DESCRIPTION
## Summary

Three domain merits (Haven, Mandragora Garden, White Ants) rendered their subtitle/label as standalone sub-rows BELOW the main row's dot column. In DOM order subtitle followed dots, breaking the consistent rightmost-dots rule every other domain merit follows.

> Peter 2026-06-16: "Dots should be last and rightmost thing in the row always for all domain merits."

## Implementation

**Edit mode** (`shRenderDomainMerits` owned-merit + virtual-row paths):
- Inline `dom-row-subtitle` span INSIDE the `infl-edit-row`, between the merit-name select and the `dom-contrib-lbl` (dots) span
- Haven / Mandragora subtitle reads `m.attached_to.destination` via `normaliseAttachedTo` (falls back to "(not attached)" placeholder)
- White Ants subtitle reads `_necroTerritoryUnion` (already computed at the top of the edit block for COLLECTIVE-1)
- Standalone `wa-territory-union` sub-row **removed** — superseded by inline
- `dom-attach-row` picker for Haven/MG **kept** (it's the interactive editor for changing the attached Safe Place)

**View mode** (read-only path):
- Inline `trait-qual dom-row-subtitle` span inside `trait-main`, between `trait-name` and `trait-right` (dots container)
- Standalone `trait-sub` "Attached: X" sub-row **removed** — superseded by inline
- Standalone `wa-territory-union` sub-row **removed** in view + virtual paths

Other domain merits (Safe Place, Feeding Grounds, Catacombs and other Necropolis targets, Trap Door, Herd, Retainer, etc): no behavioural change.

## Tests

`server/tests/issue-827-subtitle-order.test.js` — **12 cases**, behavioural per `feedback_render_wiring_placement`:

- Edit-mode subtitle-before-dots for Haven / Mandragora / White Ants (3 cases each anchored on the row's `shRemoveDomMerit(<di>)` marker, sliced and asserted that "Attached:" / "Territories:" `< dom-total-lbl` position)
- Standalone `wa-territory-union` sub-row no longer emitted
- Haven without `attached_to`: subtitle shows "(not attached)" placeholder, still before dots
- View-mode mirror: Haven inline before `trait-right`; White Ants inline before `trait-right`; standalone `trait-sub` "Attached: X" no longer emitted
- Regression sentinels: Safe Place and Feeding Grounds have NO `dom-row-subtitle` (not in the three named merits)
- Static-analysis: source emits the inline subtitle for the three names; no executable `wa-territory-union` sub-row remaining

**Collateral test update:** `collective-1-virtual-rows.test.js` had 3 assertions on the standalone `wa-territory-union` class — updated to match the new `dom-row-subtitle` / "Territories:" shape.

## Regression

- 12/12 on the new file
- **100/100 across closely-related** (#827 + #793 + n7a/b/c/d + n4a + collective-1)
- No regression on other domain merits

## Smoke test path (post-deploy)

1. Yusuf (Sepulcher + Haven attached + White Ants with territories): edit-mode and view-mode rows show subtitle "Attached: <SP>" / "Territories: ..." LHS-justified inside the main row, dots rightmost
2. Haven with no `attached_to`: subtitle shows "Attached: (not attached)"
3. Safe Place / Feeding Grounds / Catacombs / etc rows: no subtitle, layout unchanged
4. Mandragora Garden attached to Necropolis Sepulcher: subtitle "Attached: Necropolis Sepulcher"

Closes #827