### PR TITLE
fix(editor): #830 — inherited-card title CSS (subtitle scale + dim tone)

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -404,6 +404,17 @@ html:not([data-theme="dark"]) .edit-icon {
 
 /* ── Domain merit editing ── */
 .dom-edit-block{border-bottom:1px solid var(--w-a6);padding-bottom:4px;margin-bottom:4px;}
+/* Issue #830: inherited-card grouping styles. Visual hint via left rail +
+   indent so the group reads as "belongs to Sepulcher"; title at subtitle
+   scale + dim tone (matches the trait-qual.dim convention). Same shape in
+   edit + view modes since both renderers emit the same class names. */
+.dom-inherited-card{border-left:2px solid var(--gold2-a25);padding-left:8px;margin:2px 0 4px;}
+.dom-inherited-card-title{font-family:var(--fl);font-size:10px;letter-spacing:.08em;text-transform:uppercase;color:var(--txt3);margin-bottom:3px;}
+/* Issue #827: inline subtitle inside the main row (Haven attached_to /
+   Mandragora attached_to / White Ants territories). LHS-justified between
+   the merit name and the dots; subtitle scale + dim tone. Used in both
+   modes. */
+.dom-row-subtitle{font-family:var(--fl);font-size:10px;letter-spacing:.04em;color:var(--txt3);padding:0 6px;flex:1;text-align:left;}
 .dom-contrib-lbl{font-size:10px;font-family:var(--ft);color:var(--txt3);padding:0 4px;}
 .dom-total-lbl{font-size:10px;font-family:var(--ft);color:var(--accent);font-weight:600;padding:0 4px;}
 .dom-partners-row{display:flex;flex-wrap:wrap;gap:4px;padding:4px 8px;}

--- a/server/tests/issue-830-inherited-card-css.test.js
+++ b/server/tests/issue-830-inherited-card-css.test.js
@@ -1,0 +1,63 @@
+/**
+ * Issue #830 — inherited-card title CSS placement guards.
+ *
+ * Pure CSS change. The renderer emits .dom-inherited-card +
+ * .dom-inherited-card-title elements (added by #793); this issue adds the
+ * styling so the title reads as a subtitle (small + dim) and the card has
+ * a subtle visual grouping.
+ *
+ * Tests are static-analysis sanity guards (no behavioural change to
+ * shRenderDomainMerits). The #793 / #827 behavioural tests already cover
+ * the structural emission; this file just confirms the CSS rules exist
+ * and target the expected selectors with subtitle-scale properties.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+function read(rel) { return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8'); }
+
+describe('#830 — inherited-card title CSS', () => {
+  const css = read('public/css/components.css');
+
+  it('.dom-inherited-card has a left rail (border-left) and indent (padding-left)', () => {
+    // Reads the rule block by anchoring on the selector + the following `{...}` body.
+    const rule = css.match(/\.dom-inherited-card\s*\{[^}]+\}/);
+    expect(rule).not.toBeNull();
+    expect(rule[0]).toMatch(/border-left/);
+    expect(rule[0]).toMatch(/padding-left/);
+  });
+
+  it('.dom-inherited-card-title is subtitle scale (≤ 11px) and dim (uses --txt3)', () => {
+    const rule = css.match(/\.dom-inherited-card-title\s*\{[^}]+\}/);
+    expect(rule).not.toBeNull();
+    expect(rule[0]).toMatch(/font-size:\s*1[01]px/); // 10 or 11px
+    expect(rule[0]).toMatch(/color:\s*var\(--txt3\)/);
+    expect(rule[0]).toMatch(/text-transform:\s*uppercase/);
+  });
+
+  it('.dom-row-subtitle (from #827 inline subtitles) gets explicit styling here too', () => {
+    // The inline subtitle on Haven / MG / White Ants rows shares the
+    // subtitle-scale + dim treatment — making the visual language consistent
+    // across the "subtitle on row" and "card title" surfaces.
+    const rule = css.match(/\.dom-row-subtitle\s*\{[^}]+\}/);
+    expect(rule).not.toBeNull();
+    expect(rule[0]).toMatch(/font-size:\s*1[01]px/);
+    expect(rule[0]).toMatch(/color:\s*var\(--txt3\)/);
+  });
+
+  it('CSS placed in the Domain merit editing section (near .dom-edit-block)', () => {
+    // Static placement guard — keep grouped with related domain-merit CSS so
+    // future audits find the styling alongside the structural rules.
+    const editBlockIdx = css.indexOf('.dom-edit-block{');
+    const cardIdx = css.indexOf('.dom-inherited-card{');
+    expect(editBlockIdx).toBeGreaterThan(0);
+    expect(cardIdx).toBeGreaterThan(editBlockIdx);
+    // Within ~600 chars of dom-edit-block — same section
+    expect(cardIdx - editBlockIdx).toBeLessThan(600);
+  });
+});


### PR DESCRIPTION
## Summary

Pure CSS fix for #793's `.dom-inherited-card-title` (and #827's `.dom-row-subtitle`, which also shipped without explicit styling). Title rendered at body text size / weight pre-fix; now subtitle scale + dim tone matching the existing `trait-qual.dim` convention.

## CSS

`public/css/components.css`, near the existing `.dom-edit-block` block:

- `.dom-inherited-card` — left rail (`border-left: 2px solid var(--gold2-a25)`) + indent (`padding-left: 8px`) so the group visually reads as "belongs to Sepulcher"
- `.dom-inherited-card-title` — `font-size: 10px` (subtitle scale, smaller than `.trait-qual`'s 11px), letter-spacing .08em, uppercase, `color: var(--txt3)` (dim per trait-qual.dim)
- `.dom-row-subtitle` — same 10px / --txt3 treatment so the inline subtitle from #827 reads consistently with the card title; `flex: 1` so it expands LHS-justified between the merit name and dots

Both edit and view modes inherit identical styling — the renderer emits the same class names in both.

## Tests

`server/tests/issue-830-inherited-card-css.test.js` — **4 static-analysis sanity guards**:

- `.dom-inherited-card` has `border-left` + `padding-left` (left-rail + indent)
- `.dom-inherited-card-title` font-size ≤ 11px, color `--txt3`, uppercase
- `.dom-row-subtitle` styled at the same subtitle scale + dim
- Placement: card CSS placed near `.dom-edit-block` (grouped audit surface)

## Regression

- Targeted file: 4/4 pass
- #793 + #827 behavioural tests still pass: **28/28 across all three** (#793 + #827 + #830)
- Pure CSS change — no behavioural impact on the renderer

Closes #830