### PR TITLE
feat(editor): #832 — domain merits expand-on-click to show description

### DIFF
--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -1115,10 +1115,30 @@ export function shRenderDomainMerits(c, editMode) {
       } else if (m.name === 'White Ants' && _necroTerritoryUnion) {
         _subtitleInline = '<span class="dom-row-subtitle">Territories: ' + esc(_necroTerritoryUnion) + '</span>';
       }
+      // Issue #832: expand-on-click for domain merits \u2014 same exp-row /
+      // exp-body shell as shRenderMeritRow uses for general + influence
+      // merits. The click is on the infl-edit-row (the visual row containing
+      // name + dots); the rest of the dom-edit-block (qualifier / attach /
+      // bd-row pickers / partners) is below and does not toggle. Interactive
+      // controls inside the infl-edit-row (select.infl-type + remove button)
+      // get event.stopPropagation() so changing the merit type or removing
+      // it doesn't accidentally toggle the description.
+      const _expId = 'dom-' + rIdx;
+      const _expDb = meritLookup(m.name);
+      const _expDesc = _expDb && _expDb.desc ? esc(_expDb.desc) : '';
+      const _expPrereq = _expDb && _expDb.prereq ? prereqLabel(_expDb.prereq) : '';
+      const _hasExpBody = !!_expDesc;
+      const _expClass = _hasExpBody ? ' exp-row' : '';
+      const _expArr = _hasExpBody ? '<span class="exp-arr">\u203A</span>' : '';
+      const _expOnclick = _hasExpBody ? ' onclick="toggleExp(\'' + _expId + '\')"' : '';
+      const _expIdAttr = _hasExpBody ? ' id="exp-row-' + _expId + '"' : '';
+      // stopPropagation prefix for interactive controls (avoids double-event
+      // when the row click also fires from the bubble).
+      const _sp = _hasExpBody ? 'event.stopPropagation();' : '';
       if (_isNecroTargetHere) {
-        h += '<div class="dom-edit-block"><div class="infl-edit-row"><select class="infl-type" onchange="shEditDomMerit(' + di + ',\'name\',this.value)">' + tOpts + '</select>' + _subtitleInline + '<span class="dom-contrib-lbl">My dots: ' + '\u25CF'.repeat(_necroOwn) + '</span><span class="dom-total-lbl" title="Cumulative across all Sepulcher-owners (\u25CF own, \u25CB partners)">Total: ' + _necroDotsHtml + '</span><button class="dev-rm-btn" onclick="shRemoveDomMerit(' + di + ')" title="Remove">&times;</button></div>';
+        h += '<div class="dom-edit-block"><div class="infl-edit-row' + _expClass + '"' + _expIdAttr + _expOnclick + '><select class="infl-type" onclick="' + _sp + '" onchange="shEditDomMerit(' + di + ',\'name\',this.value)">' + tOpts + '</select>' + _subtitleInline + '<span class="dom-contrib-lbl">My dots: ' + '\u25CF'.repeat(_necroOwn) + '</span><span class="dom-total-lbl" title="Cumulative across all Sepulcher-owners (\u25CF own, \u25CB partners)">Total: ' + _necroDotsHtml + '</span>' + _expArr + '<button class="dev-rm-btn" onclick="' + _sp + 'shRemoveDomMerit(' + di + ')" title="Remove">&times;</button></div>';
       } else {
-        h += '<div class="dom-edit-block"><div class="infl-edit-row"><select class="infl-type" onchange="shEditDomMerit(' + di + ',\'name\',this.value)">' + tOpts + '</select>' + _subtitleInline + '<span class="dom-contrib-lbl">My dots: ' + '\u25CF'.repeat(_dPurch) + '\u25CB'.repeat(Math.max(0, dd + (m.bonus || 0) - _dPurch)) + '</span><span class="dom-total-lbl" title="Total across all contributors (\u25CF own, \u25CB partners)">Total: ' + (_isCapped ? _capTotalDots : _totalDots) + '</span><button class="dev-rm-btn" onclick="shRemoveDomMerit(' + di + ')" title="Remove">&times;</button></div>';
+        h += '<div class="dom-edit-block"><div class="infl-edit-row' + _expClass + '"' + _expIdAttr + _expOnclick + '><select class="infl-type" onclick="' + _sp + '" onchange="shEditDomMerit(' + di + ',\'name\',this.value)">' + tOpts + '</select>' + _subtitleInline + '<span class="dom-contrib-lbl">My dots: ' + '\u25CF'.repeat(_dPurch) + '\u25CB'.repeat(Math.max(0, dd + (m.bonus || 0) - _dPurch)) + '</span><span class="dom-total-lbl" title="Total across all contributors (\u25CF own, \u25CB partners)">Total: ' + (_isCapped ? _capTotalDots : _totalDots) + '</span>' + _expArr + '<button class="dev-rm-btn" onclick="' + _sp + 'shRemoveDomMerit(' + di + ')" title="Remove">&times;</button></div>';
       }
       // Qualifier input for Safe Place / Feeding Grounds
       if (['Safe Place', 'Feeding Grounds'].includes(m.name)) {
@@ -1199,6 +1219,14 @@ export function shRenderDomainMerits(c, editMode) {
       const _canShare = ['Safe Place', 'Haven'];
       if (_canShare.includes(m.name) && parts.length) { h += '<div class="dom-partners-row">'; parts.forEach(pN => { const p = chars.find(ch => ch.name === pN), pD = p ? domMeritShareable(p, m.name) : 0; h += '<span class="dom-partner-tag">' + esc(pN) + (pD ? ' ' + shDots(pD) : ' \u25CB') + '<button class="dom-partner-rm" onclick="shRemoveDomainPartner(' + di + ',\'' + pN.replace(/'/g, "\\'") + '\')">\u00D7</button></span>'; }); h += '</div>'; }
       if (_canShare.includes(m.name) && avP.length) h += '<div class="dom-add-partner-row"><select class="dom-partner-sel" onchange="if(this.value){shAddDomainPartner(' + di + ',this.value);this.value=\'\';}"><option value="">+ Add shared partner\u2026</option>' + avP.map(p => '<option value="' + esc(p.name) + '">' + esc(dropdownName(p)) + '</option>').join('') + '</select></div>';
+      // Issue #832: exp-body sibling at the end of dom-edit-block holds the
+      // collapsible description + prereq. Only emitted when the merit has a
+      // description in the rules cache (matches shRenderMeritRow's gate).
+      if (_hasExpBody) {
+        h += '<div class="exp-body" id="exp-body-' + _expId + '"><div>' + _expDesc + '</div>'
+          + (_expPrereq ? '<div style="margin-top:5px;font-style:italic;color:var(--txt3)">Prerequisite: ' + esc(_expPrereq) + '</div>' : '')
+          + '</div>';
+      }
       h += '</div>';
     };
     // Virtual-row emitter \u2014 same pattern as _emitDomRow but for synthesised
@@ -1213,20 +1241,41 @@ export function shRenderDomainMerits(c, editMode) {
       const _vSubtitle = (vName === 'White Ants' && _necroTerritoryUnion)
         ? '<span class="dom-row-subtitle">Territories: ' + esc(_necroTerritoryUnion) + '</span>'
         : '';
+      // Issue #832: virtual rows get the same expand-on-click affordance as
+      // owned rows. Look up the merit's description by name (the merit isn't
+      // on c.merits yet, but the rules cache has the doc keyed by name slug).
+      // The NECRO stepper inside the bd-row gets stopPropagation so clicking
+      // the input doesn't toggle the expand.
+      const _vExpId = 'dom-v-' + _vSlug;
+      const _vDb = meritLookup(vName);
+      const _vDesc = _vDb && _vDb.desc ? esc(_vDb.desc) : '';
+      const _vPrereq = _vDb && _vDb.prereq ? prereqLabel(_vDb.prereq) : '';
+      const _vHasExp = !!_vDesc;
+      const _vExpClass = _vHasExp ? ' exp-row' : '';
+      const _vExpArr = _vHasExp ? '<span class="exp-arr">\u203A</span>' : '';
+      const _vExpOnclick = _vHasExp ? ' onclick="toggleExp(\'' + _vExpId + '\')"' : '';
+      const _vExpIdAttr = _vHasExp ? ' id="exp-row-' + _vExpId + '"' : '';
+      const _vSp = _vHasExp ? 'event.stopPropagation();' : '';
       h += '<div class="dom-edit-block dom-edit-block--virtual">'
-        + '<div class="infl-edit-row">'
+        + '<div class="infl-edit-row' + _vExpClass + '"' + _vExpIdAttr + _vExpOnclick + '>'
         + '<span class="infl-type infl-type--virtual" title="Partner-only \u2014 click NECRO to allocate your own dots">' + esc(vName) + '</span>'
         + _vSubtitle
         + '<span class="dom-contrib-lbl">My dots: </span>'
         + '<span class="dom-total-lbl" title="Cumulative across all Sepulcher-owners (\u25CF own, \u25CB partners)">Total: ' + _vDots + '</span>'
+        + _vExpArr
         + '</div>'
         + '<div class="merit-bd-row">'
         + '<div class="bd-grp">'
         + '<span class="bd-lbl bd-bonus-lbl" id="bd-necro-vlbl-' + _vSlug + '">NECRO</span>'
-        + '<input id="bd-necro-v-' + _vSlug + '" name="bd-necro-v-' + _vSlug + '" aria-label="Necropolis pool allocation" class="merit-bd-input bd-bonus-input" type="number" min="0" value="0" onchange="shAllocateNecroVirtual(\'' + vName.replace(/'/g, "\\'") + '\',+this.value)">'
+        + '<input id="bd-necro-v-' + _vSlug + '" name="bd-necro-v-' + _vSlug + '" aria-label="Necropolis pool allocation" class="merit-bd-input bd-bonus-input" type="number" min="0" value="0" onclick="' + _vSp + '" onchange="shAllocateNecroVirtual(\'' + vName.replace(/'/g, "\\'") + '\',+this.value)">'
         + '</div>'
         + '<div class="bd-eq"><span class="bd-val">' + _vPartner + ' partner dot' + (_vPartner === 1 ? '' : 's') + '</span></div>'
         + '</div>';
+      if (_vHasExp) {
+        h += '<div class="exp-body" id="exp-body-' + _vExpId + '"><div>' + _vDesc + '</div>'
+          + (_vPrereq ? '<div style="margin-top:5px;font-style:italic;color:var(--txt3)">Prerequisite: ' + esc(_vPrereq) + '</div>' : '')
+          + '</div>';
+      }
       h += '</div>';
     };
     // Issue #793: sorted iteration with inherited-card grouping.
@@ -1372,20 +1421,45 @@ export function shRenderDomainMerits(c, editMode) {
       } else if (m.name === 'White Ants' && _necroTerritoryUnionView) {
         _subtitleInlineView = '<span class="trait-qual dom-row-subtitle">Territories: ' + esc(_necroTerritoryUnionView) + '</span>';
       }
-      h += '<div class="merit-plain"><div class="trait-row"><div class="trait-main"><span class="trait-name">' + _dispName + '</span>' + _subtitleInlineView + '<div class="trait-right">' + (dp ? _shHtml : dotHtml) + '</div></div>' + (dp ? '<div class="trait-sub"><span class="trait-qual dom-shared-lbl">Shared \u00B7 ' + dp.map(n => { const p = chars.find(ch => ch.name === n), pd = p ? domMeritShareable(p, m.name) : 0; return esc(n) + (pd ? ' ' + shDots(pd) : ''); }).join(', ') + '</span></div>' : '') + '</div>';
+      // Issue #832: view-mode expand-on-click. Mirrors shRenderMeritRow's
+      // exp-row { trait-row + trait-sub } + sibling exp-body shell. Read-
+      // only path has no interactive controls so no stopPropagation needed.
+      // Derived-note warnings (Capped / Needs attached) emit as further
+      // siblings after the exp-body \u2014 same visual intent as the existing
+      // pattern (cap warning sits beneath the row).
+      const _viewExpId = 'dom-' + c.merits.indexOf(m);
+      const _viewDb = meritLookup(m.name);
+      const _viewDesc = _viewDb && _viewDb.desc ? esc(_viewDb.desc) : '';
+      const _viewPrereq = _viewDb && _viewDb.prereq ? prereqLabel(_viewDb.prereq) : '';
+      const _viewHasExp = !!_viewDesc;
+      const _viewSharedSub = dp
+        ? '<div class="trait-sub"><span class="trait-qual dom-shared-lbl">Shared \u00B7 ' + dp.map(n => { const p = chars.find(ch => ch.name === n), pd = p ? domMeritShareable(p, m.name) : 0; return esc(n) + (pd ? ' ' + shDots(pd) : ''); }).join(', ') + '</span></div>'
+        : '';
+      const _viewArr = _viewHasExp ? '<span class="exp-arr">\u203A</span>' : '';
+      // Inner row body \u2014 trait-row + trait-main + trait-right + optional
+      // shared trait-sub. Self-contained: opens 3 divs (trait-row,
+      // trait-main, trait-right) and closes them all inline.
+      const _viewInner = '<div class="trait-row"><div class="trait-main"><span class="trait-name">' + _dispName + '</span>' + _subtitleInlineView + '<div class="trait-right">' + (dp ? _shHtml : dotHtml) + _viewArr + '</div></div></div>' + _viewSharedSub;
+      // Capped-view warnings (Needs Attached / Capped at N) \u2014 derived-note
+      // siblings after the exp-body. Hoisted out so both branches share.
+      let _viewCappedNote = '';
       if (_isCappedView) {
-        // The "Needs an attached Safe Place" warning and "Capped at N" notes
-        // remain as derived-note sub-rows (they're warnings, not subtitles).
-        // The "Attached: X" success label moved INLINE above per #827.
         const _viewAt = normaliseAttachedTo(m.attached_to);
         if (!_viewAt) {
-          h += '<div class="derived-note dom-cap-warn">Needs an attached Safe Place (0 effective dots)</div>';
+          _viewCappedNote = '<div class="derived-note dom-cap-warn">Needs an attached Safe Place (0 effective dots)</div>';
         } else if (_viewStored > de) {
-          h += '<div class="derived-note">Capped at ' + de + ' \u2014 Safe Place limits effective dots</div>';
+          _viewCappedNote = '<div class="derived-note">Capped at ' + de + ' \u2014 Safe Place limits effective dots</div>';
         }
       }
-      // Issue #827: wa-territory-union sub-row removed \u2014 moved inline above.
-      h += '</div>';
+      if (_viewHasExp) {
+        h += '<div class="exp-row" id="exp-row-' + _viewExpId + '" onclick="toggleExp(\'' + _viewExpId + '\')">' + _viewInner + '</div>';
+        h += '<div class="exp-body" id="exp-body-' + _viewExpId + '"><div>' + _viewDesc + '</div>'
+          + (_viewPrereq ? '<div style="margin-top:5px;font-style:italic;color:var(--txt3)">Prerequisite: ' + esc(_viewPrereq) + '</div>' : '')
+          + '</div>';
+        h += _viewCappedNote;
+      } else {
+        h += '<div class="merit-plain">' + _viewInner + _viewCappedNote + '</div>';
+      }
     };
     const _emitVirtualViewRow = (vName) => {
       const _vPartner = collectiveNecroDots(chars, vName);
@@ -1395,13 +1469,29 @@ export function shRenderDomainMerits(c, editMode) {
       const _vSubtitle = (vName === 'White Ants' && _necroTerritoryUnionView)
         ? '<span class="trait-qual dom-row-subtitle">Territories: ' + esc(_necroTerritoryUnionView) + '</span>'
         : '';
-      h += '<div class="merit-plain merit-plain--virtual">'
-        + '<div class="trait-row"><div class="trait-main">'
+      // Issue #832: virtual view row also gets expand-on-click. ID prefix
+      // matches the edit-mode virtual row pattern (`dom-v-<slug>`); merit
+      // looked up by name from the rules cache.
+      const _vSlug = vName.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+      const _vViewExpId = 'dom-v-' + _vSlug;
+      const _vViewDb = meritLookup(vName);
+      const _vViewDesc = _vViewDb && _vViewDb.desc ? esc(_vViewDb.desc) : '';
+      const _vViewPrereq = _vViewDb && _vViewDb.prereq ? prereqLabel(_vViewDb.prereq) : '';
+      const _vViewHasExp = !!_vViewDesc;
+      const _vViewArr = _vViewHasExp ? '<span class="exp-arr">›</span>' : '';
+      const _vViewInner = '<div class="trait-row"><div class="trait-main">'
         + '<span class="trait-name">' + esc(vName) + '</span>'
         + _vSubtitle
-        + '<div class="trait-right">' + _vDots + '</div>'
+        + '<div class="trait-right">' + _vDots + _vViewArr + '</div>'
         + '</div></div>';
-      h += '</div>';
+      if (_vViewHasExp) {
+        h += '<div class="exp-row merit-plain--virtual" id="exp-row-' + _vViewExpId + '" onclick="toggleExp(\'' + _vViewExpId + '\')">' + _vViewInner + '</div>';
+        h += '<div class="exp-body" id="exp-body-' + _vViewExpId + '"><div>' + _vViewDesc + '</div>'
+          + (_vViewPrereq ? '<div style="margin-top:5px;font-style:italic;color:var(--txt3)">Prerequisite: ' + esc(_vViewPrereq) + '</div>' : '')
+          + '</div>';
+      } else {
+        h += '<div class="merit-plain merit-plain--virtual">' + _vViewInner + '</div>';
+      }
     };
     const _virtualNamesView = _collectiveNamesView.filter(n => !_ownedNecroSetView.has(n));
     const _ownedTargetsView = _sortedDomView.filter(mm => _necroTargetSetView.has(mm.name));

--- a/server/tests/issue-832-domain-merit-expand.test.js
+++ b/server/tests/issue-832-domain-merit-expand.test.js
@@ -1,0 +1,270 @@
+/**
+ * Issue #832 — domain merit expand-on-click.
+ *
+ * Pre-#832: domain merit rows didn't expand to show description; general +
+ * influence merits did (via shRenderMeritRow's exp-row/exp-body shell).
+ *
+ * Post-#832: domain merit rows get the same exp-row/exp-body shell.
+ * Click on the infl-edit-row (edit mode) or the wrapping row (view mode)
+ * toggles the description visible. Internal interactive controls
+ * (name select, dot stepper, remove button, NECRO stepper on virtual rows)
+ * get event.stopPropagation() so editing doesn't accidentally toggle.
+ *
+ * Behavioural per feedback_render_wiring_placement — render and assert on
+ * the returned HTML shape.
+ */
+
+// Browser shims.
+globalThis.location = {
+  origin: 'http://localhost:8080',
+  hostname: 'localhost',
+  href: 'http://localhost:8080/admin',
+};
+globalThis.localStorage = {
+  _store: {},
+  getItem(k) { return this._store[k] ?? null; },
+  setItem(k, v) { this._store[k] = String(v); },
+  removeItem(k) { delete this._store[k]; },
+  clear() { this._store = {}; },
+};
+globalThis.window = globalThis.window || globalThis;
+globalThis.document = globalThis.document || {
+  getElementById: () => null,
+  createElement: () => ({ style: {}, classList: { add() {}, remove() {}, toggle() {} } }),
+};
+
+import { describe, it, expect, beforeAll, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+function read(rel) { return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8'); }
+
+let shRenderDomainMerits;
+let stateMod;
+let loadRulesMod;
+let loaderMod;
+
+const NECRO_GRANT = {
+  source: 'Necropolis Sepulcher',
+  source_slug: 'necro',
+  category: 'necro',
+  grant_type: 'pool',
+  condition: 'merit_present',
+  amount_basis: 'rating_of_source',
+  pool_targets: ['Catacombs', 'Caldarium', 'Garbage Pit', 'Labyrinth Guardians', 'Dark Temple', 'White Ants'],
+};
+
+// Stub merit-rule docs so meritLookup() returns a desc for the merits in our
+// fixtures. meritLookup reads via getRuleByKey from data/loader.js — we mock
+// that to return our minimal stub.
+const STUB_RULES = {
+  'haven': { name: 'Haven', description: 'A defensible Haven for the test character.', rating_range: [1, 5], parent: 'Kindred', sub_category: 'domain' },
+  'safe-place': { name: 'Safe Place', description: 'A reliable Safe Place against intrusion.', rating_range: [1, 5], parent: 'Kindred', sub_category: 'domain' },
+  'catacombs': { name: 'Catacombs', description: 'Subterranean Catacombs description.', rating_range: [1, 5], parent: 'Kindred', sub_category: 'domain' },
+  'labyrinth-guardians': { name: 'Labyrinth Guardians', description: 'Labyrinth Guardians description.', rating_range: [1, 5], parent: 'Kindred', sub_category: 'domain' },
+  'necropolis-sepulcher': { name: 'Necropolis Sepulcher', description: 'The Necropolis Sepulcher anchor.', rating_range: [1, 5], parent: 'Kindred', sub_category: 'domain' },
+};
+
+beforeAll(async () => {
+  const sheetUrl = pathToFileURL(path.resolve(REPO_ROOT, 'public', 'js', 'editor', 'sheet.js')).href;
+  ({ shRenderDomainMerits } = await import(sheetUrl));
+  stateMod = (await import(pathToFileURL(path.resolve(REPO_ROOT, 'public', 'js', 'data', 'state.js')).href)).default;
+  loadRulesMod = await import(pathToFileURL(path.resolve(REPO_ROOT, 'public', 'js', 'editor', 'rule_engine', 'load-rules.js')).href);
+  loaderMod = await import(pathToFileURL(path.resolve(REPO_ROOT, 'public', 'js', 'data', 'loader.js')).href);
+  vi.spyOn(loadRulesMod, 'getRulesCache').mockReturnValue({
+    rule_grant: [NECRO_GRANT],
+    rule_nine_again: [], rule_skill_bonus: [], rule_speciality_grant: [],
+    rule_tier_budget: [], rule_disc_attr: [], rule_derived_stat_modifier: [],
+  });
+  // meritLookup reads via getRuleByKey from data/loader.js — stub it.
+  vi.spyOn(loaderMod, 'getRuleByKey').mockImplementation((slug) => STUB_RULES[slug] || null);
+});
+
+function mkChar(name, merits) {
+  return {
+    _id: 'c-' + name.toLowerCase(),
+    name,
+    clan: 'Nosferatu', covenant: 'Invictus',
+    status: { city: 0, clan: 0, covenant: {} },
+    attributes: {}, skills: {}, disciplines: {}, powers: [],
+    merits,
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Edit mode — owned merit rows
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#832 — edit mode owned merit row gets exp-row/exp-body shell', () => {
+  it('Haven row carries exp-row class + id + onclick + exp-body sibling with description', () => {
+    const c = mkChar('Yusuf', [
+      { name: 'Safe Place', category: 'domain', cp: 2, xp: 0, qualifier: 'Apt' },
+      { name: 'Haven', category: 'domain', cp: 1, xp: 0, attached_to: 'Safe Place (Apt)' },
+    ]);
+    stateMod.chars = [c]; stateMod.editIdx = 0; stateMod.editMode = true;
+    const html = shRenderDomainMerits(c, true);
+    const havenRealIdx = c.merits.findIndex(m => m.name === 'Haven');
+    expect(html).toContain('id="exp-row-dom-' + havenRealIdx + '"');
+    expect(html).toContain("onclick=\"toggleExp('dom-" + havenRealIdx + "')\"");
+    expect(html).toContain('id="exp-body-dom-' + havenRealIdx + '"');
+    expect(html).toContain('A defensible Haven for the test character.');
+  });
+
+  it('Interactive controls inside Haven row get event.stopPropagation()', () => {
+    const c = mkChar('Yusuf', [
+      { name: 'Safe Place', category: 'domain', cp: 2, xp: 0, qualifier: 'Apt' },
+      { name: 'Haven', category: 'domain', cp: 1, xp: 0, attached_to: 'Safe Place (Apt)' },
+    ]);
+    stateMod.chars = [c]; stateMod.editIdx = 0; stateMod.editMode = true;
+    const html = shRenderDomainMerits(c, true);
+    // Select dropdown (merit name change) — stopPropagation prepended
+    // (semicolon is part of the inline-script prefix shape, see _sp).
+    expect(html).toMatch(/<select class="infl-type" onclick="event\.stopPropagation\(\);"/);
+    // Remove button — stopPropagation prepended
+    expect(html).toMatch(/<button class="dev-rm-btn" onclick="event\.stopPropagation\(\);shRemoveDomMerit/);
+  });
+
+  it('exp-arr chevron appears in the row (visual indicator that row is expandable)', () => {
+    const c = mkChar('Yusuf', [
+      { name: 'Safe Place', category: 'domain', cp: 2, xp: 0, qualifier: 'Apt' },
+    ]);
+    stateMod.chars = [c]; stateMod.editIdx = 0; stateMod.editMode = true;
+    const html = shRenderDomainMerits(c, true);
+    expect(html).toContain('exp-arr');
+  });
+
+  it('Merit without description (no stub rule) falls back to merit-plain — no exp-row/exp-body', () => {
+    const c = mkChar('Yusuf', [
+      { name: 'Mystery Merit XYZ', category: 'domain', cp: 1, xp: 0 }, // not in STUB_RULES
+    ]);
+    stateMod.chars = [c]; stateMod.editIdx = 0; stateMod.editMode = true;
+    const html = shRenderDomainMerits(c, true);
+    const realIdx = c.merits.findIndex(m => m.name === 'Mystery Merit XYZ');
+    expect(html).not.toContain('id="exp-row-dom-' + realIdx + '"');
+    expect(html).not.toContain('id="exp-body-dom-' + realIdx + '"');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Edit mode — virtual (Necropolis) merit rows
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#832 — edit mode virtual row gets exp-row/exp-body shell', () => {
+  it('Virtual Labyrinth Guardians row gets exp-row + exp-body + NECRO stepper has stopPropagation', () => {
+    const yusuf = mkChar('Yusuf', [
+      { name: 'Necropolis Sepulcher', category: 'domain', cp: 5, xp: 0 },
+    ]);
+    const xavier = mkChar('Xavier', [
+      { name: 'Necropolis Sepulcher', category: 'domain', cp: 4, xp: 0 },
+      { name: 'Labyrinth Guardians', category: 'domain', cp: 0, xp: 0, free_grants: { necro: 1 } },
+    ]);
+    stateMod.chars = [yusuf, xavier]; stateMod.editIdx = 0; stateMod.editMode = true;
+    const html = shRenderDomainMerits(yusuf, true);
+    // Virtual row id uses slug.
+    expect(html).toContain('id="exp-row-dom-v-labyrinth-guardians"');
+    expect(html).toContain('id="exp-body-dom-v-labyrinth-guardians"');
+    expect(html).toContain('Labyrinth Guardians description.');
+    // NECRO stepper has stopPropagation onclick (clicking input shouldn't toggle).
+    expect(html).toMatch(/<input id="bd-necro-v-labyrinth-guardians"[^>]*onclick="event\.stopPropagation\(\);"/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// View mode — owned + virtual rows
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#832 — view mode owned + virtual rows get exp-row/exp-body shell', () => {
+  it('View-mode Haven row uses exp-row wrapper + exp-body sibling', () => {
+    const c = mkChar('Yusuf', [
+      { name: 'Safe Place', category: 'domain', cp: 2, xp: 0, qualifier: 'Apt' },
+      { name: 'Haven', category: 'domain', cp: 1, xp: 0, attached_to: 'Safe Place (Apt)' },
+    ]);
+    stateMod.chars = [c]; stateMod.editIdx = 0; stateMod.editMode = false;
+    const html = shRenderDomainMerits(c, false);
+    const havenRealIdx = c.merits.findIndex(m => m.name === 'Haven');
+    expect(html).toContain('id="exp-row-dom-' + havenRealIdx + '"');
+    expect(html).toContain('id="exp-body-dom-' + havenRealIdx + '"');
+    expect(html).toContain('A defensible Haven for the test character.');
+  });
+
+  it('View-mode virtual row uses exp-row + slug id', () => {
+    const yusuf = mkChar('Yusuf', [
+      { name: 'Necropolis Sepulcher', category: 'domain', cp: 5, xp: 0 },
+    ]);
+    const xavier = mkChar('Xavier', [
+      { name: 'Necropolis Sepulcher', category: 'domain', cp: 4, xp: 0 },
+      { name: 'Labyrinth Guardians', category: 'domain', cp: 0, xp: 0, free_grants: { necro: 1 } },
+    ]);
+    stateMod.chars = [yusuf, xavier]; stateMod.editIdx = 0; stateMod.editMode = false;
+    const html = shRenderDomainMerits(yusuf, false);
+    expect(html).toContain('id="exp-row-dom-v-labyrinth-guardians"');
+    expect(html).toContain('id="exp-body-dom-v-labyrinth-guardians"');
+  });
+
+  it('View-mode merit without description falls back to merit-plain', () => {
+    const c = mkChar('Yusuf', [
+      { name: 'Mystery Merit XYZ', category: 'domain', cp: 1, xp: 0 }, // not in STUB_RULES
+    ]);
+    stateMod.chars = [c]; stateMod.editIdx = 0; stateMod.editMode = false;
+    const html = shRenderDomainMerits(c, false);
+    expect(html).toContain('class="merit-plain"');
+    const realIdx = c.merits.findIndex(m => m.name === 'Mystery Merit XYZ');
+    expect(html).not.toContain('id="exp-row-dom-' + realIdx + '"');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Prereq label
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#832 — exp-body contains prereq when present', () => {
+  it('Merit with prereq emits "Prerequisite: ..." line inside exp-body', () => {
+    // Inject a stub rule with prereq for this test.
+    const STUB_WITH_PREREQ = { ...STUB_RULES, 'gated-merit': { name: 'Gated Merit', description: 'Gated description.', prereq: { all: [{ type: 'clan', name: 'Nosferatu' }] }, rating_range: [1, 3], parent: 'Kindred', sub_category: 'domain' } };
+    vi.spyOn(loaderMod, 'getRuleByKey').mockImplementation((slug) => STUB_WITH_PREREQ[slug] || null);
+    const c = mkChar('Yusuf', [{ name: 'Gated Merit', category: 'domain', cp: 1, xp: 0 }]);
+    stateMod.chars = [c]; stateMod.editIdx = 0; stateMod.editMode = true;
+    const html = shRenderDomainMerits(c, true);
+    const realIdx = 0;
+    expect(html).toContain('id="exp-body-dom-' + realIdx + '"');
+    expect(html).toContain('Gated description.');
+    expect(html).toMatch(/Prerequisite:.*Nosferatu/);
+    // Restore the default stub for subsequent tests.
+    vi.spyOn(loaderMod, 'getRuleByKey').mockImplementation((slug) => STUB_RULES[slug] || null);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Static-analysis sanity guards
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#832 — placement sanity guards', () => {
+  const src = read('public/js/editor/sheet.js');
+
+  it('shRenderDomainMerits emits exp-row id + onclick for owned merits', () => {
+    expect(src).toMatch(/_expIdAttr = _hasExpBody \? ' id="exp-row-' \+ _expId/);
+    expect(src).toMatch(/_expOnclick = _hasExpBody \? ' onclick="toggleExp\(/);
+  });
+
+  it('shRenderDomainMerits stops propagation on select.infl-type + dev-rm-btn', () => {
+    expect(src).toMatch(/<select class="infl-type" onclick="' \+ _sp \+ '"/);
+    expect(src).toMatch(/<button class="dev-rm-btn" onclick="' \+ _sp \+ 'shRemoveDomMerit/);
+  });
+
+  it('Virtual row NECRO stepper stops propagation', () => {
+    expect(src).toMatch(/onclick="' \+ _vSp \+ '" onchange="shAllocateNecroVirtual/);
+  });
+
+  it('View-mode emits exp-row when merit has desc, merit-plain when not', () => {
+    expect(src).toMatch(/_viewHasExp[\s\S]{0,400}<div class="exp-row" id="exp-row-' \+ _viewExpId/);
+    expect(src).toMatch(/<div class="merit-plain">' \+ _viewInner/);
+  });
+
+  it('exp-body content includes the description (esc-wrapped)', () => {
+    expect(src).toMatch(/<div class="exp-body" id="exp-body-' \+ _expId/);
+    expect(src).toMatch(/<div class="exp-body" id="exp-body-' \+ _viewExpId/);
+  });
+});


### PR DESCRIPTION
## Summary

Domain merit rows didn't expand to show description; general + influence merits already did via shRenderMeritRow. Peter (2026-06-16): omission, apply the same shell.

## Implementation

`shRenderDomainMerits` — four emit sites updated (owned/virtual × edit/view).

**Edit mode owned merit row** (`_emitDomRow`):
- `infl-edit-row` gets `id=exp-row-dom-<rIdx>` + `onclick=toggleExp(...)` + `exp-row` class when merit has a description in the rules cache
- `exp-arr` chevron inserted before the remove button
- `select.infl-type` (name dropdown) and `button.dev-rm-btn` (remove) get `event.stopPropagation()` so changing merit type or removing the row doesn't toggle the description
- `exp-body` sibling div at the end of `dom-edit-block` with the desc + prereq label (when present)

**Edit mode virtual merit row** (`_emitVirtualNecroRow`):
- Same exp-row treatment via `dom-v-<slug>` id
- NECRO stepper input gets `onclick=event.stopPropagation()` so allocating dots doesn't toggle the description

**View mode owned merit row** (`_emitViewRow`):
- Refactored to clean if/else branching: `exp-row { trait-row }` + sibling `exp-body` when has-desc; `merit-plain` fallback otherwise
- Derived-note warnings (Capped at N / Needs attached) emit as further siblings after exp-body when wrapped, or inside merit-plain when not
- Removed an orphaned closing div that complicated the prior structure

**View mode virtual merit row** (`_emitVirtualViewRow`):
- Same exp-row treatment via `dom-v-<slug>` id; no interactive controls so no stopPropagation needed

Description + prereq sourced via `meritLookup(name)` — same source `shRenderMeritRow` uses for general + influence. Falls back to `merit-plain` (no expand) when the merit has no description in the rules cache.

## Tests

`server/tests/issue-832-domain-merit-expand.test.js` — **14 cases**, behavioural per `feedback_render_wiring_placement`:

**Edit-mode owned (4):**
- Haven row carries exp-row id + onclick + exp-body sibling with desc
- `select.infl-type` + `dev-rm-btn` get `event.stopPropagation()`
- `exp-arr` chevron present
- Merit with no rule desc falls back to merit-plain (no exp-row)

**Edit-mode virtual (1):**
- Virtual Labyrinth Guardians row gets exp-row + exp-body; NECRO stepper has `onclick=event.stopPropagation()`

**View-mode (3):**
- Haven row uses exp-row + exp-body sibling
- Virtual row uses `dom-v-<slug>` id
- Mystery merit (no desc) falls back to merit-plain

**Prereq (1):** exp-body contains "Prerequisite: ..." when present

**Static-analysis sanity guards (5):** exp-row id + onclick wiring; select + remove button stopPropagation; virtual stepper stopPropagation; view-mode if/else branch shape; exp-body emission paired with id.

## Regression

- Targeted file: 14/14 pass
- Across closely-related (#832 + #830 + #827 + #793 + n7a/b/c/d + n4a + collective-1): **118/118 pass**
- No regression on related domain renderer paths

## Smoke test path (post-deploy)

1. Yusuf domain merit panel: click on any merit row (Safe Place, Haven, Catacombs, etc) → description expands below
2. Click again → collapses
3. Click on the merit name dropdown / dot stepper / remove button → does NOT toggle the description (stopPropagation working)
4. Necropolis virtual row: click row → expands description; click NECRO stepper → allocates dot without toggling
5. View mode (read-only): same expand-on-click; no editor controls to worry about
6. Mystery merits with no description in the rules cache: row renders as merit-plain, no expand affordance

## Main-merge

Per-message authorisation per dispatch — surfacing to Peter on dev merge clear.

Closes #832