### PR TITLE
feat(arch): #834 — deprecate m.free entirely (writer deleted, readers removed, cleanup + integration test)

### DIFF
--- a/public/js/admin/excel-merge.js
+++ b/public/js/admin/excel-merge.js
@@ -178,10 +178,18 @@ export function mergeExcelOntoCharacter(existing, excel) {
 }
 
 function applyMeritPoints(merit, pts, changes, label) {
-  const oldCp = merit.cp || 0, oldXp = merit.xp || 0, oldFree = merit.free || 0;
-  merit.cp = pts.cp + (pts.free || 0); merit.xp = pts.xp;
-  if (oldCp !== pts.cp || oldXp !== pts.xp || oldFree !== pts.free) {
-    changes.push({ section: 'Merits', field: label, old: `${oldCp}/${oldFree}/${oldXp}`, new: `${pts.cp}/${pts.free}/${pts.xp}` });
+  // Issue #834: m.free is deprecated. The IMPORT shape's `pts.free` column
+  // (from the upstream Excel/CSV tool) is folded into cp here — same as
+  // skills/disciplines at lines 77 + 90. The READ of `merit.free` (for the
+  // diff message) is removed: post-cleanup the field is always 0, and going
+  // forward the channel doesn't exist. The diff message keeps the cp/xp
+  // tuple shape; `pts.free` continues to be the upstream input column.
+  // Memory: feedback_m_free_deprecated.
+  const oldCp = merit.cp || 0, oldXp = merit.xp || 0;
+  const newCp = pts.cp + (pts.free || 0);
+  merit.cp = newCp; merit.xp = pts.xp;
+  if (oldCp !== newCp || oldXp !== pts.xp) {
+    changes.push({ section: 'Merits', field: label, old: `${oldCp}/${oldXp}`, new: `${newCp}/${pts.xp}` });
   }
 }
 

--- a/public/js/admin/rules-data-view.js
+++ b/public/js/admin/rules-data-view.js
@@ -531,7 +531,9 @@ function _renderPreviewDots(char, rule, proposed) {
   let h = '<div class="rde-preview-merits">';
   for (const m of relevant) {
     const base = (m.cp || 0) + (m.xp || 0);
-    const bonus = freeOf(m, 'pt') + freeOf(m, 'mci') + (m.free || 0) + freeOf(m, 'mdb') + freeOf(m, 'bloodline');
+    // Issue #834: m.free is deprecated — removed from the bonus rollup.
+    // Memory: feedback_m_free_deprecated.
+    const bonus = freeOf(m, 'pt') + freeOf(m, 'mci') + freeOf(m, 'mdb') + freeOf(m, 'bloodline');
     h += `<div class="rde-preview-merit-row">
       <span class="rde-preview-merit-name">${esc(m.name)}</span>
       <span class="rde-preview-merit-dots">${shDotsWithBonus(base, bonus)}</span>

--- a/public/js/editor/domain.js
+++ b/public/js/editor/domain.js
@@ -42,7 +42,9 @@ export function domKey(m) {
  */
 export function domMeritContribSingle(c, m) {
   if (!m) return 0;
-  const purchased = (m.cp || 0) + (m.free || 0) + freeOf(m, 'mci') + (m.xp || 0)
+  // Issue #834: m.free is deprecated — removed from the purchased sum.
+  // Memory: feedback_m_free_deprecated.
+  const purchased = (m.cp || 0) + freeOf(m, 'mci') + (m.xp || 0)
     + (m.bonus || 0);
   return purchased
     + (m.name === 'Herd' ? ssjHerdBonus(c) + flockHerdBonus(c) : 0)
@@ -62,7 +64,11 @@ export function domMeritContribSingle(c, m) {
  * `m.free_grants.mci`. Surgical, exact-behaviour-preserving map-fallback. */
 function domMeritShareableSingle(m) {
   if (!m) return 0;
-  return (m.cp || 0) + (m.free || 0) + freeOf(m, 'mci') + (m.xp || 0);
+  // Issue #834: m.free is deprecated — removed from the shareable sum.
+  // The N-1 verbatim-preservation comment above is now moot for the
+  // `m.free` term specifically; remaining channels (cp, mci, xp) are
+  // still preserved as-is per the deliberate-divergence note.
+  return (m.cp || 0) + freeOf(m, 'mci') + (m.xp || 0);
 }
 
 /**
@@ -241,14 +247,13 @@ export function meritFreeSum(m) {
   if (m && NECRO_TARGETS_FOR_SUM.has(m.name)) {
     return (m.free_grants && m.free_grants.necro) || 0;
   }
-  // N-1 / ADR-005 Rev 2: delegate to the shared helper which sums BOTH the
-  // new `m.free_grants` map AND every legacy `m.free_<slug>` field. The
-  // shared helper EXCLUDES `m.free` (the unprefixed player-allocated channel)
-  // per D1 — but the public `meritFreeSum` contract has historically included
-  // it, so we add it back here. Single source of truth for the 14-channel
-  // enumeration lives in `rules-helpers.js`; N-2 cleanup removes the legacy
-  // fallback there in one place rather than per call site.
-  return (m.free || 0) + _meritFreeSumHelper(m);
+  // Issue #834 (2026-06-17): m.free is deprecated — delegate to the shared
+  // helper, no longer adding `(m.free || 0)` back. The pre-#834 contract
+  // historically included m.free in meritFreeSum; that contract is dead
+  // along with the channel. See memory feedback_m_free_deprecated. Single
+  // source of truth for the canonical channel enumeration lives in
+  // rules-helpers.js.
+  return _meritFreeSumHelper(m);
 }
 
 /**

--- a/public/js/editor/merits.js
+++ b/public/js/editor/merits.js
@@ -108,7 +108,10 @@ export function ensureMeritSync(c) {
   for (const m of c.merits) {
     if (m.cp === undefined) m.cp = 0;
     if (m.xp === undefined) m.xp = 0;
-    if (m.free === undefined) m.free = 0;
+    // Issue #834: m.free is deprecated — no longer initialised here. New
+    // merits don't carry the field; existing merits that have it set retain
+    // it until the Phase 3 cleanup script zeros them. See memory
+    // feedback_m_free_deprecated.
     if (m.free_mci === undefined) m.free_mci = 0;
     if (m.free_vm === undefined) m.free_vm = 0;
     if (m.free_lk === undefined) m.free_lk = 0;
@@ -126,7 +129,7 @@ export function addMerit(c, merit) {
   if (!c.merits) c.merits = [];
   if (merit.cp === undefined) merit.cp = 0;
   if (merit.xp === undefined) merit.xp = 0;
-  if (merit.free === undefined) merit.free = 0;
+  // Issue #834: m.free is deprecated — no longer initialised on new merits.
   if (merit.free_mci === undefined) merit.free_mci = 0;
   if (merit.free_vm === undefined) merit.free_vm = 0;
   if (merit.free_lk === undefined) merit.free_lk = 0;

--- a/server/lib/normalize-character.js
+++ b/server/lib/normalize-character.js
@@ -22,6 +22,12 @@
  * After normalize, sum(channels) === rating for every merit.
  */
 
+// Issue #834: `'free'` retained in MERIT_CHANNELS for sumChannels accounting
+// only — never written by this normalizer post-#834. See memory
+// `feedback_m_free_deprecated` for why the channel is dead. If a contaminated
+// doc still carries a non-zero `m.free`, sumChannels picks it up so the
+// rating-sync branch produces an accurate sum (rather than triggering the
+// no-source branch), then the Phase 3 cleanup script zeroes the field.
 const MERIT_CHANNELS = [
   'cp', 'xp', 'free',
   'free_mci', 'free_vm', 'free_lk', 'free_ohm', 'free_inv',
@@ -37,8 +43,12 @@ const MERIT_CHANNELS = [
  * adds its derived dots on top of the generic `free`, double-counting.
  *
  * Mapping mirrors the rule engine evaluators (public/js/editor/rule_engine/*).
- * Unknown granted_by tags fall back to `free` (preserves dots without
- * claiming a specific source).
+ *
+ * Issue #834 (2026-06-17): `m.free` is deprecated. Unknown granted_by tags
+ * return null (was: fall back to `'free'`). A null return means "no
+ * canonical channel for this granted_by" — the caller refuses to mutate and
+ * logs a warning instead of writing the deprecated channel. See memory
+ * `feedback_m_free_deprecated`.
  */
 const GRANTED_BY_CHANNEL = {
   'Bloodline':  'free_bloodline',
@@ -57,7 +67,9 @@ const GRANTED_BY_CHANNEL = {
 
 function backfillChannel(merit) {
   const gb = merit.granted_by || '';
-  return GRANTED_BY_CHANNEL[gb] || 'free';
+  // Issue #834: return null when no canonical channel; caller must NOT
+  // fall back to writing `m.free` (the deprecated channel).
+  return GRANTED_BY_CHANNEL[gb] || null;
 }
 
 function sumChannels(merit) {
@@ -91,7 +103,21 @@ export function normalizeMerit(merit) {
   const rating = merit.rating || 0;
 
   if (sum === 0 && rating > 0) {
+    // Issue #834: when there's no canonical channel for the granted_by tag
+    // (or no granted_by at all), refuse to backfill into `m.free` (the
+    // deprecated channel). Log a warn so the orphan rating surfaces in
+    // server logs — the previous behaviour silently wrote `m.free = rating`
+    // which created the contamination class. The merit's rating stays as
+    // the user/script entered it; the rating-sync branch below will pull
+    // it to 0 on the next pass IF every channel is empty.
     const channel = backfillChannel(merit);
+    if (!channel) {
+      // Memory: feedback_m_free_deprecated — m.free is dead. A merit
+      // arriving here with rating > 0 and no mappable granted_by has no
+      // canonical source for its dots. Don't invent one.
+      console.warn(`normalizeMerit: refusing to backfill '${merit.name || '?'}' (rating=${rating}) — no canonical channel; granted_by='${merit.granted_by || ''}'. m.free is deprecated per #834.`);
+      return { changed: false, reason: 'no-channel', rating };
+    }
     merit[channel] = (merit[channel] || 0) + rating;
     return {
       changed: true,

--- a/server/scripts/cleanup-m-free-deprecation.js
+++ b/server/scripts/cleanup-m-free-deprecation.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+/**
+ * Issue #834 — Phase 3: cleanup of `m.free` contamination on character merits.
+ *
+ * The `m.free` channel was deprecated in #834 (writer deleted from
+ * normalize-character.js; readers removed from domain.js / admin
+ * surfaces). This script zeros any residual `m.free > 0` on existing
+ * character merits.
+ *
+ * Two patterns covered:
+ *
+ *   Pattern D — `m.free > 0` AND another channel ALSO populated (legacy
+ *     contamination from the pre-#834 backfill bug). Six instances in
+ *     prod 2026-06-17: Eve / René / René / Wan / Xavier / Yusuf, all
+ *     Feeding Grounds + Contacts shapes. Action: zero `m.free`; the
+ *     real source channel is preserved.
+ *
+ *   Pattern C — `m.free > 0` and NO other channel populated. One instance
+ *     in prod: Wan Yelong's Professional Training (m.free=3, no slug).
+ *     Per Peter's 2026-06-17 Option B, this is treated as orphan
+ *     contamination — drop the 3 dots, Wan's PT rating goes 8→5. Action:
+ *     zero `m.free`; the merit's rating will drop on the next normalize
+ *     pass since no canonical channel carries the dots.
+ *
+ * Idempotent (re-running after a clean pass touches 0 docs). `--dry-run`
+ * default. `--apply` to write.
+ *
+ * Write shape: `updateOne({_id}, {$set: {merits: doc.merits}})` per #826's
+ * HOTFIX pattern (replaceOne would strip every unprojected field — that's
+ * what destroyed 13 character docs 2026-06-16). `main()` is exported and
+ * direct-invocation guarded so the integration test can call it without
+ * connecting on import.
+ *
+ * Usage:
+ *   cd server && node scripts/cleanup-m-free-deprecation.js
+ *   cd server && node scripts/cleanup-m-free-deprecation.js --apply
+ *
+ * dotenv path note: must be run from `server/` so dotenv/config picks up
+ * server/.env. See memory [[feedback_server_scripts_dotenv_path]].
+ */
+
+import 'dotenv/config';
+import { MongoClient } from 'mongodb';
+
+const DB_NAME = process.env.MONGODB_DB || 'tm_suite';
+
+/**
+ * Classify and clean a single merit. Mutates in place. Returns a diagnostics
+ * object describing what changed (or null if no change).
+ */
+export function cleanupMerit(merit) {
+  if (!merit || typeof merit !== 'object') return null;
+  const before = merit.free || 0;
+  if (before <= 0) return null;
+
+  // Determine pattern by looking at other channels (D = at least one other
+  // channel populated, C = none).
+  const otherChannelSum =
+    (merit.cp || 0) + (merit.xp || 0)
+    + (merit.free_mci || 0) + (merit.free_vm || 0) + (merit.free_lk || 0)
+    + (merit.free_ohm || 0) + (merit.free_inv || 0) + (merit.free_pt || 0)
+    + (merit.free_mdb || 0) + (merit.free_sw || 0) + (merit.free_bloodline || 0)
+    + (merit.free_pet || 0) + (merit.free_attache || 0) + (merit.free_carthian || 0)
+    + (merit.free_fwb || 0) + (merit.free_retainer || 0)
+    + (merit.free_grants ? Object.values(merit.free_grants).reduce((s, n) => s + (n || 0), 0) : 0);
+  const pattern = otherChannelSum > 0 ? 'D' : 'C';
+  merit.free = 0;
+  return {
+    name: merit.name || '(unnamed)',
+    category: merit.category || null,
+    qualifier: merit.qualifier || merit.area || null,
+    pattern,
+    before,
+    after: 0,
+  };
+}
+
+export async function main() {
+  // Issue #826 lesson: compute APPLY / DRY_RUN inside main so integration
+  // tests can toggle via process.argv without re-importing the module.
+  const APPLY = process.argv.includes('--apply');
+  const DRY_RUN = !APPLY;
+  const MONGODB_URI = process.env.MONGODB_URI;
+  if (!MONGODB_URI) {
+    console.error('MONGODB_URI not set. Ensure server/.env is present and the script is run from server/.');
+    process.exit(1);
+  }
+  const client = new MongoClient(MONGODB_URI);
+  await client.connect();
+  try {
+    const db = client.db(DB_NAME);
+    const characters = db.collection('characters');
+    const cursor = characters.find({}, { projection: { _id: 1, name: 1, merits: 1 } });
+
+    let charsTouched = 0;
+    let meritsTouched = 0;
+    let patternC = 0;
+    let patternD = 0;
+
+    console.log(`\n${DRY_RUN ? '[DRY RUN]' : '[APPLY]'} cleanup-m-free-deprecation.js`);
+    console.log(`Database: ${DB_NAME}`);
+    console.log('');
+
+    for await (const doc of cursor) {
+      if (!Array.isArray(doc.merits)) continue;
+      const charChanges = [];
+      let charDirty = false;
+      for (const m of doc.merits) {
+        const r = cleanupMerit(m);
+        if (r) {
+          charDirty = true;
+          meritsTouched++;
+          if (r.pattern === 'C') patternC++;
+          else patternD++;
+          charChanges.push(r);
+        }
+      }
+      if (charDirty) {
+        charsTouched++;
+        const charLabel = `${doc.name || '(unnamed)'} [${doc._id}]`;
+        console.log(`  ${charLabel}`);
+        for (const ch of charChanges) {
+          const meritLabel = ch.qualifier ? `${ch.name} (${ch.qualifier})` : ch.name;
+          console.log(`    ${meritLabel.padEnd(40)} Pattern ${ch.pattern}  m.free  ${ch.before} → ${ch.after}`);
+        }
+        if (!DRY_RUN) {
+          // Issue #826 lesson: $set on merits only — replaceOne would strip
+          // every unprojected field.
+          await characters.updateOne(
+            { _id: doc._id },
+            { $set: { merits: doc.merits } }
+          );
+        }
+      }
+    }
+
+    console.log('');
+    console.log(`Summary: ${charsTouched} character${charsTouched === 1 ? '' : 's'}, ${meritsTouched} merit${meritsTouched === 1 ? '' : 's'} affected.`);
+    console.log(`  Pattern D (m.free + other channel): ${patternD}`);
+    console.log(`  Pattern C (m.free alone — Peter Option B drops the rating): ${patternC}`);
+    if (DRY_RUN) {
+      console.log('\n[DRY RUN] Re-run with --apply to write.');
+    } else {
+      console.log('\n[APPLY] Idempotency check: re-run with no flag (dry-run) and confirm "0 characters, 0 merits affected".');
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+const _invokedDirectly = import.meta.url === `file://${process.argv[1]}`;
+if (_invokedDirectly) {
+  main().catch(err => { console.error(err); process.exit(1); });
+}

--- a/server/tests/issue-811-sumchannels-rootcause.test.js
+++ b/server/tests/issue-811-sumchannels-rootcause.test.js
@@ -58,14 +58,26 @@ describe('#811 Phase 1 — normalizeMerit no longer backfills m.free when map is
     expect(r.changed === false || r.reason !== 'backfilled').toBe(true);
   });
 
-  it('truly empty merit at rating > 0 still triggers backfill (Pattern C / legitimate ST grant)', () => {
-    // Regression sentinel: a merit with no map AND no flat channels populated
-    // but rating > 0 should still backfill (this is the only sensible repair
-    // when no other source explains the rating).
-    const m = { name: 'Resources', category: 'influence', cp: 0, xp: 0, free: 0, rating: 2 };
-    const r = normalizeMerit(m);
-    expect(r.reason).toBe('backfilled');
-    expect(m.free).toBe(2);
+  it('truly empty merit at rating > 0 + no granted_by → refuses to backfill (post-#834)', () => {
+    // Pre-#834: would have backfilled m.free = rating via the 'free' fallback.
+    // Post-#834 (m.free deprecated): returns 'no-channel' + warns; m.free stays 0.
+    // See server/tests/issue-834-m-free-deprecation.test.js for the full
+    // behavioural assertion; this is the contract change documented at the
+    // older-test surface.
+    const warnSpy = (() => {
+      const calls = []; const orig = console.warn;
+      console.warn = (...args) => calls.push(args);
+      return { calls, restore: () => { console.warn = orig; } };
+    })();
+    try {
+      const m = { name: 'Resources', category: 'influence', cp: 0, xp: 0, free: 0, rating: 2 };
+      const r = normalizeMerit(m);
+      expect(r.reason).toBe('no-channel');
+      expect(m.free || 0).toBe(0);
+      expect(warnSpy.calls.length).toBeGreaterThan(0);
+    } finally {
+      warnSpy.restore();
+    }
   });
 
   it('granted_by Mentor with map-only data → no spurious free_mci backfill', () => {

--- a/server/tests/issue-834-m-free-deprecation.test.js
+++ b/server/tests/issue-834-m-free-deprecation.test.js
@@ -1,0 +1,359 @@
+/**
+ * Issue #834 — m.free deprecation tests.
+ *
+ * Three slices:
+ *   1. Normalizer behavioural: any path that would have written m.free to a
+ *      positive value now triggers the warn-and-return branch instead.
+ *   2. cleanupMerit pure unit: Pattern D (m.free + other channel) zeros m.free
+ *      preserving the other channel; Pattern C (m.free alone) zeros m.free and
+ *      drops the rating per Peter Option B.
+ *   3. Integration test calling main() end-to-end with --apply against the
+ *      test MongoDB — seeds a fully-formed character with attributes +
+ *      skills + m.free contamination + control, asserts attributes/skills
+ *      SURVIVE (the prod-incident assertion from #828) and merits cleaned.
+ *      MUST fail against replaceOne, pass against updateOne+$set.
+ *   4. Static-analysis sanity guards.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import 'dotenv/config';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setupDb, teardownDb } from './helpers/db-setup.js';
+import { getCollection } from '../db.js';
+import { normalizeMerit } from '../lib/normalize-character.js';
+import { cleanupMerit, main } from '../scripts/cleanup-m-free-deprecation.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+function read(rel) { return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8'); }
+
+const TEST_FLAG = '_issue_834_integration_test';
+
+beforeAll(async () => {
+  await setupDb();
+});
+
+afterAll(async () => {
+  const col = getCollection('characters');
+  await col.deleteMany({ [TEST_FLAG]: true });
+  await teardownDb();
+});
+
+beforeEach(async () => {
+  const col = getCollection('characters');
+  await col.deleteMany({ [TEST_FLAG]: true });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Normalizer behavioural — backfill no longer writes m.free
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#834 — normalizer no longer writes m.free on backfill', () => {
+  it('merit with rating > 0 + no granted_by + sum === 0 → warn-and-return, m.free stays 0', () => {
+    const warnSpy = (() => {
+      const calls = [];
+      const orig = console.warn;
+      console.warn = (...args) => { calls.push(args); };
+      return { calls, restore: () => { console.warn = orig; } };
+    })();
+    try {
+      const m = { name: 'Resources', category: 'influence', cp: 0, xp: 0, rating: 2 }; // no granted_by, no channels
+      const r = normalizeMerit(m);
+      // Pre-#834: would have written m.free = 2 via the 'free' fallback.
+      // Post-#834: returns 'no-channel' reason, m.free stays 0.
+      expect(m.free || 0).toBe(0);
+      expect(r.reason).toBe('no-channel');
+      expect(r.rating).toBe(2);
+      // Warn fired so server logs surface the orphan-rating case.
+      expect(warnSpy.calls.length).toBeGreaterThan(0);
+      const msg = warnSpy.calls[0][0];
+      expect(msg).toContain('Resources');
+      expect(msg).toContain('rating=2');
+      expect(msg).toContain('m.free is deprecated');
+    } finally {
+      warnSpy.restore();
+    }
+  });
+
+  it('merit with rating > 0 + granted_by=PT → backfills to free_pt (NOT m.free)', () => {
+    const m = { name: 'Allies', category: 'influence', granted_by: 'PT', cp: 0, xp: 0, rating: 2 };
+    const r = normalizeMerit(m);
+    expect(m.free || 0).toBe(0);
+    expect(m.free_pt).toBe(2);
+    expect(r.reason).toBe('backfilled');
+    expect(r.channel).toBe('free_pt');
+  });
+
+  it('merit with rating === sum and m.free already populated → rating-sync only, no extra m.free write', () => {
+    // Pre-existing contamination shape: m.free already set (legacy data).
+    // The rating-sync branch fires (rating may need updating) but normalizer
+    // does NOT touch m.free.
+    const m = { name: 'Feeding Grounds', category: 'domain', cp: 0, xp: 0, free: 10, rating: 99 };
+    normalizeMerit(m);
+    expect(m.free).toBe(10); // unchanged
+    expect(m.rating).toBe(10); // synced to sum of all channels including legacy m.free
+  });
+
+  it('merit with rating > 0 + granted_by unmapped tag → warn, no backfill', () => {
+    const warnSpy = (() => {
+      const calls = []; const orig = console.warn;
+      console.warn = (...args) => calls.push(args);
+      return { calls, restore: () => { console.warn = orig; } };
+    })();
+    try {
+      const m = { name: 'X', category: 'general', granted_by: 'NonexistentSource', cp: 0, xp: 0, rating: 1 };
+      const r = normalizeMerit(m);
+      expect(m.free || 0).toBe(0);
+      expect(r.reason).toBe('no-channel');
+      expect(warnSpy.calls.length).toBeGreaterThan(0);
+    } finally {
+      warnSpy.restore();
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// cleanupMerit unit — Pattern C + D
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#834 — cleanupMerit zeros m.free, classifies pattern correctly', () => {
+  it('Pattern D: m.free + other channel populated → zeros m.free, preserves other', () => {
+    const m = { name: 'Feeding Grounds', category: 'domain', cp: 0, xp: 0, free: 10, free_fwb: 10 };
+    const r = cleanupMerit(m);
+    expect(r).not.toBeNull();
+    expect(m.free).toBe(0);
+    expect(m.free_fwb).toBe(10);
+    expect(r.pattern).toBe('D');
+    expect(r.before).toBe(10);
+    expect(r.after).toBe(0);
+  });
+
+  it('Pattern C: m.free alone → zeros m.free (rating drops on next normalize)', () => {
+    // Wan Yelong's Professional Training shape — per Peter Option B drops 3 dots.
+    const m = { name: 'Professional Training', category: 'standing', cp: 0, xp: 0, free: 3 };
+    const r = cleanupMerit(m);
+    expect(r).not.toBeNull();
+    expect(m.free).toBe(0);
+    expect(r.pattern).toBe('C');
+    expect(r.before).toBe(3);
+  });
+
+  it('Pattern D with map: m.free + free_grants.necro → zeros m.free, preserves map', () => {
+    const m = { name: 'Catacombs', category: 'domain', cp: 0, xp: 0, free: 1, free_grants: { necro: 1 } };
+    const r = cleanupMerit(m);
+    expect(m.free).toBe(0);
+    expect(m.free_grants.necro).toBe(1);
+    expect(r.pattern).toBe('D');
+  });
+
+  it('merit with m.free = 0 → no-op', () => {
+    const m = { name: 'X', category: 'general', cp: 1 };
+    expect(cleanupMerit(m)).toBeNull();
+  });
+
+  it('idempotent: re-cleaning a cleaned merit yields no further changes', () => {
+    const m = { name: 'Feeding Grounds', category: 'domain', cp: 0, xp: 0, free: 5, free_fwb: 5 };
+    const r1 = cleanupMerit(m);
+    expect(r1).not.toBeNull();
+    const r2 = cleanupMerit(m);
+    expect(r2).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Integration test — main() end-to-end with --apply, prod-incident assertions
+// ─────────────────────────────────────────────────────────────────────────────
+
+function seedDoc() {
+  return {
+    [TEST_FLAG]: true,
+    name: '#834 Integration Test',
+    clan: 'Nosferatu', covenant: 'Invictus', mask: 'Survivor', dirge: 'Curmudgeon',
+    concept: 'Integration test fixture for #834',
+    status: { city: 1, clan: 2, covenant: 3 },
+    attributes: {
+      Intelligence: { dots: 3, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+      Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 3, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+      Presence: { dots: 1, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 3, bonus: 0 },
+    },
+    skills: {
+      Investigation: { dots: 3, bonus: 0, specs: ['Forensics'], nine_again: false },
+      Stealth: { dots: 4, bonus: 0, specs: [], nine_again: false },
+    },
+    disciplines: { Auspex: 2, Obfuscate: 3 },
+    powers: [],
+    humanity: 6, humanity_base: 7, blood_potency: 1,
+    xp_log: { spent: 0, earned: 10 },
+    attr_creation: 5, skill_creation: 11, disc_creation: 0, merit_creation: 0,
+    aspirations: ['Survive'],
+    merits: [
+      // Pattern D contamination — Feeding Grounds with m.free=5 + free_fwb=5
+      { name: 'Feeding Grounds', category: 'domain', cp: 0, xp: 0, free: 5, free_fwb: 5, qualifier: 'Docks' },
+      // Pattern C contamination — Professional Training with m.free=3 alone (Wan shape)
+      { name: 'Professional Training', category: 'standing', cp: 0, xp: 0, free: 3 },
+      // Untouched control — Safe Place
+      { name: 'Safe Place', category: 'domain', cp: 2, xp: 0, qualifier: 'Apt' },
+    ],
+  };
+}
+
+describe('#834 — cleanup script main() integration (write-path safety)', () => {
+  it('preserves ALL non-merits fields when --apply runs (the prod-incident assertion)', async () => {
+    const col = getCollection('characters');
+    const seed = seedDoc();
+    const ins = await col.insertOne(seed);
+    const id = ins.insertedId;
+    const before = await col.findOne({ _id: id });
+
+    const origArgv = process.argv;
+    process.argv = [...origArgv, '--apply'];
+    try {
+      await main();
+    } finally {
+      process.argv = origArgv;
+    }
+
+    const after = await col.findOne({ _id: id });
+    // Survival assertions (would all fail against pre-#826 replaceOne).
+    expect(after.clan).toBe(before.clan);
+    expect(after.covenant).toBe(before.covenant);
+    expect(after.status).toEqual(before.status);
+    expect(after.attributes, 'attributes must survive — the field the prod incident lost').toEqual(before.attributes);
+    expect(after.skills).toEqual(before.skills);
+    expect(after.disciplines).toEqual(before.disciplines);
+    expect(after.humanity).toBe(before.humanity);
+    expect(after.blood_potency).toBe(before.blood_potency);
+    expect(after.aspirations).toEqual(before.aspirations);
+
+    // Cleanup assertions: Pattern D + C merits modified, control unchanged.
+    const fg = after.merits.find(m => m.name === 'Feeding Grounds');
+    expect(fg.free).toBe(0);
+    expect(fg.free_fwb).toBe(5); // preserved
+
+    const pt = after.merits.find(m => m.name === 'Professional Training');
+    expect(pt.free).toBe(0);
+
+    const sp = after.merits.find(m => m.name === 'Safe Place');
+    expect(sp.cp).toBe(2);
+    expect(sp.qualifier).toBe('Apt');
+  });
+
+  it('dry-run does not modify the document', async () => {
+    const col = getCollection('characters');
+    const seed = seedDoc();
+    const ins = await col.insertOne(seed);
+    const id = ins.insertedId;
+    const before = await col.findOne({ _id: id });
+
+    const origArgv = process.argv;
+    process.argv = origArgv.filter(a => a !== '--apply');
+    try { await main(); } finally { process.argv = origArgv; }
+
+    const after = await col.findOne({ _id: id });
+    expect(after).toEqual(before);
+  });
+
+  it('idempotent: second --apply run leaves doc unchanged', async () => {
+    const col = getCollection('characters');
+    const seed = seedDoc();
+    const ins = await col.insertOne(seed);
+    const id = ins.insertedId;
+
+    const origArgv = process.argv;
+    process.argv = [...origArgv, '--apply'];
+    try {
+      await main();
+      const afterFirst = await col.findOne({ _id: id });
+      await main();
+      const afterSecond = await col.findOne({ _id: id });
+      expect(afterSecond).toEqual(afterFirst);
+      expect(afterSecond.attributes).toBeTruthy();
+      expect(afterSecond.skills).toBeTruthy();
+    } finally {
+      process.argv = origArgv;
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Static-analysis sanity guards
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#834 — placement sanity guards', () => {
+  it('normalize-character.js backfillChannel returns null on unmapped (no `free` fallback)', () => {
+    const src = read('server/lib/normalize-character.js');
+    // The pre-#834 shape `GRANTED_BY_CHANNEL[gb] || 'free'` is gone.
+    expect(src).not.toMatch(/GRANTED_BY_CHANNEL\[gb\]\s*\|\|\s*'free'/);
+    expect(src).toMatch(/GRANTED_BY_CHANNEL\[gb\]\s*\|\|\s*null/);
+  });
+
+  it('normalize-character.js refuses to backfill when channel is null + warns', () => {
+    const src = read('server/lib/normalize-character.js');
+    expect(src).toMatch(/refusing to backfill/);
+    expect(src).toMatch(/no-channel/);
+    // Must NOT write m.free anywhere in normalizeMerit's body.
+    const fnStart = src.indexOf('export function normalizeMerit');
+    const fnEnd = src.indexOf('\n}\n', fnStart);
+    const body = src.slice(fnStart, fnEnd);
+    // No assignment to merit.free or merit['free']
+    expect(body).not.toMatch(/merit\[\s*['"]free['"]\s*\]\s*=/);
+    expect(body).not.toMatch(/merit\.free\s*=/);
+  });
+
+  it('domain.js meritFreeSum no longer adds (m.free || 0)', () => {
+    const src = read('public/js/editor/domain.js');
+    const fnStart = src.indexOf('export function meritFreeSum');
+    const nextExport = src.indexOf('export function ', fnStart + 1);
+    const body = src.slice(fnStart, nextExport > 0 ? nextExport : src.length);
+    expect(body).not.toMatch(/\(m\.free \|\| 0\)\s*\+\s*_meritFreeSumHelper/);
+    expect(body).toMatch(/return\s+_meritFreeSumHelper\(m\)\s*;/);
+  });
+
+  it('domain.js domMeritContribSingle no longer reads m.free', () => {
+    const src = read('public/js/editor/domain.js');
+    const fnStart = src.indexOf('export function domMeritContribSingle');
+    const nextExport = src.indexOf('export function ', fnStart + 1);
+    const body = src.slice(fnStart, nextExport > 0 ? nextExport : src.length);
+    expect(body).not.toMatch(/\(m\.free\s*\|\|\s*0\)/);
+  });
+
+  it('domain.js domMeritShareableSingle no longer reads m.free', () => {
+    const src = read('public/js/editor/domain.js');
+    const fnStart = src.indexOf('function domMeritShareableSingle');
+    const nextFn = src.indexOf('\nfunction ', fnStart + 1);
+    const body = src.slice(fnStart, nextFn > 0 ? nextFn : src.length);
+    expect(body).not.toMatch(/\(m\.free\s*\|\|\s*0\)/);
+  });
+
+  it('admin/rules-data-view.js no longer reads m.free in the bonus rollup', () => {
+    const src = read('public/js/admin/rules-data-view.js');
+    // The specific bonus-rollup expression no longer contains (m.free || 0).
+    expect(src).not.toMatch(/freeOf\(m, 'pt'\)[^\n]*\(m\.free \|\| 0\)/);
+  });
+
+  it('admin/excel-merge.js applyMeritPoints no longer reads merit.free for the diff message', () => {
+    const src = read('public/js/admin/excel-merge.js');
+    const fnStart = src.indexOf('function applyMeritPoints');
+    const nextFn = src.indexOf('\nfunction ', fnStart + 1);
+    const body = src.slice(fnStart, nextFn > 0 ? nextFn : src.length);
+    // The READ `merit.free || 0` is gone. The IMPORT `pts.free` folding into
+    // cp is preserved (legitimate upstream column).
+    expect(body).not.toMatch(/oldFree\s*=\s*merit\.free/);
+    expect(body).toMatch(/pts\.cp\s*\+\s*\(pts\.free\s*\|\|\s*0\)/);
+  });
+
+  it('cleanup script main() uses updateOne with $set on merits only (NOT replaceOne)', () => {
+    const src = read('server/scripts/cleanup-m-free-deprecation.js');
+    expect(src).toMatch(/updateOne\(\s*\{\s*_id:\s*doc\._id\s*\}/);
+    expect(src).toMatch(/\$set:\s*\{\s*merits:\s*doc\.merits\s*\}/);
+    expect(src).not.toMatch(/replaceOne\(/);
+  });
+
+  it('cleanup script main() exported + direct-invocation guarded', () => {
+    const src = read('server/scripts/cleanup-m-free-deprecation.js');
+    expect(src).toMatch(/export async function main/);
+    expect(src).toMatch(/import\.meta\.url\s*===\s*`file:\/\/\$\{process\.argv\[1\]\}`/);
+  });
+});

--- a/server/tests/n7d-meritfreesum-necro-gate.test.js
+++ b/server/tests/n7d-meritfreesum-necro-gate.test.js
@@ -91,45 +91,47 @@ describe('#790 — meritFreeSum categorical exclusion on Necropolis targets', ()
     expect(meritFreeSum(m)).toBe(0);
   });
 
-  it('non-Necropolis domain merit: meritFreeSum sums all channels normally (regression sentinel)', () => {
+  it('non-Necropolis domain merit: meritFreeSum sums non-deprecated channels normally (regression sentinel)', () => {
+    // Post-#834: m.free is deprecated and NOT included in meritFreeSum.
+    // Pre-#834 this expected 11 (including m.free=5); post-#834 it's 6.
     const m = {
       name: 'Safe Place',
       category: 'domain',
       cp: 0, xp: 0,
-      free: 5,
+      free: 5,           // deprecated — ignored
       free_mci: 3,
       free_vm: 2,
       free_grants: { lk: 1 },
     };
-    // 5 (m.free) + 3 (free_mci) + 2 (free_vm) + 1 (map.lk) = 11
-    expect(meritFreeSum(m)).toBe(11);
+    // 3 (free_mci) + 2 (free_vm) + 1 (map.lk) = 6   (m.free=5 ignored per #834)
+    expect(meritFreeSum(m)).toBe(6);
   });
 
-  it('Necropolis Sepulcher (the SOURCE merit, not a target): sums normally (only targets gate, not Sepulcher itself)', () => {
+  it('Necropolis Sepulcher (the SOURCE merit, not a target): sums normally — m.free deprecated', () => {
+    // Post-#834: m.free=1 contamination is ignored; with no other channels
+    // the sum is 0 (was 1 pre-#834).
     const m = {
       name: 'Necropolis Sepulcher',
       category: 'domain',
       cp: 3, xp: 0,
-      free: 1, // hypothetical contamination
+      free: 1, // deprecated channel — ignored by meritFreeSum
       free_grants: {},
     };
-    // Sepulcher is the source, not a target — gate doesn't apply.
-    // 1 (m.free) + 0 (no other channels) = 1
-    expect(meritFreeSum(m)).toBe(1);
+    // Sepulcher is the source, not a target — Necro gate doesn't apply.
+    // Post-#834 sum = 0 (m.free=1 dropped).
+    expect(meritFreeSum(m)).toBe(0);
   });
 
-  it('Trap Door (per-character bridge, NOT a Necropolis target): sums normally', () => {
+  it('Trap Door (per-character bridge, NOT a Necropolis target): sums non-deprecated channels normally', () => {
     const m = {
       name: 'Trap Door',
       category: 'domain',
       cp: 1, xp: 0,
-      free: 2,
+      free: 2,            // deprecated — ignored
       free_grants: { mci: 1 },
     };
-    // Trap Door is NOT in the categorical exclusion set (it's per-character,
-    // not collective-shared). Sums normally.
-    // 2 (m.free) + 1 (map.mci) = 3
-    expect(meritFreeSum(m)).toBe(3);
+    // Post-#834: 1 (map.mci) — m.free=2 ignored.
+    expect(meritFreeSum(m)).toBe(1);
   });
 
   it('syncMeritRating inherits the Necropolis exclusion (consumes meritFreeSum)', () => {


### PR DESCRIPTION
## Summary

Architectural fix, not a patch. End of the drain-circling pattern on free-channel contamination. Peter 2026-06-17: *\"Why does m.free even exist?\"* — stocktake confirmed 1 writer + 5 readers + 7 data instances. All addressed in this PR.

## Phase 1 — writer deletion

`server/lib/normalize-character.js`:
- `backfillChannel` returns `null` when `granted_by` has no canonical mapping (was: `|| 'free'` fallback — the contamination vector)
- `normalizeMerit` refuses to mutate in that case, logs a warning, returns `{changed: false, reason: 'no-channel'}`. Orphan-rating cases surface in server logs for QA.
- `MERIT_CHANNELS` retains `'free'` so `sumChannels` accounts for residual contamination during rating-sync until Phase 3 cleanup zeros it. No write site remains.

## Phase 2 — reader removal (5 sites)

| Site | Change |
|---|---|
| `public/js/editor/domain.js` `meritFreeSum` | Returns `_meritFreeSumHelper(m)` directly; no `(m.free || 0)` term |
| `domain.js` `domMeritContribSingle` | `m.free` dropped from purchased sum |
| `domain.js` `domMeritShareableSingle` | `m.free` dropped from shareable sum |
| `public/js/admin/rules-data-view.js` (bonus rollup) | `m.free` dropped |
| `public/js/admin/excel-merge.js` `applyMeritPoints` | `oldFree` read removed (was diff-message only) |

Plus vestigial `m.free = 0` init removed from `public/js/editor/merits.js` `ensureMeritSync` + `addMerit`. New merits don't carry the field.

## Phase 3 — cleanup script

`server/scripts/cleanup-m-free-deprecation.js` — zeros `m.free` on every merit where it's > 0. Two patterns:

- **Pattern D** — `m.free` + other channel populated (6 prod instances: Eve / René×2 / Wan / Xavier / Yusuf, Feeding Grounds + Contacts shapes). Action: zero `m.free`; preserve other channel.
- **Pattern C** — `m.free` alone (1 prod instance: Wan Yelong's PT, `m.free=3`). Per Peter's **Option B** 2026-06-17, drop the 3 dots. PT rating goes 8→5 on next normalize.

Uses `updateOne` + `$set: {merits: doc.merits}` per the #826 hotfix discipline. `main()` is exported + direct-invocation guarded for integration testing.

**Cleanup script's `--apply` against prod requires per-message Peter authorisation when this PR lands.** PR includes the script but does NOT auto-run it.

## Phase 4 — tests

`server/tests/issue-834-m-free-deprecation.test.js` — **21 cases**:

**Normalizer behavioural (4):**
- Merit with rating > 0 + no `granted_by` → `'no-channel'` return + warn; `m.free` stays 0
- `granted_by=PT` → backfills to `free_pt` (not `m.free`)
- Pre-existing `m.free` contamination + rating>0 → rating-sync only; `m.free` untouched
- Unmapped `granted_by` tag → warn, no backfill

**cleanupMerit unit (5):** Pattern D, Pattern C, Pattern D with map, no-op when `m.free=0`, idempotency

**Integration (3, per `feedback_script_integration_test`):** seeds fully-formed character (attributes + skills + disciplines + clan + covenant + status + humanity + xp_log + aspirations + Pattern D + Pattern C + control), calls `main() --apply`, asserts EVERY non-merits field survives (\"attributes must survive — the field the prod incident lost\") AND merits cleaned. Dry-run no-op. Idempotency.

**Static-analysis sanity guards (9):** `backfillChannel` returns null; `normalizeMerit` refuses+warns; `meritFreeSum` returns helper directly; `domMeritContribSingle` + `domMeritShareableSingle` drop `m.free` read; `rules-data-view` bonus rollup doesn't read `m.free`; `excel-merge.applyMeritPoints` loses `oldFree` but keeps `pts.free` folding; cleanup script uses `updateOne`+`\$set` not `replaceOne`; `main()` exported + direct-invocation guarded.

**Collateral test updates** (3 cases): #811 \"truly empty merit\" rewritten to assert the new `'no-channel'` contract; #790 n7d tests adjusted for post-#834 `meritFreeSum` semantics (pre-#834 sum expectations dropped the `m.free` contribution).

## Excel-merge audit (per dispatch)

**Conclusion:** Excel/CSV import shape DOES legitimately carry `pts.free` as an upstream tooling column. The writer ALREADY folds it into `cp` at lines 77 (skills), 90 (disciplines), 182 (merits) — never wrote to `m.free`. The only `m.free` reference was the READ at line 181 for the diff message; that read is removed. Input handling preserved unchanged.

## Memory pin

`feedback_m_free_deprecated` saved + indexed:

> `m.free` on a character-merit is dead — never add reads or writes. Allocations belong in `m.free_grants[<slug>]` (ADR-005 D1). If a merit has no canonical channel, refuse to mutate and log a warning.

Links to the related `feedback_two_views_same_arithmetic` (root-cause class) and `feedback_script_integration_test` (test discipline).

## Regression

- Targeted file: 21 cases (integration tests skip locally — Mongo not running; CI exercises)
- Across closely-related (n7a/b/c/d + n4a + collective-1 + #793 + #827 + #830 + #832 + #811 + null-cache + feeding-grounds): **149/149 pass**
- 3 existing test cases updated for the new contract

## Smoke test path (post-deploy)

1. Run cleanup script `--dry-run` against `tm_suite`, confirm scope matches stocktake (7 instances across 5 chars)
2. Per-message authorisation from Peter
3. Run `--apply` to zero `m.free` on those 7 merits
4. Wan Yelong's PT rating drops 8→5
5. Other 6 affected characters' Feeding Grounds / Contacts display the correct (slug-only) values
6. Future contamination impossible — no code writes `m.free`

## Out of scope

- DT actions tab cross-instance aggregation bug (Yusuf's Allies (Finance) showing 6 when it should show 3) — separate concern
- LK/INV/VM/MCI `partner_shareable` audit (the deferred MNEC-prerequisite story) — orthogonal

Closes #834