### PR TITLE
feat(arch): #837 — stop persisting xp_total / xp_spent (Option A)

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -99,7 +99,7 @@ function markDirty(idx) {
 }
 
 registerEditCallbacks(markDirty, renderSheet);
-registerIdentityCallbacks(markDirty, xpLeft);
+registerIdentityCallbacks(markDirty);
 registerAttrsCallbacks(markDirty);
 
 // ── ST mod overlay composition (Epic STM, issue #372) ──
@@ -915,13 +915,18 @@ async function createNewCharacter() {
 
 // Legacy parallel-array fields superseded by inline cp/xp on each object (v3 schema)
 const _LEGACY_FIELDS = new Set(['attr_creation', 'skill_creation', 'disc_creation', 'merit_creation']);
+// #837: xp_total / xp_spent removed from schema — derived at render time.
+// Strip on save so old in-memory documents that still carry them don't fail
+// schema validation on PUT.
+const _DEPRECATED_FIELDS = new Set(['xp_total', 'xp_spent', 'xp_left']);
 
 function buildSaveBody(c) {
   // Strip _id (goes in URL), all ephemeral _-prefixed runtime fields, legacy v2 fields,
-  // and c.current (tracker-state namespace set by spliceCurrent — not a schema field).
+  // deprecated derived fields (#837), and c.current (tracker-state namespace).
   const body = {};
   for (const [k, v] of Object.entries(c)) {
-    if (k === '_id' || k.startsWith('_') || k === 'current' || _LEGACY_FIELDS.has(k)) continue;
+    if (k === '_id' || k.startsWith('_') || k === 'current'
+        || _LEGACY_FIELDS.has(k) || _DEPRECATED_FIELDS.has(k)) continue;
     body[k] = v;
   }
   // N-1 (ADR-005 Rev 2, Concern #3): merit-level `_`-prefixed fields

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -47,7 +47,6 @@ import {
   clickSkillDot, toggleNineAgain, adjSkillBonus, updSkillSpec,
   registerCallbacks as registerAttrsCallbacks
 } from './editor/attrs-tab.js';
-import { xpLeft } from './editor/xp.js';
 import { devotions, rites, setStatusTerritories } from './data/accessors.js';
 import { renderCharPools } from './game/char-pools.js';
 import { renderMapStageHtml } from './components/map-overlay.js';
@@ -1056,7 +1055,7 @@ document.addEventListener('click', () => {
 
 registerEditCallbacks(markDirty, editorRenderSheet);
 registerExportCallbacks(renderList, updDirtyBadge);
-registerIdentityCallbacks(markDirty, xpLeft);
+registerIdentityCallbacks(markDirty);
 registerAttrsCallbacks(markDirty);
 
 // Wire up suite import callbacks

--- a/public/js/editor/edit.js
+++ b/public/js/editor/edit.js
@@ -10,7 +10,7 @@ import {
 } from '../data/constants.js';
 import { getRuleByKey, getRulesByCategory } from '../data/loader.js';
 import { freeOf, poolAvailableFor } from '../data/rules-helpers.js';
-import { xpToDots, xpEarned, xpSpent } from './xp.js';
+import { xpToDots } from './xp.js';
 import { meritByCategory, addMerit, removeMerit, ensureMeritSync } from './merits.js';
 import { getPoolTotal, mciPoolTotal, getMCIPoolUsed } from './mci.js';
 import { vmPool, vmUsed, investedPool, investedUsed, lorekeeperPool, lorekeeperUsed, syncMeritRating, pruneContactsSpheres } from './domain.js';
@@ -571,8 +571,7 @@ export function shEditAttrPt(attr, field, val) {
   const NINE_ATTRS = ['Intelligence', 'Wits', 'Resolve', 'Strength', 'Dexterity', 'Stamina', 'Presence', 'Manipulation', 'Composure'];
   NINE_ATTRS.forEach(a => { attrXpTotal += (c.attributes?.[a]?.xp) || 0; });
   c.xp_log.spent.attributes = attrXpTotal;
-  c.xp_total = xpEarned(c);
-  c.xp_spent = xpSpent(c);
+  // #837: xp_total / xp_spent no longer persisted — derived at render via xp.js.
   _markDirty();
   _renderSheet(c);
 }
@@ -667,8 +666,7 @@ export function shEditDiscPt(disc, field, val) {
     discXpTotal += v.xp || 0;
   });
   c.xp_log.spent.powers = discXpTotal;
-  c.xp_total = xpEarned(c);
-  c.xp_spent = xpSpent(c);
+  // #837: xp_total / xp_spent no longer persisted — derived at render via xp.js.
   _markDirty();
   _renderSheet(c);
 }
@@ -751,8 +749,7 @@ export function shEditSkillPt(skill, field, val) {
   let skXpTotal = 0;
   ALL_SKILLS.forEach(s => { skXpTotal += (c.skills?.[s]?.xp) || 0; });
   c.xp_log.spent.skills = skXpTotal;
-  c.xp_total = xpEarned(c);
-  c.xp_spent = xpSpent(c);
+  // #837: xp_total / xp_spent no longer persisted — derived at render via xp.js.
   _markDirty();
   _renderSheet(c);
 }
@@ -780,8 +777,7 @@ export function shEditXP(bucket, key, val) {
   if (!c.xp_log) c.xp_log = { earned: {}, spent: {} };
   if (!c.xp_log[bucket]) c.xp_log[bucket] = {};
   c.xp_log[bucket][key] = val || 0;
-  c.xp_total = xpEarned(c);
-  c.xp_spent = xpSpent(c);
+  // #837: xp_total / xp_spent no longer persisted — derived at render via xp.js.
   _markDirty();
   _renderSheet(c);
 }

--- a/public/js/editor/identity.js
+++ b/public/js/editor/identity.js
@@ -3,11 +3,13 @@
 import state from '../data/state.js';
 import { APPROVED_BLOODLINES, MASKS_DIRGES, CLANS, COVENANTS, COURT_TITLES } from '../data/constants.js';
 import { esc, displayName, cardName, isRedactMode, redactCharName, redactPlayer } from '../data/helpers.js';
+// #837: XP totals are derived at render time; identity.js displays them
+// directly via xp.js rather than persisting them as character fields.
+import { xpEarned, xpSpent, xpLeft } from './xp.js';
 
-let _markDirty, _xpLeft;
-export function registerCallbacks(markDirty, xpLeft) {
+let _markDirty;
+export function registerCallbacks(markDirty) {
   _markDirty = markDirty;
-  _xpLeft = xpLeft;
 }
 
 /* ── Main tab renderer ── */
@@ -124,15 +126,15 @@ export function renderIdentityTab(c) {
       <div class="form-grid">
         <div class="form-row">
           <label class="form-label">XP Total</label>
-          <input class="form-input" type="number" min="0" value="${c.xp_total || 0}" onchange="updField('xp_total',+this.value)">
+          <input class="form-input" type="number" value="${xpEarned(c)}" disabled title="Derived: 10 starting + Humanity drops + Ordeals + Game attendance">
         </div>
         <div class="form-row">
           <label class="form-label">XP Spent</label>
-          <input class="form-input" type="number" min="0" value="${c.xp_spent || 0}" onchange="updField('xp_spent',+this.value)">
+          <input class="form-input" type="number" value="${xpSpent(c)}" disabled title="Derived: sum of attr/skill/disc/merit xp allocations">
         </div>
         <div class="form-row">
           <label class="form-label">XP Left</label>
-          <input class="form-input" type="number" value="${_xpLeft(c)}" disabled title="Derived from XP Total - XP Spent">
+          <input class="form-input" type="number" value="${xpLeft(c)}" disabled title="Derived: XP Total - XP Spent">
         </div>
         <div class="form-row">
           <label class="form-label">Blood Potency</label>

--- a/public/js/suite/import.js
+++ b/public/js/suite/import.js
@@ -273,8 +273,8 @@ function parseExcelToChars(rows) {
       size: parseInt(row[h['Size']]) || 5,
       speed: parseInt(row[h['Speed']]) || 0,
       defence: parseInt(row[h['Defence']]) || 0,
-      xp_total: parseInt(row[h['XP Total']]) || 0,
-      xp_left: parseInt(row[h['XP Left']]) || 0,
+      // #837: xp_total / xp_left columns are still read by the importer
+      // but no longer persisted; XP is derived at render via xp.js.
       status: {
         city: parseInt(row[h['City Status']]) || 0,
         clan: parseInt(row[h['Clan Status']]) || 0,

--- a/public/js/tabs/wizard.js
+++ b/public/js/tabs/wizard.js
@@ -727,8 +727,8 @@ function buildCharDoc() {
     disciplines,
     merits,
     powers: [],
-    xp_total: 10,
-    xp_spent: 0,
+    // #837: xp_total / xp_spent removed — derived at render via xp.js.
+    // The 10-XP starting allowance is sourced from xpStarting() in xp.js.
     xp_log: { spent: 0, entries: [] },
     notes: null,
     retired: false,

--- a/server/schemas/character.schema.js
+++ b/server/schemas/character.schema.js
@@ -107,8 +107,10 @@ export const characterSchema = {
     humanity_base: { type: 'integer', minimum: 0, maximum: 10 },
     humanity_lost: { type: 'integer', minimum: 0 },
     humanity_xp:   { type: 'integer', minimum: 0 },
-    xp_total:      { type: 'number',  minimum: 0 },
-    xp_spent:      { type: 'number',  minimum: 0 },
+    // xp_total / xp_spent removed in #837 (Option A) — XP values are
+    // derived at render time via public/js/editor/xp.js
+    // (xpEarned() / xpSpent() / xpLeft()). additionalProperties:false on
+    // this schema rejects any incoming PUT that still tries to send them.
 
     // ── Status ────────────────────────────────────────────────
     status: {

--- a/server/scripts/cleanup-xp-totals-deprecation.js
+++ b/server/scripts/cleanup-xp-totals-deprecation.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+/**
+ * Issue #837 — Phase 3: one-shot cleanup of `xp_total` and `xp_spent` on
+ * character documents.
+ *
+ * Background: #837 (Peter Option A) removes `xp_total` / `xp_spent` from
+ * the v3 schema entirely. XP values are derived at render time via
+ * public/js/editor/xp.js (xpEarned() / xpSpent() / xpLeft()). The fields
+ * persisted on existing docs are now dead weight; leaving them risks a
+ * future reader treating them as authoritative (the precise landmine
+ * Option A is meant to eliminate).
+ *
+ * Write shape: ONE `updateMany({ ... }, { $unset: { xp_total: '', xp_spent: '' } })`
+ * targeted at docs that still carry either field. NOT replaceOne — the #826
+ * incident destroyed 13 character docs by replaceOne-with-projection, and
+ * the resulting discipline (see [[feedback_script_integration_test]]) is to
+ * use $unset / updateMany / updateOne+$set for any data-mutating script.
+ *
+ * Idempotent — re-running after a clean pass updates 0 docs.
+ *
+ * Usage:
+ *   cd server && node scripts/cleanup-xp-totals-deprecation.js
+ *   cd server && node scripts/cleanup-xp-totals-deprecation.js --apply
+ *
+ * dotenv path note: must be run from `server/` so dotenv/config picks up
+ * server/.env. See memory [[feedback_server_scripts_dotenv_path]].
+ */
+
+import 'dotenv/config';
+import { MongoClient } from 'mongodb';
+
+const DB_NAME = process.env.MONGODB_DB || 'tm_suite';
+
+export async function main() {
+  // Issue #826 lesson: compute APPLY / DRY_RUN inside main so integration
+  // tests can toggle via process.argv without re-importing the module.
+  const APPLY = process.argv.includes('--apply');
+  const DRY_RUN = !APPLY;
+  const MONGODB_URI = process.env.MONGODB_URI;
+  if (!MONGODB_URI) {
+    console.error('MONGODB_URI not set. Ensure server/.env is present and the script is run from server/.');
+    process.exit(1);
+  }
+  const client = new MongoClient(MONGODB_URI);
+  await client.connect();
+  try {
+    const db = client.db(DB_NAME);
+    const characters = db.collection('characters');
+
+    const matchFilter = {
+      $or: [
+        { xp_total: { $exists: true } },
+        { xp_spent: { $exists: true } },
+      ],
+    };
+
+    console.log(`\n${DRY_RUN ? '[DRY RUN]' : '[APPLY]'} cleanup-xp-totals-deprecation.js`);
+    console.log(`Database: ${DB_NAME}`);
+    console.log('');
+
+    // Pre-flight: list affected docs so the operator can sanity-check.
+    const affected = await characters
+      .find(matchFilter, { projection: { _id: 1, name: 1, xp_total: 1, xp_spent: 1 } })
+      .toArray();
+
+    if (affected.length === 0) {
+      console.log('No documents still carry xp_total or xp_spent. Clean already.');
+      return;
+    }
+
+    for (const doc of affected) {
+      const label = `${doc.name || '(unnamed)'} [${doc._id}]`;
+      const tot = doc.xp_total === undefined ? '—' : String(doc.xp_total);
+      const spt = doc.xp_spent === undefined ? '—' : String(doc.xp_spent);
+      console.log(`  ${label.padEnd(44)} xp_total=${tot.padStart(4)}  xp_spent=${spt.padStart(4)}`);
+    }
+    console.log('');
+
+    if (DRY_RUN) {
+      console.log(`Summary: ${affected.length} document${affected.length === 1 ? '' : 's'} carry xp_total / xp_spent and would be cleaned.`);
+      console.log('\n[DRY RUN] Re-run with --apply to write.');
+      return;
+    }
+
+    const result = await characters.updateMany(
+      matchFilter,
+      { $unset: { xp_total: '', xp_spent: '' } }
+    );
+
+    console.log(`Summary: matched=${result.matchedCount}, modified=${result.modifiedCount}.`);
+    console.log('\n[APPLY] Idempotency check: re-run with no flag (dry-run) and confirm "No documents still carry xp_total or xp_spent".');
+  } finally {
+    await client.close();
+  }
+}
+
+const _invokedDirectly = import.meta.url === `file://${process.argv[1]}`;
+if (_invokedDirectly) {
+  main().catch(err => { console.error(err); process.exit(1); });
+}

--- a/server/tests/issue-837-xp-totals-deprecation.test.js
+++ b/server/tests/issue-837-xp-totals-deprecation.test.js
@@ -1,0 +1,311 @@
+/**
+ * Issue #837 — xp_total / xp_spent deprecation tests.
+ *
+ * Four slices:
+ *   1. Schema static guard — properties block in character.schema.js no longer
+ *      declares xp_total / xp_spent. Re-introducing them in the schema
+ *      would re-enable the persistence path Option A is closing.
+ *   2. Client-write strip guard — buildSaveBody in public/js/admin.js strips
+ *      both fields before PUT (static-text check, since admin.js depends on
+ *      browser globals and can't be import()ed under vitest's node env).
+ *   3. Behavioural: render-time derivation tracks humanity drops without
+ *      any field-write on the doc (the key dispatch assertion). Imports
+ *      editor/xp.js directly (pure module).
+ *   4. Integration test calling main() end-to-end with --apply against the
+ *      test MongoDB — seeds a fully-formed character WITH xp_total/xp_spent
+ *      plus attributes/skills/etc, asserts the deprecated fields are
+ *      $unset and every other field SURVIVES (the prod-incident assertion
+ *      from #828). MUST fail against any replaceOne-with-projection variant.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import 'dotenv/config';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { setupDb, teardownDb } from './helpers/db-setup.js';
+import { getCollection } from '../db.js';
+import { characterSchema } from '../schemas/character.schema.js';
+import { main } from '../scripts/cleanup-xp-totals-deprecation.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+function read(rel) { return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8'); }
+
+const TEST_FLAG = '_issue_837_integration_test';
+
+beforeAll(async () => { await setupDb(); });
+afterAll(async () => {
+  const col = getCollection('characters');
+  await col.deleteMany({ [TEST_FLAG]: true });
+  await teardownDb();
+});
+beforeEach(async () => {
+  const col = getCollection('characters');
+  await col.deleteMany({ [TEST_FLAG]: true });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Schema static guard
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#837 — character schema no longer declares xp_total / xp_spent', () => {
+  it('characterSchema.properties does not include xp_total', () => {
+    expect(characterSchema.properties.xp_total).toBeUndefined();
+  });
+  it('characterSchema.properties does not include xp_spent', () => {
+    expect(characterSchema.properties.xp_spent).toBeUndefined();
+  });
+  it('schema still has additionalProperties:false so unknown fields are rejected', () => {
+    // This is the mechanism that makes Option A enforceable: a client that
+    // resends xp_total on PUT gets rejected at the validation boundary.
+    expect(characterSchema.additionalProperties).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Client-write strip guard
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#837 — buildSaveBody strips xp_total / xp_spent', () => {
+  const src = read('public/js/admin.js');
+
+  it('declares _DEPRECATED_FIELDS containing xp_total + xp_spent', () => {
+    expect(src).toMatch(/_DEPRECATED_FIELDS\s*=\s*new\s+Set\(\[\s*'xp_total'\s*,\s*'xp_spent'/);
+  });
+
+  it('buildSaveBody references _DEPRECATED_FIELDS in its strip check', () => {
+    const fnStart = src.indexOf('function buildSaveBody');
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnEnd = src.indexOf('\n}\n', fnStart);
+    const body = src.slice(fnStart, fnEnd);
+    expect(body).toMatch(/_DEPRECATED_FIELDS\.has\(k\)/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Behavioural — derivation tracks state mutations without field writes
+// ─────────────────────────────────────────────────────────────────────────────
+
+// xp.js transitively imports public/js/data/api.js which reads the browser
+// `location` global at module load. Stub it before dynamic import so the
+// module loads cleanly under vitest's node env. xpEarned / xpSpent / xpLeft
+// themselves don't touch fetch — they're pure derivation off the character
+// shape — so a no-op location stub is sufficient.
+
+describe('#837 — render-time derivation tracks state without persisting xp fields', () => {
+  it('xpLeft reflects humanity drop without xp_total / xp_spent being mutated on doc', async () => {
+    if (typeof globalThis.location === 'undefined') {
+      globalThis.location = { hostname: '' };
+    }
+    const { xpEarned, xpSpent, xpLeft } = await import('../../public/js/editor/xp.js');
+
+    const c = {
+      humanity: 7,
+      humanity_base: 7,
+      ordeals: [],
+      attributes: {}, skills: {}, disciplines: {}, merits: [], powers: [],
+      attr_creation: { cp: 5, xp: 0 },
+      skill_creation: { cp: 0, xp: 0 },
+      disc_creation: { cp: 0, xp: 0 },
+      merit_creation: { cp: 0, xp: 0 },
+      xp_log: { earned: {}, spent: {} },
+    };
+
+    // Starting baseline: 10 starting + 0 drops + 0 ordeals + 0 game = 10.
+    const totalBefore = xpEarned(c);
+    const spentBefore = xpSpent(c);
+    const leftBefore = xpLeft(c);
+    expect(totalBefore).toBe(10);
+    expect(leftBefore).toBe(totalBefore - spentBefore);
+
+    // Mutate humanity (drop by 2): humanity drop awards 2 XP per dot lost,
+    // so xpEarned should jump by 4 with NO field write on the doc.
+    c.humanity = 5;
+    const totalAfter = xpEarned(c);
+    const leftAfter = xpLeft(c);
+    expect(totalAfter).toBe(totalBefore + 4);
+    expect(leftAfter).toBe(totalAfter - spentBefore);
+
+    // Crucially: no safety-net field-write happened. The doc still has no
+    // xp_total / xp_spent fields. (The whole point of Option A.)
+    expect(c.xp_total).toBeUndefined();
+    expect(c.xp_spent).toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Integration test — main() end-to-end with --apply
+// ─────────────────────────────────────────────────────────────────────────────
+
+function seedDoc() {
+  return {
+    [TEST_FLAG]: true,
+    name: '#837 Integration Test',
+    clan: 'Nosferatu', covenant: 'Invictus', mask: 'Survivor', dirge: 'Curmudgeon',
+    concept: 'Integration test fixture for #837',
+    status: { city: 1, clan: 2, covenant: 3 },
+    attributes: {
+      Intelligence: { dots: 3, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+      Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 3, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+      Presence: { dots: 1, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 3, bonus: 0 },
+    },
+    skills: {
+      Investigation: { dots: 3, bonus: 0, specs: ['Forensics'], nine_again: false },
+      Stealth: { dots: 4, bonus: 0, specs: [], nine_again: false },
+    },
+    disciplines: { Auspex: 2, Obfuscate: 3 },
+    powers: [],
+    merits: [{ name: 'Safe Place', category: 'domain', cp: 2, xp: 0, qualifier: 'Apt' }],
+    humanity: 6, humanity_base: 7, blood_potency: 1,
+    aspirations: ['Survive'],
+    // The deprecated fields — these are what the script must $unset.
+    xp_total: 28,
+    xp_spent: 16,
+  };
+}
+
+describe('#837 — cleanup script main() integration (write-path safety)', () => {
+  it('unsets xp_total / xp_spent + preserves ALL other fields when --apply runs', async () => {
+    const col = getCollection('characters');
+    const seed = seedDoc();
+    const ins = await col.insertOne(seed);
+    const id = ins.insertedId;
+    const before = await col.findOne({ _id: id });
+    expect(before.xp_total).toBe(28);
+    expect(before.xp_spent).toBe(16);
+
+    const origArgv = process.argv;
+    process.argv = [...origArgv, '--apply'];
+    try { await main(); } finally { process.argv = origArgv; }
+
+    const after = await col.findOne({ _id: id });
+
+    // Primary assertion: deprecated fields are gone.
+    expect(after.xp_total).toBeUndefined();
+    expect(after.xp_spent).toBeUndefined();
+    expect('xp_total' in after).toBe(false);
+    expect('xp_spent' in after).toBe(false);
+
+    // Survival assertions (would all fail against replaceOne-with-projection).
+    expect(after.clan).toBe(before.clan);
+    expect(after.covenant).toBe(before.covenant);
+    expect(after.status).toEqual(before.status);
+    expect(after.attributes, 'attributes must survive — the field the #828 prod incident lost').toEqual(before.attributes);
+    expect(after.skills).toEqual(before.skills);
+    expect(after.disciplines).toEqual(before.disciplines);
+    expect(after.merits).toEqual(before.merits);
+    expect(after.humanity).toBe(before.humanity);
+    expect(after.humanity_base).toBe(before.humanity_base);
+    expect(after.blood_potency).toBe(before.blood_potency);
+    expect(after.aspirations).toEqual(before.aspirations);
+  });
+
+  it('dry-run does not modify the document', async () => {
+    const col = getCollection('characters');
+    const seed = seedDoc();
+    const ins = await col.insertOne(seed);
+    const id = ins.insertedId;
+    const before = await col.findOne({ _id: id });
+
+    const origArgv = process.argv;
+    process.argv = origArgv.filter(a => a !== '--apply');
+    try { await main(); } finally { process.argv = origArgv; }
+
+    const after = await col.findOne({ _id: id });
+    expect(after).toEqual(before);
+    expect(after.xp_total).toBe(28);
+    expect(after.xp_spent).toBe(16);
+  });
+
+  it('idempotent: second --apply run leaves doc unchanged', async () => {
+    const col = getCollection('characters');
+    const seed = seedDoc();
+    const ins = await col.insertOne(seed);
+    const id = ins.insertedId;
+
+    const origArgv = process.argv;
+    process.argv = [...origArgv, '--apply'];
+    try {
+      await main();
+      const afterFirst = await col.findOne({ _id: id });
+      await main();
+      const afterSecond = await col.findOne({ _id: id });
+      expect(afterSecond).toEqual(afterFirst);
+      expect(afterSecond.xp_total).toBeUndefined();
+      expect(afterSecond.xp_spent).toBeUndefined();
+      expect(afterSecond.attributes).toBeTruthy();
+      expect(afterSecond.skills).toBeTruthy();
+    } finally {
+      process.argv = origArgv;
+    }
+  });
+
+  it('no-op when no docs carry the deprecated fields (early return path)', async () => {
+    const col = getCollection('characters');
+    const seed = seedDoc();
+    delete seed.xp_total;
+    delete seed.xp_spent;
+    const ins = await col.insertOne(seed);
+    const id = ins.insertedId;
+    const before = await col.findOne({ _id: id });
+
+    const origArgv = process.argv;
+    process.argv = [...origArgv, '--apply'];
+    try { await main(); } finally { process.argv = origArgv; }
+
+    const after = await col.findOne({ _id: id });
+    expect(after).toEqual(before);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cleanup script placement / shape sanity guards
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#837 — cleanup script shape guards', () => {
+  const src = read('server/scripts/cleanup-xp-totals-deprecation.js');
+
+  it('uses updateMany with $unset (NOT replaceOne)', () => {
+    expect(src).toMatch(/updateMany\(/);
+    expect(src).toMatch(/\$unset:\s*\{\s*xp_total:\s*['"]['"]\s*,\s*xp_spent:\s*['"]['"]/);
+    expect(src).not.toMatch(/replaceOne\(/);
+  });
+
+  it('main() is exported + direct-invocation guarded', () => {
+    expect(src).toMatch(/export async function main/);
+    expect(src).toMatch(/import\.meta\.url\s*===\s*`file:\/\/\$\{process\.argv\[1\]\}`/);
+  });
+
+  it('script defaults to dry-run; requires --apply to write', () => {
+    expect(src).toMatch(/process\.argv\.includes\(['"]--apply['"]\)/);
+    expect(src).toMatch(/DRY_RUN\s*=\s*!APPLY/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Client-side deprecation sanity guards — sites that previously wrote xp_total
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#837 — client-side writer sites no longer touch xp_total / xp_spent', () => {
+  it('editor/edit.js has no `c.xp_total =` assignment anywhere', () => {
+    const src = read('public/js/editor/edit.js');
+    expect(src).not.toMatch(/c\.xp_total\s*=/);
+    expect(src).not.toMatch(/c\.xp_spent\s*=/);
+  });
+
+  it('editor/identity.js no longer renders editable xp_total / xp_spent inputs', () => {
+    const src = read('public/js/editor/identity.js');
+    // The pre-#837 shape used updField('xp_total', ...). The new shape uses
+    // disabled inputs sourced from xpEarned() / xpSpent().
+    expect(src).not.toMatch(/updField\(['"]xp_total['"]/);
+    expect(src).not.toMatch(/updField\(['"]xp_spent['"]/);
+  });
+
+  it('tabs/wizard.js initialiser no longer seeds xp_total / xp_spent on new chars', () => {
+    const src = read('public/js/tabs/wizard.js');
+    // Pre-#837: xp_total: 10, xp_spent: 0 in the blank-char shape.
+    expect(src).not.toMatch(/xp_total:\s*10/);
+    expect(src).not.toMatch(/xp_spent:\s*0/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #837. Companion to #838 (PR #839).

Peter decision 2026-06-17 — **Option A**: remove `xp_total` / `xp_spent` from storage entirely. Derive at render time via `public/js/editor/xp.js` (`xpEarned()` / `xpSpent()` / `xpLeft()`).

## Fix shape (per dispatch)

| # | Site | Change |
|---|------|--------|
| 1 | `server/schemas/character.schema.js:110-111` | Properties removed. `additionalProperties:false` (line 41) rejects incoming PUTs that still send them. |
| 2 | `public/js/admin.js` `buildSaveBody` | New `_DEPRECATED_FIELDS` set (`xp_total`, `xp_spent`, `xp_left`) added to strip check — sanitises in-memory docs loaded from not-yet-cleaned DB. |
| 3 | `public/js/editor/edit.js` | All 4 safety-net write pairs (`c.xp_total = xpEarned(c); c.xp_spent = xpSpent(c)`) removed. Vestigial since no consumer reads the stored fields. Unused `xpEarned` / `xpSpent` imports dropped. |
| 4 | `public/js/editor/identity.js` | XP Total / XP Spent inputs converted to disabled derived displays via direct import of `xpEarned` / `xpSpent` from `xp.js`. `registerCallbacks` signature simplified — `xpLeft` callback no longer needed. |
| 4b | `admin.js` + `app.js` | `registerIdentityCallbacks` call sites updated. `app.js` `xpLeft` import dropped (no remaining use site). |
| 5 | `public/js/tabs/wizard.js` | Blank-char initialiser no longer seeds `xp_total:10` / `xp_spent:0`. |
| 5b | `public/js/suite/import.js` | CSV importer no longer assigns the columns into the created doc (still reads the CSV columns for diagnostics, just doesn't persist). |
| 6 | `server/scripts/cleanup-xp-totals-deprecation.js` | One-shot `$unset` cleanup script. Dry-run default; `--apply` gate. Uses `updateMany` (NOT `replaceOne` — per `feedback_script_integration_test`). |
| 7 | Tests | 16 in `server/tests/issue-837-xp-totals-deprecation.test.js`. |
| 8 | Memory | New `feedback_xp_derived_not_stored.md` pinned (mirrors `feedback_m_free_deprecated`). |

## Behavioural test (per dispatch)

`#837 — render-time derivation tracks state without persisting xp fields`:
- Construct a character with `humanity: 7` / `humanity_base: 7`, baseline 10 XP earned.
- Mutate `c.humanity = 5` (drop 2 dots = +4 XP earned, no field write triggered).
- Assert `xpEarned(c) === before + 4`, `xpLeft(c)` tracks the delta, **and** `c.xp_total === undefined` / `c.xp_spent === undefined` (the doc was never written to).

## Integration test — write-path safety

Modelled on the #834 cleanup test (which itself encodes the #828 prod-incident defence). Seeds a fully-formed character with `xp_total: 28`, `xp_spent: 16`, attributes, skills, disciplines, merits, status, humanity, etc. Runs `main()` with `--apply`. Asserts:

- `xp_total` / `xp_spent` are gone (`undefined` AND not present via `in`).
- Every other field SURVIVES — `attributes` (the field the #828 incident destroyed), `skills`, `disciplines`, `merits`, `status`, `humanity`, `humanity_base`, `blood_potency`, `aspirations`, `clan`, `covenant`.
- Plus: dry-run is a no-op; second `--apply` is idempotent; running against a doc that already has neither field is a no-op (early return).

## Verification

```
$ cd server && npx vitest run tests/issue-837-xp-totals-deprecation.test.js
Tests  16 passed (16)
```

Full suite: 1691 passed, 4 pre-existing failures (`issue-834-m-free-deprecation.test.js` `admin/rules-data-view.js` placement check; `feat-784-confirm-outcome-btn.test.js` ×3). Confirmed pre-existing by re-running on clean `main` (git stash → run → stash pop). Orthogonal to this PR.

Parse-check on all 7 touched JS files: OK.

## NOT in this PR

- **Phase-3 prod `--apply` run.** Per dispatch, requires separate per-message Peter authorisation. Script is dry-run by default; the integration test has already exercised the write path against the test DB.

## Test plan

- [x] `npx vitest run tests/issue-837-xp-totals-deprecation.test.js` — 16 passes
- [x] `node --check` across all 7 touched JS files — parse OK
- [x] Full vitest suite — no new failures
- [ ] Manual: load admin editor, open a character, confirm Experience section shows XP Total / Spent / Left as disabled derived inputs
- [ ] Manual: drop humanity, confirm XP Total ticks up by 2/dot without dirty-badge appearing from a stray field-write (XP is now display-only)
- [ ] Phase-3 (separate auth): `cd server && node scripts/cleanup-xp-totals-deprecation.js` (dry run) then `--apply`