### PR TITLE
feat(#847): Outcome box on DT processing compact merit panel

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -7624,6 +7624,16 @@ function _renderCompactMeritPanel(entry, rev) {
   h += `</div>`;
   h += `</div>`;
 
+  // ── Outcome ── (feat.847: compact merit actions previously had no outcome box)
+  const outcomeVal = rev.outcome || '';
+  h += `<div class="proc-section proc-player-note-section">`;
+  h += `<div class="proc-mod-panel-title">Outcome</div>`;
+  h += `<div class="proc-note-add">`;
+  h += `<textarea class="proc-outcome-input" data-proc-key="${esc(key)}" rows="4" placeholder="What happened — appears in the DT result...">${esc(outcomeVal)}</textarea>`;
+  h += `<button class="dt-btn proc-confirm-outcome-btn" data-proc-key="${esc(key)}">Confirm</button>`;
+  h += `</div>`;
+  h += `</div>`;
+
   h += `</div>`; // proc-compact-merit-panel
   return h;
 }

--- a/specs/investigations/2026-06-16-815-harbour-influence.md
+++ b/specs/investigations/2026-06-16-815-harbour-influence.md
@@ -1,0 +1,47 @@
+# Investigation: #815 — Harbour influence total discrepancy
+
+- **Date:** 2026-06-16
+- **Issue:** #815 (Harbour influence total discrepancy: +17 shown vs +19 expected)
+- **Type:** read-only data investigation (no code change)
+- **Verdict:** **Not a bug. The tracker is correct.** The live Ambience screen reflects **Downtime 4** (the active cycle), where Harbour influence genuinely totals **+17** — matching the submitted data exactly. The "+19 expected" was an arithmetic miscount of a list that sums to 17.
+
+## How the confusion arose
+
+The original report referenced "DT3 processing", so the first query pass looked at **Downtime 3** and found Harbour = +13/−3/+10. But the live Ambience table the ST is actually viewing reflects the **active cycle, Downtime 4** (`6a11a3814fce658310cdee80`). The two cycles have different influence data. Everything below is DT4, which is what the screen shows.
+
+## Verification — DT4, all five territories match the screen exactly
+
+Read-only query of live `tm_suite`, DT4 cycle, all 29 `downtime_submissions`, `responses.influence_spend` parsed (JSON string keyed by territory `_id`). Summed per territory:
+
+| Territory | Contributors (DT4) | Total | Screen | Match |
+|---|---|---|---|---|
+| The Academy | Henry 17, Charlie 14, Jack 4, Yusuf 1, Anichka 1, Tegan 1 | +38 | `+38 \| -0 \| +38` | ✓ |
+| The Dockyards | Conrad 7, Hazel 5, Tegan 4, Ryan 2, Reed 2 | +20 | `+20 \| -0 \| +20` | ✓ |
+| **The Harbour** | **Wan 8, Ludica 3, Benedict 2, Reed 2, Yusuf 1, Xavier 1** | **+17** | `+17 \| -0 \| +17` | ✓ |
+| The North Shore | Brandy 7, René Meyer 2, Alice 2, Yusuf 1, Anichka 1 | +13 | `+13 \| -0 \| +13` | ✓ |
+| The Second City | Eve 7, René Meyer 5, Einar 4, Aleksei 2 | +18 | `+18 \| -0 \| +18` | ✓ |
+
+All five territories reconcile to the screenshot to the unit. `_gatherInfluence` and the Influence column are computing correctly.
+
+## The Harbour number specifically
+
+DT4 Harbour `influence_spend`: Wan 8, Ludica 3, Benedict 2, Reed 2, Yusuf 1, Xavier 1 → **+17**.
+
+This is **identical to the ST's own expected breakdown** in the report (Wan 8, Ludica 3, Reed 2, Benedict 2, Yusuf 1, Xavier 1). That list sums to **17**, not 19 — the "+19" was simply an addition error. The screen already shows exactly what the ST expected.
+
+(Benedict — flagged as "missing" in the first DT3 pass — *does* have a DT4 submission with Harbour +2. He simply had no DT3 submission. The DT4 screen includes him correctly.)
+
+## "−0" on the negative column
+
+Correct, not a bug. Every DT4 `influence_spend` value is ≥ 0 — no character submitted a negative influence this cycle — so `inf_neg` is 0 for all territories and the column renders "−0". (DT3 *did* have negatives, e.g. Jack Fallow −1, Macheath −2 on Harbour; that's why the DT3 pass showed −3. Different cycle.)
+
+## Conclusion & recommendation
+
+- **No code change.** The Ambience Influence column is accurate for the active cycle (DT4): Academy +38, Dockyards +20, Harbour +17, North Shore +13, Second City +18, all with no negatives — verified to the unit against live data.
+- The reported discrepancy was (a) a cycle mix-up (DT3 expectation vs DT4 screen) and (b) a +19/+17 arithmetic slip. Harbour is correctly +17.
+- **Recommend closing #815 as "working as intended."**
+
+## Out of scope (confirmed, not actioned)
+
+- No change to `_gatherInfluence` (it is correct).
+- Side-finding (unrelated): the `territories` collection holds ~16 `Regent Save Test` junk docs and `downtime_cycles` holds 2 `Test Cycle` junk docs (test residue) — candidate for a separate cleanup, same class as the `secondcity` residue noted in ADR-002.

--- a/specs/investigations/2026-06-16-818-territory-migration-verify.md
+++ b/specs/investigations/2026-06-16-818-territory-migration-verify.md
@@ -1,0 +1,46 @@
+# Investigation: #818 — Verify #496 territory-key migration ran on live `tm_suite`
+
+- **Date:** 2026-06-16
+- **Issue:** #818 (verify the #496 territory-key migration actually ran on live; schema now rejects slugs)
+- **Type:** read-only data verification (no code change, no data change)
+- **Verdict:** **Migration confirmed applied.** No slug-keyed / slug-valued territory residue remains in live `tm_suite`. The schema's OID-only constraint is consistent with the live data. No action required.
+
+## Concern being tested
+
+The 496.4 story noted its live `--apply` was a pre-merge gate that *may not have been run* ("toMigrate: 60 on live DB"). If un-migrated slug-keyed territory fields still existed, OID-only readers would silently return null/0 for them and the tightened schema (`^[a-f0-9]{24}$`) would 400 on re-save. This investigation checks whether any such residue exists.
+
+## Method
+
+Read-only queries of live `tm_suite` (MongoDB Atlas). Canonical territory OIDs:
+`academy 69d9e54b…bea7`, `harbour 69d5dc6a…97c6`, `dockyards 69d9e54c…bea9`, `secondcity 69d9e54c…bea8`, `northshore 69d9e54b…bea6`.
+
+## Findings
+
+### 1. Cycle-level cross-doc FKs — OID-keyed (migrated)
+`downtime_cycles.confirmed_ambience`, `discipline_profile`, and `territory_pulse` keys are all 24-hex ObjectIds across **Downtime 2, 3, 4**. (DT1 has none of these fields — predates them.) ADR-002's 2026-05-05 baseline recorded DT2 as *slug-keyed* here; it is now OID-keyed, so the rekey ran.
+
+### 2. Submission key-based fields — no slug residue
+Regex scan across **all** `downtime_submissions` for legacy slug-variant keys (`the_academy`, `the_harbour`, `the_dockyards`, `the_second_city`, `the_north_shore`, and legacy `the_city_harbour`/`the_docklands`/`the_northern_shore`) in `responses.feeding_territories`, `feeding_territories_rote`, and `influence_spend`:
+- **0 documents.**
+Spot-confirmed on the oldest structured cycle (DT2): keys are OIDs plus the legitimate `the_barrens_no_territory_` sentinel (Barrens has no OID by design; `TERRITORY_SLUG_MAP` resolves it to null).
+
+### 3. Submission value-based fields — no slug residue
+Regex scan for bare-slug values (`^(academy|harbour|dockyards|secondcity|northshore)$`) in `project_{1-4}_ambience_target`, `project_1_territory`, `project_1_target_terr`, `sphere_1_territory`:
+- **0 documents.** Consistent with the schema's OID-only constraint on these fields.
+
+### 4. DT1 (CSV-era) — not residue, by design
+DT1 submissions have **empty `responses` ({})**; DT1 is the CSV-imported cycle and its territory data lives in `_raw.feeding.territories` (display-name keys), read via the dedicated legacy `_raw` fallback path in `_getSubFedTerrs` / `_normTerrKeys`. ADR-002 Q4 deliberately left legacy submission `_raw` intact; the legacy reader handles it. This is expected and correct, not un-migrated residue in the OID-keyed fields.
+
+### Other territory-keyed collections
+- `territory_residency`: dormant (0 docs, per ADR-002) — nothing to migrate.
+- `tracker_state`: no territory reference (per ADR-002) — N/A.
+
+## Conclusion & recommendation
+
+- **The #496 migration is applied on live `tm_suite`.** Every OID-keyed/valued territory field is OID; zero slug residue in `downtime_submissions` (key- or value-based) or `downtime_cycles`. Code assumptions and the tightened schema match the data.
+- **No action required.** Recommend closing #818 as verified.
+- DT1's `_raw`-based legacy data is correctly served by the legacy reader path and is out of scope for the OID migration (ADR-002 Q4).
+
+## Out of scope (noted, not actioned)
+
+- Test residue in `territories` (~16 `Regent Save Test`) and `downtime_cycles` (2 `Test Cycle`) — tracked separately in **#823**. Unrelated to the FK migration.

--- a/specs/stories/feat.847.dt-proc-compact-outcome-box.story.md
+++ b/specs/stories/feat.847.dt-proc-compact-outcome-box.story.md
@@ -1,0 +1,286 @@
+---
+title: 'DT processing: add Outcome box to the compact merit action panel'
+type: 'feat'
+issue: 847
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/847
+branch: ms/issue-847-dt-proc-compact-outcome-box
+created: '2026-06-17'
+status: review
+recommended_model: 'sonnet — single localised render addition, reuses an existing copy-paste block and existing container-wide event wiring; no new handlers, no schema, no CSS'
+context:
+  - public/js/admin/downtime-views.js
+---
+
+## Intent
+
+In DT processing, **compact merit actions** (binary / fixed-effect / automatic
+actions — e.g. a Contacts intelligence-gathering action) render through
+`_renderCompactMeritPanel`. That panel has no Outcome box, so the ST has nowhere
+to record the narrative result of the action. Every other action panel — project
+actions and the full (rolled) merit panel — shows an Outcome textarea + Confirm
+button.
+
+This story adds the **same Outcome section** to `_renderCompactMeritPanel`. The
+section is an exact copy of the block already used by the project and full-merit
+panels. No new event wiring is required (the existing handlers are container-wide)
+and the saved value already flows to the player-facing merit summary.
+
+---
+
+## Root cause (do NOT re-investigate)
+
+### Where the Outcome box lives today
+
+The Outcome section (title "Outcome" + `proc-outcome-input` textarea rows="4" +
+`proc-confirm-outcome-btn`) is rendered in exactly two places, both added by
+feat.784 (#784):
+
+1. **Project action panel** — `public/js/admin/downtime-views.js:9427-9433`
+2. **Full merit action panel** (`_renderMeritRightPanel`) — `:10190-10197`
+
+The canonical block (from `:10190-10197`):
+
+```js
+// ── Outcome ──
+h += '<div class="proc-section proc-player-note-section">';
+h += '<div class="proc-mod-panel-title">Outcome</div>';
+h += '<div class="proc-note-add">';
+h += `<textarea class="proc-outcome-input" data-proc-key="${esc(entry.key)}" rows="4" placeholder="What happened — appears in the DT result...">${esc(outcomeVal)}</textarea>`;
+h += `<button class="dt-btn proc-confirm-outcome-btn" data-proc-key="${esc(entry.key)}">Confirm</button>`;
+h += '</div>';
+h += '</div>';
+```
+
+### Why the compact panel has none
+
+`_renderCompactMeritPanel` (`downtime-views.js:7505-7629`) is selected for
+binary/fixed-effect/automatic merit actions via `_isCompactMerit` (`:7658`). It
+renders, in order:
+
+- outcome status buttons — `_renderMeritOutcomeButtons` (`:7558`)
+- Contacts sphere / target / info-type panels (`:7561-7580`, gated on `category === 'contacts'`)
+- effect panel / Action Mode (`:7582-7594`)
+- automatic successes (`:7596-7602`)
+- ST Notes (`:7604-7625`)
+
+…then closes the `proc-compact-merit-panel` wrapper at `:7627` and returns. There
+is **no Outcome section** between the ST Notes panel and the closing div. feat.784
+added the box to the project panel and the full merit panel but not this one, so
+compact actions were left without it.
+
+### The event wiring is already container-wide (no new handlers needed)
+
+In `wireProcessingEvents`:
+
+- `:5473` — `container.querySelectorAll('.proc-outcome-input')` wires blur-save for
+  every outcome textarea in the container.
+- `:5486` — `container.querySelectorAll('.proc-confirm-outcome-btn')` wires the
+  Confirm click for every confirm button: it reads
+  `.proc-outcome-input[data-proc-key="${key}"]`, guards empty, calls
+  `saveEntryReview(entry, { outcome: text })`, then `renderProcessingMode(container)`.
+
+Because both selectors are container-wide and key off `data-proc-key`, rendering
+the same block (with `entry.key`) inside the compact panel is automatically wired.
+The compact panel is rendered inside the same processing-mode container that
+`wireProcessingEvents` binds.
+
+### The saved value already flows downstream
+
+`rev.outcome` (what Confirm saves) is read by the player-facing merit summary at
+`public/js/admin/downtime-story.js:2366`
+(`entry.outcome ? esc(entry.outcome) : '— Outcome not yet recorded —'`), and the
+"missing outcome" flag at `:2361`. So compact merit actions currently always show
+"— Outcome not yet recorded —" there; once the box exists and is filled, they will
+display the recorded outcome with no further plumbing.
+
+---
+
+## Fix specification
+
+### T1 — Add the Outcome section to `_renderCompactMeritPanel`
+
+In `_renderCompactMeritPanel` (`downtime-views.js:7505-7629`), after the ST Notes
+panel closes (`:7625`) and **before** the `proc-compact-merit-panel` wrapper closes
+(`:7627`), insert the Outcome block, mirroring `:10190-10197` exactly:
+
+```js
+// ── Outcome ──
+const outcomeVal = rev.outcome || '';
+h += '<div class="proc-section proc-player-note-section">';
+h += '<div class="proc-mod-panel-title">Outcome</div>';
+h += '<div class="proc-note-add">';
+h += `<textarea class="proc-outcome-input" data-proc-key="${esc(entry.key)}" rows="4" placeholder="What happened — appears in the DT result...">${esc(outcomeVal)}</textarea>`;
+h += `<button class="dt-btn proc-confirm-outcome-btn" data-proc-key="${esc(entry.key)}">Confirm</button>`;
+h += '</div>';
+h += '</div>';
+```
+
+Notes:
+- `rev` is already a parameter of `_renderCompactMeritPanel`; declare
+  `outcomeVal` locally as shown (the full panel computes the same value upstream).
+- Reuse the existing classes verbatim (`proc-section proc-player-note-section`,
+  `proc-outcome-input`, `proc-confirm-outcome-btn`, `dt-btn`) so the existing CSS
+  and the existing handlers apply. Do **not** invent new class names.
+- Do **not** add the `proc-player-note-input` class to the Outcome textarea —
+  feat.784 specifically removed it to stop a double-write into `player_facing_note`.
+
+### Open question resolved
+
+The issue raised multi-line `proc-outcome-input` textarea vs the one-line
+`proc-outcome-summary-input` (`:7507`). Use the **multi-line `proc-outcome-input`
+block** — it is what the project and full-merit panels show (the screenshot of
+"any other action"), it shares the already-wired handlers, and it writes to
+`rev.outcome` which the merit summary reads. The one-line
+`proc-outcome-summary-input` is a separate merit-outcome-summary control and is
+out of scope.
+
+---
+
+## Acceptance criteria
+
+- [x] **AC-1** A compact merit action (e.g. a Contacts intelligence action,
+      AUTOMATIC mode) shows an "Outcome" section with a multi-line textarea and a
+      Confirm button, matching the project / full-merit panels. _(rendered at
+      downtime-views.js:7627-7635)_
+- [x] **AC-2** Typing narrative text and clicking Confirm saves it to `rev.outcome`
+      and re-renders the panel (ribbon advances to Complete when `pool_status` is
+      already terminal), with no page reload. _(served by the pre-existing
+      container-wide handler at :5486; pending in-browser smoke on dev)_
+- [x] **AC-3** Clicking Confirm with an empty textarea is a no-op (existing handler
+      behaviour at :5491-5492).
+- [x] **AC-4** After refresh, the saved outcome persists and the player-facing merit
+      summary (`downtime-story.js:2366`) shows the recorded outcome instead of
+      "— Outcome not yet recorded —". _(downstream read unchanged; pending smoke on dev)_
+- [x] **AC-5** The fix applies to ALL compact merit actions (not Contacts-only),
+      since the box is added at the `_renderCompactMeritPanel` level.
+- [x] **AC-6** Non-compact actions (project panel, full merit panel) are unchanged —
+      no duplicate Outcome boxes appear anywhere. _(verified: exactly 3 outcome
+      sites — :7632, :9440, :10204; existing two untouched)_
+
+---
+
+## Dev notes
+
+### Do NOT change
+
+- `wireProcessingEvents` (`:5473`, `:5486`) — already container-wide; the new block
+  is picked up automatically. No new handler.
+- `saveEntryReview`, `renderProcessingMode` — unchanged; the existing Confirm
+  handler calls them.
+- `downtime-story.js:2366` merit-summary read — unchanged; it already consumes
+  `entry.outcome`.
+- The project panel (`:9427-9433`) and full merit panel (`:10190-10197`) blocks —
+  do not touch; this story only adds the missing third site.
+
+### Scope boundaries
+
+- **In scope**: the Outcome box only, in `_renderCompactMeritPanel`.
+- **Out of scope**: a Player Feedback (`player_facing_note`) section for compact
+  actions — the full panel has one (`:10199+`) but the issue asks only for the
+  Outcome box. Flag as a possible follow-up if the ST wants player-facing notes on
+  compact actions too.
+
+### CSS
+
+No CSS changes. `proc-section`, `proc-player-note-section`, `proc-note-add`,
+`proc-outcome-input`, `proc-confirm-outcome-btn`, and `dt-btn` are all already
+defined and used by the existing two Outcome sites.
+
+### Testing approach
+
+No Playwright needed (mirrors feat.784's verification). Manual smoke test on dev:
+
+1. Open DT processing; expand a compact merit action — a Contacts intelligence
+   action (INFO TYPE, Action Mode AUTOMATIC) is the reported case.
+2. Confirm an Outcome textarea + Confirm button now appear below ST Notes.
+3. Type narrative text; click Confirm. The panel re-renders (no reload); ribbon
+   advances to Complete if `pool_status` is terminal.
+4. Refresh — the outcome persists.
+5. Confirm the player-facing merit summary now shows the recorded outcome rather
+   than "— Outcome not yet recorded —".
+6. Confirm empty-textarea Confirm is a no-op, and that project / full-merit panels
+   still show exactly one Outcome box each.
+
+---
+
+## Dev Agent Record
+
+### Files to change
+
+- `public/js/admin/downtime-views.js`
+  - `_renderCompactMeritPanel` (after `:7625`, before the `:7627` wrapper close):
+    add the Outcome section (textarea `proc-outcome-input` rows="4" +
+    `proc-confirm-outcome-btn`), declaring `const outcomeVal = rev.outcome || ''`.
+
+### Files changed
+
+- `public/js/admin/downtime-views.js` — added the Outcome section to
+  `_renderCompactMeritPanel` (10 insertions at :7627-7636), after the ST Notes
+  panel and before the `proc-compact-merit-panel` wrapper close.
+
+### Completion notes
+
+- Single change, exactly as specified: inserted the Outcome block
+  (`proc-section proc-player-note-section` → "Outcome" title →
+  `proc-outcome-input` textarea rows="4" → `proc-confirm-outcome-btn`) into
+  `_renderCompactMeritPanel`, declaring `const outcomeVal = rev.outcome || ''`.
+- Used the compact panel's local `key` var and backtick-template style to match
+  surrounding code; classes/`data-proc-key` match the other two sites verbatim so
+  the existing container-wide handlers (blur-save :5473, Confirm :5486) cover it
+  with no new wiring.
+- No new handlers, no schema, no CSS. `node --check` passes.
+- Verified there are now exactly 3 outcome render sites (:7632 compact, :9440
+  project, :10204 full merit); the existing two are unchanged; `git diff --stat`
+  shows +10 in one file.
+- **Pending QA (runtime smoke on dev — cannot be run locally):** open a Contacts
+  intelligence (AUTOMATIC) action, confirm the Outcome box appears, type + Confirm
+  saves and re-renders, value persists after refresh, and the player merit summary
+  shows the recorded outcome. This is the bmad-agent-qa step.
+
+### Change Log
+
+| Date | Description |
+|------|-------------|
+| 2026-06-17 | Implemented: Outcome box added to compact merit panel. Status → review. |
+| 2026-06-17 | QA (Quinn): PASS at code level. Smoke checklist recorded; pending dev. |
+
+---
+
+## QA Results (Quinn, 2026-06-17)
+
+**Verdict: PASS at code level** — correct, surgical, regression-safe. Runtime smoke
+on dev is the remaining gate (cannot be run locally).
+
+### Verified
+- New block (`downtime-views.js:7627-7636`) matches reference sites `:9440` and
+  `:10204` verbatim (classes, `data-proc-key`). `git diff` = +10, one file; the two
+  existing sites untouched.
+- Wiring auto-covers it: blur-save (`:5473`) and Confirm (`:5486`) are
+  container-wide and resolve via `_getQueueEntry(key)`; compact panel renders inside
+  that container (`:7668`). No new handler required — confirmed.
+- Writes `rev.outcome`; merit summary reads `entry.outcome`
+  (`downtime-story.js:2366`) → AC-4. No `proc-player-note-input` class, so no
+  double-write (feat.784 fix preserved).
+- Each entry renders compact XOR full panel (early return `:7668`) → no duplicate
+  boxes (AC-6). `rev` is a guaranteed object at this call site. `node --check` passes.
+
+### Nuance flagged (not a defect)
+- Confirm handler also sets `outcome_confirmed: true` and, when the entry `hasPool`
+  and is not already moded, `roll_mode='player'` + `pool_status='validated'`
+  (`:5498-5502`). Inert for the reported AUTOMATIC/no-pool Contacts case. But
+  `_isCompactMerit` routes ALL `contacts`/`retainer` actions to the compact panel
+  (`:7476-7477`), so a pool-bearing contacts action would auto-validate on Confirm —
+  same as Confirm elsewhere, but now reachable here. Eyeball in smoke (item 3).
+
+### Smoke checklist (run on dev)
+1. Contacts intel (AUTOMATIC): box appears; Confirm saves + re-renders (ribbon →
+   Complete); persists after refresh; shows in player merit summary.
+2. Blur-save (no Confirm click) also persists the outcome.
+3. A pool-bearing contacts/retainer action (if present): confirm the Confirm
+   auto-validate side-effect is acceptable.
+4. No action type shows two Outcome boxes.
+
+### Automated tests
+None added — deliberate. Server vitest doesn't exercise browser-coupled render fns;
+a Playwright DT spec (slow/flaky) is disproportionate for a 10-line mirror of an
+already-shipped pattern (feat.784 precedent: manual smoke).


### PR DESCRIPTION
## Summary

Promotes feat.847 to production. Compact merit actions (binary/automatic — e.g. a Contacts intelligence action) render through `_renderCompactMeritPanel` and had **no outcome box**, so the ST could not record the narrative result. Adds the same Outcome block (`proc-outcome-input` textarea + `proc-confirm-outcome-btn`) used by the project and full-merit panels.

- One change, +10 lines in `public/js/admin/downtime-views.js` (`_renderCompactMeritPanel`, ~:7627-7636).
- Mirrors existing blocks at `:9440` and `:10204` verbatim; no new wiring (handlers `:5473`/`:5486` are container-wide).
- `rev.outcome` already flows to the player merit summary (`downtime-story.js:2366`).

Also carries the #815/#818 investigation docs commit (docs only).

Closes #847
Story: `specs/stories/feat.847.dt-proc-compact-outcome-box.story.md`

## QA

PASS at code level (Quinn). `node --check` clean; exactly 3 outcome sites; existing two untouched.

## Note on smoke

In-browser smoke (Contacts intel AUTOMATIC: box appears, Confirm saves/persists, shows in merit summary) is best run on dev (PR #848) before this merges to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)