### PR TITLE
docs(css): wire normalised-CSS enforcement into standards, CLAUDE.md, BMAD + skills

### DIFF
--- a/.claude/skills/tm-gh-issue-create/SKILL.md
+++ b/.claude/skills/tm-gh-issue-create/SKILL.md
@@ -39,6 +39,12 @@ Do **not** invoke for:
    - **Type**: inferred from language — bug-words ("broken", "wrong", "doesn't work") → `bug`; feature-words ("add", "support", "should also") → `feature`; otherwise ask. User's `--type` flag overrides.
    - **Epic label**: if the description mentions a known epic prefix (RDE, PP, DT, NPCR, etc.), apply `epic:<lowercase>`. User's `--epic` flag overrides.
    - **Standard labels**: always add `bmad-intake` so issues created via this skill are filterable.
+3b. **Design-system / CSS check (if the issue touches UI or styling).** The app has a normalised CSS design system that AI-implemented features routinely fail to use. As part of intake, look up the normalised CSS for the thing so the issue points the implementer straight at it:
+   - Identify the UI element/component involved and grep `public/css/components.css` and the app sheet (`suite.css` Suite / `admin-layout.css` Admin) for the analogous existing class(es), plus the relevant `public/css/theme.css` tokens.
+   - If a suitable component class exists, name it in **References** (e.g. "reuse `.dt-btn` / `.form-input` / `.exp-row`") and add a **Scope note**: "must reuse the existing normalised CSS — no inline `style=`, no bare hex/`rgba()`."
+   - If none exists, say so in References and note that a new class should be added to the correct stylesheet using `theme.css` tokens (never inlined), per `specs/architecture/coding-standards.md` → CSS Standards.
+   - For any UI issue, add an **Acceptance criterion**: "Styling uses design-system tokens and reuses existing component classes (no inline `style=`, no bare hex)."
+   Reference: `specs/project-context.md` (critical standards) and `specs/architecture/coding-standards.md` (full CSS guidance).
 4. **Build the issue body** using this template (omit empty sections):
 
    ```markdown

--- a/.claude/skills/tm-gh-issue-pickup/SKILL.md
+++ b/.claude/skills/tm-gh-issue-pickup/SKILL.md
@@ -89,6 +89,8 @@ Do **not** invoke for:
     ```
     The skill ends after surfacing this requirement; the actual frontmatter additions happen during BMAD SM's create-story flow. (If `bmad-create-story` doesn't natively accept these fields, the assistant adds them post-hoc by editing the resulting story file.)
 
+12. **If the issue touches UI or styling**, surface a one-line reminder at hand-off so the story and dev agents carry it: "UI work must reuse the normalised CSS — design-system tokens from `public/css/theme.css` and existing component classes; no inline `style=` or bare hex. See `specs/project-context.md` and `specs/architecture/coding-standards.md`." (The BMAD story/dev agents also auto-load `specs/project-context.md`; this is reinforcement.)
+
 ## Boundaries
 
 - **Never** create a branch on `main`. Always branch off a working branch or `dev`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,9 +118,10 @@ XP functions in `public/js/editor/xp.js`: `xpEarned()`, `xpSpent()`, `xpLeft()`,
 - **British English throughout**: Defence, Armour, Vigour, Honour, Socialise, capitalise
 - **No em-dashes** in output text
 - **Dots display**: `'●'.repeat(n)` using U+25CF filled circle
-- **Gold accent**: `#E0C47A` (CSS var `--gold2`)
+- **Gold accent**: CSS var `--gold2` (value differs per theme; never hardcode the hex)
 - **Font stack**: Cinzel / Cinzel Decorative for headings, Lora for body (Google Fonts CDN)
-- **CSS custom properties** defined on `:root` — dark theme with `--bg: #0D0B09`, `--surf*` surface tiers, `--gold*` accent tiers, `--crim: #8B0000` for damage states
+- **CSS custom properties** defined on `:root` in `public/css/theme.css`. Default theme is **Parchment** (warm light); `[data-theme="dark"]` is the override. Tokens flip between themes; rule bodies stay theme-agnostic.
+- **Normalised CSS (MANDATORY)**: all styling uses the design-system tokens in `theme.css`. Reuse an existing component class from `public/css/components.css` (or the app sheet `suite.css` / `admin-layout.css`) before inventing one. Never write a bare hex, `rgba()`, or inline `style="..."` in markup or JS-rendered HTML. Full guidance: `specs/architecture/coding-standards.md` → "CSS Standards"; the critical-standards summary auto-read by the BMAD dev/story agents lives in `specs/project-context.md`.
 
 ## Data Sources of Truth
 

--- a/specs/architecture/coding-standards.md
+++ b/specs/architecture/coding-standards.md
@@ -142,6 +142,54 @@ BEM-lite: `block__element--modifier`. Keep it readable, not academic.
 
 No utility class soup. No `!important`.
 
+### Component Reuse (reuse before invent)
+
+Most UI is already built from reusable classes. Before adding markup, grep for an
+analogous element and reuse its class. Inventing a one-off class (or worse, an
+inline style) when a component already exists is the single most common drift we
+clean up after.
+
+Shared, app-agnostic components live in `public/css/components.css`. App-specific
+chrome lives in `suite.css` (Suite/Game) and `admin-layout.css` (ST Admin).
+
+Common reusable classes (confirm in the CSS before use):
+
+| Need | Class(es) | File |
+|---|---|---|
+| Action button | `.dt-btn` (admin), `.nbtn` (suite nav) | admin-layout / suite |
+| Text input / select | `.form-input`, `.form-select`, `.form-label` | components |
+| Form section | `.form-section`, `.form-section-title` | components |
+| Character card / grid | `.char-card`, `.char-grid`, `.char-chip` | components |
+| Dot stepper / dots | `.dot-stepper`, `.pointed` (+`.hollow`) | components |
+| Expandable row | `.exp-row` (+`.exp-row.open`) | components |
+| Merit breakdown row | `.merit-bd-row` + `.bd-grp`/`.bd-lbl`/`.bd-eq`/`.bd-val` | components |
+| Sheet section | `.sh-sec` | components |
+| Influence / merit rows | `.infl-edit-row`, `.infl-tier-chip`, `.mci-block`, `.dom-edit-block` | components |
+| DT processing panel | `.proc-feed-mod-panel`, `.proc-pool-builder` (grouped chrome) | admin-layout |
+| Derived note / annotation | `.derived-note` | components |
+
+If nothing fits, add a class to the correct stylesheet (shared → `components.css`;
+app-specific → the app sheet) using tokens, and follow the Shared Chrome Pattern
+above. Do not fork chrome and do not inline.
+
+### Styling from JavaScript
+
+Render functions build HTML strings. **Apply a class — never an inline
+`style="color:#..."`.** Inline styles bypass tokens and theming and are the main
+source of design drift in AI-written features.
+
+```js
+// WRONG: inline style + bare hex; ignores tokens and dark theme
+h += `<span style="color:#E0C47A;font-size:10px;">${label}</span>`;
+
+// RIGHT: reuse/define a class; colour comes from a token in the stylesheet
+h += `<span class="effpool-seg effpool-merit">${label}</span>`;
+// .effpool-merit { color: var(--gold2); font-size: 10px; }  (in the app stylesheet)
+```
+
+If a one-off dynamic value is genuinely unavoidable (e.g. a computed width), it
+must still resolve to a token, never a literal colour/font.
+
 ### Responsive Design
 
 Suite views (Roll, Sheet, Territory, Tracker): mobile-first. Use `min-width` media queries.

--- a/specs/project-context.md
+++ b/specs/project-context.md
@@ -1,0 +1,68 @@
+# Project Context — Critical Implementation Standards
+
+This file is auto-loaded as a persistent fact by the BMAD story and dev agents
+(`bmad-create-story`, `bmad-dev-story` — see their `customize.toml`
+`persistent_facts`). Anything here is read on every story/dev run. Keep it short
+and high-signal: the standards an implementer must NOT violate.
+
+---
+
+## 1. Normalised CSS — reuse the design system, never write ad-hoc styles
+
+The app has a normalised CSS design system. New UI that ignores it (inline
+styles, bare hex, one-off classes) is a defect, not a shortcut. Before writing
+ANY markup or styling:
+
+1. **Use tokens, never literals.** All colours/fonts/spacing come from the
+   `:root` custom properties in `public/css/theme.css`
+   (`var(--txt)`, `var(--surf2)`, `var(--accent)`, `var(--gold2)`, `var(--fh)`,
+   etc.). Never write a hex value, `rgba(...)`, or font name in a rule body or in
+   a JS-generated `style="..."` attribute. The only place hex is allowed is the
+   `:root` / `[data-theme="dark"]` blocks in `theme.css`.
+2. **Reuse an existing component class before inventing one.** Grep
+   `public/css/components.css` (shared) and the app stylesheet
+   (`suite.css` / `admin-layout.css`) for an analogous element first. Common
+   reusable classes (verify in the CSS before use):
+   - Buttons: `.dt-btn` (admin actions), `.nbtn` (suite nav)
+   - Inputs: `.form-input`, `.form-select`, `.form-label`, `.form-section`
+   - Cards/grids: `.char-card`, `.char-grid`, `.char-chip`
+   - Dots: `.dot-stepper`, `.pointed` / `.pointed.hollow` (display: `●`/`○`)
+   - Expandable rows: `.exp-row` (+ `.exp-row.open`)
+   - Merit breakdown: `.merit-bd-row` + `.bd-grp`/`.bd-lbl`/`.bd-eq`/`.bd-val`
+   - Sheet/section: `.sh-sec`, `.form-section-title`
+   - Influence/merits: `.infl-edit-row`, `.infl-tier-chip`, `.mci-block`,
+     `.dom-edit-block`
+   - DT processing panels: `.proc-feed-mod-panel`, `.proc-pool-builder`
+     (grouped chrome — add to the canonical group, don't fork)
+   - Derived/annotation: `.derived-note`
+3. **Styling from JavaScript:** render functions build HTML strings. Apply a
+   **class**, never an inline `style="color:#..."`. If the needed style does not
+   exist as a class, add it to the right stylesheet using tokens, then apply the
+   class. Do not inline.
+4. **New shared chrome goes in a grouped selector**, not duplicated rule bodies
+   (see `coding-standards.md` → Shared Chrome Pattern).
+
+**Authoritative reference:** `specs/architecture/coding-standards.md` → "CSS
+Standards" (tokens, component reuse, styling-from-JS, shared chrome, naming).
+Token source of truth: `public/css/theme.css`.
+
+If a story touches UI, its implementation is not complete until every colour,
+font, and spacing value is a token and every element reuses or properly extends
+the component system.
+
+---
+
+## 2. Other non-negotiables (see the linked SSOT for detail)
+
+- **British English** throughout (Defence, Armour, Vigour, Honour, Socialise).
+  No em-dashes in player-facing output text.
+- **Derived stats are never stored** — health/vitae/willpower max, influence
+  total, XP are computed at render time. (Sanctioned exception: ST-mod overlay,
+  ADR-004.)
+- **Reference data has one home** — `FEED_METHODS` / `TERRITORY_DATA` live in
+  `public/js/tabs/downtime-data.js`; import, never duplicate. Full SSOT map:
+  `specs/reference-data-ssot.md`.
+- **Effective ratings** (dots + bonus) are read for pools/prereqs; bonus dots are
+  real dots.
+- Targeted tests only for the changed area; never the full suite for a small
+  change. No `| tail` on test runs (capture to a file, check the exit code).


### PR DESCRIPTION
Promotes the normalised-CSS enforcement wiring to main. Docs/config/skills only (no public/ app code; deploy is a no-op for the running app).

🤖 Generated with [Claude Code](https://claude.com/claude-code)