### PR TITLE
fix(#842): unblock issue-834 test (shebang) + complete #834 m.free removal

### DIFF
--- a/public/js/admin/rules-data-view.js
+++ b/public/js/admin/rules-data-view.js
@@ -523,8 +523,10 @@ function _renderPreviewDots(char, rule, proposed) {
   if (!merits.length) return '<p class="rde-preview-empty">No merits to display.</p>';
 
   // Show merits that have any bonus-dot source
+  // Issue #834: m.free is deprecated — dropped from this filter too (the bonus
+  // rollup at the loop below already dropped it; #834 missed this gate).
   const relevant = merits.filter(m =>
-    freeOf(m, 'pt') + freeOf(m, 'mci') + (m.free || 0) + freeOf(m, 'mdb') + freeOf(m, 'bloodline') > 0 || m.free_pt !== undefined
+    freeOf(m, 'pt') + freeOf(m, 'mci') + freeOf(m, 'mdb') + freeOf(m, 'bloodline') > 0 || m.free_pt !== undefined
   );
   if (!relevant.length) return '<p class="rde-preview-empty">No bonus-dot merits on this character.</p>';
 

--- a/server/scripts/cleanup-m-free-deprecation.js
+++ b/server/scripts/cleanup-m-free-deprecation.js
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /**
  * Issue #834 — Phase 3: cleanup of `m.free` contamination on character merits.
  *


### PR DESCRIPTION
Resolves the remaining half of #842 (the feat-784 stale assertions were already fixed via #850/#851). Two real causes — the issue's "stale assertion / line drift" framing was wrong; the test was correct:

1. **SyntaxError on load (shebang).** `server/scripts/cleanup-m-free-deprecation.js` started with `#!/usr/bin/env node`. The #834 test imports it; **vitest 4** (project just bumped to v4) does not strip shebangs in imported modules (Node/esbuild do), so the suite failed to parse with a locationless "Invalid or unexpected token". Removed the shebang (script is run via `node scripts/...`).
2. **#834 reader-removal was incomplete.** `public/js/admin/rules-data-view.js` dropped `m.free` from the bonus rollup but the `relevant` merit filter (:527) still read `(m.free || 0)`. Dropped it there too — behaviour-preserving (m.free is 0 post-cleanup). The static-analysis guard now passes.

issue-834 test: **21/21 green**; `node --check` clean. Refs #842.

Note for @Peter: #834's Phase-2 missed the rules-data-view filter site; and a shebang on a test-imported script trips vitest 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)