### PR TITLE
fix(#860): ribbon completes on merit outcome + travel discretion

### DIFF
--- a/.claude/skills/tm-gh-issue-create/SKILL.md
+++ b/.claude/skills/tm-gh-issue-create/SKILL.md
@@ -39,6 +39,12 @@ Do **not** invoke for:
    - **Type**: inferred from language — bug-words ("broken", "wrong", "doesn't work") → `bug`; feature-words ("add", "support", "should also") → `feature`; otherwise ask. User's `--type` flag overrides.
    - **Epic label**: if the description mentions a known epic prefix (RDE, PP, DT, NPCR, etc.), apply `epic:<lowercase>`. User's `--epic` flag overrides.
    - **Standard labels**: always add `bmad-intake` so issues created via this skill are filterable.
+3b. **Design-system / CSS check (if the issue touches UI or styling).** The app has a normalised CSS design system that AI-implemented features routinely fail to use. As part of intake, look up the normalised CSS for the thing so the issue points the implementer straight at it:
+   - Identify the UI element/component involved and grep `public/css/components.css` and the app sheet (`suite.css` Suite / `admin-layout.css` Admin) for the analogous existing class(es), plus the relevant `public/css/theme.css` tokens.
+   - If a suitable component class exists, name it in **References** (e.g. "reuse `.dt-btn` / `.form-input` / `.exp-row`") and add a **Scope note**: "must reuse the existing normalised CSS — no inline `style=`, no bare hex/`rgba()`."
+   - If none exists, say so in References and note that a new class should be added to the correct stylesheet using `theme.css` tokens (never inlined), per `specs/architecture/coding-standards.md` → CSS Standards.
+   - For any UI issue, add an **Acceptance criterion**: "Styling uses design-system tokens and reuses existing component classes (no inline `style=`, no bare hex)."
+   Reference: `specs/project-context.md` (critical standards) and `specs/architecture/coding-standards.md` (full CSS guidance).
 4. **Build the issue body** using this template (omit empty sections):
 
    ```markdown

--- a/.claude/skills/tm-gh-issue-pickup/SKILL.md
+++ b/.claude/skills/tm-gh-issue-pickup/SKILL.md
@@ -89,6 +89,8 @@ Do **not** invoke for:
     ```
     The skill ends after surfacing this requirement; the actual frontmatter additions happen during BMAD SM's create-story flow. (If `bmad-create-story` doesn't natively accept these fields, the assistant adds them post-hoc by editing the resulting story file.)
 
+12. **If the issue touches UI or styling**, surface a one-line reminder at hand-off so the story and dev agents carry it: "UI work must reuse the normalised CSS — design-system tokens from `public/css/theme.css` and existing component classes; no inline `style=` or bare hex. See `specs/project-context.md` and `specs/architecture/coding-standards.md`." (The BMAD story/dev agents also auto-load `specs/project-context.md`; this is reinforcement.)
+
 ## Boundaries
 
 - **Never** create a branch on `main`. Always branch off a working branch or `dev`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,9 +118,10 @@ XP functions in `public/js/editor/xp.js`: `xpEarned()`, `xpSpent()`, `xpLeft()`,
 - **British English throughout**: Defence, Armour, Vigour, Honour, Socialise, capitalise
 - **No em-dashes** in output text
 - **Dots display**: `'●'.repeat(n)` using U+25CF filled circle
-- **Gold accent**: `#E0C47A` (CSS var `--gold2`)
+- **Gold accent**: CSS var `--gold2` (value differs per theme; never hardcode the hex)
 - **Font stack**: Cinzel / Cinzel Decorative for headings, Lora for body (Google Fonts CDN)
-- **CSS custom properties** defined on `:root` — dark theme with `--bg: #0D0B09`, `--surf*` surface tiers, `--gold*` accent tiers, `--crim: #8B0000` for damage states
+- **CSS custom properties** defined on `:root` in `public/css/theme.css`. Default theme is **Parchment** (warm light); `[data-theme="dark"]` is the override. Tokens flip between themes; rule bodies stay theme-agnostic.
+- **Normalised CSS (MANDATORY)**: all styling uses the design-system tokens in `theme.css`. Reuse an existing component class from `public/css/components.css` (or the app sheet `suite.css` / `admin-layout.css`) before inventing one. Never write a bare hex, `rgba()`, or inline `style="..."` in markup or JS-rendered HTML. Full guidance: `specs/architecture/coding-standards.md` → "CSS Standards"; the critical-standards summary auto-read by the BMAD dev/story agents lives in `specs/project-context.md`.
 
 ## Data Sources of Truth
 

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -8447,6 +8447,10 @@ function _deriveActionRibbonState(rev) {
   const ps = rev?.pool_status || 'pending';
   if (ps === 'pending') return 'pending';
   if (rev?.outcome_confirmed) return 'complete';
+  // #860: merit actions complete on an outcome verdict (Approved/Partial/Failed);
+  // travel actions complete on a discretion choice (obvious/neutral/subtle).
+  if (rev?.merit_outcome) return 'complete';
+  if (ps === 'obvious' || ps === 'neutral' || ps === 'subtle') return 'complete';
   return 'valid';
 }
 

--- a/server/tests/feat-784-confirm-outcome-btn.test.js
+++ b/server/tests/feat-784-confirm-outcome-btn.test.js
@@ -6,8 +6,9 @@
  * which is the appropriate coverage level for a DOM-rendering change.
  *
  * ACs covered:
- *   AC-1: Outcome textarea rows="4" at both render sites
- *   AC-2: proc-confirm-outcome-btn present at both render sites
+ *   AC-1: Outcome textarea rows="4" at all three render sites
+ *         (project, full merit, and — since feat.847/#847 — compact merit)
+ *   AC-2: proc-confirm-outcome-btn present at all three render sites
  *   AC-5: proc-player-note-input absent from Outcome textarea
  *         (still present on Player Feedback textarea only)
  */
@@ -41,18 +42,23 @@ describe('feat-784 — Confirm Outcome button source assertions', () => {
       expect(outcomeRows2).toHaveLength(0);
     });
 
-    it('exactly two proc-outcome-input textareas exist with rows="4"', () => {
+    it('exactly three proc-outcome-input textareas exist with rows="4"', () => {
+      // Three render sites: project action panel, full merit panel, and
+      // (since feat.847 / #847) the compact merit panel.
       const hits = matchingLines(/class="proc-outcome-input"[^>]*rows="4"/);
-      expect(hits).toHaveLength(2);
+      expect(hits).toHaveLength(3);
     });
   });
 
   // ── AC-2: Confirm Outcome button at both render sites ────────────────────
 
   describe('AC-2: proc-confirm-outcome-btn present at both render sites', () => {
-    it('exactly two Confirm Outcome button render lines', () => {
-      const hits = matchingLines(/proc-confirm-outcome-btn.*Confirm Outcome/);
-      expect(hits).toHaveLength(2);
+    it('exactly three Confirm button render lines', () => {
+      // Button label is "Confirm" (renamed from "Confirm Outcome"); three
+      // render sites since feat.847 added the compact merit panel. The double
+      // quote after the class excludes the querySelectorAll handler line.
+      const hits = matchingLines(/proc-confirm-outcome-btn"[^>]*>Confirm</);
+      expect(hits).toHaveLength(3);
     });
 
     it('event handler wires proc-confirm-outcome-btn', () => {
@@ -64,14 +70,18 @@ describe('feat-784 — Confirm Outcome button source assertions', () => {
       // Find the confirm-outcome handler block
       const handlerStart = lines.findIndex(l => /querySelectorAll\(.*proc-confirm-outcome-btn/.test(l));
       expect(handlerStart).toBeGreaterThan(0);
-      // The next ~10 lines should contain saveEntryReview with outcome
-      const handlerBlock = lines.slice(handlerStart, handlerStart + 12).join('\n');
-      expect(handlerBlock).toMatch(/saveEntryReview.*outcome/);
+      // The handler builds a `patch` containing `outcome` and passes it to
+      // saveEntryReview. Window widened (handler grew a roll_mode/pool_status
+      // branch) and the two tokens are matched separately since `patch` and the
+      // call are now on different lines.
+      const handlerBlock = lines.slice(handlerStart, handlerStart + 20).join('\n');
+      expect(handlerBlock).toMatch(/outcome/);
+      expect(handlerBlock).toMatch(/saveEntryReview/);
     });
 
     it('handler calls renderProcessingMode after save', () => {
       const handlerStart = lines.findIndex(l => /querySelectorAll\(.*proc-confirm-outcome-btn/.test(l));
-      const handlerBlock = lines.slice(handlerStart, handlerStart + 14).join('\n');
+      const handlerBlock = lines.slice(handlerStart, handlerStart + 20).join('\n');
       expect(handlerBlock).toMatch(/renderProcessingMode\(container\)/);
     });
 

--- a/specs/architecture/coding-standards.md
+++ b/specs/architecture/coding-standards.md
@@ -142,6 +142,54 @@ BEM-lite: `block__element--modifier`. Keep it readable, not academic.
 
 No utility class soup. No `!important`.
 
+### Component Reuse (reuse before invent)
+
+Most UI is already built from reusable classes. Before adding markup, grep for an
+analogous element and reuse its class. Inventing a one-off class (or worse, an
+inline style) when a component already exists is the single most common drift we
+clean up after.
+
+Shared, app-agnostic components live in `public/css/components.css`. App-specific
+chrome lives in `suite.css` (Suite/Game) and `admin-layout.css` (ST Admin).
+
+Common reusable classes (confirm in the CSS before use):
+
+| Need | Class(es) | File |
+|---|---|---|
+| Action button | `.dt-btn` (admin), `.nbtn` (suite nav) | admin-layout / suite |
+| Text input / select | `.form-input`, `.form-select`, `.form-label` | components |
+| Form section | `.form-section`, `.form-section-title` | components |
+| Character card / grid | `.char-card`, `.char-grid`, `.char-chip` | components |
+| Dot stepper / dots | `.dot-stepper`, `.pointed` (+`.hollow`) | components |
+| Expandable row | `.exp-row` (+`.exp-row.open`) | components |
+| Merit breakdown row | `.merit-bd-row` + `.bd-grp`/`.bd-lbl`/`.bd-eq`/`.bd-val` | components |
+| Sheet section | `.sh-sec` | components |
+| Influence / merit rows | `.infl-edit-row`, `.infl-tier-chip`, `.mci-block`, `.dom-edit-block` | components |
+| DT processing panel | `.proc-feed-mod-panel`, `.proc-pool-builder` (grouped chrome) | admin-layout |
+| Derived note / annotation | `.derived-note` | components |
+
+If nothing fits, add a class to the correct stylesheet (shared → `components.css`;
+app-specific → the app sheet) using tokens, and follow the Shared Chrome Pattern
+above. Do not fork chrome and do not inline.
+
+### Styling from JavaScript
+
+Render functions build HTML strings. **Apply a class — never an inline
+`style="color:#..."`.** Inline styles bypass tokens and theming and are the main
+source of design drift in AI-written features.
+
+```js
+// WRONG: inline style + bare hex; ignores tokens and dark theme
+h += `<span style="color:#E0C47A;font-size:10px;">${label}</span>`;
+
+// RIGHT: reuse/define a class; colour comes from a token in the stylesheet
+h += `<span class="effpool-seg effpool-merit">${label}</span>`;
+// .effpool-merit { color: var(--gold2); font-size: 10px; }  (in the app stylesheet)
+```
+
+If a one-off dynamic value is genuinely unavoidable (e.g. a computed width), it
+must still resolve to a token, never a literal colour/font.
+
 ### Responsive Design
 
 Suite views (Roll, Sheet, Territory, Tracker): mobile-first. Use `min-width` media queries.

--- a/specs/project-context.md
+++ b/specs/project-context.md
@@ -1,0 +1,68 @@
+# Project Context — Critical Implementation Standards
+
+This file is auto-loaded as a persistent fact by the BMAD story and dev agents
+(`bmad-create-story`, `bmad-dev-story` — see their `customize.toml`
+`persistent_facts`). Anything here is read on every story/dev run. Keep it short
+and high-signal: the standards an implementer must NOT violate.
+
+---
+
+## 1. Normalised CSS — reuse the design system, never write ad-hoc styles
+
+The app has a normalised CSS design system. New UI that ignores it (inline
+styles, bare hex, one-off classes) is a defect, not a shortcut. Before writing
+ANY markup or styling:
+
+1. **Use tokens, never literals.** All colours/fonts/spacing come from the
+   `:root` custom properties in `public/css/theme.css`
+   (`var(--txt)`, `var(--surf2)`, `var(--accent)`, `var(--gold2)`, `var(--fh)`,
+   etc.). Never write a hex value, `rgba(...)`, or font name in a rule body or in
+   a JS-generated `style="..."` attribute. The only place hex is allowed is the
+   `:root` / `[data-theme="dark"]` blocks in `theme.css`.
+2. **Reuse an existing component class before inventing one.** Grep
+   `public/css/components.css` (shared) and the app stylesheet
+   (`suite.css` / `admin-layout.css`) for an analogous element first. Common
+   reusable classes (verify in the CSS before use):
+   - Buttons: `.dt-btn` (admin actions), `.nbtn` (suite nav)
+   - Inputs: `.form-input`, `.form-select`, `.form-label`, `.form-section`
+   - Cards/grids: `.char-card`, `.char-grid`, `.char-chip`
+   - Dots: `.dot-stepper`, `.pointed` / `.pointed.hollow` (display: `●`/`○`)
+   - Expandable rows: `.exp-row` (+ `.exp-row.open`)
+   - Merit breakdown: `.merit-bd-row` + `.bd-grp`/`.bd-lbl`/`.bd-eq`/`.bd-val`
+   - Sheet/section: `.sh-sec`, `.form-section-title`
+   - Influence/merits: `.infl-edit-row`, `.infl-tier-chip`, `.mci-block`,
+     `.dom-edit-block`
+   - DT processing panels: `.proc-feed-mod-panel`, `.proc-pool-builder`
+     (grouped chrome — add to the canonical group, don't fork)
+   - Derived/annotation: `.derived-note`
+3. **Styling from JavaScript:** render functions build HTML strings. Apply a
+   **class**, never an inline `style="color:#..."`. If the needed style does not
+   exist as a class, add it to the right stylesheet using tokens, then apply the
+   class. Do not inline.
+4. **New shared chrome goes in a grouped selector**, not duplicated rule bodies
+   (see `coding-standards.md` → Shared Chrome Pattern).
+
+**Authoritative reference:** `specs/architecture/coding-standards.md` → "CSS
+Standards" (tokens, component reuse, styling-from-JS, shared chrome, naming).
+Token source of truth: `public/css/theme.css`.
+
+If a story touches UI, its implementation is not complete until every colour,
+font, and spacing value is a token and every element reuses or properly extends
+the component system.
+
+---
+
+## 2. Other non-negotiables (see the linked SSOT for detail)
+
+- **British English** throughout (Defence, Armour, Vigour, Honour, Socialise).
+  No em-dashes in player-facing output text.
+- **Derived stats are never stored** — health/vitae/willpower max, influence
+  total, XP are computed at render time. (Sanctioned exception: ST-mod overlay,
+  ADR-004.)
+- **Reference data has one home** — `FEED_METHODS` / `TERRITORY_DATA` live in
+  `public/js/tabs/downtime-data.js`; import, never duplicate. Full SSOT map:
+  `specs/reference-data-ssot.md`.
+- **Effective ratings** (dots + bonus) are read for pools/prereqs; bonus dots are
+  real dots.
+- Targeted tests only for the changed area; never the full suite for a small
+  change. No `| tail` on test runs (capture to a file, check the exit code).

--- a/specs/stories/fix.860.ribbon-merit-travel-complete.story.md
+++ b/specs/stories/fix.860.ribbon-merit-travel-complete.story.md
@@ -1,0 +1,144 @@
+---
+title: 'DT processing ribbon: merit outcome + travel discretion should mark action Complete'
+type: 'fix'
+issue: 860
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/860
+branch: ms/issue-860-ribbon-merit-travel-complete
+created: '2026-06-17'
+status: review
+recommended_model: 'sonnet — single-function logic fix (2 added lines); no handlers, schema, or CSS'
+context:
+  - public/js/admin/downtime-views.js
+---
+
+## Intent
+
+The DT processing action ribbon (Pending → Valid → Complete) never reaches
+**Complete** for merit actions (Approved/Partial/Failed) or travel actions
+(Obvious/Neutral/Subtle), because completion is derived solely from
+`outcome_confirmed` (the typed-outcome path). The ST records a terminal verdict
+for these action types via buttons that don't set `outcome_confirmed`, so the
+ribbon stalls at Valid. Fix the derivation so the action-type-appropriate signal
+completes the ribbon.
+
+## Root cause (do NOT re-investigate)
+
+`_deriveActionRibbonState(rev)` (`public/js/admin/downtime-views.js:8446-8451`):
+
+```js
+function _deriveActionRibbonState(rev) {
+  const ps = rev?.pool_status || 'pending';
+  if (ps === 'pending') return 'pending';
+  if (rev?.outcome_confirmed) return 'complete';
+  return 'valid';
+}
+```
+
+- **Merit outcome buttons** save `{ merit_outcome: <approved|partial|failed>,
+  pool_status: 'resolved' }` (`downtime-views.js:6361-6369`) — terminal
+  `pool_status` but NO `outcome_confirmed` → returns `'valid'`.
+- **Travel discretion buttons** save `pool_status` = `obvious|neutral|subtle`
+  (persisted to `st_review.travel_discretion`, `:3702-3705`; read back by
+  `getEntryReview` at `:3685`). These are already in `DONE_STATUSES` (`:277`) but
+  there is NO `outcome_confirmed` → returns `'valid'`.
+
+The buttons already persist the right signal; only the ribbon *derivation* is
+missing the cases.
+
+## Fix specification
+
+### T1 — extend `_deriveActionRibbonState` (the entire change)
+
+```js
+function _deriveActionRibbonState(rev) {
+  const ps = rev?.pool_status || 'pending';
+  if (ps === 'pending') return 'pending';
+  if (rev?.outcome_confirmed) return 'complete';
+  // #860: merit actions complete on an outcome verdict (Approved/Partial/Failed);
+  // travel actions complete on a discretion choice (obvious/neutral/subtle).
+  if (rev?.merit_outcome) return 'complete';
+  if (ps === 'obvious' || ps === 'neutral' || ps === 'subtle') return 'complete';
+  return 'valid';
+}
+```
+
+No other change. Do NOT touch the merit/travel click handlers, `DONE_STATUSES`,
+`getEntryReview`, or `saveEntryReview` — they already do their part.
+
+## Acceptance criteria
+
+- [x] **AC-1** Merit action with `merit_outcome` set → ribbon `complete`. _(new
+      `if (rev?.merit_outcome) return 'complete'` branch; runtime re-render already
+      happens via `renderProcessingMode` in the button handler. Visual confirm =
+      smoke.)_
+- [x] **AC-2** Travel action with discretion obvious/neutral/subtle → ribbon
+      `complete`. _(new `pool_status` branch.)_
+- [x] **AC-3** Project / full-merit unchanged — additive branches don't fire for
+      them (they carry neither `merit_outcome` nor a discretion `pool_status`);
+      `outcome_confirmed` is still checked first.
+- [x] **AC-4** Diff confined to `_deriveActionRibbonState` — `git diff --stat` =
+      +4 in `downtime-views.js` only; no handler/schema/CSS changes.
+- [x] **AC-5** `node --check public/js/admin/downtime-views.js` clean.
+
+## Dev notes
+
+### Why this is safe / additive
+- `merit_outcome` is only ever set by the merit outcome buttons
+  (`downtime-views.js:6367`), so the new `if (rev?.merit_outcome)` branch fires
+  only for merit actions.
+- `obvious`/`neutral`/`subtle` are travel-discretion values; no other action type
+  uses them as `pool_status`. So the discretion branch is travel-specific in
+  practice.
+- Project/full-merit completion still flows through `outcome_confirmed`
+  (unchanged), which is checked first.
+- `DONE_STATUSES`-based phase/character completion counts are unaffected — merit
+  `resolved` and the discretion values are already in `DONE_STATUSES`.
+
+### Open question (resolve at implementation)
+The issue scopes ALL three merit verdicts (Approved/Partial/Failed) as completing
+the ribbon — they are all terminal ST decisions. Default: keep
+`if (rev?.merit_outcome)` (any of the three). If the ST later wants ONLY Approved
+to complete, narrow to `rev.merit_outcome === 'approved'`. Implement the default.
+
+### Testing approach
+No client test framework — verification is reasoning + manual smoke on dev:
+1. Open a merit action, click **Approved** → ribbon advances to **Complete**
+   (re-render already happens: the handler calls `renderProcessingMode`). Repeat
+   for Partial / Failed.
+2. Open a travel action, click **Obvious** (then Neutral / Subtle) → ribbon
+   **Complete**.
+3. A project action with a terminal `pool_status` but no confirmed outcome stays
+   at **Valid** until the Outcome is typed + Confirmed (no regression).
+Plus `node --check`. Do NOT mandate Playwright.
+
+## Dev Agent Record
+
+### Files to change
+- `public/js/admin/downtime-views.js` — `_deriveActionRibbonState` (~:8446): add
+  the `merit_outcome` and discretion-`pool_status` complete branches.
+
+### Files changed
+- `public/js/admin/downtime-views.js` — `_deriveActionRibbonState` (:8446): added
+  two complete branches (`merit_outcome` set → complete; `pool_status` ∈
+  obvious/neutral/subtle → complete) after the existing `outcome_confirmed` check.
+  +4 lines (2 logic + 2 comment).
+
+### Completion notes
+- Implemented exactly as specified — additive, single function, no handler/schema/
+  CSS changes. Default scope kept (any of Approved/Partial/Failed completes the
+  ribbon).
+- Regression-safe by construction: `outcome_confirmed` is still checked first;
+  the merit branch only fires when `merit_outcome` is set (only the merit outcome
+  buttons set it); the discretion branch only fires for obvious/neutral/subtle
+  (travel-only `pool_status` values). Project/full-merit reviews carry none of
+  these, so their behaviour is unchanged.
+- `node --check` clean; `git diff --stat` = +4 in downtime-views.js only.
+- **Pending QA / smoke on dev (cannot run locally):** merit action → Complete
+  after Approved (and Partial/Failed); travel action → Complete after a discretion
+  button; project action still needs typed+Confirmed outcome.
+
+### Change Log
+
+| Date | Description |
+|------|-------------|
+| 2026-06-17 | Implemented: ribbon completes on merit_outcome / travel discretion. +4 lines in _deriveActionRibbonState. Status → review. |


### PR DESCRIPTION
Promotes the ribbon-completion fix to production. `_deriveActionRibbonState` now also reaches Complete on `merit_outcome` (merit verdict) and travel discretion `pool_status` (obvious/neutral/subtle), additive to the existing `outcome_confirmed` path. +4 lines, one function, no handler/schema/CSS changes. `node --check` clean.

Closes #860

🤖 Generated with [Claude Code](https://claude.com/claude-code)