### PR TITLE
feat(ecm): #868 — collection, schema, CRUD API for equipment_catalogue

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -38,6 +38,7 @@ import stModsRouter, { auditRouter as stModAuditRouter } from './routes/st_mods.
 import appSettingsRouter from './routes/app-settings.js';
 import devlogRouter from './routes/devlog.js';
 import equipmentRouter from './routes/equipment.js';
+import buildEquipmentCatalogueRouter from './routes/equipment-catalogue.js';
 import chaptersRouter from './routes/chapters.js';
 import { attachWS } from './ws.js';
 // NOTE: The old /api/pdf route was removed. Character sheet PDFs are now
@@ -76,8 +77,14 @@ app.get('/api/health', (req, res) => {
 // Auth routes (public — no middleware)
 app.use('/api/auth', authRouter);
 
-// Equipment catalogue (public — no auth; DT form and player app both need access)
+// Equipment catalogue (public reads; DT form and player app both need access).
+// Epic ECM (#868): the new `equipment_catalogue` collection lives at
+// /api/equipment_catalogue. Writes are ST-gated per-handler inside the
+// router (requireAuth + requireRole('st')) — the parent mount is unauthed.
+// /api/equipment/catalogue (the EQ-1 endpoint) remains as a thin alias
+// of GET /api/equipment_catalogue for one release cycle (epic D3 / ECM-7).
 app.use('/api/equipment', equipmentRouter);
+app.use('/api/equipment_catalogue', buildEquipmentCatalogueRouter(requireAuth));
 
 // Protected routes — require valid token (role resolved from players collection)
 // Characters and downtime submissions have internal role filtering (ST vs player)

--- a/server/routes/equipment-catalogue.js
+++ b/server/routes/equipment-catalogue.js
@@ -1,0 +1,162 @@
+/**
+ * Equipment Catalogue routes (ECM-1, issue #868).
+ *
+ * Epic ECM (specs/epic-ecm-equipment-catalogue-migration.md). Mongo-backed
+ * replacement for the static EQUIPMENT_CATALOGUE module. Reads are public
+ * (the DT form and player app both need them without a token); writes are
+ * ST-gated.
+ *
+ * Mounted via a factory so the test app can substitute its mockAuth for the
+ * production requireAuth without the router needing to know which one is
+ * in play. The mixed-auth shape (no-auth reads + ST-auth writes) does not
+ * fit the parent-route-mount pattern used elsewhere; per-handler auth chains
+ * with an injected requireAuth keep the wiring explicit.
+ *
+ * Endpoints (per epic D3):
+ *
+ *   GET    /api/equipment_catalogue              public   list all
+ *   GET    /api/equipment_catalogue/:id          public   single by ObjectId
+ *   GET    /api/equipment_catalogue/:id/impact   public   holder count + names
+ *   POST   /api/equipment_catalogue              ST       create
+ *   PATCH  /api/equipment_catalogue/:id          ST       partial update
+ *   DELETE /api/equipment_catalogue/:id          ST       409 if any holder
+ *
+ * Write paths broadcast `broadcastCatalogueUpdate(itemId, op)` on the WS so
+ * ECM-4/5/6 dropdown clients can refetch the catalogue. Wired in ECM-1 even
+ * though no client listens yet — the cost of firing into an empty WS is nil
+ * and ECM-6 inherits the wiring rather than having to add it.
+ */
+
+import { Router } from 'express';
+import { ObjectId } from 'mongodb';
+import { getCollection } from '../db.js';
+import { requireRole } from '../middleware/auth.js';
+import { validate } from '../middleware/validate.js';
+import {
+  equipmentCatalogueSchema,
+  EQUIPMENT_CATALOGUE_UPDATABLE_FIELDS,
+} from '../schemas/equipment_catalogue.schema.js';
+import { broadcastCatalogueUpdate } from '../ws.js';
+
+/**
+ * Validate :id param as a 24-char ObjectId hex. On failure short-circuit
+ * with 404 — same surface a non-existent doc returns, so probing clients
+ * can't distinguish "malformed id" from "no such id".
+ */
+function withObjectId(req, res, next) {
+  if (!ObjectId.isValid(req.params.id) || String(new ObjectId(req.params.id)) !== req.params.id) {
+    return res.status(404).json({ error: 'NOT_FOUND', message: 'Item not found' });
+  }
+  req._oid = new ObjectId(req.params.id);
+  next();
+}
+
+/**
+ * Factory: returns the equipment_catalogue router with the supplied auth
+ * middleware applied to the write handlers. `authMiddleware` runs before
+ * `requireRole('st')`; in prod that's `requireAuth`, in tests `mockAuth`.
+ */
+export default function buildEquipmentCatalogueRouter(authMiddleware) {
+  const router = Router();
+  const col = () => getCollection('equipment_catalogue');
+  const chars = () => getCollection('characters');
+
+  // ─────────────────────────────────────────────────────────────────────────
+  //  Public reads
+  // ─────────────────────────────────────────────────────────────────────────
+
+  router.get('/', async (req, res) => {
+    const docs = await col().find({}).sort({ bucket: 1, name: 1 }).toArray();
+    res.json(docs);
+  });
+
+  router.get('/:id/impact', withObjectId, async (req, res) => {
+    const item = await col().findOne({ _id: req._oid });
+    if (!item) return res.status(404).json({ error: 'NOT_FOUND', message: 'Item not found' });
+    const holders = await chars()
+      .find({ 'equipment.catalogue_id': req._oid }, { projection: { name: 1 } })
+      .toArray();
+    res.json({
+      holders: holders.length,
+      character_names: holders.map(c => c.name).filter(Boolean),
+    });
+  });
+
+  router.get('/:id', withObjectId, async (req, res) => {
+    const doc = await col().findOne({ _id: req._oid });
+    if (!doc) return res.status(404).json({ error: 'NOT_FOUND', message: 'Item not found' });
+    res.json(doc);
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  //  ST-only writes
+  // ─────────────────────────────────────────────────────────────────────────
+
+  router.post('/',
+    authMiddleware, requireRole('st'),
+    validate(equipmentCatalogueSchema),
+    async (req, res) => {
+      const now = new Date().toISOString();
+      const doc = { ...req.body, created_at: now, updated_at: now };
+      // Don't trust client-supplied _id on create.
+      delete doc._id;
+      const result = await col().insertOne(doc);
+      const created = await col().findOne({ _id: result.insertedId });
+      broadcastCatalogueUpdate(result.insertedId, 'create');
+      res.status(201).json(created);
+    }
+  );
+
+  router.patch('/:id',
+    authMiddleware, requireRole('st'),
+    withObjectId,
+    async (req, res) => {
+      const filtered = {};
+      for (const [field, value] of Object.entries(req.body)) {
+        if (EQUIPMENT_CATALOGUE_UPDATABLE_FIELDS.has(field)) filtered[field] = value;
+      }
+      if (!Object.keys(filtered).length) {
+        return res.status(400).json({
+          error: 'VALIDATION_ERROR',
+          message: 'No updatable fields provided',
+        });
+      }
+      filtered.updated_at = new Date().toISOString();
+      const result = await col().findOneAndUpdate(
+        { _id: req._oid },
+        { $set: filtered },
+        { returnDocument: 'after' }
+      );
+      if (!result) return res.status(404).json({ error: 'NOT_FOUND', message: 'Item not found' });
+      broadcastCatalogueUpdate(req._oid, 'update');
+      res.json(result);
+    }
+  );
+
+  router.delete('/:id',
+    authMiddleware, requireRole('st'),
+    withObjectId,
+    async (req, res) => {
+      // D5 + ECM-6 HALT-DAR pin: hard-block at the API layer when held.
+      const holders = await chars()
+        .find({ 'equipment.catalogue_id': req._oid }, { projection: { name: 1 } })
+        .toArray();
+      if (holders.length > 0) {
+        return res.status(409).json({
+          error: 'CONFLICT',
+          message: `Cannot delete — item is held by ${holders.length} character${holders.length === 1 ? '' : 's'}`,
+          holders: holders.length,
+          character_names: holders.map(c => c.name).filter(Boolean),
+        });
+      }
+      const result = await col().deleteOne({ _id: req._oid });
+      if (result.deletedCount === 0) {
+        return res.status(404).json({ error: 'NOT_FOUND', message: 'Item not found' });
+      }
+      broadcastCatalogueUpdate(req._oid, 'delete');
+      res.status(204).end();
+    }
+  );
+
+  return router;
+}

--- a/server/routes/equipment.js
+++ b/server/routes/equipment.js
@@ -1,18 +1,28 @@
 /**
  * Equipment routes (EQ-1, issue #654).
  *
- * GET /api/equipment/catalogue — returns the full EQUIPMENT_CATALOGUE.
- * No auth required: the DT form and player app both need access without a token.
+ * Epic ECM (issue #868) made this endpoint a thin alias of the new
+ * GET /api/equipment_catalogue for one release cycle — the DT form and
+ * player app still call /api/equipment/catalogue today; ECM-4 / ECM-5
+ * switch them to the new endpoint, then ECM-7 removes the alias.
+ *
+ * Both endpoints intentionally serve the same shape (array of catalogue
+ * docs from the equipment_catalogue collection); during the transition
+ * window before ECM-2 seeds, the collection is empty and this endpoint
+ * returns []. That matches what the new endpoint returns; clients still
+ * reading from this alias see the same view of the data they would after
+ * ECM-7's swap.
  */
 
 import { Router } from 'express';
-import { EQUIPMENT_CATALOGUE } from '../data/equipment-catalogue.js';
+import { getCollection } from '../db.js';
 
 const router = Router();
 
-// GET /api/equipment/catalogue — full static catalogue, no auth.
-router.get('/catalogue', (req, res) => {
-  res.json(EQUIPMENT_CATALOGUE);
+router.get('/catalogue', async (req, res) => {
+  const docs = await getCollection('equipment_catalogue')
+    .find({}).sort({ bucket: 1, name: 1 }).toArray();
+  res.json(docs);
 });
 
 export default router;

--- a/server/schemas/equipment_catalogue.schema.js
+++ b/server/schemas/equipment_catalogue.schema.js
@@ -1,0 +1,59 @@
+/**
+ * JSON Schema (Draft-07) for TM Equipment Catalogue Item.
+ * Collection: equipment_catalogue
+ *
+ * Epic ECM (issue #868 + epic spec specs/epic-ecm-equipment-catalogue-migration.md).
+ * Mirrors the EQ-1 catalogue shape — `_id: ObjectId` is the only identity,
+ * no slug field. Bucket-specific fields explicit-null where absent (matches
+ * the EQ_NULLS / WP_NULLS / AR_NULLS / AS_NULLS pattern from
+ * server/data/equipment-catalogue.js).
+ *
+ * Per epic Non-Goals: NO state-enum per-bucket schema validation in this epic
+ * — that's a separate bugfix. Bucket-specific fields are loosely typed (nullable
+ * primitives) so the schema accepts every existing seed entry without further
+ * coercion in ECM-2.
+ */
+
+export const equipmentCatalogueSchema = {
+  $schema: 'http://json-schema.org/draft-07/schema#',
+  title: 'TM Equipment Catalogue Item',
+  type: 'object',
+  required: ['bucket', 'name'],
+  additionalProperties: false,
+
+  properties: {
+    // MongoDB _id — injected on insert, present on read.
+    _id: {},
+
+    // ── Identity / core ──
+    bucket:       { type: 'string', enum: ['weapon', 'armour', 'equipment', 'asset'] },
+    name:         { type: 'string', minLength: 1 },
+    description:  { type: ['string', 'null'] },
+    availability: { type: ['integer', 'null'], minimum: 0, maximum: 5 },
+    tags:         { type: 'array', items: { type: 'string' } },
+
+    // ── Bucket-specific (explicit null where absent) ──
+    damage_mod:      { type: ['integer', 'null'] },
+    damage_type:     { type: ['string',  'null'] },
+    weapon_type:     { type: ['string',  'null'] },
+    armour_value:    { type: ['integer', 'null'] },
+    defence_penalty: { type: ['integer', 'null'] },
+    skill_domain:    { type: ['string',  'null'] },
+    bonus_dice:      { type: ['integer', 'null'] },
+
+    // ── Audit-light metadata (kept minimal per epic D1 / Non-Goals) ──
+    created_at: { type: 'string' },
+    updated_at: { type: 'string' },
+  },
+};
+
+// Allowlisted fields for PATCH updates. `_id`, `bucket`, `created_at` are
+// immutable. `bucket` is excluded specifically: a bucket change would
+// orphan bucket-specific field semantics and invalidate render assumptions
+// in ECM-4 / ECM-5; force the ST to delete + recreate if bucket needs to change.
+export const EQUIPMENT_CATALOGUE_UPDATABLE_FIELDS = new Set([
+  'name', 'description', 'availability', 'tags',
+  'damage_mod', 'damage_type', 'weapon_type',
+  'armour_value', 'defence_penalty',
+  'skill_domain', 'bonus_dice',
+]);

--- a/server/tests/equipment.test.js
+++ b/server/tests/equipment.test.js
@@ -51,34 +51,21 @@ afterAll(async () => {
 });
 
 // ── GET /api/equipment/catalogue ─────────────────────────────────────────────
+//
+// Epic ECM (#868) made this endpoint a thin alias of GET /api/equipment_catalogue
+// for one release cycle. The legacy assertions (full-catalogue length > 0,
+// per-bucket presence, `entry.id` string slug field) reflected the pre-ECM-1
+// static-data shape; with the alias in place the data shape and population
+// follow the Mongo collection, which may be empty during the transition window
+// until ECM-2 seeds. Detailed alias-behaviour coverage lives in
+// tests/issue-868-ecm-1-equipment-catalogue-api.test.js — this slice keeps a
+// minimal smoke test so a regression to the static path still trips here.
 
-describe('GET /api/equipment/catalogue', () => {
-  it('returns 200 with the full catalogue array (no auth required)', async () => {
+describe('GET /api/equipment/catalogue (ECM-1 alias)', () => {
+  it('returns 200 with a JSON array (no auth required) — alias to GET /api/equipment_catalogue', async () => {
     const res = await request(app).get('/api/equipment/catalogue');
     expect(res.status).toBe(200);
     expect(Array.isArray(res.body)).toBe(true);
-    expect(res.body.length).toBeGreaterThan(0);
-  });
-
-  it('every entry has the required universal fields', async () => {
-    const res = await request(app).get('/api/equipment/catalogue');
-    for (const entry of res.body) {
-      expect(typeof entry.id).toBe('string');
-      expect(['weapon', 'armour', 'equipment', 'asset']).toContain(entry.bucket);
-      expect(typeof entry.name).toBe('string');
-      expect(typeof entry.description).toBe('string');
-      expect(typeof entry.availability).toBe('number');
-      expect(Array.isArray(entry.tags)).toBe(true);
-    }
-  });
-
-  it('contains at least one entry per bucket', async () => {
-    const res = await request(app).get('/api/equipment/catalogue');
-    const buckets = new Set(res.body.map(e => e.bucket));
-    expect(buckets.has('weapon')).toBe(true);
-    expect(buckets.has('armour')).toBe(true);
-    expect(buckets.has('equipment')).toBe(true);
-    expect(buckets.has('asset')).toBe(true);
   });
 });
 

--- a/server/tests/helpers/test-app.js
+++ b/server/tests/helpers/test-app.js
@@ -30,6 +30,7 @@ import stModsRouter, { auditRouter as stModAuditRouter } from '../../routes/st_m
 import appSettingsRouter from '../../routes/app-settings.js';
 import devlogRouter from '../../routes/devlog.js';
 import equipmentRouter from '../../routes/equipment.js';
+import buildEquipmentCatalogueRouter from '../../routes/equipment-catalogue.js';
 import { chaptersRouter } from '../../routes/chapters.js';
 
 /**
@@ -60,6 +61,11 @@ export function createTestApp() {
 
   // Equipment catalogue (public — no auth, mirrors prod mount order)
   app.use('/api/equipment', equipmentRouter);
+  // Epic ECM (#868) equipment_catalogue — same factory pattern as prod, but
+  // injects mockAuth (the test app's per-request auth surface) instead of
+  // requireAuth. Reads stay public; writes still gate on the X-Test-User
+  // header followed by requireRole('st').
+  app.use('/api/equipment_catalogue', buildEquipmentCatalogueRouter(mockAuth));
 
   // Protected routes with mock auth.
   // Issue #255: mirror prod Cache-Control discipline so tests can assert

--- a/server/tests/issue-868-ecm-1-equipment-catalogue-api.test.js
+++ b/server/tests/issue-868-ecm-1-equipment-catalogue-api.test.js
@@ -1,0 +1,389 @@
+/**
+ * Issue #868 — ECM-1: CRUD API for equipment_catalogue.
+ *
+ * Covers all five endpoints from epic D3 plus the /:id/impact endpoint
+ * ECM-6 will consume. Negative paths per the AC: 400 invalid bucket /
+ * missing required, 401 unauth write, 404 missing id, 409 delete with
+ * holders.
+ *
+ * Also asserts the /api/equipment/catalogue alias forwards to the same
+ * data the new bulk-read returns (epic D3 / AC#3).
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import request from 'supertest';
+import 'dotenv/config';
+import { ObjectId } from 'mongodb';
+import { createTestApp, stUser, playerUser } from './helpers/test-app.js';
+import { setupDb, teardownDb } from './helpers/db-setup.js';
+import { getCollection } from '../db.js';
+
+let app;
+const seededItemIds = [];
+const seededCharIds = [];
+
+beforeAll(async () => {
+  await setupDb();
+  app = createTestApp();
+});
+
+afterAll(async () => {
+  if (seededItemIds.length) {
+    await getCollection('equipment_catalogue').deleteMany({ _id: { $in: seededItemIds } });
+  }
+  if (seededCharIds.length) {
+    await getCollection('characters').deleteMany({ _id: { $in: seededCharIds } });
+  }
+  await teardownDb();
+});
+
+afterEach(async () => {
+  if (seededItemIds.length) {
+    await getCollection('equipment_catalogue').deleteMany({ _id: { $in: seededItemIds } });
+    seededItemIds.length = 0;
+  }
+  if (seededCharIds.length) {
+    await getCollection('characters').deleteMany({ _id: { $in: seededCharIds } });
+    seededCharIds.length = 0;
+  }
+});
+
+async function seedItem(overrides = {}) {
+  const now = new Date().toISOString();
+  const doc = {
+    bucket: 'equipment',
+    name: 'Test Item',
+    description: 'fixture',
+    availability: 2,
+    tags: ['test'],
+    damage_mod: null, damage_type: null, weapon_type: null,
+    armour_value: null, defence_penalty: null,
+    skill_domain: null, bonus_dice: 1,
+    created_at: now, updated_at: now,
+    ...overrides,
+  };
+  const result = await getCollection('equipment_catalogue').insertOne(doc);
+  seededItemIds.push(result.insertedId);
+  return { _id: result.insertedId, ...doc };
+}
+
+async function seedCharWithItem(catalogueId, name = 'Test Holder') {
+  const result = await getCollection('characters').insertOne({
+    name,
+    _ecm1_test: true,
+    equipment: [{ catalogue_id: catalogueId, state: 'owned', acquired_cycle: 0 }],
+  });
+  seededCharIds.push(result.insertedId);
+  return result.insertedId;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/equipment_catalogue (public — list)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/equipment_catalogue', () => {
+  it('returns 200 with all items, no auth required', async () => {
+    await seedItem({ name: 'Alpha', bucket: 'weapon' });
+    await seedItem({ name: 'Bravo', bucket: 'armour' });
+    const res = await request(app).get('/api/equipment_catalogue');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    const names = res.body.map(d => d.name);
+    expect(names).toContain('Alpha');
+    expect(names).toContain('Bravo');
+  });
+
+  it('sorts by bucket then name (deterministic order across calls)', async () => {
+    await seedItem({ name: 'Zebra', bucket: 'equipment' });
+    await seedItem({ name: 'Aardvark', bucket: 'equipment' });
+    const res = await request(app).get('/api/equipment_catalogue');
+    const equip = res.body.filter(d => d.bucket === 'equipment');
+    const idxA = equip.findIndex(d => d.name === 'Aardvark');
+    const idxZ = equip.findIndex(d => d.name === 'Zebra');
+    expect(idxA).toBeLessThan(idxZ);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/equipment_catalogue/:id
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/equipment_catalogue/:id', () => {
+  it('returns 200 with the single item', async () => {
+    const seed = await seedItem({ name: 'Single' });
+    const res = await request(app).get(`/api/equipment_catalogue/${seed._id}`);
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('Single');
+    expect(String(res.body._id)).toBe(String(seed._id));
+  });
+
+  it('returns 404 for non-existent ObjectId', async () => {
+    const ghostId = new ObjectId();
+    const res = await request(app).get(`/api/equipment_catalogue/${ghostId}`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('NOT_FOUND');
+  });
+
+  it('returns 404 for malformed id (collapses to NOT_FOUND surface)', async () => {
+    const res = await request(app).get('/api/equipment_catalogue/not-a-valid-id');
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/equipment_catalogue
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('POST /api/equipment_catalogue', () => {
+  it('creates a new item when ST + body valid', async () => {
+    const res = await request(app)
+      .post('/api/equipment_catalogue')
+      .set('X-Test-User', stUser())
+      .send({ bucket: 'weapon', name: 'Glock 17', description: 'Pistol', availability: 2, damage_mod: 2 });
+    expect(res.status).toBe(201);
+    expect(res.body._id).toBeDefined();
+    expect(res.body.name).toBe('Glock 17');
+    expect(res.body.created_at).toBeDefined();
+    expect(res.body.updated_at).toBeDefined();
+    seededItemIds.push(new ObjectId(res.body._id));
+  });
+
+  it('returns 401 without auth header', async () => {
+    const res = await request(app)
+      .post('/api/equipment_catalogue')
+      .send({ bucket: 'equipment', name: 'X' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when caller is a player (not ST)', async () => {
+    const res = await request(app)
+      .post('/api/equipment_catalogue')
+      .set('X-Test-User', playerUser())
+      .send({ bucket: 'equipment', name: 'X' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when required `name` is missing', async () => {
+    const res = await request(app)
+      .post('/api/equipment_catalogue')
+      .set('X-Test-User', stUser())
+      .send({ bucket: 'equipment' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 when required `bucket` is missing', async () => {
+    const res = await request(app)
+      .post('/api/equipment_catalogue')
+      .set('X-Test-User', stUser())
+      .send({ name: 'No bucket' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 400 when bucket is outside the enum', async () => {
+    const res = await request(app)
+      .post('/api/equipment_catalogue')
+      .set('X-Test-User', stUser())
+      .send({ bucket: 'wandwood', name: 'Magic Stick' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('VALIDATION_ERROR');
+  });
+
+  it('does not honour a client-supplied _id', async () => {
+    const sentinel = new ObjectId();
+    const res = await request(app)
+      .post('/api/equipment_catalogue')
+      .set('X-Test-User', stUser())
+      .send({ _id: sentinel, bucket: 'equipment', name: 'Try-injection' });
+    // Either 201 (with a fresh _id) or a validation rejection — both acceptable,
+    // but the document must NOT end up with the client _id.
+    if (res.status === 201) {
+      expect(String(res.body._id)).not.toBe(String(sentinel));
+      seededItemIds.push(new ObjectId(res.body._id));
+    } else {
+      expect(res.status).toBe(400);
+    }
+    const probe = await getCollection('equipment_catalogue').findOne({ _id: sentinel });
+    expect(probe).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PATCH /api/equipment_catalogue/:id
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('PATCH /api/equipment_catalogue/:id', () => {
+  it('updates allowlisted fields when ST', async () => {
+    const seed = await seedItem({ name: 'Old' });
+    const res = await request(app)
+      .patch(`/api/equipment_catalogue/${seed._id}`)
+      .set('X-Test-User', stUser())
+      .send({ name: 'New', availability: 4 });
+    expect(res.status).toBe(200);
+    expect(res.body.name).toBe('New');
+    expect(res.body.availability).toBe(4);
+    expect(res.body.updated_at).not.toBe(seed.updated_at);
+  });
+
+  it('ignores non-allowlisted fields (immutable bucket, _id, created_at)', async () => {
+    const seed = await seedItem({ bucket: 'equipment', name: 'Stable' });
+    const res = await request(app)
+      .patch(`/api/equipment_catalogue/${seed._id}`)
+      .set('X-Test-User', stUser())
+      .send({ bucket: 'weapon', _id: new ObjectId(), created_at: '1999-01-01T00:00:00.000Z', name: 'OK' });
+    expect(res.status).toBe(200);
+    expect(res.body.bucket).toBe('equipment');
+    expect(String(res.body._id)).toBe(String(seed._id));
+    expect(res.body.name).toBe('OK');
+  });
+
+  it('returns 400 when no updatable fields provided', async () => {
+    const seed = await seedItem();
+    const res = await request(app)
+      .patch(`/api/equipment_catalogue/${seed._id}`)
+      .set('X-Test-User', stUser())
+      .send({ bucket: 'weapon' });   // bucket is non-updatable
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('VALIDATION_ERROR');
+  });
+
+  it('returns 401 without auth header', async () => {
+    const seed = await seedItem();
+    const res = await request(app)
+      .patch(`/api/equipment_catalogue/${seed._id}`)
+      .send({ name: 'X' });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when caller is a player', async () => {
+    const seed = await seedItem();
+    const res = await request(app)
+      .patch(`/api/equipment_catalogue/${seed._id}`)
+      .set('X-Test-User', playerUser())
+      .send({ name: 'X' });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 for non-existent id', async () => {
+    const res = await request(app)
+      .patch(`/api/equipment_catalogue/${new ObjectId()}`)
+      .set('X-Test-User', stUser())
+      .send({ name: 'Phantom' });
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DELETE /api/equipment_catalogue/:id
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('DELETE /api/equipment_catalogue/:id', () => {
+  it('deletes the item when ST + no holders', async () => {
+    const seed = await seedItem({ name: 'Deletable' });
+    const res = await request(app)
+      .delete(`/api/equipment_catalogue/${seed._id}`)
+      .set('X-Test-User', stUser());
+    expect(res.status).toBe(204);
+    const probe = await getCollection('equipment_catalogue').findOne({ _id: seed._id });
+    expect(probe).toBeNull();
+  });
+
+  it('returns 409 with holder count + names when held by characters (D5)', async () => {
+    const seed = await seedItem({ name: 'Held Item' });
+    await seedCharWithItem(seed._id, 'Holder One');
+    await seedCharWithItem(seed._id, 'Holder Two');
+    const res = await request(app)
+      .delete(`/api/equipment_catalogue/${seed._id}`)
+      .set('X-Test-User', stUser());
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe('CONFLICT');
+    expect(res.body.holders).toBe(2);
+    expect(res.body.character_names).toEqual(expect.arrayContaining(['Holder One', 'Holder Two']));
+    const probe = await getCollection('equipment_catalogue').findOne({ _id: seed._id });
+    expect(probe).not.toBeNull();
+  });
+
+  it('returns 401 without auth header', async () => {
+    const seed = await seedItem();
+    const res = await request(app).delete(`/api/equipment_catalogue/${seed._id}`);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when caller is a player', async () => {
+    const seed = await seedItem();
+    const res = await request(app)
+      .delete(`/api/equipment_catalogue/${seed._id}`)
+      .set('X-Test-User', playerUser());
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 for non-existent id', async () => {
+    const res = await request(app)
+      .delete(`/api/equipment_catalogue/${new ObjectId()}`)
+      .set('X-Test-User', stUser());
+    expect(res.status).toBe(404);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/equipment_catalogue/:id/impact  (ECM-6 banner data)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/equipment_catalogue/:id/impact', () => {
+  it('returns zero holders for an unheld item', async () => {
+    const seed = await seedItem({ name: 'Unheld' });
+    const res = await request(app).get(`/api/equipment_catalogue/${seed._id}/impact`);
+    expect(res.status).toBe(200);
+    expect(res.body.holders).toBe(0);
+    expect(res.body.character_names).toEqual([]);
+  });
+
+  it('returns holder count + names for a held item', async () => {
+    const seed = await seedItem({ name: 'Held' });
+    await seedCharWithItem(seed._id, 'Alice');
+    await seedCharWithItem(seed._id, 'Bob');
+    const res = await request(app).get(`/api/equipment_catalogue/${seed._id}/impact`);
+    expect(res.status).toBe(200);
+    expect(res.body.holders).toBe(2);
+    expect(res.body.character_names).toEqual(expect.arrayContaining(['Alice', 'Bob']));
+  });
+
+  it('returns 404 for non-existent id', async () => {
+    const res = await request(app).get(`/api/equipment_catalogue/${new ObjectId()}/impact`);
+    expect(res.status).toBe(404);
+  });
+
+  it('does not require auth', async () => {
+    const seed = await seedItem();
+    const res = await request(app).get(`/api/equipment_catalogue/${seed._id}/impact`);
+    expect(res.status).toBe(200);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Legacy alias — GET /api/equipment/catalogue serves the same view as
+// the new bulk read (epic D3 / AC#3, ECM-7 will remove the alias)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('GET /api/equipment/catalogue (legacy alias)', () => {
+  it('returns the same data as GET /api/equipment_catalogue', async () => {
+    await seedItem({ name: 'AliasSeedA', bucket: 'weapon' });
+    await seedItem({ name: 'AliasSeedB', bucket: 'armour' });
+    const [neu, legacy] = await Promise.all([
+      request(app).get('/api/equipment_catalogue'),
+      request(app).get('/api/equipment/catalogue'),
+    ]);
+    expect(neu.status).toBe(200);
+    expect(legacy.status).toBe(200);
+    // Same array length, same _ids (stringified) — proves shared backing.
+    const neuIds = neu.body.map(d => String(d._id)).sort();
+    const legIds = legacy.body.map(d => String(d._id)).sort();
+    expect(legIds).toEqual(neuIds);
+  });
+
+  it('no auth required (matches new bulk-read auth posture)', async () => {
+    const res = await request(app).get('/api/equipment/catalogue');
+    expect(res.status).toBe(200);
+  });
+});

--- a/server/ws.js
+++ b/server/ws.js
@@ -104,6 +104,36 @@ export function broadcastStModUpdate(characterId, op, stModId) {
   }
 }
 
+/**
+ * Broadcast an equipment catalogue create/update/delete event to all
+ * connected clients (Epic ECM, ECM-1 / issue #868).
+ *
+ * Frame shape: { type: 'catalogue', item_id, op }. Wired in ECM-1 so the
+ * route layer already fires the event; ECM-4 / ECM-5 (dropdown clients)
+ * and ECM-6 (admin UI) consume it to invalidate their module-level
+ * catalogue cache and refetch via GET /api/equipment_catalogue.
+ *
+ * Clients treat the op as advisory and refetch regardless, so an unknown
+ * op degrades gracefully to "refetch" — mirrors broadcastStModUpdate's
+ * resilience pattern.
+ *
+ * @param {string|ObjectId} itemId — the affected catalogue doc _id
+ * @param {'create' | 'update' | 'delete'} op
+ */
+export function broadcastCatalogueUpdate(itemId, op) {
+  if (!_wss) return;
+  const msg = JSON.stringify({
+    type: 'catalogue',
+    item_id: String(itemId),
+    op,
+  });
+  for (const ws of _wss.clients) {
+    if (ws.readyState === 1) { // OPEN
+      ws.send(msg);
+    }
+  }
+}
+
 // ── Token resolution (mirrors middleware/auth.js logic) ──
 
 const _tokenCache = new Map();


### PR DESCRIPTION
## Summary

Closes #868. First story of Epic ECM ([epic spec](../blob/dev/specs/epic-ecm-equipment-catalogue-migration.md)). Establishes the Mongo-backed catalogue surface that ECM-2..ECM-9 build on. **No client wiring** — that's ECM-4 / ECM-5.

## Endpoints (per epic D3)

| Endpoint | Auth | Purpose |
|---|---|---|
| `GET /api/equipment_catalogue` | none | list all |
| `GET /api/equipment_catalogue/:id` | none | single by ObjectId |
| `GET /api/equipment_catalogue/:id/impact` | none | `{ holders, character_names }` for ECM-6 banner |
| `POST /api/equipment_catalogue` | ST | create |
| `PATCH /api/equipment_catalogue/:id` | ST | partial update |
| `DELETE /api/equipment_catalogue/:id` | ST | 409 if held by any character (D5) |

Plus: `GET /api/equipment/catalogue` (the EQ-1 endpoint) becomes a **thin alias** of the new bulk-read per epic D3 / AC#3. ECM-7 removes the alias later.

## Architect-question defaults accepted

Both defaults from the issue body fit. No deviation; no ping to Imhotep.
1. **Schema-validation tooling** → `validate(equipmentCatalogueSchema)` middleware on POST (matches the `purchasable_powers` pattern in `server/routes/rules.js`).
2. **WebSocket broadcaster naming** → `broadcastCatalogueUpdate(itemId, op)`. Mirrors `broadcastTrackerUpdate` / `broadcastStModUpdate`. Wired into POST / PATCH / DELETE in ECM-1 so ECM-6 inherits the wiring rather than having to add it.

## Mixed-auth architecture

The router has both public reads and ST-auth writes — doesn't fit the single-parent-mount pattern (`app.use('/api/foo', requireAuth, ...)`) used elsewhere. Solution: a **router factory** that takes the auth middleware as a parameter. Prod wires `requireAuth`, the test app wires its `mockAuth`. Writes are gated per-handler (`authMiddleware, requireRole('st')`); reads have no auth chain.

```js
// prod
app.use('/api/equipment_catalogue', buildEquipmentCatalogueRouter(requireAuth));

// test
app.use('/api/equipment_catalogue', buildEquipmentCatalogueRouter(mockAuth));
```

## Notes on the impact / holders query

Pre-ECM-3, `character.equipment[].catalogue_id` is still a string slug. Post-ECM-3 it's an ObjectId. The impact endpoint queries `{ 'equipment.catalogue_id': <ObjectId> }`; pre-ECM-3 that match returns 0 (BSON type mismatch). That's safe — ECM-1 ships with the delete-block correctly permissive (no false-positive 409s) and ECM-3 enables the real holder count.

## Schema (D1 highlights)

- `_id: ObjectId` is the only identity. **No slug field** — Khepri's dispatch reinforced this.
- `bucket` enum: `weapon | armour | equipment | asset`.
- Bucket-specific fields nullable (matches the `EQ_NULLS` / `WP_NULLS` / `AR_NULLS` / `AS_NULLS` pattern from the static `server/data/equipment-catalogue.js`).
- Per epic Non-Goals: **no state-enum per-bucket validation in this story.**
- `EQUIPMENT_CATALOGUE_UPDATABLE_FIELDS` allowlist on PATCH excludes `bucket` so a switch can't orphan bucket-specific render assumptions; delete + recreate if bucket needs to change.

## Tests (29 cases in `tests/issue-868-ecm-1-equipment-catalogue-api.test.js`)

- GET list / single / impact happy paths + 404s.
- POST happy + 401 / 403 / 400 (missing name, missing bucket, out-of-enum bucket) + client-supplied `_id` ignored.
- PATCH happy + immutable-field drop + no-updatable-fields 400 + 401 / 403 / 404.
- DELETE happy + 409-with-holders + 401 / 403 / 404.
- Legacy alias coverage — same shape and same data as new bulk read, no auth required.

Plus equipment.test.js's legacy GET block updated — the static-shape assertions (`length > 0`, per-bucket presence, `entry.id` string slug) no longer hold under the alias. Trimmed to a minimal smoke test (200 + array); detailed alias behaviour lives in the new file.

## Verification

```
$ npx vitest run tests/issue-868-ecm-1-equipment-catalogue-api.test.js
Tests  29 passed (29)

$ npx vitest run                       # full suite
Test Files  4 failed | 131 passed (135)
Tests  1706 passed (1706)
```

The 4 file-failures are pre-existing **suite-load failures** in 0-test files (`feature.691.hos-city-status-power`, `migrate-submission-cycle-id-to-oid`, `migrate-submission-territory-keys`, `stm-13-backfill`) — same on clean dev. Zero individual test failures.

Parse-check on all touched JS files: OK.

## Note on workdir mid-flight

Worktree-built. The shared workdir (Ma'at + Ptah, per `feedback_test_merge_shared_workdir`) got switched out from under me mid-edit; recovered cleanly via `git worktree add /tmp/tm-ecm-1` and re-applied the edits to existing files there. No data lost.

## Test plan

- [x] `npx vitest run tests/issue-868-ecm-1-equipment-catalogue-api.test.js` — 29 passes
- [x] `node --check` on all touched JS files — parse OK
- [x] Full suite — 0 new failures
- [ ] Manual smoke (after merge): `curl /api/equipment_catalogue` returns `[]` (empty until ECM-2 seeds); ST-auth POST creates an item; subsequent GET returns it; `:id/impact` reflects 0 holders; DELETE 204s
- [ ] ECM-2 (next story) will seed the catalogue and exercise the WS broadcast end-to-end