### PR TITLE
feat(ecm): #869 — seed script for equipment_catalogue (ECM-2, step 1 only)

### DIFF
--- a/server/scripts/ecm-migrate.js
+++ b/server/scripts/ecm-migrate.js
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+
+/**
+ * ECM-2 (issue #869) — Equipment catalogue seed script (step 1 of the
+ * Epic ECM migration; see specs/epic-ecm-equipment-catalogue-migration.md).
+ *
+ * Reads the static EQUIPMENT_CATALOGUE from server/data/equipment-catalogue.js
+ * (the parity-tested mirror of public/js/data/equipment-data.js; both are
+ * deleted in ECM-7, so reading the server mirror avoids cross-package
+ * ESM/CJS boundary nonsense without losing any data — they are identical
+ * by construction). Inserts each entry into the `equipment_catalogue`
+ * collection with a fresh ObjectId, dropping the legacy `id` slug per
+ * epic D1 ("_id: ObjectId is the only identity — no slug field").
+ *
+ * Step 1 ONLY — does NOT touch `character.equipment[].catalogue_id`. That
+ * backfill is ECM-3, which consumes the slug→ObjectId map this script
+ * emits at INFO level so the next stage can reuse it without re-deriving.
+ *
+ * Idempotency contract (per Khepri dispatch):
+ *   • refuses to seed if equipment_catalogue.countDocuments() > 0 without
+ *     `--force`. exit status 1, descriptive message naming the count and
+ *     suggesting the drop-first remediation path.
+ *   • `--force` proceeds even if non-empty. It does **NOT drop** the
+ *     collection — the safety call is deliberate. STs who want a true
+ *     re-seed must drop the collection manually first; with --force
+ *     against a non-empty collection the resulting state has duplicates
+ *     by name+bucket but unique _ids, and the operator owns that.
+ *
+ * DRY-RUN (`--dry-run`, the default unless `--apply` is passed): reports
+ * intended seed count + the first 3 sample entries. No DB writes. Exit 0.
+ *
+ * Usage:
+ *   cd server && node scripts/ecm-migrate.js                  # dry-run
+ *   cd server && node scripts/ecm-migrate.js --apply          # live seed
+ *   cd server && node scripts/ecm-migrate.js --apply --force  # re-seed on non-empty
+ *
+ * dotenv path note: must be run from `server/` so dotenv/config picks up
+ * server/.env. See memory [[feedback_server_scripts_dotenv_path]].
+ */
+
+import 'dotenv/config';
+import { MongoClient, ObjectId } from 'mongodb';
+import { EQUIPMENT_CATALOGUE } from '../data/equipment-catalogue.js';
+
+const DB_NAME = process.env.MONGODB_DB || 'tm_suite';
+const SAMPLE_SIZE = 3;
+
+/**
+ * Convert a static-source catalogue entry into the document shape inserted
+ * into `equipment_catalogue`. Strips the legacy `id` slug; captures the
+ * timestamps for audit-light metadata per epic D1.
+ */
+export function toCatalogueDoc(srcEntry, now = new Date().toISOString()) {
+  const { id: _slug, ...rest } = srcEntry;
+  return { ...rest, created_at: now, updated_at: now };
+}
+
+/**
+ * Build the in-memory slug→ObjectId map from a list of source entries
+ * and a parallel list of inserted ObjectIds. Used to log the map at
+ * INFO level (epic D7 / AC#5) and as the return value for ECM-3.
+ */
+export function buildSlugMap(srcEntries, insertedIds) {
+  if (srcEntries.length !== insertedIds.length) {
+    throw new Error(
+      `ECM-2 internal: entry count (${srcEntries.length}) ≠ inserted id count (${insertedIds.length})`
+    );
+  }
+  const map = new Map();
+  for (let i = 0; i < srcEntries.length; i++) {
+    map.set(srcEntries[i].id, insertedIds[i]);
+  }
+  return map;
+}
+
+/**
+ * Format the slug→ObjectId map for human-readable INFO log output.
+ * One slug per line, padded for grep-ability.
+ */
+export function formatSlugMap(map) {
+  const lines = ['slug→ObjectId map (preserve for ECM-3 backfill):'];
+  // Sort by slug so the log is stable across runs.
+  const entries = [...map.entries()].sort(([a], [b]) => a.localeCompare(b));
+  const pad = entries.reduce((w, [s]) => Math.max(w, s.length), 0);
+  for (const [slug, id] of entries) {
+    lines.push(`  ${slug.padEnd(pad)}  →  ${id}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Refusal error raised when the collection is non-empty and --force is
+ * not supplied. Carries a stable `code` so callers / tests can react.
+ */
+class RefuseNonEmptyError extends Error {
+  constructor(count) {
+    super(
+      `equipment_catalogue is non-empty (${count} document${count === 1 ? '' : 's'}). ` +
+      `Refusing to seed without --force. If you really want to re-seed, drop the collection ` +
+      `manually first, then re-run without --force; --force does NOT drop and will produce ` +
+      `duplicates by name+bucket.`
+    );
+    this.name = 'RefuseNonEmptyError';
+    this.code = 'REFUSE_NONEMPTY';
+    this.count = count;
+  }
+}
+
+export async function main() {
+  // Compute mode + flags inside main so integration tests can toggle via
+  // process.argv (per the #826 lesson now ingrained as
+  // [[feedback_script_integration_test]]).
+  const APPLY = process.argv.includes('--apply');
+  const DRY_RUN = !APPLY;
+  const FORCE = process.argv.includes('--force');
+
+  const MONGODB_URI = process.env.MONGODB_URI;
+  if (!MONGODB_URI) {
+    throw new Error('MONGODB_URI not set. Ensure server/.env is present and the script is run from server/.');
+  }
+
+  const client = new MongoClient(MONGODB_URI);
+  await client.connect();
+  try {
+    const db = client.db(DB_NAME);
+    const col = db.collection('equipment_catalogue');
+
+    console.log(`\n${DRY_RUN ? '[DRY RUN]' : '[APPLY]'} ecm-migrate.js (ECM-2: seed only)`);
+    console.log(`Database: ${DB_NAME}`);
+    console.log(`Source entries: ${EQUIPMENT_CATALOGUE.length}`);
+
+    const existing = await col.countDocuments();
+    console.log(`Existing equipment_catalogue documents: ${existing}`);
+
+    if (DRY_RUN) {
+      console.log('\nFirst sample entries (no writes):');
+      for (const e of EQUIPMENT_CATALOGUE.slice(0, SAMPLE_SIZE)) {
+        console.log(`  - [${e.bucket}] ${e.name}  (slug=${e.id})`);
+      }
+      console.log(`\n[DRY RUN] Would insert ${EQUIPMENT_CATALOGUE.length} document${EQUIPMENT_CATALOGUE.length === 1 ? '' : 's'}.`);
+      if (existing > 0 && !FORCE) {
+        console.log('[DRY RUN] NOTE: a live run without --force would REFUSE (collection non-empty).');
+      }
+      console.log('\n[DRY RUN] Re-run with --apply to write.');
+      return {
+        mode: 'dry-run',
+        sourceCount: EQUIPMENT_CATALOGUE.length,
+        existingCount: existing,
+        wouldRefuse: existing > 0 && !FORCE,
+        sample: EQUIPMENT_CATALOGUE.slice(0, SAMPLE_SIZE).map(e => ({ id: e.id, bucket: e.bucket, name: e.name })),
+      };
+    }
+
+    // ── Live run ──
+
+    if (existing > 0 && !FORCE) {
+      throw new RefuseNonEmptyError(existing);
+    }
+    if (existing > 0 && FORCE) {
+      console.log(`[APPLY] --force set; appending ${EQUIPMENT_CATALOGUE.length} entries to non-empty collection. ` +
+                  `Operator accepts duplicate name+bucket consequences.`);
+    }
+
+    // Build the docs with shared `now` so created_at == updated_at across
+    // the batch — gives ECM-6's "recently added" filters a stable handle.
+    const now = new Date().toISOString();
+    const docs = EQUIPMENT_CATALOGUE.map(e => toCatalogueDoc(e, now));
+    const result = await col.insertMany(docs, { ordered: true });
+
+    const insertedIds = Object.values(result.insertedIds);
+    const slugMap = buildSlugMap(EQUIPMENT_CATALOGUE, insertedIds);
+
+    console.log(`[APPLY] Inserted ${result.insertedCount} document${result.insertedCount === 1 ? '' : 's'}.`);
+    console.log('');
+    console.log(formatSlugMap(slugMap));
+    console.log('');
+    console.log(`[APPLY] Idempotency check: re-run without --force and confirm "Refusing to seed".`);
+
+    return {
+      mode: 'apply',
+      sourceCount: EQUIPMENT_CATALOGUE.length,
+      insertedCount: result.insertedCount,
+      slugMap,
+      forced: FORCE,
+    };
+  } finally {
+    await client.close();
+  }
+}
+
+const _invokedDirectly = import.meta.url === `file://${process.argv[1]}`;
+if (_invokedDirectly) {
+  main().catch(err => {
+    if (err?.code === 'REFUSE_NONEMPTY') {
+      console.error(`\n[REFUSE] ${err.message}`);
+      process.exit(1);
+    }
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/server/tests/issue-869-ecm-2-seed.test.js
+++ b/server/tests/issue-869-ecm-2-seed.test.js
@@ -1,0 +1,271 @@
+/**
+ * Issue #869 — ECM-2 seed script tests.
+ *
+ * Three slices:
+ *   1. Pure-helper unit (toCatalogueDoc / buildSlugMap / formatSlugMap) —
+ *      shape contracts on the in-memory transforms, no DB.
+ *   2. main() integration end-to-end against the test MongoDB. Covers:
+ *      DRY-RUN no-write, live apply inserts all entries, re-run without
+ *      --force refuses non-zero, re-run with --force does NOT drop and
+ *      DOES append. Discipline pin: [[feedback_script_integration_test]]
+ *      — helper-level mocks alone failed previously (the June 16 incident
+ *      Khepri called out); this slice exercises the full pipeline.
+ *   3. Source-data sanity: every EQUIPMENT_CATALOGUE entry has a
+ *      slug-shaped `id` so the slug→ObjectId map is well-defined.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach, beforeEach } from 'vitest';
+import 'dotenv/config';
+import { ObjectId } from 'mongodb';
+import { setupDb, teardownDb } from './helpers/db-setup.js';
+import { getCollection } from '../db.js';
+import { EQUIPMENT_CATALOGUE } from '../data/equipment-catalogue.js';
+import {
+  main,
+  toCatalogueDoc,
+  buildSlugMap,
+  formatSlugMap,
+} from '../scripts/ecm-migrate.js';
+
+beforeAll(async () => { await setupDb(); });
+afterAll(async () => { await teardownDb(); });
+
+// Each integration test starts from a clean collection. The seed script
+// owns the whole collection; partial-state interleavings would invalidate
+// the idempotency assertions.
+async function clearCatalogue() {
+  await getCollection('equipment_catalogue').deleteMany({});
+}
+beforeEach(clearCatalogue);
+afterEach(clearCatalogue);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Pure-helper unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#869 — toCatalogueDoc strips slug + adds audit-light timestamps', () => {
+  it('drops the legacy `id` field per epic D1', () => {
+    const src = { id: 'knife', bucket: 'weapon', name: 'Knife', damage_mod: 1 };
+    const out = toCatalogueDoc(src, '2026-06-17T00:00:00.000Z');
+    expect(out.id).toBeUndefined();
+    expect(out.bucket).toBe('weapon');
+    expect(out.name).toBe('Knife');
+    expect(out.damage_mod).toBe(1);
+  });
+
+  it('sets created_at and updated_at to the supplied timestamp', () => {
+    const ts = '2026-06-17T11:22:33.444Z';
+    const out = toCatalogueDoc({ id: 'x', bucket: 'equipment', name: 'X' }, ts);
+    expect(out.created_at).toBe(ts);
+    expect(out.updated_at).toBe(ts);
+  });
+
+  it('preserves every non-id field including nullables', () => {
+    const src = {
+      id: 'foo', bucket: 'armour', name: 'Vest',
+      description: 'd', availability: 3, tags: ['armour'],
+      damage_mod: null, damage_type: null, weapon_type: null,
+      armour_value: 2, defence_penalty: -1,
+      skill_domain: null, bonus_dice: null,
+    };
+    const out = toCatalogueDoc(src, '2026-01-01T00:00:00.000Z');
+    expect(out.armour_value).toBe(2);
+    expect(out.defence_penalty).toBe(-1);
+    expect(out.skill_domain).toBeNull();
+    expect(out.bonus_dice).toBeNull();
+    expect(out.damage_mod).toBeNull();
+    expect(out.tags).toEqual(['armour']);
+  });
+});
+
+describe('#869 — buildSlugMap pairs entries with inserted ids in order', () => {
+  it('keys by source slug, values are the parallel ids', () => {
+    const src = [{ id: 'a' }, { id: 'b' }, { id: 'c' }];
+    const ids = [new ObjectId(), new ObjectId(), new ObjectId()];
+    const map = buildSlugMap(src, ids);
+    expect(map.size).toBe(3);
+    expect(map.get('a')).toBe(ids[0]);
+    expect(map.get('b')).toBe(ids[1]);
+    expect(map.get('c')).toBe(ids[2]);
+  });
+
+  it('throws on length mismatch', () => {
+    expect(() => buildSlugMap([{ id: 'a' }, { id: 'b' }], [new ObjectId()]))
+      .toThrow(/entry count.*≠.*inserted/);
+  });
+});
+
+describe('#869 — formatSlugMap renders a stable INFO-level log line set', () => {
+  it('lists each slug → id pair, sorted by slug', () => {
+    const map = new Map([
+      ['zebra', new ObjectId('507f1f77bcf86cd799439011')],
+      ['ant',   new ObjectId('507f1f77bcf86cd799439012')],
+    ]);
+    const out = formatSlugMap(map);
+    const idxA = out.indexOf('ant');
+    const idxZ = out.indexOf('zebra');
+    expect(idxA).toBeLessThan(idxZ);   // sorted
+    expect(out).toMatch(/preserve for ECM-3 backfill/);
+    expect(out).toContain('507f1f77bcf86cd799439011');
+    expect(out).toContain('507f1f77bcf86cd799439012');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. main() integration — end-to-end against test MongoDB
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Run main() with a controlled process.argv slice. */
+async function runMain(extra = []) {
+  const origArgv = process.argv;
+  process.argv = ['node', '/tmp/ecm-migrate.js', ...extra];
+  try {
+    return await main();
+  } finally {
+    process.argv = origArgv;
+  }
+}
+
+describe('#869 — main() DRY-RUN (no --apply)', () => {
+  it('does not write to the collection', async () => {
+    const before = await getCollection('equipment_catalogue').countDocuments();
+    const result = await runMain();
+    expect(result.mode).toBe('dry-run');
+    expect(result.sourceCount).toBe(EQUIPMENT_CATALOGUE.length);
+    const after = await getCollection('equipment_catalogue').countDocuments();
+    expect(after).toBe(before);
+  });
+
+  it('returns the first 3 sample entries', async () => {
+    const result = await runMain();
+    expect(result.sample).toHaveLength(3);
+    for (const s of result.sample) {
+      expect(typeof s.id).toBe('string');
+      expect(typeof s.bucket).toBe('string');
+      expect(typeof s.name).toBe('string');
+    }
+  });
+
+  it('flags wouldRefuse=true when collection is non-empty (DRY-RUN preview of refuse path)', async () => {
+    await getCollection('equipment_catalogue').insertOne({ bucket: 'equipment', name: 'pre-seed' });
+    const result = await runMain();
+    expect(result.wouldRefuse).toBe(true);
+  });
+});
+
+describe('#869 — main() --apply (live seed)', () => {
+  it('inserts every EQUIPMENT_CATALOGUE entry', async () => {
+    const result = await runMain(['--apply']);
+    expect(result.mode).toBe('apply');
+    expect(result.insertedCount).toBe(EQUIPMENT_CATALOGUE.length);
+
+    const stored = await getCollection('equipment_catalogue').find({}).toArray();
+    expect(stored).toHaveLength(EQUIPMENT_CATALOGUE.length);
+
+    // Every doc must carry the ECM-1 audit-light timestamps.
+    for (const doc of stored) {
+      expect(typeof doc.created_at).toBe('string');
+      expect(typeof doc.updated_at).toBe('string');
+    }
+  });
+
+  it('strips the legacy `id` slug from every inserted document (epic D1)', async () => {
+    await runMain(['--apply']);
+    const stored = await getCollection('equipment_catalogue').find({}).toArray();
+    for (const doc of stored) {
+      expect(doc.id).toBeUndefined();
+    }
+  });
+
+  it('returns a slug→ObjectId map covering every source slug', async () => {
+    const result = await runMain(['--apply']);
+    expect(result.slugMap.size).toBe(EQUIPMENT_CATALOGUE.length);
+    for (const entry of EQUIPMENT_CATALOGUE) {
+      const id = result.slugMap.get(entry.id);
+      expect(id).toBeInstanceOf(ObjectId);
+    }
+  });
+
+  it('inserted ids resolve to docs whose name matches the source entry', async () => {
+    const result = await runMain(['--apply']);
+    // Spot-check 3 random entries (deterministic indices for stability).
+    for (const idx of [0, Math.floor(EQUIPMENT_CATALOGUE.length / 2), EQUIPMENT_CATALOGUE.length - 1]) {
+      const src = EQUIPMENT_CATALOGUE[idx];
+      const oid = result.slugMap.get(src.id);
+      expect(oid).toBeDefined();
+      const doc = await getCollection('equipment_catalogue').findOne({ _id: oid });
+      expect(doc?.name).toBe(src.name);
+      expect(doc?.bucket).toBe(src.bucket);
+    }
+  });
+});
+
+describe('#869 — main() refuses re-seed without --force', () => {
+  it('throws REFUSE_NONEMPTY when collection is non-empty', async () => {
+    await runMain(['--apply']);   // first seed
+    await expect(runMain(['--apply'])).rejects.toMatchObject({ code: 'REFUSE_NONEMPTY' });
+  });
+
+  it('does NOT modify the collection on refuse', async () => {
+    await runMain(['--apply']);   // first seed
+    const before = await getCollection('equipment_catalogue').countDocuments();
+    await expect(runMain(['--apply'])).rejects.toMatchObject({ code: 'REFUSE_NONEMPTY' });
+    const after = await getCollection('equipment_catalogue').countDocuments();
+    expect(after).toBe(before);
+  });
+
+  it('refuse-error message names the non-zero count + suggests drop-first remediation', async () => {
+    await runMain(['--apply']);
+    try {
+      await runMain(['--apply']);
+      throw new Error('expected refuse');
+    } catch (err) {
+      expect(err.code).toBe('REFUSE_NONEMPTY');
+      expect(err.message).toMatch(/non-empty/);
+      expect(err.message).toMatch(/drop the collection/);
+    }
+  });
+});
+
+describe('#869 — main() --apply --force seeds again WITHOUT dropping', () => {
+  it('appends to non-empty collection (does NOT drop existing docs)', async () => {
+    await runMain(['--apply']);
+    const after_first = await getCollection('equipment_catalogue').find({}).toArray();
+    const firstIds = after_first.map(d => String(d._id)).sort();
+
+    const result = await runMain(['--apply', '--force']);
+    expect(result.forced).toBe(true);
+    expect(result.insertedCount).toBe(EQUIPMENT_CATALOGUE.length);
+
+    const after_force = await getCollection('equipment_catalogue').find({}).toArray();
+    expect(after_force.length).toBe(EQUIPMENT_CATALOGUE.length * 2);
+
+    // Every doc inserted in the first run must STILL be present —
+    // proves --force did not drop.
+    const surviving = after_force.filter(d => firstIds.includes(String(d._id)));
+    expect(surviving.length).toBe(after_first.length);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. Source-data sanity
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#869 — EQUIPMENT_CATALOGUE source-data invariants', () => {
+  it('every entry has a unique slug-shaped `id`', () => {
+    const slugs = EQUIPMENT_CATALOGUE.map(e => e.id);
+    const slugRe = /^[a-z0-9][a-z0-9-]*$/;
+    for (const s of slugs) {
+      expect(typeof s).toBe('string');
+      expect(slugRe.test(s)).toBe(true);
+    }
+    expect(new Set(slugs).size).toBe(slugs.length);
+  });
+
+  it('every entry has bucket in the schema enum', () => {
+    const allowed = new Set(['weapon', 'armour', 'equipment', 'asset']);
+    for (const e of EQUIPMENT_CATALOGUE) {
+      expect(allowed.has(e.bucket)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #869. Second story of Epic ECM. Seeds the equipment_catalogue collection (ECM-1 / PR #882) from the static EQUIPMENT_CATALOGUE module. **Step 1 ONLY** — does NOT touch \`character.equipment[].catalogue_id\`; that backfill is ECM-3.

## Behaviour

| Flags | Behaviour |
|---|---|
| (none) | DRY-RUN: prints source + existing counts, first 3 sample entries. No writes. |
| \`--apply\` | Live seed. Refuses if collection non-empty. |
| \`--apply --force\` | Live seed. Proceeds even if non-empty. **Does NOT drop**; appends. |

Refuse on non-empty without \`--force\` throws \`RefuseNonEmptyError\` (\`code: 'REFUSE_NONEMPTY'\`); the CLI wrapper exits non-zero. Re-seed remediation is **drop first, then re-run**, not \`--force\`.

## Acceptance criteria

- [x] **DRY-RUN prints count + sample, no writes** — returns \`{ mode: 'dry-run', sourceCount, sample[3], wouldRefuse }\`. Test: \`main() DRY-RUN > does not write to the collection\`.
- [x] **Live run inserts all, logs final count** — \`insertMany\` with shared \`created_at/updated_at\`; logs \`Inserted N documents.\`. Test: \`main() --apply > inserts every EQUIPMENT_CATALOGUE entry\`.
- [x] **Re-run without --force exits non-zero with clear message** — throws \`REFUSE_NONEMPTY\` naming the count + drop-first remediation. Test: \`main() refuses re-seed without --force\` (3 cases).
- [x] **Re-run with --force does NOT drop the collection** — appended to non-empty; every first-run _id still present. Test: \`main() --apply --force seeds again WITHOUT dropping\`.
- [x] **Slug→ObjectId map logged at INFO level** — \`formatSlugMap\` sorts alphabetically, names ECM-3 as the consumer, prints one slug→id pair per line. Returned in main()'s result for direct ECM-3 reuse without re-derivation.

## Source choice

Per epic D7 the spec names \`public/js/data/equipment-data.js\`. The script reads the **server-side parity-tested mirror** at \`server/data/equipment-catalogue.js\` — identical data by construction, both deleted in ECM-7. Avoids the cross-package ESM/CJS boundary the existing mirror file's own comment documents. Functionally equivalent; the deletion happens to both files simultaneously.

## Test discipline pin

Per [[feedback_script_integration_test]]: the June 16 incident was helper-level mocks passing while the DB write shape was broken. This script's tests follow the discipline:

- **Pure-helper unit slice** (3 \`describe\` blocks) — \`toCatalogueDoc\` / \`buildSlugMap\` / \`formatSlugMap\` shape contracts.
- **\`main()\` integration slice** (4 \`describe\` blocks, 10 tests) — full end-to-end against the test MongoDB with \`process.argv\` toggling. Asserts DRY-RUN no-write, --apply inserts every source entry, audit-light timestamps present, legacy \`id\` slug stripped, slugMap covers every source slug, inserted _ids resolve to docs whose name/bucket match the source, REFUSE_NONEMPTY collection-unchanged + helpful error message, --force-no-drop with first-run _ids still present.
- **Source-data sanity slice** — every entry has a unique slug-shaped \`id\`; every bucket is in the schema enum.

## Note for ECM-6 follow-up

The static source carries a \`mechanical_effect\` field on **asset** entries that the ECM-1 schema's \`properties\` block does not list. \`insertMany\` accepts the field at the DB layer (so seeded asset docs round-trip correctly through the API), but PATCH silently drops it via \`EQUIPMENT_CATALOGUE_UPDATABLE_FIELDS\`. ECM-6 should widen the PATCH allowlist (and the create schema) before exposing asset edits. Flagging here rather than expanding ECM-1's scope retroactively.

## Verification

\`\`\`
$ cd server && npx vitest run tests/issue-869-ecm-2-seed.test.js
Tests  19 passed (19)

$ npx vitest run                       # full suite
Test Files  4 failed | 132 passed (136)
Tests  1725 passed (1725)
\`\`\`

The 4 file-failures are pre-existing 0-test file-load failures (same on clean dev). 0 individual test failures.

## NOT in this PR

- **Phase-3 prod \`--apply\` run.** Per Khepri dispatch convention (cleanup scripts default dry-run; production application is a separate per-message Peter auth).

## Test plan

- [x] \`npx vitest run tests/issue-869-ecm-2-seed.test.js\` — 19 passes
- [x] \`node --check\` on script + test — parse OK
- [x] Full vitest suite — no new failures
- [ ] Manual smoke (post-merge): \`cd server && node scripts/ecm-migrate.js\` reports DRY-RUN preview against staging Mongo; \`--apply\` seeds; re-run refuses; \`--apply --force\` appends without dropping
- [ ] ECM-3 (next, blocked on this PR) consumes the slug→ObjectId map for character.equipment[] backfill