### PR TITLE
feat(ecm): #873 — admin sidebar (Equipment Catalogue CRUD UI) + mechanical_effect schema-widen

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -60,6 +60,7 @@
       <button class="sidebar-btn" data-domain="tickets">Tickets</button>
       <button class="sidebar-btn" data-domain="rules">Rule Data</button>
       <button class="sidebar-btn" data-domain="rde">Rules Engine</button>
+      <button class="sidebar-btn" data-domain="equipment-catalogue">Equipment Catalogue</button>
       <button class="sidebar-btn" data-domain="st-mods">ST Mods</button>
       <button class="sidebar-btn" data-domain="st-mods-audit">ST Mods Audit</button>
       <button class="sidebar-btn" data-domain="devlog">Devlog</button>
@@ -194,6 +195,11 @@
     <section id="d-rde" class="domain">
       <div class="domain-header"><h2>Rules Engine</h2></div>
       <div id="rde-content"></div>
+    </section>
+
+    <section id="d-equipment-catalogue" class="domain">
+      <div class="domain-header"><h2>Equipment Catalogue</h2></div>
+      <div id="equipment-catalogue-content"></div>
     </section>
 
     <section id="d-st-mods" class="domain">

--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -10220,3 +10220,155 @@ html:not([data-theme="dark"]) .rules-tbl tbody tr:hover            { background:
 .or-prefs-cell { text-align: center; font-variant-numeric: tabular-nums; }
 .or-prefs-null { opacity: 0.35; }
 .or-prefs-date { font-size: 0.75em; color: var(--txt3); }
+
+/* ── Equipment Catalogue admin (ECM-6, issue #873) ─────────────────────────── */
+
+.ec-admin { padding: 12px; }
+.ec-empty { color: var(--txt3); text-align: center; padding: 24px 12px; }
+
+.ec-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: end;
+  margin-bottom: 12px;
+  padding: 10px 12px;
+  background: var(--surf1);
+  border: 1px solid var(--bdr);
+  border-radius: 6px;
+}
+.ec-toolbar-field { display: flex; flex-direction: column; gap: 3px; font-size: 0.85em; }
+.ec-toolbar-field > span { color: var(--txt3); letter-spacing: 0.04em; }
+.ec-toolbar-field select,
+.ec-toolbar-field input {
+  padding: 5px 7px;
+  border: 1px solid var(--bdr2);
+  background: var(--surf);
+  color: var(--txt);
+  border-radius: 4px;
+  min-width: 160px;
+}
+
+.ec-btn-sm {
+  padding: 4px 10px;
+  font-size: 0.85em;
+  border: 1px solid var(--bdr2);
+  background: var(--surf1);
+  color: var(--txt);
+  border-radius: 4px;
+  cursor: pointer;
+}
+.ec-btn-sm:hover:not([disabled]) { background: var(--surf2); border-color: var(--bdr3); }
+.ec-btn-sm[disabled] { opacity: 0.4; cursor: not-allowed; }
+.ec-btn-danger { color: var(--crim); border-color: var(--crim2); }
+.ec-btn-danger:hover:not([disabled]) { background: var(--crim-a1); }
+
+.ec-btn-primary {
+  padding: 6px 14px;
+  font-size: 0.95em;
+  border: 1px solid var(--gold2);
+  background: var(--gold);
+  color: var(--txt-on-gold);
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 500;
+}
+.ec-btn-primary:hover { background: var(--gold2); }
+
+.ec-count { font-size: 0.85em; color: var(--txt3); margin-bottom: 6px; }
+
+.ec-table { width: 100%; border-collapse: collapse; font-size: 0.9em; }
+.ec-table th {
+  text-align: left;
+  padding: 6px 10px;
+  color: var(--txt3);
+  font-weight: 400;
+  border-bottom: 1px solid var(--bdr2);
+  letter-spacing: 0.03em;
+}
+.ec-table td { padding: 6px 10px; border-bottom: 1px solid var(--surf2); }
+.ec-table tbody tr:hover { background: var(--surf1); }
+.ec-row-actions { display: flex; gap: 6px; }
+
+.ec-bucket-tag {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-size: 0.8em;
+  background: var(--surf2);
+  color: var(--txt2);
+}
+.ec-bucket-weapon    { background: rgba(139, 0, 0, 0.18); color: var(--crim); }
+.ec-bucket-armour    { background: rgba(70, 90, 120, 0.22); color: var(--txt2); }
+.ec-bucket-equipment { background: rgba(108, 117, 125, 0.22); color: var(--txt2); }
+.ec-bucket-asset     { background: rgba(224, 196, 122, 0.18); color: var(--gold2); }
+
+/* ── Forms ────────────────────────────────────────────────────────────────── */
+
+.ec-form-panel {
+  margin-top: 18px;
+  padding: 14px;
+  background: var(--surf1);
+  border: 1px solid var(--bdr);
+  border-radius: 6px;
+}
+.ec-form-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+.ec-form-header h3 { margin: 0; font-size: 1.05em; }
+
+.ec-impact-banner {
+  padding: 10px 12px;
+  margin-bottom: 12px;
+  background: rgba(224, 196, 122, 0.12);
+  border-left: 3px solid var(--gold2);
+  border-radius: 3px;
+  font-size: 0.9em;
+}
+.ec-impact-banner strong { color: var(--gold2); }
+.ec-impact-list { display: block; margin-top: 4px; font-size: 0.85em; color: var(--txt3); }
+
+.ec-form-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px 14px;
+}
+.ec-form-field { display: flex; flex-direction: column; gap: 3px; font-size: 0.9em; }
+.ec-form-field--wide { grid-column: 1 / -1; }
+.ec-form-field label { color: var(--txt3); font-size: 0.85em; letter-spacing: 0.03em; }
+.ec-form-field input,
+.ec-form-field textarea,
+.ec-form-field select {
+  padding: 6px 8px;
+  border: 1px solid var(--bdr2);
+  background: var(--surf);
+  color: var(--txt);
+  border-radius: 4px;
+  font: inherit;
+}
+.ec-form-hint { color: var(--txt3); font-size: 0.85em; }
+.ec-form-readonly { padding: 6px 8px; color: var(--txt2); }
+
+.ec-bucket-fieldset {
+  margin: 6px 0 0 0;
+  padding: 8px 12px 12px;
+  border: 1px solid var(--bdr);
+  border-radius: 4px;
+}
+.ec-bucket-fieldset legend { padding: 0 6px; color: var(--txt3); font-size: 0.85em; }
+.ec-bucket-fieldset .ec-form-field { margin-top: 6px; }
+
+.ec-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 12px;
+  margin-top: 14px;
+}
+.ec-form-msg { font-size: 0.85em; }
+.ec-form-msg--ok    { color: var(--green2); }
+.ec-form-msg--error { color: var(--crim); }
+.ec-form-msg--info  { color: var(--txt3); }

--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -36,6 +36,7 @@ import { initPrimerAdmin } from './admin/primer-admin.js';
 import { initTicketsView } from './admin/tickets-views.js';
 import { initRulesView } from './admin/rules-view.js';
 import { initRulesDataView } from './admin/rules-data-view.js';
+import { initEquipmentCatalogueAdmin } from './admin/equipment-catalogue-admin.js';
 import { initStModsAudit } from './admin/st-mods-audit.js';
 import { initDevlogAdmin } from './admin/devlog-admin.js';
 import { initStModsPanel } from './admin/st-mods-panel.js';
@@ -286,6 +287,7 @@ function switchDomain(domain) {
   if (domain === 'tickets') initTicketsView(document.getElementById('tickets-admin-content'));
   if (domain === 'rules') initRulesView(document.getElementById('rules-content'), chars);
   if (domain === 'rde') initRulesDataView(document.getElementById('rde-content'));
+  if (domain === 'equipment-catalogue') initEquipmentCatalogueAdmin(document.getElementById('equipment-catalogue-content'), chars);
   if (domain === 'st-mods-audit') initStModsAudit(document.getElementById('st-mods-audit-content'), chars);
   if (domain === 'devlog') initDevlogAdmin(document.getElementById('devlog-admin-content'));
   if (domain === 'st-mods') {

--- a/public/js/admin/equipment-catalogue-admin.js
+++ b/public/js/admin/equipment-catalogue-admin.js
@@ -1,0 +1,423 @@
+/**
+ * Equipment Catalogue admin view (ECM-6, issue #873).
+ *
+ * Epic ECM (specs/epic-ecm-equipment-catalogue-migration.md). Browser-side
+ * CRUD over the Mongo-backed equipment_catalogue established by ECM-1.
+ *
+ * UX (epic D4 / D5 / D6):
+ *   - List view: filter by bucket, search by name, sort by availability.
+ *     Each row shows name / bucket / availability / holders count / actions.
+ *   - Create form: bucket selector reveals bucket-specific fields. Soft
+ *     duplicate warning when an existing item matches by name+bucket
+ *     (case-insensitive). Non-blocking — ST can override.
+ *   - Edit form: same field set + impact warning banner ("Held by N
+ *     characters; edits will apply to all") sourced from
+ *     GET /api/equipment_catalogue/:id/impact.
+ *   - Delete control: hard-disabled with explanatory tooltip when
+ *     holders > 0. API enforces 409 server-side; UI mirrors the gate.
+ *
+ * Holders count is derived **client-side** from the character set passed
+ * by switchDomain. The server's /:id/impact endpoint is reused for the
+ * edit-form banner only (it does the same join but is the SSOT for the
+ * delete gate; we render its message inline if the API returns 409).
+ *
+ * Write paths broadcast `broadcastCatalogueUpdate` server-side (wired in
+ * ECM-1); ECM-4 / ECM-5 dropdown clients refresh on receipt. This view
+ * refreshes its own list via `loadItems()` on each successful mutation.
+ */
+
+import { apiGet, apiPost, apiPatch, apiRaw } from '../data/api.js';
+import { esc } from '../data/helpers.js';
+
+const BUCKETS = ['weapon', 'armour', 'equipment', 'asset'];
+
+// Bucket → list of optional fields shown in create/edit forms. Mirrors
+// the EQ-1 null-template pattern (EQ_NULLS / WP_NULLS / AR_NULLS / AS_NULLS).
+const BUCKET_FIELDS = {
+  weapon:    ['damage_mod', 'damage_type', 'weapon_type'],
+  armour:    ['armour_value', 'defence_penalty'],
+  equipment: ['skill_domain', 'bonus_dice'],
+  asset:     ['mechanical_effect'],
+};
+
+// Module-level state — re-rendered on every mutation. Single-view module
+// (admin sidebar is mutually exclusive), so a singleton is fine.
+let _container = null;
+let _allChars = [];
+let _items = [];
+let _filterBucket = '';
+let _searchName = '';
+let _sortKey = 'name';        // 'name' | 'availability' | 'bucket'
+let _sortDir = 'asc';
+let _editingId = null;        // ObjectId-string or null when create mode
+
+/**
+ * Compute holders count per catalogue _id from the character set.
+ * Returns Map<string-id, number>. Pre-ECM-3 character.equipment[].catalogue_id
+ * is still a string slug, so this returns 0 for everything; post-ECM-3 it
+ * resolves correctly. The delete gate is API-enforced regardless.
+ */
+function buildHoldersIndex(chars) {
+  const idx = new Map();
+  for (const c of chars || []) {
+    for (const item of c.equipment || []) {
+      const key = String(item.catalogue_id);
+      idx.set(key, (idx.get(key) || 0) + 1);
+    }
+  }
+  return idx;
+}
+
+export async function initEquipmentCatalogueAdmin(container, chars) {
+  _container = container;
+  _allChars = Array.isArray(chars) ? chars : [];
+  _editingId = null;
+  _container.innerHTML = '<div class="ec-admin"><div class="ec-empty">Loading equipment catalogue…</div></div>';
+  await loadItems();
+  render();
+}
+
+async function loadItems() {
+  try {
+    _items = await apiGet('/api/equipment_catalogue');
+  } catch (err) {
+    console.error('[equipment-catalogue-admin] load failed:', err);
+    _items = [];
+  }
+}
+
+function filteredSorted() {
+  const search = (_searchName || '').toLowerCase();
+  let rows = _items.filter(it => {
+    if (_filterBucket && it.bucket !== _filterBucket) return false;
+    if (search && !(it.name || '').toLowerCase().includes(search)) return false;
+    return true;
+  });
+  const dir = _sortDir === 'desc' ? -1 : 1;
+  rows.sort((a, b) => {
+    let av, bv;
+    if (_sortKey === 'availability') { av = a.availability ?? -1; bv = b.availability ?? -1; }
+    else if (_sortKey === 'bucket') { av = a.bucket || ''; bv = b.bucket || ''; }
+    else { av = (a.name || '').toLowerCase(); bv = (b.name || '').toLowerCase(); }
+    if (av < bv) return -1 * dir;
+    if (av > bv) return  1 * dir;
+    return 0;
+  });
+  return rows;
+}
+
+function render() {
+  if (!_container) return;
+  const holders = buildHoldersIndex(_allChars);
+  const rows = filteredSorted();
+  const bucketOpts = ['<option value="">All buckets</option>']
+    .concat(BUCKETS.map(b => `<option value="${b}"${_filterBucket === b ? ' selected' : ''}>${b}</option>`))
+    .join('');
+
+  const html = `
+    <div class="ec-admin">
+      <div class="ec-toolbar">
+        <label class="ec-toolbar-field">
+          <span>Bucket</span>
+          <select id="ec-filter-bucket">${bucketOpts}</select>
+        </label>
+        <label class="ec-toolbar-field">
+          <span>Name search</span>
+          <input id="ec-filter-search" type="text" value="${esc(_searchName)}" placeholder="filter…">
+        </label>
+        <label class="ec-toolbar-field">
+          <span>Sort by</span>
+          <select id="ec-sort-key">
+            <option value="name"${_sortKey === 'name' ? ' selected' : ''}>Name</option>
+            <option value="bucket"${_sortKey === 'bucket' ? ' selected' : ''}>Bucket</option>
+            <option value="availability"${_sortKey === 'availability' ? ' selected' : ''}>Availability</option>
+          </select>
+          <button id="ec-sort-dir" class="ec-btn-sm" title="Toggle direction">${_sortDir === 'asc' ? '↑' : '↓'}</button>
+        </label>
+        <button id="ec-new" class="ec-btn-primary">+ New item</button>
+      </div>
+
+      <div class="ec-count">${rows.length} of ${_items.length} item${_items.length === 1 ? '' : 's'}</div>
+
+      <table class="ec-table">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Bucket</th>
+            <th>Avail.</th>
+            <th>Holders</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${rows.map(it => renderRow(it, holders.get(String(it._id)) || 0)).join('')}
+        </tbody>
+      </table>
+
+      <div id="ec-form-host"></div>
+    </div>
+  `;
+  _container.innerHTML = html;
+  wireListEvents();
+}
+
+function renderRow(it, holdersCount) {
+  const deleteAttrs = holdersCount > 0
+    ? `disabled title="Held by ${holdersCount} character${holdersCount === 1 ? '' : 's'} — remove from holders before deleting."`
+    : '';
+  return `
+    <tr data-id="${esc(String(it._id))}">
+      <td>${esc(it.name || '')}</td>
+      <td><span class="ec-bucket-tag ec-bucket-${esc(it.bucket || '')}">${esc(it.bucket || '')}</span></td>
+      <td>${it.availability ?? '—'}</td>
+      <td>${holdersCount > 0 ? `<strong>${holdersCount}</strong>` : '0'}</td>
+      <td class="ec-row-actions">
+        <button class="ec-btn-sm" data-action="edit">Edit</button>
+        <button class="ec-btn-sm ec-btn-danger" data-action="delete" ${deleteAttrs}>Delete</button>
+      </td>
+    </tr>
+  `;
+}
+
+function wireListEvents() {
+  const $ = id => document.getElementById(id);
+  $('ec-filter-bucket')?.addEventListener('change', e => { _filterBucket = e.target.value; render(); });
+  $('ec-filter-search')?.addEventListener('input', e => { _searchName = e.target.value; render(); });
+  $('ec-sort-key')?.addEventListener('change', e => { _sortKey = e.target.value; render(); });
+  $('ec-sort-dir')?.addEventListener('click', () => { _sortDir = _sortDir === 'asc' ? 'desc' : 'asc'; render(); });
+  $('ec-new')?.addEventListener('click', () => openCreateForm());
+
+  _container.querySelectorAll('.ec-table tbody tr').forEach(row => {
+    const id = row.dataset.id;
+    row.querySelector('[data-action="edit"]')?.addEventListener('click', () => openEditForm(id));
+    const delBtn = row.querySelector('[data-action="delete"]');
+    if (delBtn && !delBtn.disabled) {
+      delBtn.addEventListener('click', () => onDelete(id));
+    }
+  });
+}
+
+// ── Forms ──────────────────────────────────────────────────────────────────
+
+function openCreateForm() {
+  _editingId = null;
+  renderForm({ bucket: 'equipment', tags: [] });
+}
+
+async function openEditForm(id) {
+  _editingId = id;
+  const item = _items.find(it => String(it._id) === String(id));
+  if (!item) return;
+  // Fetch authoritative impact info for the banner. The list-view holders
+  // count is a client-side join (may be stale); the API count is SSOT.
+  let impact = { holders: 0, character_names: [] };
+  try {
+    impact = await apiGet(`/api/equipment_catalogue/${id}/impact`);
+  } catch (err) {
+    console.warn('[equipment-catalogue-admin] impact fetch failed:', err);
+  }
+  renderForm(item, impact);
+}
+
+function renderForm(initial, impact = null) {
+  const host = document.getElementById('ec-form-host');
+  if (!host) return;
+  const isEdit = !!_editingId;
+  const bucket = initial.bucket || 'equipment';
+  const bucketOpts = BUCKETS.map(b =>
+    `<option value="${b}"${bucket === b ? ' selected' : ''}>${b}</option>`
+  ).join('');
+
+  const banner = isEdit && impact && impact.holders > 0
+    ? `<div class="ec-impact-banner">
+         <strong>Held by ${impact.holders} character${impact.holders === 1 ? '' : 's'}.</strong>
+         Edits will apply to all current holders.
+         <span class="ec-impact-list">(${impact.character_names.map(esc).join(', ')})</span>
+       </div>`
+    : '';
+
+  host.innerHTML = `
+    <div class="ec-form-panel">
+      <div class="ec-form-header">
+        <h3>${isEdit ? 'Edit item' : 'New item'}</h3>
+        <button id="ec-form-close" class="ec-btn-sm">Close</button>
+      </div>
+      ${banner}
+      <div class="ec-form-grid">
+        ${isEdit
+          ? `<div class="ec-form-field"><label>Bucket</label><div class="ec-form-readonly">${esc(bucket)} <span class="ec-form-hint">(immutable — delete + recreate to change bucket)</span></div></div>`
+          : `<div class="ec-form-field"><label>Bucket</label><select id="ec-f-bucket">${bucketOpts}</select></div>`
+        }
+        <div class="ec-form-field">
+          <label>Name *</label>
+          <input id="ec-f-name" type="text" value="${esc(initial.name || '')}" required>
+        </div>
+        <div class="ec-form-field ec-form-field--wide">
+          <label>Description</label>
+          <textarea id="ec-f-description" rows="3">${esc(initial.description || '')}</textarea>
+        </div>
+        <div class="ec-form-field">
+          <label>Availability (0-5)</label>
+          <input id="ec-f-availability" type="number" min="0" max="5" value="${initial.availability ?? ''}">
+        </div>
+        <div class="ec-form-field">
+          <label>Tags <span class="ec-form-hint">(comma-separated)</span></label>
+          <input id="ec-f-tags" type="text" value="${esc((initial.tags || []).join(', '))}">
+        </div>
+        <div id="ec-bucket-fields" class="ec-form-field--wide">
+          ${renderBucketFields(bucket, initial)}
+        </div>
+      </div>
+      <div class="ec-form-actions">
+        <span id="ec-form-msg" class="ec-form-msg"></span>
+        <button id="ec-form-save" class="ec-btn-primary">${isEdit ? 'Save changes' : 'Create item'}</button>
+      </div>
+    </div>
+  `;
+  wireFormEvents(initial);
+}
+
+function renderBucketFields(bucket, initial) {
+  const fields = BUCKET_FIELDS[bucket] || [];
+  if (!fields.length) return '';
+  const labels = {
+    damage_mod: 'Damage mod',
+    damage_type: 'Damage type (lethal / bashing)',
+    weapon_type: 'Weapon type',
+    armour_value: 'Armour value',
+    defence_penalty: 'Defence penalty',
+    skill_domain: 'Skill domain',
+    bonus_dice: 'Bonus dice',
+    mechanical_effect: 'Mechanical effect',
+  };
+  const numericFields = new Set(['damage_mod', 'armour_value', 'defence_penalty', 'bonus_dice']);
+  const longFields = new Set(['mechanical_effect']);
+  return `<fieldset class="ec-bucket-fieldset"><legend>${bucket}-specific</legend>${
+    fields.map(f => {
+      const val = initial[f];
+      const type = numericFields.has(f) ? 'number' : 'text';
+      const inputHtml = longFields.has(f)
+        ? `<textarea id="ec-f-${f}" rows="2">${esc(val ?? '')}</textarea>`
+        : `<input id="ec-f-${f}" type="${type}" value="${esc(val ?? '')}">`;
+      return `<div class="ec-form-field"><label>${labels[f] || f}</label>${inputHtml}</div>`;
+    }).join('')
+  }</fieldset>`;
+}
+
+function wireFormEvents(initial) {
+  const $ = id => document.getElementById(id);
+  $('ec-form-close')?.addEventListener('click', () => {
+    document.getElementById('ec-form-host').innerHTML = '';
+    _editingId = null;
+  });
+  $('ec-f-bucket')?.addEventListener('change', e => {
+    // Re-render only the bucket-specific fieldset; keep other field values intact.
+    const fresh = collectFormValues(false);
+    fresh.bucket = e.target.value;
+    document.getElementById('ec-bucket-fields').innerHTML = renderBucketFields(fresh.bucket, fresh);
+  });
+  $('ec-form-save')?.addEventListener('click', () => onSave(initial));
+}
+
+/**
+ * Read current form values. `coerce=true` casts numeric fields to numbers /
+ * null for the API. `coerce=false` (used by bucket-switch re-render) keeps
+ * raw strings so the form preserves user input across renders.
+ */
+function collectFormValues(coerce = true) {
+  const $ = id => document.getElementById(id);
+  const bucket = $('ec-f-bucket')?.value || (_editingId ? (_items.find(it => String(it._id) === String(_editingId))?.bucket) : 'equipment');
+  const name = ($('ec-f-name')?.value || '').trim();
+  const description = ($('ec-f-description')?.value || '').trim() || null;
+  const availRaw = $('ec-f-availability')?.value;
+  const availability = availRaw === '' || availRaw === undefined ? null : Number(availRaw);
+  const tagsRaw = $('ec-f-tags')?.value || '';
+  const tags = tagsRaw.split(',').map(t => t.trim()).filter(Boolean);
+
+  const out = { bucket, name, description, availability, tags };
+
+  const fields = BUCKET_FIELDS[bucket] || [];
+  const numericFields = new Set(['damage_mod', 'armour_value', 'defence_penalty', 'bonus_dice']);
+  for (const f of fields) {
+    const raw = $(`ec-f-${f}`)?.value;
+    if (raw === undefined) continue;
+    if (!coerce) { out[f] = raw; continue; }
+    if (raw === '' || raw === null) { out[f] = null; continue; }
+    out[f] = numericFields.has(f) ? Number(raw) : raw;
+  }
+  return out;
+}
+
+function showFormMsg(text, kind = 'info') {
+  const el = document.getElementById('ec-form-msg');
+  if (!el) return;
+  el.textContent = text;
+  el.className = `ec-form-msg ec-form-msg--${kind}`;
+}
+
+async function onSave(initial) {
+  const values = collectFormValues(true);
+  if (!values.name) { showFormMsg('Name is required.', 'error'); return; }
+  if (!values.bucket) { showFormMsg('Bucket is required.', 'error'); return; }
+
+  if (!_editingId) {
+    // Soft duplicate warning per epic D6 — non-blocking. Match by
+    // name+bucket, case-insensitive.
+    const dup = _items.find(it =>
+      it.bucket === values.bucket &&
+      (it.name || '').toLowerCase() === values.name.toLowerCase()
+    );
+    if (dup && !confirm(
+      `An item with name "${dup.name}" already exists in bucket "${dup.bucket}". ` +
+      `Continue anyway? (Inspect the existing item by closing this form.)`
+    )) return;
+  }
+
+  showFormMsg('Saving…', 'info');
+  try {
+    if (_editingId) {
+      // PATCH — only send updatable fields. The server allowlist also
+      // strips, but pruning client-side keeps the payload small.
+      const { bucket: _b, ...patchBody } = values;
+      await apiPatch(`/api/equipment_catalogue/${_editingId}`, patchBody);
+      showFormMsg('Saved.', 'ok');
+    } else {
+      await apiPost('/api/equipment_catalogue', values);
+      showFormMsg('Created.', 'ok');
+    }
+    await loadItems();
+    _editingId = null;
+    render();
+  } catch (err) {
+    showFormMsg(err.message || 'Save failed.', 'error');
+  }
+}
+
+async function onDelete(id) {
+  const item = _items.find(it => String(it._id) === String(id));
+  if (!item) return;
+  if (!confirm(`Delete "${item.name}" from the catalogue?`)) return;
+  try {
+    const res = await apiRaw('DELETE', `/api/equipment_catalogue/${id}`);
+    if (res.status === 204) {
+      await loadItems();
+      render();
+      return;
+    }
+    if (res.status === 409 && res.body) {
+      // Server hard-block (epic D5 + ECM-6 HALT-DAR). Surface the holder
+      // names so the ST knows where to clean up.
+      alert(
+        `Cannot delete — held by ${res.body.holders} character${res.body.holders === 1 ? '' : 's'}: ` +
+        `${(res.body.character_names || []).join(', ')}.`
+      );
+      // Refresh the list so the holders column reflects fresh truth.
+      await loadItems();
+      render();
+      return;
+    }
+    alert((res.body && (res.body.message || res.body.error)) || 'Delete failed.');
+  } catch (err) {
+    alert(err.message || 'Delete failed.');
+  }
+}

--- a/server/schemas/equipment_catalogue.schema.js
+++ b/server/schemas/equipment_catalogue.schema.js
@@ -33,13 +33,22 @@ export const equipmentCatalogueSchema = {
     tags:         { type: 'array', items: { type: 'string' } },
 
     // ── Bucket-specific (explicit null where absent) ──
-    damage_mod:      { type: ['integer', 'null'] },
-    damage_type:     { type: ['string',  'null'] },
-    weapon_type:     { type: ['string',  'null'] },
-    armour_value:    { type: ['integer', 'null'] },
-    defence_penalty: { type: ['integer', 'null'] },
-    skill_domain:    { type: ['string',  'null'] },
-    bonus_dice:      { type: ['integer', 'null'] },
+    damage_mod:        { type: ['integer', 'null'] },
+    damage_type:       { type: ['string',  'null'] },
+    weapon_type:       { type: ['string',  'null'] },
+    armour_value:      { type: ['integer', 'null'] },
+    defence_penalty:   { type: ['integer', 'null'] },
+    skill_domain:      { type: ['string',  'null'] },
+    bonus_dice:        { type: ['integer', 'null'] },
+    // mechanical_effect — asset-bucket-only in practice (free-text note on
+    // what the asset does mechanically); follows the same nullable shape as
+    // the other bucket-specific fields. Widened in ECM-6 (#873) after the
+    // ECM-2 seed surfaced that the source carries this field on asset
+    // entries — ECM-1's properties block had omitted it, causing PATCH to
+    // silently drop edits via the allowlist. Per epic Non-Goal "no state-
+    // enum per-bucket schema validation", the schema does not enforce
+    // bucket=asset; the field is nullable across all buckets.
+    mechanical_effect: { type: ['string',  'null'] },
 
     // ── Audit-light metadata (kept minimal per epic D1 / Non-Goals) ──
     created_at: { type: 'string' },
@@ -56,4 +65,5 @@ export const EQUIPMENT_CATALOGUE_UPDATABLE_FIELDS = new Set([
   'damage_mod', 'damage_type', 'weapon_type',
   'armour_value', 'defence_penalty',
   'skill_domain', 'bonus_dice',
+  'mechanical_effect',
 ]);

--- a/server/tests/issue-868-ecm-1-equipment-catalogue-api.test.js
+++ b/server/tests/issue-868-ecm-1-equipment-catalogue-api.test.js
@@ -248,6 +248,20 @@ describe('PATCH /api/equipment_catalogue/:id', () => {
     expect(res.body.error).toBe('VALIDATION_ERROR');
   });
 
+  // #873 ECM-6 schema-widen: mechanical_effect added to the schema and PATCH
+  // allowlist after ECM-2 surfaced the field on asset entries. Per epic
+  // Non-Goal "no state-enum per-bucket validation", the schema accepts the
+  // field across all buckets; the admin UI scopes it to assets.
+  it('accepts mechanical_effect on PATCH (ECM-6 schema-widen)', async () => {
+    const seed = await seedItem({ bucket: 'asset', name: 'Warehouse', mechanical_effect: null });
+    const res = await request(app)
+      .patch(`/api/equipment_catalogue/${seed._id}`)
+      .set('X-Test-User', stUser())
+      .send({ mechanical_effect: 'Confers +1 Resources for the cycle.' });
+    expect(res.status).toBe(200);
+    expect(res.body.mechanical_effect).toBe('Confers +1 Resources for the cycle.');
+  });
+
   it('returns 401 without auth header', async () => {
     const seed = await seedItem();
     const res = await request(app)

--- a/server/tests/issue-873-ecm-6-admin-sidebar.test.js
+++ b/server/tests/issue-873-ecm-6-admin-sidebar.test.js
@@ -1,0 +1,118 @@
+/**
+ * Issue #873 — ECM-6 admin sidebar (Equipment Catalogue CRUD UI).
+ *
+ * Server-side: the schema-widen for `mechanical_effect` (the asset-bucket
+ * field ECM-2 surfaced) lives in this PR — covered alongside the existing
+ * ECM-1 tests at issue-868-ecm-1-equipment-catalogue-api.test.js.
+ *
+ * Client side: vanilla JS module + admin.html sidebar wiring. No browser
+ * harness in this repo, so the slice is static-analysis: assert the
+ * wiring lands and the module exports the expected entry point. UI
+ * smoke is captured in the PR test plan.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+function read(rel) { return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8'); }
+function exists(rel) { return fs.existsSync(path.join(REPO_ROOT, rel)); }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Schema-widen — `mechanical_effect` in properties + PATCH allowlist
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#873 — equipment_catalogue schema widened for mechanical_effect', () => {
+  const src = read('server/schemas/equipment_catalogue.schema.js');
+
+  it('schema.properties declares mechanical_effect (nullable string)', () => {
+    expect(src).toMatch(/mechanical_effect:\s*\{\s*type:\s*\[\s*['"]string['"]\s*,\s*['"]null['"]\s*\]/);
+  });
+
+  it('EQUIPMENT_CATALOGUE_UPDATABLE_FIELDS contains mechanical_effect', () => {
+    // Match the named export Set literal and check the field appears as a
+    // string element. Substring-of-name false positives blocked by the
+    // surrounding quotes.
+    const setStart = src.indexOf('EQUIPMENT_CATALOGUE_UPDATABLE_FIELDS');
+    expect(setStart).toBeGreaterThan(-1);
+    const block = src.slice(setStart, src.indexOf(';', setStart));
+    expect(block).toMatch(/['"]mechanical_effect['"]/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Client wiring — admin sidebar, view module, dispatch
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#873 — admin sidebar wires Equipment Catalogue domain', () => {
+  it('admin.html declares the sidebar button with data-domain="equipment-catalogue"', () => {
+    const src = read('public/admin.html');
+    expect(src).toMatch(/data-domain="equipment-catalogue"[^>]*>\s*Equipment Catalogue/);
+  });
+
+  it('admin.html declares the domain section with id="d-equipment-catalogue"', () => {
+    const src = read('public/admin.html');
+    expect(src).toMatch(/<section\s+id="d-equipment-catalogue"\s+class="domain"/);
+    expect(src).toMatch(/id="equipment-catalogue-content"/);
+  });
+
+  it('admin.js imports initEquipmentCatalogueAdmin', () => {
+    const src = read('public/js/admin.js');
+    expect(src).toMatch(/import\s+\{\s*initEquipmentCatalogueAdmin\s*\}\s+from\s+['"]\.\/admin\/equipment-catalogue-admin\.js['"]/);
+  });
+
+  it('admin.js dispatches the equipment-catalogue domain in switchDomain', () => {
+    const src = read('public/js/admin.js');
+    expect(src).toMatch(/domain\s*===\s*['"]equipment-catalogue['"]\s*\)\s*initEquipmentCatalogueAdmin/);
+  });
+});
+
+describe('#873 — view module file shape', () => {
+  it('public/js/admin/equipment-catalogue-admin.js exists', () => {
+    expect(exists('public/js/admin/equipment-catalogue-admin.js')).toBe(true);
+  });
+
+  it('exports initEquipmentCatalogueAdmin', () => {
+    const src = read('public/js/admin/equipment-catalogue-admin.js');
+    expect(src).toMatch(/export\s+async\s+function\s+initEquipmentCatalogueAdmin\b/);
+  });
+
+  it('uses apiGet / apiPost / apiPatch / apiRaw (DELETE-with-409 inspection)', () => {
+    const src = read('public/js/admin/equipment-catalogue-admin.js');
+    expect(src).toMatch(/apiGet\(/);
+    expect(src).toMatch(/apiPost\(/);
+    expect(src).toMatch(/apiPatch\(/);
+    expect(src).toMatch(/apiRaw\(['"]DELETE['"]/);
+  });
+
+  it('renders soft duplicate warning at create-time (name + bucket case-insensitive)', () => {
+    const src = read('public/js/admin/equipment-catalogue-admin.js');
+    expect(src).toMatch(/name\s*\|\|\s*['"]['"]\s*\)\.toLowerCase\(\)/);
+    expect(src).toMatch(/values\.name\.toLowerCase\(\)/);
+    expect(src).toMatch(/already exists/);
+  });
+
+  it('fetches /:id/impact for the edit-form banner', () => {
+    const src = read('public/js/admin/equipment-catalogue-admin.js');
+    expect(src).toMatch(/\/api\/equipment_catalogue\/\$\{[^}]+\}\/impact/);
+  });
+
+  it('disables delete control when holders > 0', () => {
+    const src = read('public/js/admin/equipment-catalogue-admin.js');
+    expect(src).toMatch(/holdersCount\s*>\s*0\s*\?\s*['"`]disabled/);
+  });
+
+  it('handles 409 from DELETE by surfacing the API holders payload', () => {
+    const src = read('public/js/admin/equipment-catalogue-admin.js');
+    expect(src).toMatch(/res\.status\s*===\s*409/);
+    expect(src).toMatch(/character_names/);
+  });
+
+  it('bucket selector is immutable in edit mode (delete + recreate to change bucket)', () => {
+    const src = read('public/js/admin/equipment-catalogue-admin.js');
+    expect(src).toMatch(/immutable.*delete \+ recreate/i);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #873. Browser-side CRUD over the Mongo-backed equipment_catalogue established by ECM-1 + the \`mechanical_effect\` schema-widen Khepri folded into this story after ECM-2 surfaced the gap.

## What's in the box

| Layer | Change |
|---|---|
| Schema | `mechanical_effect` added to `equipment_catalogue.schema.js` properties (nullable string) + the `EQUIPMENT_CATALOGUE_UPDATABLE_FIELDS` allowlist. Per epic Non-Goal "no state-enum per-bucket validation", the field is accepted across all buckets; admin UI scopes it to assets via `BUCKET_FIELDS`. |
| HTML | New sidebar button + domain section (`id="d-equipment-catalogue"`), placed adjacent to Rule Data / Rules Engine. |
| JS view | `public/js/admin/equipment-catalogue-admin.js` — single entry point `initEquipmentCatalogueAdmin(container, chars)`. List view with filter / search / sort, create form with soft duplicate warning, edit form with impact banner, delete control gated on holders count. |
| CSS | ~150 lines in `admin-layout.css` reusing existing tokens (`--surf*`, `--bdr*`, `--gold*`, `--crim*`, `--green*`). |
| Tests | 13 static-analysis guards + 1 PATCH-happy-path for the schema-widen on the ECM-1 file. |

## UX (per epic D4 / D5 / D6)

- **List view** — bucket filter, name search (case-insensitive substring), sortable by name / bucket / availability, ascending/descending toggle. Each row: name / bucket tag / availability / **holders count** / Edit + Delete actions.
- **Holders count** — derived **client-side** from the character set (`chars[].equipment[].catalogue_id`). Pre-ECM-3 the slug→ObjectId mismatch makes this 0 for everything; same behaviour as the server's `/:id/impact`. ECM-3 wires up real numbers.
- **Create form** — bucket selector reveals bucket-specific fields. **Soft duplicate warning** at save: case-insensitive name match in the same bucket → confirm dialog with override option per epic D6. Non-blocking.
- **Edit form** — same field set + **impact warning banner** sourced from `GET /api/equipment_catalogue/:id/impact` (ECM-1's endpoint). Bucket is immutable in edit mode; label tells the ST "delete + recreate to change bucket".
- **Delete control** — UI-disabled with explanatory tooltip when holders > 0. API enforces the hard-block (409) regardless. UI catches the 409 response and renders the holder names so the ST sees where to clean up.

## Holders gate — two layers, same answer

Client gate (disabled button) is convenience. Server gate (409 from ECM-1) is correctness. The UI's `onDelete` uses `apiRaw('DELETE', ...)` specifically so it can inspect the 409 response body for `holders` + `character_names` rather than letting `apiDelete`'s throw lose them.

## Schema-widen rationale (folded in per Khepri)

\`mechanical_effect\` is in the static EQUIPMENT_CATALOGUE source on asset entries. ECM-1's properties block omitted it. Without the widen, PATCH from this admin UI would silently drop edits to the field (`EQUIPMENT_CATALOGUE_UPDATABLE_FIELDS` allowlist strips unknown keys). Fixing in ECM-6 is the right positioning:
1. The field becomes user-visible HERE.
2. ECM-1 + ECM-2 are already merged — retroactive PRs would be churn.
3. ECM-3's backfill runs against asset documents; preserving the field end-to-end means widening the allowlist BEFORE any ST touches the catalogue admin.

## What this PR does NOT do

- **ECM-4 / ECM-5** (dropdown clients in DT form + character editor) — still consume the static module. The WS `broadcastCatalogueUpdate` is wired in ECM-1's route, but no client listens yet. Those stories switch the consumers.
- **ECM-3** (character backfill) — until it ships, holders count is 0 for all items and the delete gate is permissive. That's the intended sequencing.
- **Bulk actions / undo / soft-delete** — out of epic scope.

## Verification

\`\`\`
$ cd server && npx vitest run tests/issue-873-ecm-6-admin-sidebar.test.js tests/issue-868-ecm-1-equipment-catalogue-api.test.js
Tests  44 passed (44)

$ npx vitest run                       # full suite
Test Files  4 failed | 132 passed (136)
Tests  1721 passed (1721)
\`\`\`

The 4 file-failures are pre-existing 0-test file-load failures. 0 individual test failures. Note: this worktree branched off dev BEFORE ECM-2 merged, so its baseline test count is 4 less than ECM-2's branch — will rebase if needed at merge.

Parse-check on all touched JS files: OK.

## Test plan

- [x] Vitest — 44 passes (this PR's 14 + ECM-1's 30 including schema-widen)
- [x] `node --check` on all touched JS files — parse OK
- [x] Full suite — 0 new failures
- [ ] Manual browser smoke:
  - Open admin app, click new **Equipment Catalogue** sidebar entry
  - Empty state shows "0 of 0 items" with **+ New item** button
  - Create an asset with \`mechanical_effect: "Confers +1 Resources"\` → appears in list
  - Edit the item → impact banner shows "Held by 0 characters"
  - Try to delete with holders count 0 → 204, item gone
  - Create two items with the same name/bucket → soft duplicate warning fires
- [ ] After ECM-3 lands: holders count populates from the chars array; delete gate kicks in on held items