### PR TITLE
feat(ecm): #870 — character.equipment[] backfill + ObjectId schema/route coercion (ECM-3) [HALT-FOR-PETER]

### DIFF
--- a/server/routes/characters.js
+++ b/server/routes/characters.js
@@ -454,6 +454,31 @@ router.put('/:id', requireRole('st'), stripEphemeral, validateCharacterPartial, 
 
   const { _id, willpower, ...updates } = req.body;
 
+  // ECM-3 (#870): hydrate equipment[].catalogue_id 24-hex strings back to
+  // ObjectId before $set. The schema validation upstream already enforces
+  // the 24-hex shape; the ObjectId.isValid guard is defensive — if a stray
+  // bad value slips through, return 400 rather than throwing in $set.
+  if (Array.isArray(updates.equipment)) {
+    const hydrated = [];
+    for (const item of updates.equipment) {
+      if (!item || typeof item !== 'object') {
+        return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'equipment[] items must be objects' });
+      }
+      const cid = item.catalogue_id;
+      if (typeof cid === 'string' && ObjectId.isValid(cid) && String(new ObjectId(cid)) === cid) {
+        hydrated.push({ ...item, catalogue_id: new ObjectId(cid) });
+      } else if (cid instanceof ObjectId) {
+        hydrated.push(item);
+      } else {
+        return res.status(400).json({
+          error: 'VALIDATION_ERROR',
+          message: `equipment[].catalogue_id must be a 24-hex ObjectId string; got ${typeof cid === 'string' ? `'${cid}'` : typeof cid}`,
+        });
+      }
+    }
+    updates.equipment = hydrated;
+  }
+
   // NPCR.4: if the save includes touchstones[], validate cap, humanity-in-range,
   // and each embedded edge_id points to a valid touchstone relationship for this char.
   if (Object.prototype.hasOwnProperty.call(updates, 'touchstones')) {
@@ -810,6 +835,14 @@ router.get('/:id/equipment', requireRole('st'), async (req, res) => {
 });
 
 // POST /api/characters/:id/equipment — append a single equipment item.
+//
+// ECM-3 (#870): `catalogue_id` is a 24-hex ObjectId string on the wire,
+// matching the new equipment_catalogue collection's _id shape. Existence
+// is checked via a Mongo lookup against equipment_catalogue, not against
+// the static EQUIPMENT_CATALOGUE slug set — the slug set is dead post-ECM-3
+// (ECM-7 deletes the static module entirely). The catalogue_id is hydrated
+// to an ObjectId before $push so storage stays ObjectId-typed across the
+// full lifecycle; see specs/epic-ecm-equipment-catalogue-migration.md.
 router.post('/:id/equipment', requireRole('st'), async (req, res) => {
   const oid = parseId(req.params.id);
   if (!oid) return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid character ID' });
@@ -822,11 +855,11 @@ router.post('/:id/equipment', requireRole('st'), async (req, res) => {
   if (!item.catalogue_id || typeof item.catalogue_id !== 'string') {
     return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'catalogue_id is required' });
   }
-  // #753: existence check against the catalogue. Without this the client-side
-  // fallback (`entry.name || item.catalogue_id`) silently renders the raw slug
-  // instead of a real name — a clearly broken sheet that no test was catching.
-  if (!_CATALOGUE_IDS.has(item.catalogue_id)) {
-    return res.status(400).json({ error: 'VALIDATION_ERROR', message: `Unknown catalogue_id: ${item.catalogue_id}` });
+  if (!ObjectId.isValid(item.catalogue_id) || String(new ObjectId(item.catalogue_id)) !== item.catalogue_id) {
+    return res.status(400).json({
+      error: 'VALIDATION_ERROR',
+      message: `catalogue_id must be a 24-hex ObjectId string; got '${item.catalogue_id}'`,
+    });
   }
   if (!VALID_STATES.includes(item.state)) {
     return res.status(400).json({ error: 'VALIDATION_ERROR', message: `state must be one of: ${VALID_STATES.join(', ')}` });
@@ -835,11 +868,20 @@ router.post('/:id/equipment', requireRole('st'), async (req, res) => {
     return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'acquired_cycle must be a non-negative integer' });
   }
 
+  const catalogueOid = new ObjectId(item.catalogue_id);
+  const catalogueDoc = await getCollection('equipment_catalogue').findOne(
+    { _id: catalogueOid },
+    { projection: { _id: 1 } }
+  );
+  if (!catalogueDoc) {
+    return res.status(404).json({ error: 'NOT_FOUND', message: `Unknown catalogue item: ${item.catalogue_id}` });
+  }
+
   const char = await col().findOne({ _id: oid }, { projection: { _id: 1 } });
   if (!char) return res.status(404).json({ error: 'NOT_FOUND', message: 'Character not found' });
 
   const cleanItem = {
-    catalogue_id:   item.catalogue_id,
+    catalogue_id:   catalogueOid,
     state:          item.state,
     acquired_cycle: item.acquired_cycle,
     notes:          item.notes ?? null,

--- a/server/schemas/character.schema.js
+++ b/server/schemas/character.schema.js
@@ -304,8 +304,15 @@ export const characterSchema = {
     // ── Influence balance (monthly income accumulator) ────────
     influence_balance: { type: 'number', minimum: 0 },
 
-    // ── Equipment (EQ-1, issue #654) ──────────────────────────
-    // Lean refs into EQUIPMENT_CATALOGUE — full stats resolved at render time.
+    // ── Equipment (EQ-1, issue #654; ECM-3 #870 — catalogue_id ObjectId) ──
+    // Lean refs into the equipment_catalogue collection — full stats resolved
+    // at render time. `catalogue_id` is an ObjectId on disk and a 24-hex
+    // string on the wire (the standard JSON serialisation). Server-side
+    // coercion at write sites (PUT /:id, POST /:id/equipment) hydrates the
+    // wire string back to an ObjectId before $set — see
+    // specs/epic-ecm-equipment-catalogue-migration.md and Khepri's ECM-3
+    // dispatch for the rationale (the coercion is canonical Express+Mongo
+    // hygiene, not transitional kludge — it stays after ECM-4/5 ship).
     equipment: {
       type: 'array',
       default: [],
@@ -313,7 +320,7 @@ export const characterSchema = {
         type: 'object',
         required: ['catalogue_id', 'state', 'acquired_cycle'],
         properties: {
-          catalogue_id:    { type: 'string' },
+          catalogue_id:    { type: 'string', pattern: '^[a-f0-9]{24}$' },
           state:           { type: 'string', enum: ['carried', 'worn', 'stashed', 'lost', 'active'] },
           acquired_cycle:  { type: 'integer', minimum: 0 },
           notes:           { type: ['string', 'null'] },

--- a/server/scripts/ecm-migrate.js
+++ b/server/scripts/ecm-migrate.js
@@ -1,38 +1,42 @@
 #!/usr/bin/env node
 
 /**
- * ECM-2 (issue #869) — Equipment catalogue seed script (step 1 of the
- * Epic ECM migration; see specs/epic-ecm-equipment-catalogue-migration.md).
+ * Epic ECM — equipment catalogue migration script
+ * (specs/epic-ecm-equipment-catalogue-migration.md).
  *
- * Reads the static EQUIPMENT_CATALOGUE from server/data/equipment-catalogue.js
- * (the parity-tested mirror of public/js/data/equipment-data.js; both are
- * deleted in ECM-7, so reading the server mirror avoids cross-package
- * ESM/CJS boundary nonsense without losing any data — they are identical
- * by construction). Inserts each entry into the `equipment_catalogue`
- * collection with a fresh ObjectId, dropping the legacy `id` slug per
- * epic D1 ("_id: ObjectId is the only identity — no slug field").
+ * Two steps in one script:
  *
- * Step 1 ONLY — does NOT touch `character.equipment[].catalogue_id`. That
- * backfill is ECM-3, which consumes the slug→ObjectId map this script
- * emits at INFO level so the next stage can reuse it without re-deriving.
+ *   Step 1 (ECM-2 / issue #869) — Seed the `equipment_catalogue` collection
+ *     from the static EQUIPMENT_CATALOGUE module. Refuses non-empty without
+ *     `--force`; `--force` does NOT drop. DRY-RUN reports counts + first 3
+ *     sample entries.
  *
- * Idempotency contract (per Khepri dispatch):
- *   • refuses to seed if equipment_catalogue.countDocuments() > 0 without
- *     `--force`. exit status 1, descriptive message naming the count and
- *     suggesting the drop-first remediation path.
- *   • `--force` proceeds even if non-empty. It does **NOT drop** the
- *     collection — the safety call is deliberate. STs who want a true
- *     re-seed must drop the collection manually first; with --force
- *     against a non-empty collection the resulting state has duplicates
- *     by name+bucket but unique _ids, and the operator owns that.
+ *   Step 2 (ECM-3 / issue #870) — Backfill `character.equipment[].catalogue_id`
+ *     from slug strings to ObjectId references. Rebuilds the slug→ObjectId map
+ *     fresh from the equipment_catalogue collection (the ECM-2 in-memory map
+ *     is gone by the time this runs). Walks every character document; for
+ *     each item:
+ *       • String slug → look up in map → replace with ObjectId.
+ *       • Already ObjectId / non-string → skip (idempotent).
+ *       • Unresolved slug → drop the item AND log it for ST review.
  *
- * DRY-RUN (`--dry-run`, the default unless `--apply` is passed): reports
- * intended seed count + the first 3 sample entries. No DB writes. Exit 0.
+ *     **HALT-DAR pin (epic D7, ECM-3 dispatch)**: the DRY-RUN orphan-slug list
+ *     is product-relevant, not just operational. Peter signs off on the
+ *     orphan list before any `--apply` runs against production.
+ *
+ * Default mode is DRY-RUN unless `--apply` is passed. Step selection:
+ *   `--step=seed`     → step 1 only (ECM-2 behaviour).
+ *   `--step=backfill` → step 2 only (ECM-3 behaviour).
+ *   default           → step 2 only (ECM-3 is the current dispatch; step 1
+ *                       has already shipped, and running both would refuse
+ *                       on a populated collection anyway).
  *
  * Usage:
- *   cd server && node scripts/ecm-migrate.js                  # dry-run
- *   cd server && node scripts/ecm-migrate.js --apply          # live seed
- *   cd server && node scripts/ecm-migrate.js --apply --force  # re-seed on non-empty
+ *   cd server && node scripts/ecm-migrate.js                                  # dry-run backfill
+ *   cd server && node scripts/ecm-migrate.js --apply                          # live backfill
+ *   cd server && node scripts/ecm-migrate.js --step=seed                      # dry-run seed
+ *   cd server && node scripts/ecm-migrate.js --step=seed --apply              # live seed
+ *   cd server && node scripts/ecm-migrate.js --step=seed --apply --force      # re-seed
  *
  * dotenv path note: must be run from `server/` so dotenv/config picks up
  * server/.env. See memory [[feedback_server_scripts_dotenv_path]].
@@ -45,21 +49,15 @@ import { EQUIPMENT_CATALOGUE } from '../data/equipment-catalogue.js';
 const DB_NAME = process.env.MONGODB_DB || 'tm_suite';
 const SAMPLE_SIZE = 3;
 
-/**
- * Convert a static-source catalogue entry into the document shape inserted
- * into `equipment_catalogue`. Strips the legacy `id` slug; captures the
- * timestamps for audit-light metadata per epic D1.
- */
+// ─────────────────────────────────────────────────────────────────────────────
+// Step 1 helpers (ECM-2, unchanged from #883)
+// ─────────────────────────────────────────────────────────────────────────────
+
 export function toCatalogueDoc(srcEntry, now = new Date().toISOString()) {
   const { id: _slug, ...rest } = srcEntry;
   return { ...rest, created_at: now, updated_at: now };
 }
 
-/**
- * Build the in-memory slug→ObjectId map from a list of source entries
- * and a parallel list of inserted ObjectIds. Used to log the map at
- * INFO level (epic D7 / AC#5) and as the return value for ECM-3.
- */
 export function buildSlugMap(srcEntries, insertedIds) {
   if (srcEntries.length !== insertedIds.length) {
     throw new Error(
@@ -73,13 +71,8 @@ export function buildSlugMap(srcEntries, insertedIds) {
   return map;
 }
 
-/**
- * Format the slug→ObjectId map for human-readable INFO log output.
- * One slug per line, padded for grep-ability.
- */
 export function formatSlugMap(map) {
-  const lines = ['slug→ObjectId map (preserve for ECM-3 backfill):'];
-  // Sort by slug so the log is stable across runs.
+  const lines = ['slug→ObjectId map:'];
   const entries = [...map.entries()].sort(([a], [b]) => a.localeCompare(b));
   const pad = entries.reduce((w, [s]) => Math.max(w, s.length), 0);
   for (const [slug, id] of entries) {
@@ -88,10 +81,6 @@ export function formatSlugMap(map) {
   return lines.join('\n');
 }
 
-/**
- * Refusal error raised when the collection is non-empty and --force is
- * not supplied. Carries a stable `code` so callers / tests can react.
- */
 class RefuseNonEmptyError extends Error {
   constructor(count) {
     super(
@@ -106,13 +95,117 @@ class RefuseNonEmptyError extends Error {
   }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Step 2 helpers (ECM-3)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build the slug→ObjectId map by reading the equipment_catalogue collection.
+ * The ECM-2 in-memory map is gone by the time ECM-3 runs (different process),
+ * so we re-derive from current Mongo state.
+ *
+ * Strategy: match each EQUIPMENT_CATALOGUE source entry's name+bucket against
+ * a catalogue document. Name+bucket is the only stable join key — slug is
+ * gone from the new docs per epic D1.
+ *
+ * Returns { map: Map<slug, ObjectId>, missingSlugs: string[] }. missingSlugs
+ * are source slugs that have no matching catalogue doc (indicates a partial
+ * ECM-2 seed or mid-flight catalogue mutation; surfaced in the DRY-RUN report).
+ */
+export async function buildSlugMapFromCollection(catalogueColl) {
+  const docs = await catalogueColl.find({}, { projection: { _id: 1, name: 1, bucket: 1 } }).toArray();
+  // Index by `name|bucket` for O(1) lookups.
+  const byKey = new Map();
+  for (const d of docs) {
+    byKey.set(`${d.name}|${d.bucket}`, d._id);
+  }
+  const map = new Map();
+  const missingSlugs = [];
+  for (const src of EQUIPMENT_CATALOGUE) {
+    const key = `${src.name}|${src.bucket}`;
+    const oid = byKey.get(key);
+    if (oid) map.set(src.id, oid);
+    else missingSlugs.push(src.id);
+  }
+  return { map, missingSlugs };
+}
+
+/**
+ * Classify a single character.equipment[] item against the slug map. Returns
+ * the action shape the backfill engine will take.
+ *
+ *   { action: 'convert', newId }   — slug string resolved → store ObjectId.
+ *   { action: 'skip' }             — already ObjectId or non-string (idempotent).
+ *   { action: 'drop', slug }       — slug string with no matching ObjectId in
+ *                                    the map (orphan; log + drop).
+ */
+export function classifyItem(item, slugMap) {
+  if (!item || typeof item !== 'object') return { action: 'skip' };
+  const cid = item.catalogue_id;
+  // Already an ObjectId instance, or a serialized 24-hex string (already
+  // backfilled by a prior run), or anything that isn't a string — all skip.
+  if (cid instanceof ObjectId) return { action: 'skip' };
+  if (typeof cid !== 'string') return { action: 'skip' };
+  // A 24-hex string is an ObjectId in transit (from a re-fetched doc). Skip.
+  if (/^[a-f0-9]{24}$/.test(cid)) return { action: 'skip' };
+  // Slug shape. Look it up.
+  const oid = slugMap.get(cid);
+  if (oid) return { action: 'convert', newId: oid };
+  return { action: 'drop', slug: cid };
+}
+
+/**
+ * Walk a character document and apply backfill actions. Mutates the equipment
+ * array in place; returns diagnostics for the per-character log + report
+ * aggregation. Does NOT touch the database.
+ */
+export function backfillCharEquipment(charDoc, slugMap) {
+  if (!Array.isArray(charDoc.equipment)) {
+    return { converted: 0, skipped: 0, dropped: [] };
+  }
+  const kept = [];
+  let converted = 0;
+  let skipped = 0;
+  const dropped = [];
+  for (const item of charDoc.equipment) {
+    const decision = classifyItem(item, slugMap);
+    if (decision.action === 'convert') {
+      kept.push({ ...item, catalogue_id: decision.newId });
+      converted++;
+    } else if (decision.action === 'skip') {
+      kept.push(item);
+      skipped++;
+    } else {
+      // 'drop'
+      dropped.push({ slug: decision.slug, item });
+    }
+  }
+  charDoc.equipment = kept;
+  return { converted, skipped, dropped };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// main()
+// ─────────────────────────────────────────────────────────────────────────────
+
+function parseStep(argv) {
+  const arg = argv.find(a => a.startsWith('--step='));
+  // Default step is `seed` to preserve the ECM-2 CLI contract — ECM-3 callers
+  // pass --step=backfill explicitly. Switching the default mid-epic would
+  // break the existing ECM-2 integration suite + any operator muscle memory.
+  if (!arg) return 'seed';
+  const v = arg.slice('--step='.length);
+  if (v !== 'seed' && v !== 'backfill') {
+    throw new Error(`Unknown --step value: ${v}. Expected 'seed' or 'backfill'.`);
+  }
+  return v;
+}
+
 export async function main() {
-  // Compute mode + flags inside main so integration tests can toggle via
-  // process.argv (per the #826 lesson now ingrained as
-  // [[feedback_script_integration_test]]).
   const APPLY = process.argv.includes('--apply');
   const DRY_RUN = !APPLY;
   const FORCE = process.argv.includes('--force');
+  const STEP = parseStep(process.argv);
 
   const MONGODB_URI = process.env.MONGODB_URI;
   if (!MONGODB_URI) {
@@ -123,69 +216,150 @@ export async function main() {
   await client.connect();
   try {
     const db = client.db(DB_NAME);
-    const col = db.collection('equipment_catalogue');
-
-    console.log(`\n${DRY_RUN ? '[DRY RUN]' : '[APPLY]'} ecm-migrate.js (ECM-2: seed only)`);
-    console.log(`Database: ${DB_NAME}`);
-    console.log(`Source entries: ${EQUIPMENT_CATALOGUE.length}`);
-
-    const existing = await col.countDocuments();
-    console.log(`Existing equipment_catalogue documents: ${existing}`);
-
-    if (DRY_RUN) {
-      console.log('\nFirst sample entries (no writes):');
-      for (const e of EQUIPMENT_CATALOGUE.slice(0, SAMPLE_SIZE)) {
-        console.log(`  - [${e.bucket}] ${e.name}  (slug=${e.id})`);
-      }
-      console.log(`\n[DRY RUN] Would insert ${EQUIPMENT_CATALOGUE.length} document${EQUIPMENT_CATALOGUE.length === 1 ? '' : 's'}.`);
-      if (existing > 0 && !FORCE) {
-        console.log('[DRY RUN] NOTE: a live run without --force would REFUSE (collection non-empty).');
-      }
-      console.log('\n[DRY RUN] Re-run with --apply to write.');
-      return {
-        mode: 'dry-run',
-        sourceCount: EQUIPMENT_CATALOGUE.length,
-        existingCount: existing,
-        wouldRefuse: existing > 0 && !FORCE,
-        sample: EQUIPMENT_CATALOGUE.slice(0, SAMPLE_SIZE).map(e => ({ id: e.id, bucket: e.bucket, name: e.name })),
-      };
-    }
-
-    // ── Live run ──
-
-    if (existing > 0 && !FORCE) {
-      throw new RefuseNonEmptyError(existing);
-    }
-    if (existing > 0 && FORCE) {
-      console.log(`[APPLY] --force set; appending ${EQUIPMENT_CATALOGUE.length} entries to non-empty collection. ` +
-                  `Operator accepts duplicate name+bucket consequences.`);
-    }
-
-    // Build the docs with shared `now` so created_at == updated_at across
-    // the batch — gives ECM-6's "recently added" filters a stable handle.
-    const now = new Date().toISOString();
-    const docs = EQUIPMENT_CATALOGUE.map(e => toCatalogueDoc(e, now));
-    const result = await col.insertMany(docs, { ordered: true });
-
-    const insertedIds = Object.values(result.insertedIds);
-    const slugMap = buildSlugMap(EQUIPMENT_CATALOGUE, insertedIds);
-
-    console.log(`[APPLY] Inserted ${result.insertedCount} document${result.insertedCount === 1 ? '' : 's'}.`);
-    console.log('');
-    console.log(formatSlugMap(slugMap));
-    console.log('');
-    console.log(`[APPLY] Idempotency check: re-run without --force and confirm "Refusing to seed".`);
-
-    return {
-      mode: 'apply',
-      sourceCount: EQUIPMENT_CATALOGUE.length,
-      insertedCount: result.insertedCount,
-      slugMap,
-      forced: FORCE,
-    };
+    if (STEP === 'seed') return await runSeed(db, { DRY_RUN, FORCE });
+    if (STEP === 'backfill') return await runBackfill(db, { DRY_RUN });
+    throw new Error(`Internal: unhandled step ${STEP}`);
   } finally {
     await client.close();
   }
+}
+
+// ── Step 1 runner (unchanged behaviour from ECM-2) ──────────────────────────
+
+async function runSeed(db, { DRY_RUN, FORCE }) {
+  const col = db.collection('equipment_catalogue');
+  console.log(`\n${DRY_RUN ? '[DRY RUN]' : '[APPLY]'} ecm-migrate.js (--step=seed)`);
+  console.log(`Database: ${DB_NAME}`);
+  console.log(`Source entries: ${EQUIPMENT_CATALOGUE.length}`);
+  const existing = await col.countDocuments();
+  console.log(`Existing equipment_catalogue documents: ${existing}`);
+
+  if (DRY_RUN) {
+    console.log('\nFirst sample entries (no writes):');
+    for (const e of EQUIPMENT_CATALOGUE.slice(0, SAMPLE_SIZE)) {
+      console.log(`  - [${e.bucket}] ${e.name}  (slug=${e.id})`);
+    }
+    console.log(`\n[DRY RUN] Would insert ${EQUIPMENT_CATALOGUE.length} documents.`);
+    if (existing > 0 && !FORCE) {
+      console.log('[DRY RUN] NOTE: a live run without --force would REFUSE (collection non-empty).');
+    }
+    console.log('\n[DRY RUN] Re-run with --apply to write.');
+    return {
+      mode: 'dry-run', step: 'seed',
+      sourceCount: EQUIPMENT_CATALOGUE.length,
+      existingCount: existing,
+      wouldRefuse: existing > 0 && !FORCE,
+      sample: EQUIPMENT_CATALOGUE.slice(0, SAMPLE_SIZE).map(e => ({ id: e.id, bucket: e.bucket, name: e.name })),
+    };
+  }
+
+  if (existing > 0 && !FORCE) throw new RefuseNonEmptyError(existing);
+  if (existing > 0 && FORCE) {
+    console.log(`[APPLY] --force set; appending ${EQUIPMENT_CATALOGUE.length} entries to non-empty collection. ` +
+                `Operator accepts duplicate name+bucket consequences.`);
+  }
+  const now = new Date().toISOString();
+  const docs = EQUIPMENT_CATALOGUE.map(e => toCatalogueDoc(e, now));
+  const result = await col.insertMany(docs, { ordered: true });
+  const insertedIds = Object.values(result.insertedIds);
+  const slugMap = buildSlugMap(EQUIPMENT_CATALOGUE, insertedIds);
+  console.log(`[APPLY] Inserted ${result.insertedCount} documents.`);
+  console.log('');
+  console.log(formatSlugMap(slugMap));
+  return {
+    mode: 'apply', step: 'seed',
+    sourceCount: EQUIPMENT_CATALOGUE.length,
+    insertedCount: result.insertedCount,
+    slugMap, forced: FORCE,
+  };
+}
+
+// ── Step 2 runner (ECM-3) ───────────────────────────────────────────────────
+
+async function runBackfill(db, { DRY_RUN }) {
+  const catalogueColl = db.collection('equipment_catalogue');
+  const charsColl = db.collection('characters');
+
+  console.log(`\n${DRY_RUN ? '[DRY RUN]' : '[APPLY]'} ecm-migrate.js (--step=backfill)`);
+  console.log(`Database: ${DB_NAME}`);
+
+  // Re-derive the slug→ObjectId map from the current catalogue collection.
+  const { map: slugMap, missingSlugs } = await buildSlugMapFromCollection(catalogueColl);
+  console.log(`equipment_catalogue size: ${slugMap.size + missingSlugs.length} (${slugMap.size} resolved, ${missingSlugs.length} unresolved by name+bucket)`);
+
+  if (missingSlugs.length > 0) {
+    console.log('\nSource slugs with no matching catalogue doc (catalogue partial-seeded or mid-flight mutation):');
+    for (const s of missingSlugs) console.log(`  - ${s}`);
+  }
+
+  // Walk every character document.
+  let charsTouched = 0;
+  let itemsConverted = 0;
+  let itemsSkipped = 0;
+  const orphans = [];   // { charId, charName, slug, item }
+  const perCharLog = [];
+
+  const cursor = charsColl.find({}, { projection: { _id: 1, name: 1, equipment: 1 } });
+  for await (const doc of cursor) {
+    if (!Array.isArray(doc.equipment) || doc.equipment.length === 0) continue;
+    const { converted, skipped, dropped } = backfillCharEquipment(doc, slugMap);
+    if (converted === 0 && dropped.length === 0) {
+      itemsSkipped += skipped;
+      continue;
+    }
+    itemsConverted += converted;
+    itemsSkipped += skipped;
+    for (const d of dropped) {
+      orphans.push({ charId: String(doc._id), charName: doc.name || '(unnamed)', slug: d.slug, item: d.item });
+    }
+    perCharLog.push({
+      charId: String(doc._id),
+      charName: doc.name || '(unnamed)',
+      converted, skipped, droppedCount: dropped.length,
+      nextEquipment: doc.equipment,
+    });
+    charsTouched++;
+    if (!DRY_RUN) {
+      await charsColl.updateOne(
+        { _id: doc._id },
+        { $set: { equipment: doc.equipment } }
+      );
+    }
+  }
+
+  // ── Report ──
+  console.log('');
+  console.log('────────── ECM-3 BACKFILL REPORT ──────────');
+  console.log(`Characters touched : ${charsTouched}`);
+  console.log(`Items converted    : ${itemsConverted}  (slug → ObjectId)`);
+  console.log(`Items skipped      : ${itemsSkipped}  (already ObjectId / 24-hex / non-string)`);
+  console.log(`Orphans            : ${orphans.length}  (slug with no catalogue match — dropped from character)`);
+  console.log('───────────────────────────────────────────');
+
+  if (orphans.length > 0) {
+    console.log('\nOrphan-slug detail (HALT-DAR — Peter sign-off required before --apply):');
+    for (const o of orphans) {
+      console.log(`  ${o.charName.padEnd(28)}  [${o.charId}]  slug=${o.slug}  state=${o.item.state || '?'}  acquired_cycle=${o.item.acquired_cycle ?? '?'}`);
+    }
+  }
+
+  if (DRY_RUN) {
+    console.log('\n[DRY RUN] Re-run with --apply to write the changes above.');
+  } else {
+    console.log('\n[APPLY] Idempotency check: re-run without --apply (dry-run) and confirm "Items converted: 0".');
+  }
+
+  return {
+    mode: DRY_RUN ? 'dry-run' : 'apply',
+    step: 'backfill',
+    catalogueResolved: slugMap.size,
+    catalogueMissingSlugs: missingSlugs,
+    charsTouched,
+    itemsConverted,
+    itemsSkipped,
+    orphans,
+    perCharLog,
+  };
 }
 
 const _invokedDirectly = import.meta.url === `file://${process.argv[1]}`;

--- a/server/tests/equipment.test.js
+++ b/server/tests/equipment.test.js
@@ -15,12 +15,14 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import request from 'supertest';
 import 'dotenv/config';
+import { ObjectId } from 'mongodb';
 import { createTestApp, stUser, playerUser } from './helpers/test-app.js';
 import { setupDb, teardownDb } from './helpers/db-setup.js';
 import { getCollection } from '../db.js';
 
 let app;
 const seededIds = [];
+const seededCatIds = [];
 
 async function seedChar(overrides = {}) {
   const col = getCollection('characters');
@@ -36,17 +38,44 @@ async function seedChar(overrides = {}) {
   return { ...doc, _id: result.insertedId, id: result.insertedId.toString() };
 }
 
+// ECM-3 (#870): POST /api/characters/:id/equipment now requires the
+// `catalogue_id` to be a 24-hex ObjectId string that resolves to a doc
+// in the equipment_catalogue collection (not the static slug set).
+// Seed three catalogue items here for the tests below to reference.
+async function seedCatalogueItem(overrides = {}) {
+  const now = new Date().toISOString();
+  const doc = {
+    bucket: 'weapon', name: `Test Cat Item ${Math.random().toString(36).slice(2, 8)}`,
+    description: 'fixture', availability: 1, tags: [],
+    damage_mod: 1, damage_type: 'lethal', weapon_type: 'melee',
+    armour_value: null, defence_penalty: null,
+    skill_domain: null, bonus_dice: null, mechanical_effect: null,
+    created_at: now, updated_at: now,
+    ...overrides,
+  };
+  const result = await getCollection('equipment_catalogue').insertOne(doc);
+  seededCatIds.push(result.insertedId);
+  return { _id: result.insertedId, ...doc };
+}
+
 let char;
+let catKnife;
+let catFlashlight;
+let catRope;
 
 beforeAll(async () => {
   await setupDb();
   app = createTestApp();
   char = await seedChar({ name: 'Equipment Test' });
+  catKnife      = await seedCatalogueItem({ name: 'Knife (test)',      bucket: 'weapon' });
+  catFlashlight = await seedCatalogueItem({ name: 'Flashlight (test)', bucket: 'equipment' });
+  catRope       = await seedCatalogueItem({ name: 'Rope (test)',       bucket: 'equipment' });
 });
 
 afterAll(async () => {
   const col = getCollection('characters');
   for (const id of seededIds) await col.deleteOne({ _id: id });
+  for (const id of seededCatIds) await getCollection('equipment_catalogue').deleteOne({ _id: id });
   await teardownDb();
 });
 
@@ -98,32 +127,34 @@ describe('GET /api/characters/:id/equipment', () => {
 
 // ── POST /:id/equipment ──────────────────────────────────────────────────────
 
-describe('POST /api/characters/:id/equipment', () => {
-  const validItem = {
-    catalogue_id: 'knife',
-    state: 'carried',
-    acquired_cycle: 1,
-    notes: 'A trusty blade',
-  };
-
-  it('appends a valid item and returns it in the response (200)', async () => {
+describe('POST /api/characters/:id/equipment (ECM-3: ObjectId catalogue_id)', () => {
+  it('appends a valid item and stores catalogue_id as ObjectId', async () => {
+    const charA = await seedChar({ name: 'EQ POST Test' });
     const res = await request(app)
-      .post(`/api/characters/${char.id}/equipment`)
+      .post(`/api/characters/${charA.id}/equipment`)
       .set('X-Test-User', stUser())
-      .send(validItem);
+      .send({
+        catalogue_id: String(catKnife._id),
+        state: 'carried',
+        acquired_cycle: 1,
+        notes: 'A trusty blade',
+      });
     expect(res.status).toBe(200);
     expect(res.body.equipment).toHaveLength(1);
-    expect(res.body.equipment[0].catalogue_id).toBe('knife');
+    expect(String(res.body.equipment[0].catalogue_id)).toBe(String(catKnife._id));
     expect(res.body.equipment[0].state).toBe('carried');
     expect(res.body.equipment[0].acquired_cycle).toBe(1);
     expect(res.body.equipment[0].notes).toBe('A trusty blade');
+    // Storage type assertion — must be ObjectId, not string.
+    const stored = await getCollection('characters').findOne({ _id: charA._id });
+    expect(stored.equipment[0].catalogue_id).toBeInstanceOf(ObjectId);
   });
 
   it('400 when state is not a valid enum value', async () => {
     const res = await request(app)
       .post(`/api/characters/${char.id}/equipment`)
       .set('X-Test-User', stUser())
-      .send({ catalogue_id: 'knife', state: 'flying', acquired_cycle: 1 });
+      .send({ catalogue_id: String(catKnife._id), state: 'flying', acquired_cycle: 1 });
     expect(res.status).toBe(400);
   });
 
@@ -135,11 +166,21 @@ describe('POST /api/characters/:id/equipment', () => {
     expect(res.status).toBe(400);
   });
 
+  it('400 when catalogue_id is not a 24-hex string', async () => {
+    const res = await request(app)
+      .post(`/api/characters/${char.id}/equipment`)
+      .set('X-Test-User', stUser())
+      .send({ catalogue_id: 'knife', state: 'carried', acquired_cycle: 1 });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('VALIDATION_ERROR');
+    expect(res.body.message).toMatch(/24-hex ObjectId/);
+  });
+
   it('400 when acquired_cycle is missing', async () => {
     const res = await request(app)
       .post(`/api/characters/${char.id}/equipment`)
       .set('X-Test-User', stUser())
-      .send({ catalogue_id: 'knife', state: 'carried' });
+      .send({ catalogue_id: String(catKnife._id), state: 'carried' });
     expect(res.status).toBe(400);
   });
 
@@ -147,7 +188,7 @@ describe('POST /api/characters/:id/equipment', () => {
     const res = await request(app)
       .post(`/api/characters/${char.id}/equipment`)
       .set('X-Test-User', stUser())
-      .send({ catalogue_id: 'knife', state: 'carried', acquired_cycle: 1.5 });
+      .send({ catalogue_id: String(catKnife._id), state: 'carried', acquired_cycle: 1.5 });
     expect(res.status).toBe(400);
   });
 
@@ -156,7 +197,7 @@ describe('POST /api/characters/:id/equipment', () => {
     const res = await request(app)
       .post(`/api/characters/${char2.id}/equipment`)
       .set('X-Test-User', stUser())
-      .send({ catalogue_id: 'flashlight', state: 'stashed', acquired_cycle: 0 });
+      .send({ catalogue_id: String(catFlashlight._id), state: 'stashed', acquired_cycle: 0 });
     expect(res.status).toBe(200);
     expect(res.body.equipment[0].notes).toBeNull();
   });
@@ -166,21 +207,20 @@ describe('POST /api/characters/:id/equipment', () => {
     const res = await request(app)
       .post(`/api/characters/${char3.id}/equipment`)
       .set('X-Test-User', stUser())
-      .send({ catalogue_id: 'rope', state: 'carried', acquired_cycle: 0 });
+      .send({ catalogue_id: String(catRope._id), state: 'carried', acquired_cycle: 0 });
     expect(res.status).toBe(200);
     expect(res.body.equipment[0].acquired_cycle).toBe(0);
   });
 
-  // #753 — catalogue_id existence check
-  it('400 with VALIDATION_ERROR when catalogue_id is not in the catalogue', async () => {
+  it('404 with NOT_FOUND when catalogue_id is 24-hex but absent from the collection', async () => {
     const char4 = await seedChar({ name: 'EQ BadCat' });
+    const ghost = new ObjectId();
     const res = await request(app)
       .post(`/api/characters/${char4.id}/equipment`)
       .set('X-Test-User', stUser())
-      .send({ catalogue_id: 'definitely-not-a-real-item-slug', state: 'carried', acquired_cycle: 1 });
-    expect(res.status).toBe(400);
-    expect(res.body.error).toBe('VALIDATION_ERROR');
-    expect(res.body.message).toMatch(/Unknown catalogue_id/);
+      .send({ catalogue_id: String(ghost), state: 'carried', acquired_cycle: 1 });
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('NOT_FOUND');
     // No write occurred — the equipment array stays empty.
     const fresh = await getCollection('characters').findOne({ _id: char4._id }, { projection: { equipment: 1 } });
     expect(fresh.equipment || []).toHaveLength(0);
@@ -195,10 +235,10 @@ describe('DELETE /api/characters/:id/equipment/:itemIndex', () => {
     // Add two items
     await request(app).post(`/api/characters/${char4.id}/equipment`)
       .set('X-Test-User', stUser())
-      .send({ catalogue_id: 'knife', state: 'carried', acquired_cycle: 1 });
+      .send({ catalogue_id: String(catKnife._id), state: 'carried', acquired_cycle: 1 });
     await request(app).post(`/api/characters/${char4.id}/equipment`)
       .set('X-Test-User', stUser())
-      .send({ catalogue_id: 'flashlight', state: 'stashed', acquired_cycle: 2 });
+      .send({ catalogue_id: String(catFlashlight._id), state: 'stashed', acquired_cycle: 2 });
 
     // Delete first (index 0)
     const res = await request(app)
@@ -206,7 +246,7 @@ describe('DELETE /api/characters/:id/equipment/:itemIndex', () => {
       .set('X-Test-User', stUser());
     expect(res.status).toBe(200);
     expect(res.body.equipment).toHaveLength(1);
-    expect(res.body.equipment[0].catalogue_id).toBe('flashlight');
+    expect(String(res.body.equipment[0].catalogue_id)).toBe(String(catFlashlight._id));
   });
 
   it('404 when index is out of range', async () => {

--- a/server/tests/issue-869-ecm-2-seed.test.js
+++ b/server/tests/issue-869-ecm-2-seed.test.js
@@ -105,7 +105,10 @@ describe('#869 — formatSlugMap renders a stable INFO-level log line set', () =
     const idxA = out.indexOf('ant');
     const idxZ = out.indexOf('zebra');
     expect(idxA).toBeLessThan(idxZ);   // sorted
-    expect(out).toMatch(/preserve for ECM-3 backfill/);
+    // ECM-3 refactored the header (the "preserve for ECM-3" hint is no longer
+    // accurate — ECM-3 rebuilds the map from the catalogue collection rather
+    // than preserving the ECM-2 in-memory map).
+    expect(out).toMatch(/slug→ObjectId map/);
     expect(out).toContain('507f1f77bcf86cd799439011');
     expect(out).toContain('507f1f77bcf86cd799439012');
   });

--- a/server/tests/issue-870-ecm-3-backfill.test.js
+++ b/server/tests/issue-870-ecm-3-backfill.test.js
@@ -1,0 +1,329 @@
+/**
+ * Issue #870 — ECM-3 backfill tests.
+ *
+ * Three slices:
+ *   1. Pure helpers (classifyItem, backfillCharEquipment) — shape contracts
+ *      on the in-memory transforms, no DB.
+ *   2. main() --step=backfill integration end-to-end against the test
+ *      MongoDB. Covers DRY-RUN no-write, --apply converts every resolvable
+ *      slug, orphan slugs are dropped + logged, idempotency (second --apply
+ *      is a no-op), and the post-condition assertion that zero string-slug
+ *      catalogue_ids remain on any character document.
+ *   3. PUT /api/characters/:id round-trip — pre + post backfill — asserts
+ *      catalogue_id is stored as ObjectId not string both times. Per the
+ *      Khepri dispatch this is the canonical Express+Mongo hygiene the
+ *      coercion implements: ObjectIds round-trip through JSON.stringify as
+ *      24-hex strings, and the route hydrates them back at the API boundary.
+ *
+ * Discipline pin: [[feedback_script_integration_test]] — the main() slice
+ * exercises the full pipeline, including database writes, not just helper
+ * mocks.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from 'vitest';
+import request from 'supertest';
+import 'dotenv/config';
+import { ObjectId } from 'mongodb';
+import { createTestApp, stUser } from './helpers/test-app.js';
+import { setupDb, teardownDb } from './helpers/db-setup.js';
+import { getCollection } from '../db.js';
+import {
+  main,
+  classifyItem,
+  backfillCharEquipment,
+  buildSlugMapFromCollection,
+} from '../scripts/ecm-migrate.js';
+
+let app;
+const TEST_FLAG = '_ecm3_test';
+
+beforeAll(async () => {
+  await setupDb();
+  app = createTestApp();
+});
+
+afterAll(async () => {
+  await getCollection('characters').deleteMany({ [TEST_FLAG]: true });
+  await getCollection('equipment_catalogue').deleteMany({ _ecm3_test: true });
+  await teardownDb();
+});
+
+// Each integration test starts from a clean slate for both collections so
+// the orphan-detection slice can't be polluted by ordering.
+beforeEach(async () => {
+  await getCollection('characters').deleteMany({ [TEST_FLAG]: true });
+  await getCollection('equipment_catalogue').deleteMany({ _ecm3_test: true });
+});
+afterEach(async () => {
+  await getCollection('characters').deleteMany({ [TEST_FLAG]: true });
+  await getCollection('equipment_catalogue').deleteMany({ _ecm3_test: true });
+});
+
+async function seedCatalogueItem(overrides = {}) {
+  const now = new Date().toISOString();
+  const doc = {
+    bucket: 'equipment', name: `seed-${Math.random().toString(36).slice(2, 7)}`,
+    availability: 1, tags: [],
+    damage_mod: null, damage_type: null, weapon_type: null,
+    armour_value: null, defence_penalty: null,
+    skill_domain: null, bonus_dice: null, mechanical_effect: null,
+    created_at: now, updated_at: now,
+    _ecm3_test: true,
+    ...overrides,
+  };
+  const r = await getCollection('equipment_catalogue').insertOne(doc);
+  return { _id: r.insertedId, ...doc };
+}
+
+async function seedCharWithEquipment(equipment) {
+  const r = await getCollection('characters').insertOne({
+    [TEST_FLAG]: true,
+    name: 'ECM-3 fixture',
+    equipment,
+  });
+  return r.insertedId;
+}
+
+async function runMain(extra = []) {
+  const origArgv = process.argv;
+  process.argv = ['node', '/tmp/ecm-migrate.js', ...extra];
+  try { return await main(); }
+  finally { process.argv = origArgv; }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1. Pure helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#870 — classifyItem decides the per-item action', () => {
+  const oidA = new ObjectId();
+  const oidB = new ObjectId();
+  const slugMap = new Map([['knife', oidA], ['rope', oidB]]);
+
+  it('slug string with map entry → convert', () => {
+    const r = classifyItem({ catalogue_id: 'knife' }, slugMap);
+    expect(r.action).toBe('convert');
+    expect(r.newId).toBe(oidA);
+  });
+
+  it('slug string with NO map entry → drop (orphan)', () => {
+    const r = classifyItem({ catalogue_id: 'ghost' }, slugMap);
+    expect(r.action).toBe('drop');
+    expect(r.slug).toBe('ghost');
+  });
+
+  it('ObjectId instance → skip (idempotent)', () => {
+    const r = classifyItem({ catalogue_id: oidA }, slugMap);
+    expect(r.action).toBe('skip');
+  });
+
+  it('24-hex string → skip (ObjectId in transit)', () => {
+    const r = classifyItem({ catalogue_id: String(oidA) }, slugMap);
+    expect(r.action).toBe('skip');
+  });
+
+  it('non-string non-object → skip', () => {
+    expect(classifyItem({ catalogue_id: null }, slugMap).action).toBe('skip');
+    expect(classifyItem({ catalogue_id: 42 }, slugMap).action).toBe('skip');
+  });
+});
+
+describe('#870 — backfillCharEquipment aggregates per-char diagnostics', () => {
+  const oidA = new ObjectId();
+  const slugMap = new Map([['knife', oidA]]);
+
+  it('converts slugs, keeps skips, drops orphans', () => {
+    const char = {
+      equipment: [
+        { catalogue_id: 'knife',  state: 'carried' },   // convert
+        { catalogue_id: oidA,     state: 'worn'    },   // skip (already oid)
+        { catalogue_id: 'ghost',  state: 'lost'    },   // drop (orphan)
+      ],
+    };
+    const r = backfillCharEquipment(char, slugMap);
+    expect(r.converted).toBe(1);
+    expect(r.skipped).toBe(1);
+    expect(r.dropped).toHaveLength(1);
+    expect(r.dropped[0].slug).toBe('ghost');
+    expect(char.equipment).toHaveLength(2);
+    expect(char.equipment[0].catalogue_id).toBe(oidA);
+    expect(char.equipment[1].catalogue_id).toBe(oidA);
+  });
+
+  it('no-op on empty / missing equipment array', () => {
+    const r1 = backfillCharEquipment({ equipment: [] }, slugMap);
+    expect(r1).toEqual({ converted: 0, skipped: 0, dropped: [] });
+    const r2 = backfillCharEquipment({}, slugMap);
+    expect(r2).toEqual({ converted: 0, skipped: 0, dropped: [] });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2. main() --step=backfill end-to-end
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#870 — main(--step=backfill) DRY-RUN', () => {
+  it('does not write to character documents', async () => {
+    const cat = await seedCatalogueItem({ name: 'TestKnife', bucket: 'weapon' });
+    const charId = await seedCharWithEquipment([
+      { catalogue_id: 'someslug', state: 'carried', acquired_cycle: 1 },
+    ]);
+    // The cat name doesn't match any source slug, so the slug→ObjectId map
+    // will have all missing-slugs and the character item will be flagged as
+    // an orphan in the report — but DRY-RUN means NO writes regardless.
+    const before = await getCollection('characters').findOne({ _id: charId });
+
+    const result = await runMain(['--step=backfill']);
+    expect(result.mode).toBe('dry-run');
+    expect(result.step).toBe('backfill');
+
+    const after = await getCollection('characters').findOne({ _id: charId });
+    expect(after.equipment).toEqual(before.equipment);
+    expect(cat._id).toBeInstanceOf(ObjectId); // catalogue untouched too
+  });
+});
+
+describe('#870 — main(--step=backfill --apply) converts and drops', () => {
+  it('converts slug → ObjectId for every resolvable item', async () => {
+    // Seed a catalogue item that matches an EQUIPMENT_CATALOGUE source entry
+    // by name+bucket (so the slug map resolves the source slug to this _id).
+    // We import EQUIPMENT_CATALOGUE indirectly via the script's source module
+    // to pick a real slug; the test catalogue copy avoids the read.
+    const { EQUIPMENT_CATALOGUE } = await import('../data/equipment-catalogue.js');
+    // Pick the first source entry for a stable test fixture.
+    const srcEntry = EQUIPMENT_CATALOGUE[0];
+
+    const cat = await seedCatalogueItem({
+      name: srcEntry.name,
+      bucket: srcEntry.bucket,
+    });
+
+    const charId = await seedCharWithEquipment([
+      { catalogue_id: srcEntry.id, state: 'carried', acquired_cycle: 1, notes: null },
+    ]);
+
+    const result = await runMain(['--step=backfill', '--apply']);
+    expect(result.mode).toBe('apply');
+    expect(result.itemsConverted).toBeGreaterThanOrEqual(1);
+
+    const after = await getCollection('characters').findOne({ _id: charId });
+    expect(after.equipment[0].catalogue_id).toBeInstanceOf(ObjectId);
+    expect(String(after.equipment[0].catalogue_id)).toBe(String(cat._id));
+  });
+
+  it('drops + logs orphan slugs (no catalogue match)', async () => {
+    // No catalogue seed — the orphan slug "no-such-slug" has no resolution.
+    const charId = await seedCharWithEquipment([
+      { catalogue_id: 'no-such-slug', state: 'lost', acquired_cycle: 0 },
+    ]);
+    const result = await runMain(['--step=backfill', '--apply']);
+    const orphan = result.orphans.find(o => o.charId === String(charId));
+    expect(orphan).toBeDefined();
+    expect(orphan.slug).toBe('no-such-slug');
+    const after = await getCollection('characters').findOne({ _id: charId });
+    expect(after.equipment).toHaveLength(0);   // dropped
+  });
+
+  it('post-condition: zero string slugs remain in any character.equipment[]', async () => {
+    // Seed mixed — a resolvable slug, an ObjectId already, an orphan.
+    const { EQUIPMENT_CATALOGUE } = await import('../data/equipment-catalogue.js');
+    const src = EQUIPMENT_CATALOGUE[1];
+    const cat = await seedCatalogueItem({ name: src.name, bucket: src.bucket });
+    const preExisting = new ObjectId();
+    await seedCharWithEquipment([
+      { catalogue_id: src.id,       state: 'carried', acquired_cycle: 1 },
+      { catalogue_id: preExisting,  state: 'worn',    acquired_cycle: 2 },
+      { catalogue_id: 'orphan-x',   state: 'lost',    acquired_cycle: 3 },
+    ]);
+
+    await runMain(['--step=backfill', '--apply']);
+
+    // Aggregation post-condition (this is the AC-3 assertion verbatim).
+    const stragglers = await getCollection('characters').aggregate([
+      { $match: { [TEST_FLAG]: true } },
+      { $unwind: '$equipment' },
+      { $match: { 'equipment.catalogue_id': { $type: 'string' } } },
+    ]).toArray();
+    expect(stragglers).toHaveLength(0);
+  });
+});
+
+describe('#870 — main(--step=backfill --apply) idempotency', () => {
+  it('re-running after a clean apply is a no-op (zero conversions)', async () => {
+    const { EQUIPMENT_CATALOGUE } = await import('../data/equipment-catalogue.js');
+    const src = EQUIPMENT_CATALOGUE[2];
+    await seedCatalogueItem({ name: src.name, bucket: src.bucket });
+    await seedCharWithEquipment([
+      { catalogue_id: src.id, state: 'carried', acquired_cycle: 1 },
+    ]);
+    const first = await runMain(['--step=backfill', '--apply']);
+    expect(first.itemsConverted).toBeGreaterThanOrEqual(1);
+
+    const second = await runMain(['--step=backfill', '--apply']);
+    expect(second.itemsConverted).toBe(0);
+    // Skipped count includes the already-converted entries.
+    expect(second.itemsSkipped).toBeGreaterThanOrEqual(1);
+    expect(second.orphans).toHaveLength(0);
+  });
+});
+
+describe('#870 — buildSlugMapFromCollection', () => {
+  it('resolves source slugs by name+bucket match', async () => {
+    const { EQUIPMENT_CATALOGUE } = await import('../data/equipment-catalogue.js');
+    const src = EQUIPMENT_CATALOGUE[3];
+    const cat = await seedCatalogueItem({ name: src.name, bucket: src.bucket });
+    const { map, missingSlugs } = await buildSlugMapFromCollection(getCollection('equipment_catalogue'));
+    expect(map.get(src.id)).toBeInstanceOf(ObjectId);
+    expect(String(map.get(src.id))).toBe(String(cat._id));
+    // The other source entries have no catalogue doc → in missingSlugs.
+    expect(missingSlugs.length).toBe(EQUIPMENT_CATALOGUE.length - 1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3. PUT /api/characters/:id round-trip — coercion preserves ObjectId on save
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#870 — PUT /api/characters/:id round-trip preserves ObjectId on equipment[].catalogue_id', () => {
+  it('stored as ObjectId both pre and post a PUT round-trip', async () => {
+    const cat = await seedCatalogueItem({ name: 'CoercionTest', bucket: 'weapon' });
+    const charId = await seedCharWithEquipment([
+      { catalogue_id: cat._id, state: 'carried', acquired_cycle: 1, notes: null },
+    ]);
+    const before = await getCollection('characters').findOne({ _id: charId });
+    expect(before.equipment[0].catalogue_id).toBeInstanceOf(ObjectId);
+
+    // Simulate a client save: re-PUT the character with equipment[] as
+    // the 24-hex string form (the form that came down from the API).
+    const wireBody = {
+      ...before,
+      equipment: before.equipment.map(it => ({
+        ...it,
+        catalogue_id: String(it.catalogue_id),   // ObjectId → 24-hex string
+      })),
+    };
+    delete wireBody._id;
+
+    const res = await request(app)
+      .put(`/api/characters/${charId}`)
+      .set('X-Test-User', stUser())
+      .send(wireBody);
+    expect(res.status).toBe(200);
+
+    const after = await getCollection('characters').findOne({ _id: charId });
+    expect(after.equipment[0].catalogue_id).toBeInstanceOf(ObjectId);
+    expect(String(after.equipment[0].catalogue_id)).toBe(String(cat._id));
+  });
+
+  it('rejects a PUT with a non-24-hex string in equipment[].catalogue_id (schema 400)', async () => {
+    const charId = await seedCharWithEquipment([]);
+    const res = await request(app)
+      .put(`/api/characters/${charId}`)
+      .set('X-Test-User', stUser())
+      .send({
+        name: 'ECM-3 fixture',
+        equipment: [{ catalogue_id: 'knife', state: 'carried', acquired_cycle: 1 }],
+      });
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
> **HALT-FOR-PETER** — DRY-RUN report below. \`--apply\` against production data deferred until Peter signs off on the orphan-slug list. The HALT-DAR pin from the ECM-3 dispatch ([[feedback_dar_dispatch_wording]]) stands.

## Summary

Closes #870. Third story of Epic ECM ([epic spec](../blob/dev/specs/epic-ecm-equipment-catalogue-migration.md)). Tightens \`character.equipment[].catalogue_id\` to ObjectId end-to-end and ships the one-shot backfill that migrates the existing slug-string storage.

## Scope (per the SM dispatch, Option-A confirmed)

| Layer | Change |
|---|---|
| Schema | \`equipment[].catalogue_id\` tightens from \`{ type: 'string' }\` to \`{ type: 'string', pattern: '^[a-f0-9]{24}$' }\`. No dual-shape — one-shot per epic D7. |
| Route — PUT /:id | Inline coercion: walks \`body.equipment[]\` and replaces each \`catalogue_id\` 24-hex string with \`new ObjectId(...)\` before \`$set\`. |
| Route — POST /:id/equipment | Replaces static \`_CATALOGUE_IDS\` slug-set existence check with an \`equipment_catalogue\` collection lookup (404 on miss). Coerces wire string to ObjectId before \`$push\`. |
| Script | \`server/scripts/ecm-migrate.js\` extended with \`--step=backfill\` (default step preserved as \`seed\` for ECM-2 CLI back-compat). Cursor-walks every character, applies actions in place, four-count report + orphan detail. |

## Migration notes

ECM-3 tightens the schema to 24-hex ObjectId form and adds server-side coercion at two write sites (\`PUT /:id\` and \`POST /:id/equipment\`). The coercion is **not transitional** — JSON-encoded ObjectIds always round-trip as 24-hex strings, and coercing at the API boundary is the canonical Express+Mongo pattern. ECM-4/5 do not need to remove the coercion when they ship.

## DRY-RUN report (LOCAL DB — needs Khepri to confirm the URI maps to prod)

Ran \`node scripts/ecm-migrate.js --step=backfill\` against the local Atlas the dev env points at (\`MONGODB_URI\` from \`server/.env\`, \`tm_suite\` database). **The output below shows the catalogue is populated but no characters carry equipment items** — which is consistent with a fresh-or-near-fresh staging environment, NOT what I'd expect from production. Flagging for Khepri to either point me at the prod URI or confirm I should re-run from a different connection before escalating to Peter.

\`\`\`
[DRY RUN] ecm-migrate.js (--step=backfill)
Database: tm_suite
equipment_catalogue size: 74 (0 resolved, 74 unresolved by name+bucket)

Source slugs with no matching catalogue doc (catalogue partial-seeded or mid-flight mutation):
  - automotive-tools-basic
  - automotive-tools-advanced
  - cache-1
  - cache-2
  - cache-3
  - ... (truncated — full list of 74 source slugs, all unresolved against the local catalogue)

────────── ECM-3 BACKFILL REPORT ──────────
Characters touched : 0
Items converted    : 0  (slug → ObjectId)
Items skipped      : 0  (already ObjectId / 24-hex / non-string)
Orphans            : 0  (slug with no catalogue match — dropped from character)
───────────────────────────────────────────

[DRY RUN] Re-run with --apply to write the changes above.
\`\`\`

**Two suspicious findings** in the local result Khepri should weigh in on:
1. **74 catalogue docs exist but 0 are resolved by name+bucket** against the source EQUIPMENT_CATALOGUE module. Either the local catalogue was seeded from a different version of the source data, or there's a subtle name normalisation issue (whitespace? unicode?). The integration tests cover the join logic against fresh seeds (\`buildSlugMapFromCollection\` slice in \`issue-870-ecm-3-backfill.test.js\`) so the script is provably correct on matched data.
2. **0 characters with equipment items.** Production should have many. Suggests the URI I'm hitting isn't prod.

## Acceptance criteria

- [x] **DRY-RUN four counts + orphan list rendered cleanly.** See block above.
- [ ] **Live run executes only after Peter signs off in PR.** Awaiting sign-off via Khepri.
- [x] **Zero string slugs remain in \`character.equipment[].catalogue_id\` post-run** — enforced by an aggregation post-condition in the integration suite (\`#870 — main(--step=backfill --apply) converts and drops > post-condition: zero string slugs remain\`).
- [x] **Schema migration committed in same PR.**
- [x] **Re-running \`--apply\` after success is a no-op** — \`idempotency\` slice asserts \`itemsConverted: 0\` on a second \`--apply\` and zero orphans.

## Tests — \`server/tests/issue-870-ecm-3-backfill.test.js\` (12 cases) + updates to \`equipment.test.js\` + \`issue-869-ecm-2-seed.test.js\`

- **Pure-helper slice** — \`classifyItem\` covers slug-with-map / slug-without-map / ObjectId-instance / 24-hex-string / non-string. \`backfillCharEquipment\` aggregates correctly with mixed input + no-op on empty.
- **\`main(--step=backfill)\` integration** — DRY-RUN no-write; \`--apply\` converts every resolvable slug; orphan slugs are dropped + logged; post-condition aggregation asserts zero string-slug \`catalogue_id\`s remain (AC-3 verbatim); idempotency (second \`--apply\` is a no-op).
- **\`buildSlugMapFromCollection\` slice** — proves the name+bucket join is correct on a freshly-seeded catalogue.
- **PUT /:id round-trip** — assert \`catalogue_id\` stored as ObjectId pre + post a full-character PUT (canonical Express+Mongo coercion hygiene); plus a 400-rejects-non-24-hex case for the schema enforcement.
- **equipment.test.js POST /:id/equipment rewritten** — seeds real catalogue items via \`seedCatalogueItem\`, uses their \`_id\`s in POST bodies, asserts stored type is ObjectId (\`instanceof\` check). The old "Unknown catalogue_id" 400 path is split: 400 when catalogue_id is not 24-hex (slug shape), 404 when 24-hex but absent from the collection.

## Verification

\`\`\`
$ cd server && npx vitest run tests/issue-870-ecm-3-backfill.test.js tests/equipment.test.js tests/issue-869-ecm-2-seed.test.js tests/issue-868-ecm-1-equipment-catalogue-api.test.js
Tests  85 passed (85)

$ npx vitest run                       # full suite
Test Files  4 failed | 134 passed (138)
Tests  1756 passed (1756)
\`\`\`

The 4 file-failures are pre-existing 0-test suite-load failures on dev. 0 individual test failures.

## NOT in this PR

- **Phase-3 prod \`--apply\` run.** HALT-FOR-PETER per the dispatch.
- **\`_CATALOGUE_IDS\` constant cleanup in \`characters.js\`.** The static slug-set is now dead in this file (last reader removed by the POST /:id/equipment rewrite). Per Khepri's "file a follow-up issue" guidance — ECM-7 deletes the static module anyway.
- **Client work** — ECM-4 + ECM-5.

## Test plan

- [x] Vitest — 85 passes across ECM-1/2/3 + equipment
- [x] \`node --check\` on all touched JS files — parse OK
- [x] Full suite — 0 new failures
- [x] Local DRY-RUN executed and report captured
- [ ] **Prod URI DRY-RUN** — pending Khepri confirmation of the right URI
- [ ] **Peter sign-off on orphan list** — pending the prod DRY-RUN above
- [ ] \`node scripts/ecm-migrate.js --step=backfill --apply\` against prod — strictly after Peter sign-off