### PR TITLE
fix(#886): wire progress chips to DT-Processing completion + card chrome normalisation

### DIFF
--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -7409,7 +7409,7 @@ html:not([data-theme="dark"]) .roll-btn-save:hover { border-color: var(--success
    Replaces the redundant narrative-drafting layer — the player-facing outcome
    is now written directly in DT Processing and only displayed here. Reuses the
    dt-feed-val-row dt/dd pattern; Dice pool + Feedback rows are muted. */
-.dt-story-resolved-card { margin: 0 0 10px; }
+.dt-story-resolved-card { margin-bottom: 10px; padding: 10px 12px; }
 .dt-story-resolved-title { font-family: var(--fh); font-size: 14px; color: var(--txt1); margin: 0 0 6px; }
 .dt-story-resolved-card .dt-feed-val-row dd { white-space: pre-wrap; }
 .dt-story-muted-row dt,
@@ -7442,6 +7442,7 @@ html:not([data-theme="dark"]) .roll-btn-save:hover { border-color: var(--success
 
 /* ── Story-tab inner cards: canonical chrome (CSS-9) ── */
 .dt-story-proj-card,
+.dt-story-resolved-card,
 .dt-story-merit-card,
 .dt-story-resources-card,
 .dt-story-context-block,

--- a/public/js/admin/downtime-story.js
+++ b/public/js/admin/downtime-story.js
@@ -1290,14 +1290,22 @@ function getSectionProgress(stNarrative, sectionKey, sub) {
 
   if (sectionKey === 'project_responses') {
     const resolved   = sub?.projects_resolved || [];
-    const applicable = resolved.filter(r => r?.pool_status !== 'skipped');
+    const applicable = resolved
+      .map((r, idx) => ({ r, idx }))
+      .filter(({ r, idx }) => r?.pool_status !== 'skipped' && !_isDeletedProjectAction(sub, idx));
     if (!applicable.length) return { state: 'complete', done: 0, total: 0 };
-    const responses   = sn.project_responses || [];
-    const done        = applicable.filter((_, i) => responses[i]?.status === 'complete').length;
-    const hasRevision = applicable.some((_, i) => responses[i]?.status === 'needs_revision');
-    const hasDraft    = applicable.some((_, i) => responses[i]?.response);
-    const state = done === applicable.length ? 'complete' : hasRevision ? 'revision' : hasDraft ? 'draft' : 'empty';
+    // #886: a project is complete when its player-facing outcome is written in
+    // DT Processing (rev.outcome), not when a Story-tab draft was marked complete.
+    const done  = applicable.filter(({ r }) => (r?.outcome || '').trim()).length;
+    const state = done === applicable.length ? 'complete' : done > 0 ? 'draft' : 'empty';
     return { state, done, total: applicable.length };
+  }
+
+  if (sectionKey === 'merit_summary') {
+    // #886: reflect DT Processing completion (outcomes recorded), mirroring
+    // meritSummaryComplete / isSectionDone so the chip is not stuck on "empty".
+    const done = meritSummaryComplete(sub);
+    return { state: done ? 'complete' : 'empty', done: done ? 1 : 0, total: 1 };
   }
 
   if (sectionKey === 'territory_reports') {

--- a/specs/stories/feat.886.dt-story-resolved-outcomes.story.md
+++ b/specs/stories/feat.886.dt-story-resolved-outcomes.story.md
@@ -362,6 +362,15 @@ claude-opus-4-8 (BMAD dev-story)
   repointed to the same source; Home Report removed (superseded by Territory Pulse);
   completion-gating moved from draft-status to resolved-outcome. Tests added/updated;
   36/36 pass. Status → review.
+- 2026-06-18 (post-merge follow-ups, from dev smoke) — (1) **Completion wiring:**
+  `getSectionProgress` (progress-tracker chips) project count now derives from
+  `rev.outcome` (was stuck at "Projects 0/4" on the old draft-status count); added a
+  `merit_summary` branch wired to `meritSummaryComplete` so its chip is no longer
+  always "empty". Feeding chip already correct via `isSectionDone`. (2) **CSS
+  normalisation:** `.dt-story-resolved-card` joined the canonical "Story-tab inner
+  cards" chrome group (`var(--surf2)` bg + border + radius) + matching padding/margin
+  — it had forked with margin-only and rendered flat/borderless. Per coding-standards
+  Shared Chrome Pattern.
 - 2026-06-18 (QA, Quinn) — Reviewed diff for correctness/regression/AC + CSS. Verified
   data assumptions (`feeding_review.outcome`, `projects_resolved[].outcome` via
   `saveEntryReview` source-branching, `downtime-views.js:3709/3718`;


### PR DESCRIPTION
Follow-up to #888 (already merged to dev). Smoke-test findings from the #886 resolved-outcome cards on dev.

## Changes

**1. Progress-tracker chips wired to DT Processing completion**
- `getSectionProgress` project chip counted via the old `st_narrative` draft status, so it showed "Projects 0/4" even when every project had a DT-Processing outcome. Now counts projects with `rev.outcome`.
- Added a `merit_summary` branch (→ `meritSummaryComplete`) so the "Allies & Asset Summary" chip reflects completion instead of always rendering "empty".
- Feeding chip already correct (routes through the updated `isSectionDone`).

**2. CSS normalisation**
- `.dt-story-resolved-card` joined the canonical "Story-tab inner cards" chrome group (`var(--surf2)` bg + border + radius) + matching padding/margin. It had forked with margin-only and rendered flat/borderless. Shared Chrome Pattern per `coding-standards.md`; tokens only, no inline `style=`/hex.

## Test plan
- Server unit tests: 36/36 pass. `node --check` clean.
- **Pending dev smoke** (cannot run locally): chip counts now read "Projects N/N" when outcomes are recorded; resolved cards render as proper bordered card boxes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)