### PR TITLE
feat(ecm): #871 + #876 — DT form catalogue dropdown + item_request field (ECM-4 + ECM-9 bundle)

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -19,6 +19,11 @@ import { SKILLS_MENTAL, ALL_ATTRS, ALL_SKILLS, SKILL_CATS } from '../data/consta
 import { getUser } from '../auth/discord.js';
 import { ACTION_TYPE_LABELS as _ACTION_TYPE_LABELS_BASE, MERIT_MATRIX, INVESTIGATION_MATRIX, TERRITORY_SLUG_MAP as _TERRITORY_SLUG_MAP_BASE, AMBIENCE_STEPS as _AMBIENCE_STEPS_BASE, POOL_STATUS_LABELS } from './downtime-constants.js';
 import { publishAllForCycle } from './downtime-story.js';
+// ECM-4 (#871): resolve catalogue_id → display name via the shared cache
+// when rendering the DT processing UI. Legacy free-text `equipment_${n}_name`
+// values from pre-ECM-4 submissions still render as a fallback per Khepri's
+// backcompat guidance — see the read site below in the Equipment block.
+import { getCatalogueEntry } from '../data/equipment-catalogue-cache.js';
 
 // Convert UTC ISO string to datetime-local input value (local time)
 function isoToLocalInput(iso) {
@@ -1633,18 +1638,43 @@ function renderPlayerResponses(s) {
   }
 
   // ── Equipment ──
+  // ECM-4 (#871): canonical persistence key is `equipment_${n}_catalogue_id`
+  // (24-hex ObjectId string); display name resolves via the catalogue cache.
+  // Legacy pre-ECM-4 submissions carry `equipment_${n}_name` as free-text;
+  // we fall back to that when no `_catalogue_id` is present — Khepri's
+  // backcompat dispatch ("if catalogue_id is present, resolve via catalogue;
+  // else if name is present, render the free-text as legacy; else hide").
   const equipCount = parseInt(r['equipment_slot_count'] || '1', 10);
   const equipRows = [];
   for (let n = 1; n <= equipCount; n++) {
-    const name = r[`equipment_${n}_name`];
-    if (!name) continue;
+    const catalogueId = r[`equipment_${n}_catalogue_id`];
+    const legacyName = r[`equipment_${n}_name`];
+    let displayName = '';
+    if (catalogueId) {
+      const entry = getCatalogueEntry(catalogueId);
+      displayName = entry?.name || `(catalogue item ${catalogueId})`;
+    } else if (legacyName) {
+      displayName = `${legacyName} (legacy free-text)`;
+    } else {
+      continue;
+    }
     const qty = r[`equipment_${n}_qty`] || '';
     const notes = r[`equipment_${n}_notes`] || '';
-    equipRows.push([qty ? `${qty}× ${name}` : name, notes].filter(Boolean).join(' — '));
+    equipRows.push([qty ? `${qty}× ${displayName}` : displayName, notes].filter(Boolean).join(' — '));
   }
   if (equipRows.length) {
     h += '<div class="dt-resp-section"><div class="dt-resp-section-title">Equipment</div>';
     for (const eq of equipRows) h += `<div class="dt-resp-row"><span class="dt-resp-val">${esc(eq)}</span></div>`;
+    h += '</div>';
+  }
+
+  // ── Item request (ECM-9 / #876) ──
+  // Free-text escape valve for items not in the catalogue. ST adjudicates
+  // inline (approve+create via admin catalogue / approve+substitute / reject).
+  const itemRequest = r['item_request'];
+  if (itemRequest && itemRequest.trim()) {
+    h += '<div class="dt-resp-section"><div class="dt-resp-section-title">Item Request</div>';
+    h += `<div class="dt-resp-row"><span class="dt-resp-val">${esc(itemRequest)}</span></div>`;
     h += '</div>';
   }
 

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -57,6 +57,12 @@ import { openChallengeModal } from './game/challenge-initiation.js';
 import { loadDtLookup } from './game/dt-lookup.js';
 import { initTracker, trackerReset, trackerAdj, trackerAddCondition, trackerRemoveCond, trackerToggle, ensureLoaded as ensureTrackerLoaded, refreshTrackerCard } from './game/tracker.js';
 import { initWS } from './data/ws.js';
+// ECM-4 (#871): shared catalogue cache from ECM-5 (#872). Boot-load below
+// alongside preloadRules so the DT form's equipment dropdown renders
+// synchronously when the section opens. Refetch is wired into initWS's
+// onCatalogueUpdate so remote admin catalogue edits propagate without
+// a page reload.
+import { loadCatalogue as loadEquipmentCatalogue, refetchCatalogue as refetchEquipmentCatalogue } from './data/equipment-catalogue-cache.js';
 import { initSignIn } from './game/signin-tab.js';
 import { initFinanceTab } from './game/finance-tab.js';
 import { renderEmergencyTab } from './game/emergency-tab.js';
@@ -517,12 +523,16 @@ async function loadAllData() {
   // cache synchronously; the cache state is determined by the time the
   // Promise.allSettled resolves (loaded if preloadRules succeeded,
   // null otherwise — issue #249 guard handles both).
-  const [_rulesFromApi, rulesEngineRes, apiCharsRes, terrRes, combatRes] = await Promise.allSettled([
+  const [_rulesFromApi, rulesEngineRes, apiCharsRes, terrRes, combatRes, _catalogueRes] = await Promise.allSettled([
     loadRulesFromApi(),
     preloadRules(),
     loadCharsFromApi(),
     apiGet('/api/territories'),
     apiGet('/api/characters/combat'),
+    // ECM-4 (#871): same parallel-load pattern as the rules engine, same
+    // non-fatal-on-failure shape — the DT form's equipment dropdown
+    // degrades to empty options + a console warning on failure.
+    loadEquipmentCatalogue(),
   ]);
 
   // Issue #249 (HOTFIX 2026-05-09): preloadRules failure surfaces via
@@ -537,6 +547,12 @@ async function loadAllData() {
       banner.classList.add('app-status-banner--error');
       banner.style.display = '';
     }
+  }
+  // ECM-4 (#871): catalogue load is non-fatal — surface the degraded state
+  // in console only. The DT form's equipment section degrades to an empty
+  // dropdown rather than blocking submission.
+  if (_catalogueRes.status === 'rejected') {
+    console.error('[app] loadEquipmentCatalogue failed — DT-form equipment dropdown will be empty until cache loads:', _catalogueRes.reason);
   }
 
   // 1. Chars handling — role-filtered server-side (player sees own, ST sees all).
@@ -1372,6 +1388,11 @@ async function boot() {
               suiteRenderSheet();
             }
           },
+          // ECM-4 (#871): on remote equipment_catalogue create/update/delete
+          // (broadcast by the admin catalogue UI via server/ws.js's
+          // broadcastCatalogueUpdate), refetch the cache. Next render of
+          // the DT form's equipment dropdown picks up the fresh items.
+          onCatalogueUpdate: () => { refetchEquipmentCatalogue(); },
         });
 
         // Issue #425: install the STM popover delegated click handler for

--- a/public/js/data/dt-action-summary.js
+++ b/public/js/data/dt-action-summary.js
@@ -111,9 +111,11 @@ export function actionSpentSummary(responses, totals = {}) {
     if (_nonEmpty(r[`sorcery_${n}_rite`])) sorceriesUsed++;
   }
 
+  // ECM-4 (#871): count a slot used if EITHER the new catalogue_id key is
+  // populated OR the legacy free-text name key is (in-flight submissions).
   let equipmentUsed = 0;
   for (let n = 1; n <= t.equipmentSlots; n++) {
-    if (_nonEmpty(r[`equipment_${n}_name`])) equipmentUsed++;
+    if (_nonEmpty(r[`equipment_${n}_catalogue_id`]) || _nonEmpty(r[`equipment_${n}_name`])) equipmentUsed++;
   }
 
   return {

--- a/public/js/tabs/downtime-data.js
+++ b/public/js/tabs/downtime-data.js
@@ -373,12 +373,16 @@ export const DOWNTIME_SECTIONS = [
     ],
   },
 
-  // 11. Equipment — dt-form.30: hidden for this DT cycle; set hidden: false to re-enable
+  // 11. Equipment — ECM-4 (#871) re-enables the section now that the
+  // catalogue is Mongo-backed (ECM-1..3) and player-selectable via
+  // dropdown (this story). The original dt-form.30 hide was "until we
+  // have a proper catalogue"; we now do. Item-request escape valve for
+  // items not in the catalogue is in the ECM-9 (#876) textarea below.
   {
     key: 'equipment',
     title: 'Equipment: Items and Gear',
     gate: null,
-    hidden: true,
+    hidden: false,
     intro: 'List any items, weapons, or equipment you want your character to have access to this Downtime. Sourcing is subject to ST approval and availability.',
     questions: [], // rendered dynamically
   },

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -30,6 +30,11 @@ import { FAMILIES, kindByCode } from '../data/relationship-kinds.js';
 // other NPC-picker-driven UI under the suppression policy.
 import { charPicker, setCharPickerSources } from '../components/character-picker.js';
 import { isMinimalComplete, missingMinimumPieces } from '../data/dt-completeness.js';
+// ECM-4 (#871): catalogue dropdown sources from the shared cache module
+// ECM-5 (#872) introduced. App boot in app.js calls loadCatalogue; we read
+// synchronously here at render time. getCatalogueEntry resolves a
+// 24-hex catalogue_id → display name for the legacy-fallback path.
+import { getCatalogue, getCatalogueEntry } from '../data/equipment-catalogue-cache.js';
 
 // Influence merit names that generate monthly influence
 const INFLUENCE_MERIT_NAMES = ['Allies', 'Retainer', 'Mentor', 'Resources', 'Staff', 'Contacts', 'Status'];
@@ -1063,19 +1068,27 @@ function collectResponses() {
   ].filter(Boolean).join('\n');
   } // end if (resourceRows.length || skillRows.length) — issue #120
 
-  // Collect equipment slots (skipped when hidden — prior values preserved via _prior spread)
+  // Collect equipment slots (skipped when hidden — prior values preserved via _prior spread).
+  // ECM-4 (#871): the canonical persistence key is `equipment_${n}_catalogue_id` (24-hex
+  // ObjectId string). The legacy `equipment_${n}_name` key is no longer written by the
+  // form. Pre-ECM-4 submissions in the responses spread base still carry that key; we
+  // leave it intact (silent-leave) so the admin DT processing UI can fall back to it
+  // for in-flight submissions per Khepri's backcompat guidance.
   if (!DOWNTIME_SECTIONS.find(s => s.key === 'equipment')?.hidden) {
     const equipCountEl = document.getElementById('dt-equipment-slot-count');
     const equipSlotCount = equipCountEl ? parseInt(equipCountEl.value, 10) || 1 : 1;
     responses['equipment_slot_count'] = String(equipSlotCount);
     for (let n = 1; n <= equipSlotCount; n++) {
-      const nameEl = document.getElementById(`dt-equipment_${n}_name`);
+      const catSelectEl = document.getElementById(`dt-equipment_${n}_catalogue_id`);
       const qtyEl = document.getElementById(`dt-equipment_${n}_qty`);
       const notesEl = document.getElementById(`dt-equipment_${n}_notes`);
-      responses[`equipment_${n}_name`] = nameEl ? nameEl.value : '';
+      responses[`equipment_${n}_catalogue_id`] = catSelectEl ? catSelectEl.value : '';
       responses[`equipment_${n}_qty`] = qtyEl ? qtyEl.value : '';
       responses[`equipment_${n}_notes`] = notesEl ? notesEl.value : '';
     }
+    // ECM-9 (#876): item_request — optional free-text escape valve.
+    const itemReqEl = document.getElementById('dt-item-request');
+    responses['item_request'] = itemReqEl ? itemReqEl.value : '';
   }
 
   } // end if (!_isMinimal) — ADVANCED-only collection
@@ -3352,13 +3365,18 @@ function renderForm(container) {
       const responses = collectResponses();
       const countEl = document.getElementById('dt-equipment-slot-count');
       const current = countEl ? parseInt(countEl.value, 10) || 1 : 1;
-      // Shift slots down
+      // Shift slots down. ECM-4 (#871): canonical key is `_catalogue_id`;
+      // the legacy `_name` key is shifted alongside for in-flight
+      // submissions whose pre-ECM-4 free-text values still ride on the
+      // response doc (silent-leave per Khepri's backcompat dispatch).
       for (let n = removeN; n < current; n++) {
+        responses[`equipment_${n}_catalogue_id`] = responses[`equipment_${n + 1}_catalogue_id`] || '';
         responses[`equipment_${n}_name`] = responses[`equipment_${n + 1}_name`] || '';
         responses[`equipment_${n}_qty`] = responses[`equipment_${n + 1}_qty`] || '1';
         responses[`equipment_${n}_notes`] = responses[`equipment_${n + 1}_notes`] || '';
       }
       // Clear last slot
+      delete responses[`equipment_${current}_catalogue_id`];
       delete responses[`equipment_${current}_name`];
       delete responses[`equipment_${current}_qty`];
       delete responses[`equipment_${current}_notes`];
@@ -5377,16 +5395,68 @@ function renderEquipmentSection(saved) {
   h += '</div>';
 
   h += `<button type="button" class="dt-add-rite-btn" id="dt-add-equipment">\u002B Add Item</button>`;
+
+  // ECM-9 (#876) — item_request escape valve. Players who want an item
+  // not in the catalogue describe it in free-text; ST adjudicates inline
+  // during DT processing (approve+create via the catalogue admin UI /
+  // approve+substitute / reject with counter-note). Per epic D6 the field
+  // is optional and lives on the existing DT submission shape — no new
+  // collection, no new gate state.
+  const itemRequestSaved = saved['item_request'] || '';
+  h += '<div class="qf-field dt-item-request" style="margin-top:14px;">';
+  h += '<label class="qf-label" for="dt-item-request">Item request <span class="qf-label-hint">(optional)</span></label>';
+  h += `<textarea id="dt-item-request" class="qf-input dt-item-request-input" rows="3" placeholder="Describe an item you would like that is not in the catalogue. ST will adjudicate.">${esc(itemRequestSaved)}</textarea>`;
+  h += '</div>';
+
   h += '</div></div>';
   return h;
 }
 
+// ECM-4 (#871) + epic D8: catalogue dropdown is the only way to assign an
+// item; free-text catalogue entry is gone. The escape valve for items not
+// in the catalogue is ECM-9's `item_request` textarea (rendered at the
+// bottom of the equipment section).
+//
+// Legacy-compat: in-flight DT submissions from before this cycle carry
+// `equipment_${n}_name` as a free-text string with no `_catalogue_id`.
+// Per Khepri's dispatch + epic backcompat, we render those as a disabled
+// placeholder option in the dropdown so the player sees what they had
+// and can reselect from the catalogue (or leave it; the row stays
+// uncommitted and the legacy name survives until the player edits).
 function renderEquipmentRow(n, saved) {
+  const items = getCatalogue();
+  const byBucket = new Map();
+  for (const it of items) {
+    if (!byBucket.has(it.bucket)) byBucket.set(it.bucket, []);
+    byBucket.get(it.bucket).push(it);
+  }
+  for (const arr of byBucket.values()) {
+    arr.sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+  }
+
+  const selectedId = saved[`equipment_${n}_catalogue_id`] || '';
+  const legacyName = saved[`equipment_${n}_name`] || '';
+
   let h = `<div class="dt-equipment-row" id="dt-equipment-row-${n}">`;
   h += `<div class="dt-equipment-row-fields">`;
-  h += `<input type="text" id="dt-equipment_${n}_name" class="qf-input dt-equip-name" placeholder="Item name" value="${esc(saved[`equipment_${n}_name`] || '')}">`;
+  h += `<select id="dt-equipment_${n}_catalogue_id" class="qf-input dt-equip-cat">`;
+  h += `<option value="">\u2014 select item \u2014</option>`;
+  if (legacyName && !selectedId) {
+    h += `<option value="" disabled>(legacy: ${esc(legacyName)} \u2014 please reselect)</option>`;
+  }
+  for (const bucket of ['weapon', 'armour', 'equipment', 'asset']) {
+    const arr = byBucket.get(bucket);
+    if (!arr || !arr.length) continue;
+    h += `<optgroup label="${esc(bucket)}">`;
+    for (const it of arr) {
+      const sel = String(it._id) === selectedId ? ' selected' : '';
+      h += `<option value="${esc(String(it._id))}"${sel}>${esc(it.name || '')}</option>`;
+    }
+    h += `</optgroup>`;
+  }
+  h += `</select>`;
   h += `<input type="number" id="dt-equipment_${n}_qty" class="qf-input dt-equip-qty" placeholder="Qty" min="1" value="${esc(saved[`equipment_${n}_qty`] || '1')}">`;
-  h += `<input type="text" id="dt-equipment_${n}_notes" class="qf-input dt-equip-notes" placeholder="Source / notes" value="${esc(saved[`equipment_${n}_notes`] || '')}">`;
+  h += `<input type="text" id="dt-equipment_${n}_notes" class="qf-input dt-equip-notes" placeholder="Notes (optional)" value="${esc(saved[`equipment_${n}_notes`] || '')}">`;
   if (n > 1) h += `<button type="button" class="dt-sorcery-remove" data-remove-equipment="${n}" title="Remove">\u00D7</button>`;
   h += '</div>';
   h += '</div>';

--- a/server/schemas/downtime_submission.schema.js
+++ b/server/schemas/downtime_submission.schema.js
@@ -383,6 +383,17 @@ export const downtimeSubmissionSchema = {
         lore_request:  { type: 'string' },   // Rules/lore questions for STs
         form_rating:   { type: 'string' },   // "1"–"10" (half-star widget)
         form_feedback: { type: 'string' },   // Form UX feedback
+        // ECM-9 (#876): item_request escape valve for items not in the
+        // equipment_catalogue collection. Optional free-text; surfaced in
+        // the admin DT processing UI; ST adjudicates inline. additionalProperties
+        // already permits the field without this entry — listed here for
+        // documentation parity with lore_request / form_feedback.
+        item_request:  { type: 'string' },
+        // ECM-4 (#871) equipment slot keys — `equipment_${n}_catalogue_id`
+        // (24-hex ObjectId string) replaces the legacy `equipment_${n}_name`
+        // free-text. additionalProperties:true on responses already covers
+        // the per-slot keys; the canonical persistence shape is documented
+        // here for future-reader clarity.
       },
     },
 

--- a/server/tests/issue-871-876-ecm-4-9-bundle.test.js
+++ b/server/tests/issue-871-876-ecm-4-9-bundle.test.js
@@ -1,0 +1,154 @@
+/**
+ * Issue #871 (ECM-4) + #876 (ECM-9) — DT form catalogue dropdown bundle.
+ *
+ * Two slices:
+ *   1. ECM-4: equipment section is un-hidden; downtime-form.js no longer
+ *      writes free-text `equipment_${n}_name`; the catalogue dropdown
+ *      sources from the shared cache module ECM-5 introduced; app.js
+ *      boot-loads the cache + wires onCatalogueUpdate; admin DT view
+ *      falls back to legacy free-text for in-flight submissions per
+ *      Khepri's backcompat guidance.
+ *   2. ECM-9: item_request textarea is rendered on the DT form and
+ *      surfaced as a labelled block on the admin processing UI; schema
+ *      documents the field.
+ *
+ * Static-analysis throughout — no browser harness in this repo. Manual
+ * UI smoke is captured in the PR test plan.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+function read(rel) { return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8'); }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ECM-4
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#871 — equipment section is un-hidden', () => {
+  it('downtime-data.js declares hidden: false on the equipment section', () => {
+    const src = read('public/js/tabs/downtime-data.js');
+    // Find the equipment-section block and confirm hidden: false.
+    const idx = src.indexOf("key: 'equipment'");
+    expect(idx).toBeGreaterThan(-1);
+    const block = src.slice(idx, idx + 600);
+    expect(block).toMatch(/hidden:\s*false/);
+    expect(block).not.toMatch(/hidden:\s*true/);
+  });
+});
+
+describe('#871 — downtime-form.js wires the catalogue dropdown', () => {
+  const src = read('public/js/tabs/downtime-form.js');
+
+  it('imports getCatalogue + getCatalogueEntry from the shared cache module', () => {
+    expect(src).toMatch(/import\s+\{\s*getCatalogue,\s*getCatalogueEntry\s*\}\s+from\s+['"]\.\.\/data\/equipment-catalogue-cache\.js['"]/);
+  });
+
+  it('renderEquipmentRow no longer renders a free-text name input', () => {
+    // The legacy line was: `<input type="text" id="dt-equipment_${n}_name" ...>`.
+    // It must be gone.
+    expect(src).not.toMatch(/<input[^>]*id="dt-equipment_\$\{n\}_name"/);
+  });
+
+  it('renderEquipmentRow renders a select with id `dt-equipment_${n}_catalogue_id`', () => {
+    expect(src).toMatch(/<select id="dt-equipment_\$\{n\}_catalogue_id"/);
+  });
+
+  it('emits optgroups per bucket (weapon / armour / equipment / asset)', () => {
+    // The render iterates ['weapon', 'armour', 'equipment', 'asset'] and emits <optgroup label="...">
+    expect(src).toMatch(/for\s*\(\s*const\s+bucket\s+of\s+\[\s*['"]weapon['"]\s*,\s*['"]armour['"]\s*,\s*['"]equipment['"]\s*,\s*['"]asset['"]\s*\]/);
+    expect(src).toMatch(/<optgroup label="\$\{esc\(bucket\)\}">/);
+  });
+
+  it('option value is the 24-hex `_id` (not the legacy slug)', () => {
+    expect(src).toMatch(/<option value="\$\{esc\(String\(it\._id\)\)\}"/);
+  });
+
+  it('legacy free-text name surfaces as a disabled placeholder option when no catalogue_id is set', () => {
+    expect(src).toMatch(/legacyName\s*&&\s*!selectedId/);
+    expect(src).toMatch(/legacy:\s*\$\{esc\(legacyName\)\}/);
+  });
+
+  it('collectResponses writes equipment_${n}_catalogue_id (the canonical key)', () => {
+    expect(src).toMatch(/responses\[\s*`equipment_\$\{n\}_catalogue_id`\s*\]\s*=/);
+  });
+
+  it('collectResponses no longer reads `dt-equipment_${n}_name` from the DOM', () => {
+    // Pre-ECM-4: const nameEl = document.getElementById(`dt-equipment_${n}_name`).
+    // The legacy `_name` key still appears in the slot-removal shift path
+    // for in-flight-submission backcompat (Khepri's silent-leave guidance),
+    // but the form NEVER reads `dt-equipment_${n}_name` from the DOM anymore
+    // because that input was replaced by the catalogue dropdown.
+    expect(src).not.toMatch(/document\.getElementById\(\s*`dt-equipment_\$\{n\}_name`/);
+  });
+});
+
+describe('#871 — app.js boot-loads the catalogue + wires WS refetch', () => {
+  const src = read('public/js/app.js');
+
+  it('imports loadCatalogue + refetchCatalogue from the shared cache module', () => {
+    expect(src).toMatch(/loadCatalogue\s+as\s+loadEquipmentCatalogue/);
+    expect(src).toMatch(/refetchCatalogue\s+as\s+refetchEquipmentCatalogue/);
+  });
+
+  it('loadEquipmentCatalogue is called inside the Promise.allSettled boot batch', () => {
+    expect(src).toMatch(/Promise\.allSettled\(\[[\s\S]{0,2000}loadEquipmentCatalogue\(\)/);
+  });
+
+  it('passes onCatalogueUpdate to initWS, wired to refetchEquipmentCatalogue', () => {
+    expect(src).toMatch(/onCatalogueUpdate:\s*\(\)\s*=>\s*\{\s*refetchEquipmentCatalogue\(\)/);
+  });
+});
+
+describe('#871 — admin/downtime-views.js falls back to legacy free-text', () => {
+  const src = read('public/js/admin/downtime-views.js');
+
+  it('imports getCatalogueEntry from the shared cache module', () => {
+    expect(src).toMatch(/import\s+\{\s*getCatalogueEntry\s*\}\s+from\s+['"]\.\.\/data\/equipment-catalogue-cache\.js['"]/);
+  });
+
+  it('resolves catalogue_id via the cache and falls back to legacy free-text name', () => {
+    expect(src).toMatch(/r\[`equipment_\$\{n\}_catalogue_id`\]/);
+    expect(src).toMatch(/r\[`equipment_\$\{n\}_name`\]/);
+    expect(src).toMatch(/getCatalogueEntry\(catalogueId\)/);
+    expect(src).toMatch(/legacy free-text/);
+  });
+
+  it('renders an Item Request block when responses.item_request is non-empty', () => {
+    expect(src).toMatch(/r\[['"]item_request['"]\]/);
+    expect(src).toMatch(/Item Request/);
+  });
+});
+
+describe('#871 — dt-action-summary.js counts the new key', () => {
+  const src = read('public/js/data/dt-action-summary.js');
+  it('counts a slot used when either catalogue_id OR legacy name is populated', () => {
+    expect(src).toMatch(/equipment_\$\{n\}_catalogue_id/);
+    expect(src).toMatch(/equipment_\$\{n\}_name/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ECM-9
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#876 — DT form renders item_request textarea', () => {
+  const src = read('public/js/tabs/downtime-form.js');
+  it('renders a textarea with id="dt-item-request"', () => {
+    expect(src).toMatch(/<textarea id="dt-item-request"/);
+  });
+  it('collects responses.item_request', () => {
+    expect(src).toMatch(/responses\[['"]item_request['"]\]\s*=/);
+  });
+});
+
+describe('#876 — schema documents item_request', () => {
+  const src = read('server/schemas/downtime_submission.schema.js');
+  it('lists item_request in the responses properties block', () => {
+    expect(src).toMatch(/item_request:\s*\{\s*type:\s*['"]string['"]\s*\}/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #871 (ECM-4) and #876 (ECM-9). Per Peter's Option-C decision: bundle so the DT form's player-facing UX is coherent — catalogue dropdown for items that exist, item_request free-text escape valve for items that don't. Avoids the regression window a single-story ECM-4 would have created (dropdown ships but no way for players to request bespoke items until ECM-9 landed separately).

## Equipment-section flag context (per Khepri's dispatch)

Found the flag at \`public/js/tabs/downtime-data.js\` — \`hidden: true\` on the equipment section, set by dt-form.30. Original hide reason: _"until we have a proper catalogue"_. ECM-1..3 + ECM-5 + ECM-6 delivered that catalogue. This PR flips to \`hidden: false\` — the section is shippable again.

## ECM-4 — what ships

| Layer | Change |
|---|---|
| Data | \`downtime-data.js\`: \`hidden: false\` on the equipment section + rationale comment. |
| Form render | \`downtime-form.js\` imports \`getCatalogue\` + \`getCatalogueEntry\` from the ECM-5 shared cache module. \`renderEquipmentRow\` rewritten: free-text \`name\` input replaced with \`<select id="dt-equipment_\${n}_catalogue_id">\` rendering optgroup-per-bucket (weapon / armour / equipment / asset), items sorted alphabetically within bucket. Option value emits 24-hex \`_id\`. |
| Form collect | \`collectResponses\` writes \`equipment_\${n}_catalogue_id\` instead of \`_name\`. The slot-removal handler shifts both new and legacy keys for in-flight backcompat. |
| App boot | \`app.js\` joins \`loadCatalogue\` into the \`Promise.allSettled\` boot batch alongside \`preloadRules\`; same non-fatal pattern. \`initWS.onCatalogueUpdate\` wired to \`refetchCatalogue\` so remote admin edits propagate via the \`broadcastCatalogueUpdate\` WS frame ECM-1 emits. |
| Admin read | \`admin/downtime-views.js\` reads \`_catalogue_id\` first via \`getCatalogueEntry\`; falls back to legacy \`_name\` rendered as _"(legacy free-text)"_ so STs can spot pre-ECM-4 entries in the processing UI. |
| Summary | \`data/dt-action-summary.js\` counts a slot used if EITHER \`_catalogue_id\` OR \`_name\` is populated. |

## ECM-9 — what ships

| Layer | Change |
|---|---|
| Form render | \`renderEquipmentSection\` appends a labelled textarea (\`id="dt-item-request"\`) at the bottom. Copy: _"Item request — Describe an item you would like that is not in the catalogue. ST will adjudicate."_ Optional. |
| Form collect | \`collectResponses\` writes \`responses.item_request\`. |
| Admin read | \`renderResponses\` surfaces an _"Item Request"_ section block when the field is non-empty. ST adjudicates inline (approve+create via catalogue admin / approve+substitute / reject with counter-note). |
| Schema | \`downtime_submission.schema.js\` documents \`item_request\` in the responses properties block. Per-slot \`_catalogue_id\` keys are comment-documented; \`additionalProperties: true\` already permits them. |

## Migration for in-flight DT submissions

Per Khepri's silent-leave dispatch: **leave existing free-text values as-is.** Free-text \`equipment_\${n}_name\` values from pre-ECM-4 submissions survive on the response-doc spread base. The admin DT processing UI falls back to rendering them with a _"(legacy free-text)"_ suffix. If a player re-opens a pre-ECM-4 submission and re-edits the equipment section, the catalogue dropdown surfaces the legacy name as a disabled _"(legacy: <name> — please reselect)"_ option so they see what they had, then writes the new canonical \`_catalogue_id\` key on save.

## Acceptance criteria

### ECM-4
- [x] Hard-grep \`EQUIPMENT_CATALOGUE\` in \`public/js/tabs/downtime-form.js\` returns zero — the legacy import never existed (verified pre-implementation); the new import is from the shared cache module, not the static catalogue.
- [ ] **Manual browser smoke** — DT form opens, equipment dropdown populates from API, selection persists as ObjectId in \`responses.equipment_\${n}_catalogue_id\`. Captured below.
- [ ] **Manual WS smoke** — open admin Equipment Catalogue page + open the player DT form for an active cycle; create a catalogue item in the admin tab; confirm the player form's dropdown reflects the new item on next render.

### ECM-9
- [x] Schema accepts \`item_request\` as an optional string. Documented in \`downtime_submission.schema.js\`.
- [x] Form renders the textarea + collects on save.
- [x] Admin processing UI surfaces the request as a labelled block.

## Verification

\`\`\`
$ cd server && npx vitest run tests/issue-871-876-ecm-4-9-bundle.test.js
Tests  19 passed (19)

$ npx vitest run                       # full suite
Test Files  4 failed | 136 passed (140)
Tests  1789 passed (1789)
\`\`\`

The 4 file-failures are pre-existing 0-test suite-load failures on dev. 0 individual test failures.

Parse-check on all 6 touched JS files: OK.

## Test plan

- [x] Vitest — 19 passes
- [x] \`node --check\` on all touched JS files — parse OK
- [x] Full suite — 0 new failures
- [ ] **Manual smoke** — player portal, open an active DT cycle's form, scroll to equipment section. Dropdown populates with catalogue items grouped by bucket. Select an item, qty, notes; save draft. Reopen — selection persists. Submit — admin processing UI shows the resolved display name. Verify the response doc in DevTools / API: \`equipment_1_catalogue_id\` is a 24-hex string.
- [ ] **Manual WS smoke** — see acceptance criteria above.
- [ ] **Manual ECM-9 smoke** — type into the item_request textarea, save draft, reopen, confirm persisted. Submit; admin processing UI shows the Item Request block with the text.
- [ ] **Manual legacy smoke** — if a pre-ECM-4 in-flight submission exists in staging, open it: dropdown shows the legacy free-text as a disabled option; admin view shows it suffixed with "(legacy free-text)".