### PR TITLE
fix(#886): resolved-card title uses Lato like other headers

### DIFF
--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -7410,7 +7410,7 @@ html:not([data-theme="dark"]) .roll-btn-save:hover { border-color: var(--success
    is now written directly in DT Processing and only displayed here. Reuses the
    dt-feed-val-row dt/dd pattern; Dice pool + Feedback rows are muted. */
 .dt-story-resolved-card { margin-bottom: 10px; padding: 10px 12px; }
-.dt-story-resolved-title { font-family: var(--fh); font-size: 14px; color: var(--txt1); margin: 0 0 6px; }
+.dt-story-resolved-title { font-family: var(--fl); font-size: 13px; font-weight: 700; letter-spacing: .02em; color: var(--txt1); margin: 0 0 6px; }
 .dt-story-resolved-card .dt-feed-val-row dd { white-space: pre-wrap; }
 .dt-story-muted-row dt,
 .dt-story-muted-row dd { color: var(--txt3); }


### PR DESCRIPTION
Follow-up to #888/#889. The #886 resolved-card title was set in Cinzel (`var(--fh)`); normalise to the Lato header treatment used elsewhere in the DT Story tab (`var(--fl)`, 13px, 700). Tokens only.

Pending dev smoke: card title renders in Lato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)