### PR TITLE
feat: #879 — defence_penalty wire-in (ADR-006)

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -11,6 +11,9 @@ import { esc, clanIcon, covIcon, shortCov, cardName, displayName, sortName, reda
 import { setStatusTerritories, calcWillpowerMax, calcVitaeMax } from './data/accessors.js';
 import { ensureLoaded as loadTrackerState } from './game/tracker.js';
 import { loadStMods, applyStMods, spliceCurrent, stripOverlay, applyOverlayToAll } from './data/st-mods.js';
+// Issue #879 (ADR-006 D4): materialise c.derived.defence between calcDefence and
+// applyStMods so STM overlay composes on top of the armour-adjusted base.
+import { materialiseDerivedDefence } from './data/equipment-derivation.js';
 import { loadGlobalSettings, getGlobalSettings } from './data/app-settings.js';
 import { installStModPopover } from './editor/st-mod-popover.js';
 import { initWS } from './data/ws.js';
@@ -117,12 +120,25 @@ async function renderSheetWithOverlay(c) {
 
   if (editorState.editMode) {
     stripOverlay(c);
+    // Issue #879 (ADR-006 D4): re-materialise armour-adjusted defence
+    // after strip so the edit-mode view shows the canonical mechanical
+    // base (calcDefence - armourPenalty), not a stale STM-modded value.
+    materialiseDerivedDefence(c);
     renderSheet(c);
     return;
   }
 
   const tracker = await loadTrackerState(c).catch(() => null);
   spliceCurrent(c, tracker, { calcWillpowerMax, calcVitaeMax });
+
+  // Issue #879 (ADR-006 D3 + D4): composition order is
+  //   calcDefence(c) → subtract armourDefencePenalty(c) → floor → applyStMods.
+  // materialiseDerivedDefence handles the first three steps and writes the
+  // result to c.derived.defence. applyStMods then reads c.derived.defence
+  // as the base for any 'derived.defence' mod and composes additively on
+  // top, fixing the pre-existing ADR-004 D5 display bug where the marker
+  // appeared but the value didn't update.
+  materialiseDerivedDefence(c);
 
   const mods = await loadStMods(c._id);
   const settings = getGlobalSettings();
@@ -197,6 +213,9 @@ async function boot() {
         onStModUpdate: async (charId) => {
           const target = chars.find(c => String(c._id) === String(charId));
           if (!target) return;
+          // Issue #879 (ADR-006 D4): re-materialise before re-applying so the
+          // armour-adjusted base is current at composition time.
+          materialiseDerivedDefence(target);
           await applyOverlayToAll([target], getGlobalSettings()?.st_mods_enabled !== false);
           const idx = editorState.editIdx;
           if (idx != null && idx >= 0 && chars[idx] === target) {
@@ -1293,6 +1312,11 @@ async function init() {
     // holds across all admin views, mirroring app.js's pattern.
     await loadGlobalSettings();
     const globalEnabled = getGlobalSettings()?.st_mods_enabled !== false;
+    // Issue #879 (ADR-006 D4): materialise armour-adjusted defence on every
+    // char BEFORE applyOverlayToAll, so any 'derived.defence' STM mod
+    // composes additively on top of the real mechanical base instead of
+    // the pre-ADR-006 default-zero base.
+    for (const c of chars) materialiseDerivedDefence(c);
     await applyOverlayToAll(chars, globalEnabled);
 
     renderCharGrid();

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -103,6 +103,9 @@ import { loadDowntimeHoldFlag } from './data/dt-hold-flag.js';
 import { applyDerivedMerits } from './editor/mci.js';
 import { preloadRules } from './editor/rule_engine/load-rules.js';
 import { applyOverlayToAll } from './data/st-mods.js';
+// Issue #879 (ADR-006 D4): armour-adjusted defence materialised before
+// applyOverlayToAll so STM mods on derived.defence compose on top.
+import { materialiseDerivedDefence } from './data/equipment-derivation.js';
 import { loadGlobalSettings, getGlobalSettings } from './data/app-settings.js';
 import { installStModPopover } from './editor/st-mod-popover.js';
 import { loadPool, chgPool, chgMod, updPool, setAgain, togMod, togSpec, doRoll, clrHist, effPool, togEquipChip, updWeaponRef } from './suite/roll.js';
@@ -611,6 +614,10 @@ async function loadAllData() {
   // restores canonical values, so the suite stays operational without mods.
   await loadGlobalSettings();
   const globalEnabled = getGlobalSettings()?.st_mods_enabled !== false;
+  // Issue #879 (ADR-006 D4): materialise armour-adjusted defence on every
+  // char BEFORE applyOverlayToAll so 'derived.defence' STM mods compose
+  // additively on top of the real mechanical base.
+  for (const c of (suiteState.chars || [])) materialiseDerivedDefence(c);
   await applyOverlayToAll(suiteState.chars, globalEnabled);
   // editorState.chars is the same set of references for the player-owned
   // subset (sortedChars came from editorState.chars.slice()). Combat-only
@@ -1378,6 +1385,9 @@ async function boot() {
           onStModUpdate: async (charId) => {
             const target = (suiteState.chars || []).find(c => String(c._id) === String(charId));
             if (!target) return;
+            // Issue #879 (ADR-006 D4): re-materialise before re-applying so
+            // the armour-adjusted base is current at composition time.
+            materialiseDerivedDefence(target);
             await applyOverlayToAll([target], getGlobalSettings()?.st_mods_enabled !== false);
             // Issue #425: full suite sheet re-render (not just tracker
             // repaint) so the modded dots + markers refresh. STM-9

--- a/public/js/data/equipment-derivation.js
+++ b/public/js/data/equipment-derivation.js
@@ -1,0 +1,151 @@
+/**
+ * equipment-derivation.js — armour penalty + derived-defence materialisation.
+ *
+ * Issue #879 (ADR-006). Lifts EQ-1's "calcDefence does not read the equipment
+ * array without an ADR" gate. ADR-006 specifies:
+ *
+ *   D1: armourDefencePenalty(c, catalogueLookup?) reads c.equipment[] filtered
+ *       by state === 'worn' + bucket === 'armour'; injectable catalogue
+ *       lookup (default: the ECM-5 cache reader).
+ *   D2: worst-case math — Math.max(...penalties). The editor surfaces a soft
+ *       hint when >1 armour is worn (wording is concern #8 below).
+ *   D2-FLOOR: floor at 0 lives ONLY at the helper composition site. STM overlay
+ *       composes additively on top per ADR-004's no-bounds contract; the
+ *       sheet renderer adds NO further clamp.
+ *   D3: composition order — calcDefence(c) → subtract helper → floor → applyStMods.
+ *   D4: STM overlay composes on top of c.derived.defence (the armour-adjusted
+ *       base materialised by this module's materialiseDerivedDefence).
+ *   D5: pure helper, symmetric with discAttrBonus.
+ *
+ * Concern #2 from ADR-006: the per-item armour annotation in editor/sheet.js:2240
+ * must KEEP calling raw calcDefence(c). Its display intent is "if you wore only
+ * this item, defence would be X" — a hypothetical pre-armour baseline, NOT the
+ * live armour-adjusted value. Don't migrate that read site.
+ *
+ * Concern #9 from ADR-006: NO redundant floor clamps anywhere else (not in
+ * applyStMods, not in the sheet renderer). The clamp lives in exactly one
+ * place — the materialisation call below.
+ */
+
+import { calcDefence } from './accessors.js';
+import { getCatalogueEntry } from './equipment-catalogue-cache.js';
+
+/**
+ * Sum-by-worst-case of defence penalties from currently-worn armour.
+ * Returns a non-negative integer (the magnitude — composition site subtracts).
+ *
+ * Per ADR-006 D2: worst-case stacking. Math.max of all qualifying penalties;
+ * 0 when no qualifying armour is worn. Negative defence_penalty values are
+ * non-sensical for armour and are filtered out before combination.
+ *
+ * Per ADR-006 D1: state === 'worn' is the only state that contributes. The
+ * positive predicate is preferred over a not-stashed/not-lost shape because
+ * a future state-enum addition would silently affect a negative predicate
+ * (Concern #3).
+ *
+ * @param {object} c - character document
+ * @param {function} [catalogueLookup] - (id) => catalogue entry | undefined.
+ *   Default: the ECM-5 cache reader. Tests inject a synthetic map.
+ * @returns {number} non-negative integer penalty magnitude
+ */
+export function armourDefencePenalty(c, catalogueLookup = getCatalogueEntry) {
+  if (!c || !Array.isArray(c.equipment)) return 0;
+  const penalties = [];
+  for (const item of c.equipment) {
+    if (!item || item.state !== 'worn') continue;
+    const entry = catalogueLookup(item.catalogue_id);
+    if (!entry || entry.bucket !== 'armour') continue;
+    const p = Number.isInteger(entry.defence_penalty) ? entry.defence_penalty : 0;
+    if (p > 0) penalties.push(p);
+  }
+  if (penalties.length === 0) return 0;
+  return Math.max(...penalties);
+}
+
+/**
+ * Count of armour items currently in state==='worn'. Drives the editor hint
+ * surfaced when >1 armour is worn (ADR-006 D2 + Concern #8 — wording verbatim
+ * in editor/sheet.js armour-section header).
+ *
+ * @param {object} c - character document
+ * @param {function} [catalogueLookup]
+ * @returns {number} count of worn armour items
+ */
+export function wornArmourCount(c, catalogueLookup = getCatalogueEntry) {
+  if (!c || !Array.isArray(c.equipment)) return 0;
+  let n = 0;
+  for (const item of c.equipment) {
+    if (!item || item.state !== 'worn') continue;
+    const entry = catalogueLookup(item.catalogue_id);
+    if (entry?.bucket === 'armour') n++;
+  }
+  return n;
+}
+
+/**
+ * Compute and materialise `c.derived.defence` per ADR-006 D3 + D4.
+ *
+ *   c.derived.defence = max(0, calcDefence(c) - armourDefencePenalty(c))
+ *
+ * This is the armour-adjusted base. applyStMods (called AFTER this, per the
+ * render-path orchestrator) reads `c.derived.defence` as base, applies the
+ * STM delta on top, and writes back — no longer the pre-ADR-006 bug where
+ * applyStMods treated missing base as 0 (so STM mods on derived.defence
+ * silently composed against 0 instead of the real mechanical base).
+ *
+ * Per ADR-006 D2-FLOOR + Concern #9: floor lives HERE, only HERE. No
+ * defensive clamp in applyStMods or the sheet renderer.
+ *
+ * @param {object} c - character document (mutated)
+ * @param {function} [catalogueLookup]
+ * @returns {number} the materialised armour-adjusted defence (pre-overlay)
+ */
+export function materialiseDerivedDefence(c, catalogueLookup = getCatalogueEntry) {
+  if (!c) return 0;
+  const base = calcDefence(c);
+  const penalty = armourDefencePenalty(c, catalogueLookup);
+  const adjusted = Math.max(0, base - penalty);
+  c.derived = c.derived || {};
+  c.derived.defence = adjusted;
+  return adjusted;
+}
+
+/**
+ * Read-site helper: returns the modded c.derived.defence when it's been
+ * materialised (the common case post-boot per the D8 cache-entry invariant);
+ * falls back to a fresh armour-adjusted computation when not materialised
+ * (edge cases — fresh chars, test contexts). The fallback is the same
+ * computation materialiseDerivedDefence performs; the difference is whether
+ * the result is cached on c.derived.defence or computed on the fly.
+ *
+ * Used by sheet.js, suite/sheet.js, roll calc, DT player pool, DT admin
+ * resolution view — every consumer that previously called calcDefence(c)
+ * directly migrates here.
+ *
+ * @param {object} c - character document
+ * @param {function} [catalogueLookup]
+ * @returns {number} displayed defence (overlay-modded if applicable)
+ */
+export function defenceForDisplay(c, catalogueLookup = getCatalogueEntry) {
+  if (c && c.derived && typeof c.derived.defence === 'number') return c.derived.defence;
+  if (!c) return 0;
+  return Math.max(0, calcDefence(c) - armourDefencePenalty(c, catalogueLookup));
+}
+
+/**
+ * Export-site helper: canonical mechanical defence (armour-adjusted, no
+ * STM overlay). Always computes fresh — does NOT read c.derived.defence
+ * which may carry an overlay-modded value at export time.
+ *
+ * Per ADR-004: STM overlays are scene-only adjustments and NOT canonical
+ * character state. Character export (JSON / CSV / snapshot) captures the
+ * mechanical baseline; overlays are a separate concern.
+ *
+ * @param {object} c - character document
+ * @param {function} [catalogueLookup]
+ * @returns {number} mechanical defence baseline (armour-adjusted)
+ */
+export function defenceMechanicalBase(c, catalogueLookup = getCatalogueEntry) {
+  if (!c) return 0;
+  return Math.max(0, calcDefence(c) - armourDefencePenalty(c, catalogueLookup));
+}

--- a/public/js/editor/csv-format.js
+++ b/public/js/editor/csv-format.js
@@ -7,6 +7,9 @@ import {
   calcSize, calcSpeed, calcDefence, calcHealth, calcWillpowerMax, calcVitaeMax,
   calcCityStatus, BP_TABLE
 } from '../data/accessors.js';
+// Issue #879 (ADR-006 D3): CSV export captures canonical mechanical defence
+// (armour-adjusted, no STM overlay).
+import { defenceMechanicalBase } from '../data/equipment-derivation.js';
 import { xpLeft, xpEarned } from './xp.js';
 import { getWillpower } from '../data/helpers.js';
 import { applyDerivedMerits } from './mci.js';
@@ -336,7 +339,7 @@ export function charToRow(c) {
   // Derived stats
   row.push(calcSize(c));
   row.push(calcSpeed(c));
-  row.push(calcDefence(c));
+  row.push(defenceMechanicalBase(c));
 
   // Willpower triggers — derived from Mask/Dirge, not stored
   const wp = getWillpower(c);

--- a/public/js/editor/export-character.js
+++ b/public/js/editor/export-character.js
@@ -15,6 +15,7 @@ import {
   calcCityStatus, titleStatusBonus, BP_TABLE,
 } from '../data/accessors.js';
 import { isInClanDisc } from '../data/accessors.js';
+import { defenceMechanicalBase } from '../data/equipment-derivation.js';
 import { meritLookup } from './merits.js';
 import { fmtRuleStats } from '../suite/sheet-helpers.js';
 import {
@@ -82,7 +83,10 @@ export function serialiseForPrint(c, territories) {
     humanity: c.humanity != null ? c.humanity : 7,
     health: calcHealth(c),
     willpower: calcWillpowerMax(c),
-    defence: calcDefence(c),
+    // Issue #879 (ADR-006 D3): canonical mechanical defence is armour-adjusted
+    // (no STM overlay). defenceMechanicalBase computes fresh, never reads
+    // c.derived.defence which may carry an overlay-modded value at export time.
+    defence: defenceMechanicalBase(c),
     speed: calcSpeed(c),
     size: calcSize(c),
     vitae_max: calcVitaeMax(c),

--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -8,6 +8,15 @@ import { ICONS } from '../data/icons.js';
 import { CLAN_ICON_KEY, COV_ICON_KEY, clanIcon, covIcon, shDots, shDotsWithBonus, esc, formatSpecs, hasAoE, displayName, cardName, dropdownName, sortName, getWillpower, redactPlayer, redactCharName, isRedactMode } from '../data/helpers.js';
 import { getAttrVal, getAttrBonus, getSkillObj, calcCityStatus, titleStatusBonus, regentAmienceBonus, getRegentTerritoryFor, isInClanDisc, riteCost } from '../data/accessors.js';
 import { calcHealth, calcWillpowerMax, calcSize, calcSpeed, calcDefence } from '../data/derived.js';
+// Issue #879 (ADR-006 D4): displayed defence reads the armour-adjusted +
+// overlay-modded value from c.derived.defence (with on-the-fly fallback for
+// unmaterialised contexts). The per-item armour annotation below intentionally
+// still reads raw calcDefence(c) per ADR-006 Concern #2 (the "if you wore only
+// this item, defence would be X" hypothetical baseline).
+//
+// wornArmourCount drives the >1 worn armour editor hint (ADR-006 D2 + Concern
+// #8, wording locked).
+import { defenceForDisplay, wornArmourCount } from '../data/equipment-derivation.js';
 import { xpToDots, xpEarned, xpSpent, xpLeft, xpStarting, xpHumanityDrop, xpOrdeals, xpGame, xpPT5, xpSpentAttrs, xpSpentSkills, xpSpentMerits, xpSpentPowers, xpSpentSpecial, setDevotionsDB, meritBdRow } from './xp.js';
 import { meritBase, meritDotCount, meritLookup, meritFixedRating, buildMeritOptions, buildSubCategoryMeritOptions, buildMCIGrantOptions, buildFThiefOptions, ensureMeritSync, meetsDevPrereqs, devPrereqStr, meetsPrereq, prereqLabel } from './merits.js';
 // N-1 (Concern #11): every read of m.attached_to goes through this normaliser.
@@ -438,7 +447,7 @@ export function shRenderStatsStrip(c) {
   const healthDisplay = `${calcHealth(c)}${markerFor(c, 'derived.health_max')}`;
   const sizeDisplay = `${calcSize(c)}${markerFor(c, 'derived.size')}`;
   const speedDisplay = `${calcSpeed(c)}${markerFor(c, 'derived.speed')}`;
-  const defDisplay = `${calcDefence(c)}${markerFor(c, 'derived.defence')}`;
+  const defDisplay = `${defenceForDisplay(c)}${markerFor(c, 'derived.defence')}`;
   return '<div class="sh-stats-strip">' + bpCell + humCell + s(HEALTH_SVG, healthDisplay, 'Health') + s(WP_SVG, wpDisplay, _wpLbl) + s(STAT_SVG, sizeDisplay, 'Size') + s(STAT_SVG, speedDisplay, 'Speed') + s(STAT_SVG, defDisplay, 'Defence') + '</div>';
 }
 
@@ -2237,6 +2246,14 @@ export function shRenderEquipment(c, editMode) {
   // ── Armour ──
   if (byBucket.armour.length) {
     h += '<div class="sh-sub-title">Armour</div>';
+    // Issue #879 (ADR-006 D2 + Concern #8): soft non-blocking hint when
+    // multiple armour items are in state==='worn'. Stacking rule is
+    // worst-case (Math.max of all defence_penalties); the hint exists so
+    // an ST hitting a multi-worn debug case doesn't misinterpret the math.
+    // Wording locked verbatim per Concern #8 — must not drift.
+    if (wornArmourCount(c) > 1) {
+      h += '<div class="sh-armour-hint" style="font-size:0.85em;opacity:0.75;margin-bottom:6px;">Only one armour applies; highest defence_penalty wins.</div>';
+    }
     const baseDefence = calcDefence(c);
     for (const { item, entry, idx } of byBucket.armour) {
       const name  = entry.name || item.catalogue_id;

--- a/public/js/game/char-pools.js
+++ b/public/js/game/char-pools.js
@@ -6,6 +6,9 @@ import {
   getAttrEffective, getAttrBonus, skTotal, skNineAgain,
   calcDefence, calcHealth, calcWillpowerMax, calcVitaeMax, calcSpeed,
 } from '../data/accessors.js';
+// Issue #879 (ADR-006 D4): roll calculator's derived-stats strip reads
+// the armour-adjusted + overlay-modded defence.
+import { defenceForDisplay } from '../data/equipment-derivation.js';
 import { getPool } from '../shared/pools.js';
 import { getRulesByCategory } from '../data/loader.js';
 import { esc } from '../data/helpers.js';
@@ -56,7 +59,7 @@ let _pools = [];
 export function renderCharPools(el, char, onTap) {
   _pools = [];
 
-  const defence = calcDefence(char);
+  const defence = defenceForDisplay(char);
   const hp      = calcHealth(char);
   const wp      = calcWillpowerMax(char);
   const vitae   = calcVitaeMax(char);

--- a/public/js/game/combat-tab.js
+++ b/public/js/game/combat-tab.js
@@ -7,6 +7,9 @@
 
 import suiteState from '../suite/data.js';
 import { getAttrEffective, calcDefence, calcHealth } from '../data/accessors.js';
+// Issue #879 (ADR-006 D4): combat scene captures the armour-adjusted +
+// overlay-modded defence at snapshot time.
+import { defenceForDisplay } from '../data/equipment-derivation.js';
 import { esc } from '../data/helpers.js';
 import { trackerAdj, trackerRead } from './tracker.js';
 import { loadPool, doRoll } from '../suite/roll.js';
@@ -62,7 +65,7 @@ function _combatantFromChar(c) {
     name: c.moniker || c.name,
     initiative: null,
     initBase: _initPool(c),
-    defence: calcDefence(c),
+    defence: defenceForDisplay(c),
     defenceUsed: false,
     maxHp: calcHealth(c),
     attackPools: _attackPools(c),

--- a/public/js/suite/sheet.js
+++ b/public/js/suite/sheet.js
@@ -22,6 +22,10 @@ import {
   calcCityStatus,
   getSkillObj
 } from '../data/accessors.js';
+// Issue #879 (ADR-006 D4): displayed defence reads the armour-adjusted +
+// overlay-modded value from c.derived.defence (fallback to on-the-fly
+// computation when unmaterialised).
+import { defenceForDisplay } from '../data/equipment-derivation.js';
 import { xpEarned, xpSpent, xpLeft } from '../editor/xp.js';
 import { trackerRead, trackerReadRaw, trackerAdj, trackerWriteField } from '../game/tracker.js';
 import { calcTotalInfluence, influenceBreakdown } from '../editor/domain.js';
@@ -333,7 +337,7 @@ export function renderSheet() {
     <div class="sh-stat-cell"><div class="sh-stat-icon">${HUM_SVG}<span class="sh-stat-n">${c.humanity || 0}${markerFor(c, 'humanity')}</span></div><div class="sh-stat-lbl">Humanity</div></div>
     <div class="sh-stat-cell"><div class="sh-stat-icon">${STAT_SVG}<span class="sh-stat-n">${calcSize(c)}${markerFor(c, 'derived.size')}</span></div><div class="sh-stat-lbl">Size</div></div>
     <div class="sh-stat-cell"><div class="sh-stat-icon">${STAT_SVG}<span class="sh-stat-n">${calcSpeed(c)}${markerFor(c, 'derived.speed')}</span></div><div class="sh-stat-lbl">Speed</div></div>
-    <div class="sh-stat-cell"><div class="sh-stat-icon">${STAT_SVG}<span class="sh-stat-n">${calcDefence(c)}${markerFor(c, 'derived.defence')}</span></div><div class="sh-stat-lbl">Defence</div></div>
+    <div class="sh-stat-cell"><div class="sh-stat-icon">${STAT_SVG}<span class="sh-stat-n">${defenceForDisplay(c)}${markerFor(c, 'derived.defence')}</span></div><div class="sh-stat-lbl">Defence</div></div>
   </div>`;
 
   // ── TRACKERS ──

--- a/server/tests/issue-879-defence-penalty-wirein.test.js
+++ b/server/tests/issue-879-defence-penalty-wirein.test.js
@@ -1,0 +1,402 @@
+/**
+ * Issue #879 — defence_penalty wire-in (ADR-006).
+ *
+ * Three slices anchored on the SM brief's verbatim N-1 acceptance gates:
+ *
+ *   1. **Concern #4 (regression):** STM mod on derived.defence is visibly
+ *      reflected in the displayed value, not just the marker. The
+ *      pre-ADR-006 bug at sheet.js:441 + ADR-004 D5 — overlay populated
+ *      `c._st_mod_overlay['derived.defence']` but the sheet read raw
+ *      `calcDefence(c)` so the modded value never reached the DOM.
+ *
+ *   2. **Concern #8 (editor hint wording):** when >1 armour item is in
+ *      state==='worn', editor/sheet.js surfaces the verbatim string
+ *      _"Only one armour applies; highest defence_penalty wins."_ Wording
+ *      must not drift; static-text assertion guards against rewording.
+ *
+ *   3. **Concern #9 (single-floor invariant):** the floor at 0 lives in
+ *      exactly one place — the helper composition in equipment-derivation.js.
+ *      No redundant `Math.max(0, ...)` clamps in the sheet renderer or in
+ *      `applyStMods`. STM overlay can legitimately push the rendered value
+ *      below 0 per ADR-004's no-bounds contract.
+ *
+ * Plus pure-helper tests for armourDefencePenalty, wornArmourCount,
+ * materialiseDerivedDefence, defenceForDisplay, defenceMechanicalBase —
+ * the behaviour contract from ADR-006 D1 / D2 / D2-FLOOR / D3 / D4 / D5.
+ *
+ * The behavioural slice imports equipment-derivation.js via dynamic import
+ * with a browser-globals stub (the module reaches the cache module → api.js
+ * which uses `location`). Same pattern ECM-1 / ECM-5 use.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+function read(rel) { return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8'); }
+function exists(rel) { return fs.existsSync(path.join(REPO_ROOT, rel)); }
+
+// Convenience: deterministic test characters (no rules cache; minimal shape).
+function mkChar(overrides = {}) {
+  return {
+    name: 'Fixture',
+    attributes: {
+      Dexterity: { dots: 3, bonus: 0 }, Wits: { dots: 3, bonus: 0 },
+      Strength: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+      Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 },
+      Composure: { dots: 2, bonus: 0 }, Intelligence: { dots: 2, bonus: 0 },
+      Resolve: { dots: 2, bonus: 0 },
+    },
+    skills: { Athletics: { dots: 2, bonus: 0, specs: [], nine_again: false } },
+    disciplines: {}, merits: [], equipment: [],
+    ...overrides,
+  };
+}
+
+// Synthetic catalogue lookup — tests inject this rather than reaching the cache.
+function mkLookup(items) {
+  const byId = new Map(items.map(it => [String(it._id), it]));
+  return (id) => byId.get(String(id));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Static-analysis — file existence, exports, no redundant clamps
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#879 — equipment-derivation.js module shape', () => {
+  it('the helper module exists', () => {
+    expect(exists('public/js/data/equipment-derivation.js')).toBe(true);
+  });
+
+  const src = read('public/js/data/equipment-derivation.js');
+
+  it('exports armourDefencePenalty, materialiseDerivedDefence, defenceForDisplay, defenceMechanicalBase, wornArmourCount (D1 + D2 + D2-FLOOR + D3 + D4 + D5)', () => {
+    expect(src).toMatch(/export\s+function\s+armourDefencePenalty\b/);
+    expect(src).toMatch(/export\s+function\s+materialiseDerivedDefence\b/);
+    expect(src).toMatch(/export\s+function\s+defenceForDisplay\b/);
+    expect(src).toMatch(/export\s+function\s+defenceMechanicalBase\b/);
+    expect(src).toMatch(/export\s+function\s+wornArmourCount\b/);
+  });
+
+  it('helper signature accepts an injectable catalogue lookup (default = ECM-5 cache reader)', () => {
+    // armourDefencePenalty(c, catalogueLookup = getCatalogueEntry)
+    expect(src).toMatch(/armourDefencePenalty\s*\(\s*c\s*,\s*catalogueLookup\s*=\s*getCatalogueEntry\s*\)/);
+  });
+
+  it('filters by state === \'worn\' (positive predicate, not !==)', () => {
+    expect(src).toMatch(/item\.state\s*!==\s*['"]worn['"]/);
+    expect(src).not.toMatch(/item\.state\s*===\s*['"]stashed['"]/);
+  });
+
+  it('filters by bucket === \'armour\'', () => {
+    expect(src).toMatch(/entry\.bucket\s*!==\s*['"]armour['"]/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Concern #9 (single-floor invariant) — static-analysis
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#879 — Concern #9 (single-floor invariant)', () => {
+  it('the floor lives in equipment-derivation.js (Math.max(0, ...) on calcDefence)', () => {
+    const src = read('public/js/data/equipment-derivation.js');
+    // Both materialiseDerivedDefence and defenceMechanicalBase contain the clamp.
+    const matches = src.match(/Math\.max\(\s*0\s*,\s*calcDefence\(c\)\s*-\s*armourDefencePenalty/g) || [];
+    expect(matches.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('public/js/data/st-mods.js adds NO defence-specific floor clamp', () => {
+    const src = read('public/js/data/st-mods.js');
+    // applyStMods's mechanical core only does base + delta; no defence-specific clamp.
+    expect(src).not.toMatch(/Math\.max\(\s*0\s*,\s*[^)]*derived\.defence/);
+  });
+
+  it('public/js/editor/sheet.js adds NO defence-specific floor clamp at the render site', () => {
+    const src = read('public/js/editor/sheet.js');
+    // The defDisplay render line should not wrap the value in Math.max(0, ...).
+    // It reads defenceForDisplay(c) verbatim.
+    expect(src).toMatch(/defenceForDisplay\(c\)\}\$\{markerFor\(c,\s*['"]derived\.defence['"]/);
+    expect(src).not.toMatch(/defDisplay\s*=\s*`\$\{Math\.max\(0/);
+  });
+
+  it('public/js/suite/sheet.js adds NO defence-specific floor clamp at the render site', () => {
+    const src = read('public/js/suite/sheet.js');
+    expect(src).toMatch(/defenceForDisplay\(c\)/);
+    expect(src).not.toMatch(/\$\{Math\.max\(0,\s*defenceForDisplay/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Concern #8 (editor hint wording verbatim)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#879 — Concern #8 (editor hint wording verbatim)', () => {
+  const src = read('public/js/editor/sheet.js');
+
+  it('renders the soft hint exactly as: "Only one armour applies; highest defence_penalty wins."', () => {
+    // Verbatim match — drift in the hint wording is a failed AC.
+    expect(src).toContain('Only one armour applies; highest defence_penalty wins.');
+  });
+
+  it('gates the hint on wornArmourCount(c) > 1 (not on byBucket.armour.length > 1, which would also count carried/stashed)', () => {
+    expect(src).toMatch(/wornArmourCount\(c\)\s*>\s*1/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Render-path orchestrator — materialisation runs BEFORE applyStMods
+// (Concern #4 / pre-existing ADR-004 D5 display bug fix)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#879 — Concern #4 (render-path orchestrator wires materialisation before applyStMods)', () => {
+  it('admin.js renderSheetWithOverlay calls materialiseDerivedDefence before applyStMods', () => {
+    const src = read('public/js/admin.js');
+    const fnStart = src.indexOf('async function renderSheetWithOverlay');
+    expect(fnStart).toBeGreaterThan(-1);
+    const fnBody = src.slice(fnStart, fnStart + 1800);
+    const idxMaterialise = fnBody.indexOf('materialiseDerivedDefence');
+    const idxApply       = fnBody.indexOf('applyStMods(');
+    expect(idxMaterialise).toBeGreaterThan(-1);
+    expect(idxApply).toBeGreaterThan(-1);
+    expect(idxMaterialise).toBeLessThan(idxApply);
+  });
+
+  it('admin.js boot pre-loops materialiseDerivedDefence BEFORE applyOverlayToAll', () => {
+    const src = read('public/js/admin.js');
+    // The bulk path: `for (const c of chars) materialiseDerivedDefence(c); await applyOverlayToAll(...)`.
+    expect(src).toMatch(/for\s*\(\s*const\s+c\s+of\s+chars\s*\)\s*materialiseDerivedDefence\(c\)/);
+  });
+
+  it('app.js (player portal) pre-loops materialiseDerivedDefence BEFORE applyOverlayToAll at boot', () => {
+    const src = read('public/js/app.js');
+    expect(src).toMatch(/for\s*\(\s*const\s+c\s+of\s+\(suiteState\.chars\s*\|\|\s*\[\]\)\s*\)\s*materialiseDerivedDefence\(c\)/);
+  });
+
+  it('admin.js + app.js onStModUpdate paths re-materialise before re-applying', () => {
+    const adminSrc = read('public/js/admin.js');
+    const appSrc   = read('public/js/app.js');
+    // Both should call materialiseDerivedDefence(target) before the
+    // applyOverlayToAll([target], ...) call in their onStModUpdate handlers.
+    expect(adminSrc).toMatch(/materialiseDerivedDefence\(target\);\s*await\s+applyOverlayToAll\(\[target\]/);
+    expect(appSrc).toMatch(/materialiseDerivedDefence\(target\);\s*await\s+applyOverlayToAll\(\[target\]/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Read-site sweep (sheet, suite/sheet, roll calc, combat-tab, exports)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#879 — read-site sweep migrates to defenceForDisplay / defenceMechanicalBase', () => {
+  it('editor/sheet.js defDisplay reads defenceForDisplay (overlay-aware)', () => {
+    const src = read('public/js/editor/sheet.js');
+    expect(src).toMatch(/const\s+defDisplay\s*=\s*`\$\{defenceForDisplay\(c\)\}\$\{markerFor\(c,\s*['"]derived\.defence['"]\)/);
+  });
+
+  it('editor/sheet.js per-item armour annotation STILL calls raw calcDefence(c) per ADR-006 Concern #2', () => {
+    const src = read('public/js/editor/sheet.js');
+    // The pre-armour, pre-overlay hypothetical baseline: "if you wore only this item, defence would be X".
+    expect(src).toMatch(/const\s+baseDefence\s*=\s*calcDefence\(c\)/);
+  });
+
+  it('suite/sheet.js defence cell reads defenceForDisplay', () => {
+    const src = read('public/js/suite/sheet.js');
+    expect(src).toMatch(/\$\{defenceForDisplay\(c\)\}\$\{markerFor\(c,\s*['"]derived\.defence['"]\)/);
+  });
+
+  it('game/char-pools.js (roll calculator) reads defenceForDisplay', () => {
+    const src = read('public/js/game/char-pools.js');
+    expect(src).toMatch(/const\s+defence\s*=\s*defenceForDisplay\(char\)/);
+  });
+
+  it('game/combat-tab.js (combat scene snapshot) reads defenceForDisplay', () => {
+    const src = read('public/js/game/combat-tab.js');
+    expect(src).toMatch(/defence:\s*defenceForDisplay\(c\)/);
+  });
+
+  it('editor/export-character.js JSON export uses defenceMechanicalBase (no overlay)', () => {
+    const src = read('public/js/editor/export-character.js');
+    expect(src).toMatch(/defence:\s*defenceMechanicalBase\(c\)/);
+  });
+
+  it('editor/csv-format.js CSV export uses defenceMechanicalBase (no overlay)', () => {
+    const src = read('public/js/editor/csv-format.js');
+    expect(src).toMatch(/row\.push\(\s*defenceMechanicalBase\(c\)\s*\)/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Behavioural — dynamic import the helper module under the location stub.
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#879 — armourDefencePenalty behaviour (D1 + D2)', () => {
+  it('returns 0 when no worn armour is present', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    const c = mkChar({ equipment: [] });
+    expect(mod.armourDefencePenalty(c)).toBe(0);
+  });
+
+  it('returns 0 for armour items in non-worn states', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    const items = [
+      { _id: 'aaa1', bucket: 'armour', defence_penalty: 2 },
+      { _id: 'aaa2', bucket: 'armour', defence_penalty: 3 },
+    ];
+    const c = mkChar({ equipment: [
+      { catalogue_id: 'aaa1', state: 'carried' },
+      { catalogue_id: 'aaa2', state: 'stashed' },
+    ]});
+    expect(mod.armourDefencePenalty(c, mkLookup(items))).toBe(0);
+  });
+
+  it('D1: filters by bucket === \'armour\' — ignores worn non-armour items', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    const items = [
+      { _id: 'wep1', bucket: 'weapon', defence_penalty: 5 },   // not armour, ignored
+      { _id: 'arm1', bucket: 'armour', defence_penalty: 2 },
+    ];
+    const c = mkChar({ equipment: [
+      { catalogue_id: 'wep1', state: 'worn' },
+      { catalogue_id: 'arm1', state: 'worn' },
+    ]});
+    expect(mod.armourDefencePenalty(c, mkLookup(items))).toBe(2);
+  });
+
+  it('D2: returns the MAX defence_penalty across multiple worn armour items (worst-case stacking)', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    const items = [
+      { _id: 'arm1', bucket: 'armour', defence_penalty: 1 },
+      { _id: 'arm2', bucket: 'armour', defence_penalty: 3 },
+      { _id: 'arm3', bucket: 'armour', defence_penalty: 2 },
+    ];
+    const c = mkChar({ equipment: [
+      { catalogue_id: 'arm1', state: 'worn' },
+      { catalogue_id: 'arm2', state: 'worn' },
+      { catalogue_id: 'arm3', state: 'worn' },
+    ]});
+    expect(mod.armourDefencePenalty(c, mkLookup(items))).toBe(3);
+  });
+
+  it('treats null/undefined/non-integer defence_penalty as 0', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    const items = [
+      { _id: 'a1', bucket: 'armour', defence_penalty: null },
+      { _id: 'a2', bucket: 'armour', defence_penalty: undefined },
+      { _id: 'a3', bucket: 'armour', defence_penalty: 'bad' },
+    ];
+    const c = mkChar({ equipment: items.map(it => ({ catalogue_id: it._id, state: 'worn' })) });
+    expect(mod.armourDefencePenalty(c, mkLookup(items))).toBe(0);
+  });
+
+  it('ignores items with no catalogue match (fail-soft per Concern #5)', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    const c = mkChar({ equipment: [{ catalogue_id: 'ghost', state: 'worn' }] });
+    expect(mod.armourDefencePenalty(c, () => undefined)).toBe(0);
+  });
+});
+
+describe('#879 — wornArmourCount (drives the editor hint)', () => {
+  it('counts only worn-state armour items', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    const items = [
+      { _id: 'a1', bucket: 'armour' }, { _id: 'a2', bucket: 'armour' },
+      { _id: 'a3', bucket: 'armour' }, { _id: 'w1', bucket: 'weapon' },
+    ];
+    const c = mkChar({ equipment: [
+      { catalogue_id: 'a1', state: 'worn' },
+      { catalogue_id: 'a2', state: 'worn' },
+      { catalogue_id: 'a3', state: 'carried' },
+      { catalogue_id: 'w1', state: 'worn' },
+    ]});
+    expect(mod.wornArmourCount(c, mkLookup(items))).toBe(2);
+  });
+});
+
+describe('#879 — materialiseDerivedDefence (D3 + D4)', () => {
+  it('writes c.derived.defence = max(0, calcDefence - armourDefencePenalty), floors at 0', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    const accessors = await import('../../public/js/data/accessors.js');
+    // calcDefence on the mkChar fixture: min(Dex=3, Wits=3) + Athletics=2 + discBonus=0 = 5.
+    const c = mkChar({ equipment: [{ catalogue_id: 'arm1', state: 'worn' }] });
+    const items = [{ _id: 'arm1', bucket: 'armour', defence_penalty: 2 }];
+    const result = mod.materialiseDerivedDefence(c, mkLookup(items));
+    expect(result).toBe(accessors.calcDefence(c) - 2);
+    expect(c.derived.defence).toBe(result);
+  });
+
+  it('D2-FLOOR: clamps to 0 when armourPenalty exceeds base defence', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    // Tiny char: Dex=1, Wits=1, Athletics=0 → calcDefence = 1.
+    const tinyChar = mkChar({
+      attributes: { ...mkChar().attributes, Dexterity: { dots: 1, bonus: 0 }, Wits: { dots: 1, bonus: 0 } },
+      skills: {},
+      equipment: [{ catalogue_id: 'arm1', state: 'worn' }],
+    });
+    const items = [{ _id: 'arm1', bucket: 'armour', defence_penalty: 5 }];
+    expect(mod.materialiseDerivedDefence(tinyChar, mkLookup(items))).toBe(0);
+  });
+});
+
+describe('#879 — defenceForDisplay (read-site helper)', () => {
+  it('returns materialised c.derived.defence when present', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    const c = mkChar({ derived: { defence: 42 } });
+    expect(mod.defenceForDisplay(c)).toBe(42);
+  });
+
+  it('Concern #4 verbatim: STM mod on derived.defence is visibly reflected (modded > base)', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    const accessors = await import('../../public/js/data/accessors.js');
+    // Materialise then simulate applyStMods writing the modded value to c.derived.defence.
+    const c = mkChar({ equipment: [] });
+    mod.materialiseDerivedDefence(c);
+    const base = accessors.calcDefence(c);
+    expect(c.derived.defence).toBe(base);
+    // Simulate STM mod: +3
+    c.derived.defence = base + 3;
+    expect(mod.defenceForDisplay(c)).toBe(base + 3);
+  });
+
+  it('Concern #4 verbatim: STM mod can push displayed defence below 0 per ADR-004 no-bounds (single-floor invariant Concern #9)', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    // Pre-condition: c.derived.defence = 1 (post-materialisation, no overlay).
+    // STM mod = -5 → c.derived.defence = -4.
+    const c = mkChar({ derived: { defence: -4 } });
+    // defenceForDisplay reads the materialised value verbatim — no defensive
+    // clamp. The renderer displays -4. (Concern #9: floor lives only at
+    // materialiseDerivedDefence, NOT here.)
+    expect(mod.defenceForDisplay(c)).toBe(-4);
+  });
+});
+
+describe('#879 — defenceMechanicalBase (export-site helper)', () => {
+  it('always computes fresh — ignores c.derived.defence (which may carry overlay)', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    const accessors = await import('../../public/js/data/accessors.js');
+    // Even if c.derived.defence is overlay-modded to some weird value,
+    // defenceMechanicalBase returns the canonical mechanical baseline.
+    const c = mkChar({
+      equipment: [{ catalogue_id: 'arm1', state: 'worn' }],
+      derived: { defence: 99 },   // overlay-modded; should be ignored
+    });
+    const items = [{ _id: 'arm1', bucket: 'armour', defence_penalty: 2 }];
+    const result = mod.defenceMechanicalBase(c, mkLookup(items));
+    expect(result).toBe(Math.max(0, accessors.calcDefence(c) - 2));
+    expect(result).not.toBe(99);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #879. Lifts EQ-1's _"calcDefence does not read the equipment array without an ADR"_ gate per [ADR-006 Rev 2](../blob/dev/specs/architecture/adr-006-defence-penalty-readpath.md). Implements the helper + render-path composition + read-site sweep across all five locked decisions (D1 / D2 / D2-FLOOR / D3 / D4 / D5).

## The three N-1 verbatim gates (Concerns #4, #8, #9)

### Concern #4 — STM regression test for the pre-existing ADR-004 D5 display bug

**Pre-ADR-006:** the STM marker installed at `sheet.js:441` but the displayed value came from raw `calcDefence(c)` — never read `c.derived.defence`. STM mods on the defence path were silently invisible.

**Fixed by:** D4's render-path orchestrator materialises `c.derived.defence` between base derivation and `applyStMods`. The displayed value reads the materialised field via `defenceForDisplay(c)`. Behavioural test asserts STM mod on `derived.defence` is visibly reflected (Concern #4 verbatim).

### Concern #8 — Editor hint wording verbatim

When `wornArmourCount(c) > 1`, the editor armour section renders:

> **Only one armour applies; highest defence_penalty wins.**

Wording test pins the exact substring; drift in the copy is a failed AC.

### Concern #9 — No redundant floor clamps

The floor at 0 lives in exactly one place: `materialiseDerivedDefence` and `defenceMechanicalBase` (both call `Math.max(0, calcDefence(c) - armourDefencePenalty(c))`). Static-analysis tests assert:
- ≥2 matching clamps in `equipment-derivation.js` (the two consumers).
- Zero defence-specific clamps in `st-mods.js`.
- Zero `Math.max(0, ...)` wraps at the sheet render sites.

STM overlay can legitimately push the displayed value below 0 per ADR-004's no-bounds contract. A behavioural test fixture with `c.derived.defence = -4` asserts `defenceForDisplay` returns -4 verbatim.

## Architecture (per ADR-006)

| Decision | Implementation |
|---|---|
| **D1** read path | `armourDefencePenalty(c, catalogueLookup?)` — `c.equipment` filtered by `state==='worn'` + `entry.bucket==='armour'`; positive-predicate filter (Concern #3); injectable catalogue lookup defaults to the ECM-5 cache reader. Fail-soft on missing catalogue entries / non-integer `defence_penalty`. |
| **D2** stacking | Worst-case `Math.max(...penalties)` across all qualifying worn items. Multiple-worn UX clarity surfaced via the Concern #8 hint. |
| **D2-FLOOR** | Single clamp at the helper composition site. Documented + enforced via Concern #9 static-analysis assertions. |
| **D3** composition order | `calcDefence(c)` → subtract helper → floor → applyStMods (all sequenced in the render-path orchestrator). |
| **D4** STM overlay interaction | `materialiseDerivedDefence` writes `c.derived.defence` BEFORE `applyStMods` runs. The pre-existing ADR-004 D5 bug (STM marker installed but value unchanged) is fixed by this composition. |
| **D5** helper shape | New pure-function module `public/js/data/equipment-derivation.js`; symmetric with `discAttrBonus`; testable in isolation via injectable catalogue lookup. |

## Render-path orchestrator wiring (admin.js + app.js)

Four call sites of `applyOverlayToAll` (boot batch + WS update handler × 2 apps) now pre-loop `materialiseDerivedDefence(c)` so the cache-entry invariant (D8 / STM-7) extends to `derived.defence`. The per-sheet path (`renderSheetWithOverlay`) materialises immediately before `applyStMods`. The edit-mode path materialises AFTER `stripOverlay` so the canonical mechanical base is shown in edit mode (no stale modded number).

## Read-site sweep

| Site | Migration |
|---|---|
| `editor/sheet.js:441` (sheet defence display) | `calcDefence(c)` → `defenceForDisplay(c)` |
| `editor/sheet.js:2249` (per-item armour annotation) | **UNCHANGED — keeps raw `calcDefence(c)` per ADR-006 Concern #2** ("if you wore only this item, defence would be X" hypothetical) |
| `suite/sheet.js:336` (suite defence cell) | `calcDefence(c)` → `defenceForDisplay(c)` |
| `game/char-pools.js` (roll calculator derived strip) | `calcDefence(char)` → `defenceForDisplay(char)` |
| `game/combat-tab.js` (combat scene snapshot) | `calcDefence(c)` → `defenceForDisplay(c)` |
| `editor/export-character.js` (JSON export) | `calcDefence(c)` → `defenceMechanicalBase(c)` — exports capture canonical mechanical baseline, NOT overlay-modded value |
| `editor/csv-format.js` (CSV export) | `calcDefence(c)` → `defenceMechanicalBase(c)` |

Two helpers, two intentions:
- **`defenceForDisplay`** — read-site for rendering; returns the materialised (potentially overlay-modded) value.
- **`defenceMechanicalBase`** — read-site for exports; always computes fresh, never reads the materialised field.

## Verification

\`\`\`
$ cd server && npx vitest run tests/issue-879-defence-penalty-wirein.test.js
Tests  35 passed (35)

$ npx vitest run                       # full suite
Test Files  4 failed | 138 passed (142)
Tests  1829 passed (1829)
\`\`\`

The 4 file-failures are pre-existing 0-test suite-load failures on dev. 0 individual test failures.

Parse-check on all 9 touched JS files: OK.

## Test plan

- [x] Vitest — 35 passes (helper module shape + Concern #4/8/9 verbatim assertions + render-path wiring + read-site sweep + behavioural slices for armourDefencePenalty / wornArmourCount / materialiseDerivedDefence / defenceForDisplay / defenceMechanicalBase)
- [x] \`node --check\` on all 9 touched JS files — parse OK
- [x] Full suite — 0 new failures
- [ ] **Manual browser smoke**: open a character with worn armour in the editor; verify the defence cell displays the armour-adjusted value (base − penalty, floored at 0); the per-item armour annotation in the equipment panel still shows the pre-armour "Defence X(X-penalty)" hypothetical.
- [ ] **Manual STM smoke (Concern #4 fix)**: with STM mods enabled, install a `derived.defence: -2` mod; verify the displayed defence drops by 2 — both in the editor sheet and the suite sheet. Pre-ADR-006 this didn't happen.
- [ ] **Manual multi-armour smoke (Concern #8 verbatim)**: equip two armour items in `state: 'worn'` (use the ECM-6 catalogue admin if needed). Verify the editor sheet shows the soft hint: _"Only one armour applies; highest defence_penalty wins."_ — exact wording. Math should pick the higher penalty.
- [ ] **Manual no-bounds smoke (Concern #9)**: install an STM mod large enough to push displayed defence below 0 (e.g. `derived.defence: -10` on a character with adjusted base = 3); verify the displayed value is `-7`, not `0`. The single-floor invariant means the renderer respects the overlay-modded value verbatim.