### PR TITLE
docs(ecm): #875 — CLAUDE.md amendment (Epic ECM final)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,11 +107,28 @@ XP functions in `public/js/editor/xp.js`: `xpEarned()`, `xpSpent()`, `xpLeft()`,
 
 ## Immutable reference data (baked into JS modules)
 
-- `CLANS` (5), `COVENANTS` (5), `MASKS_DIRGES` (26)
-- `MERITS_DB` (203+ entries with prerequisites and descriptions)
-- `DEVOTIONS_DB` (42: 31 general + 11 bloodline-exclusive)
-- `MAN_DB` (manoeuvre definitions)
-- `CLAN_BANES`, `BLOODLINE_DISCS`
+Small fixed enums that genuinely belong in code (changing them is a rule change, not a data update):
+
+- `CLANS` (5)
+- `COVENANTS` (5)
+- `MASKS_DIRGES` (26)
+- `CLAN_BANES` (per-clan free-text descriptions)
+- `BLOODLINE_DISCS` (per-bloodline discipline lists)
+
+All of the above live in `public/js/data/constants.js`.
+
+### Previously-static data now MongoDB-backed
+
+The "everything in JS modules" pattern was the original shape, but most reference data has since migrated to MongoDB:
+
+- **Epic PP** moved `MERITS_DB`, `DEVOTIONS_DB`, `MAN_DB`, and the rules engine into MongoDB (`purchasable_powers` collection + `rule_*` per-category collections). Live reads go through `public/js/data/loader.js` (`getRuleByKey`, `getRulesByCategory`) and the rule-engine cache at `public/js/editor/rule_engine/load-rules.js`. Server-side: `server/routes/rules.js` + `server/routes/rules-engine.js`.
+- **Epic ECM** moved the equipment catalogue from `public/js/data/equipment-data.js` + `server/data/equipment-catalogue.js` (both deleted in ECM-7 #874) into the `equipment_catalogue` MongoDB collection. Live reads go through `public/js/data/equipment-catalogue-cache.js` (the shared cache module ECM-5 introduced; refetches on the `broadcastCatalogueUpdate` WS frame). Server-side: `server/routes/equipment-catalogue.js` + `server/schemas/equipment_catalogue.schema.js`. Admin CRUD lives at `public/js/admin/equipment-catalogue-admin.js`.
+
+### Convention
+
+**Any new reference-data introduction must default to MongoDB-backed. Static JS modules require an explicit ADR carve-out.**
+
+The static enums above qualify because they encode rule-system facts (the five clans, the five covenants, the 26 mask/dirge archetypes) that change only as a system-level decision. New reference data — items, merits, rules, scenes, anything ST-editable — goes into a collection. The cost of a JS module re-introduction is the same cost the Epic PP and Epic ECM cleanups paid: every new bespoke item or rule edit requires a code deploy.
 
 ## Conventions
 


### PR DESCRIPTION
## Summary

Closes #875. Last beat of Epic ECM. Same load-bearing pattern as STM-2's CLAUDE.md amendment — the file is the first thing a future agent reads, so it must reflect the current state.

## What the amendment does (single section, lines ~108–134 post-merge)

### 1. Remaining-static list, trimmed to reality

Verified by `grep -rn "export const " public/js/data/constants.js` for the surviving enums post-Epic PP + Epic ECM. What stays:

- `CLANS` (5)
- `COVENANTS` (5)
- `MASKS_DIRGES` (26)
- `CLAN_BANES`
- `BLOODLINE_DISCS`

All live in `public/js/data/constants.js`. Section now explicitly notes this.

### 2. Migration acknowledgements (new subsection)

What moved to MongoDB and where the live reads now go:

| Epic | What migrated | Client read path | Server |
|---|---|---|---|
| Epic PP | `MERITS_DB`, `DEVOTIONS_DB`, `MAN_DB`, rules engine | `public/js/data/loader.js` + `public/js/editor/rule_engine/load-rules.js` | `server/routes/rules.js` + `server/routes/rules-engine.js` |
| Epic ECM | equipment catalogue | `public/js/data/equipment-catalogue-cache.js` (ECM-5 shared cache; refetches on `broadcastCatalogueUpdate` WS frame) | `server/routes/equipment-catalogue.js` + `server/schemas/equipment_catalogue.schema.js` |

Plus admin CRUD for the catalogue at `public/js/admin/equipment-catalogue-admin.js`.

### 3. Load-bearing convention pin (verbatim per dispatch)

> **Any new reference-data introduction must default to MongoDB-backed. Static JS modules require an explicit ADR carve-out.**

Plus a rationale paragraph: the static carve-out is legitimate when the data encodes rule-system facts (the five clans, the five covenants, the 26 archetypes) that change only as a system-level decision. It is NOT legitimate for anything ST-editable, anything bespoke per-campaign, or anything that would require a code deploy for content edits.

## Acceptance criteria

- [x] CLAUDE.md section reflects current state post-ECM.
- [x] Convention pin explicit + verbatim wording from the dispatch.
- [x] Pure docs — zero code change.
- [x] Title format per dispatch: `docs(ecm): #875 — CLAUDE.md amendment (Epic ECM final)`.

## After this lands

Epic ECM is fully shipped on dev. Per Khepri's dispatch:
1. Khepri manually closes #875 (dev auto-close gap).
2. Khepri verifies no remaining ECM-* issues open.
3. Khepri surfaces to Peter for the dev → main promotion call (Peter's call alone).
4. Worktrees torn down whenever convenient.

## Test plan

- [x] Single-file docs change; `node --check`/vitest not applicable.
- [ ] Visual review of the amended section (markdown renders cleanly; no broken cross-references).