### PR TITLE
feat: #896 — equipment availability filter + Fixer errata

### DIFF
--- a/data/reference/TM_rules_merit_2026-04-17.json
+++ b/data/reference/TM_rules_merit_2026-04-17.json
@@ -1729,7 +1729,7 @@
       2,
       2
     ],
-    "description": "Arrange illegal services and contacts.",
+    "description": "Arrange illegal services and contacts. Reduces the availability cost of all items by 1.",
     "pool": null,
     "resistance": null,
     "cost": null,

--- a/public/js/data/equipment-derivation.js
+++ b/public/js/data/equipment-derivation.js
@@ -29,6 +29,10 @@
 
 import { calcDefence } from './accessors.js';
 import { getCatalogueEntry } from './equipment-catalogue-cache.js';
+// #896: meritEffectiveRating respects free dots / cp / xp / bonus channels.
+// Used to detect Resources cap and Fixer presence without rewriting the
+// accessor chain.
+import { meritEffectiveRating } from '../editor/domain.js';
 
 /**
  * Sum-by-worst-case of defence penalties from currently-worn armour.
@@ -148,4 +152,91 @@ export function defenceForDisplay(c, catalogueLookup = getCatalogueEntry) {
 export function defenceMechanicalBase(c, catalogueLookup = getCatalogueEntry) {
   if (!c) return 0;
   return Math.max(0, calcDefence(c) - armourDefencePenalty(c, catalogueLookup));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #896 — Equipment availability filter + Fixer errata (Peter 2026-06-18).
+//
+// Composition is simple subtraction with no overlay/scene-state interaction
+// (per Khepri dispatch — no ADR needed). The helpers below are pure: take
+// (item, c) → number / boolean. Read sites use them at render time; DT form
+// uses them to gate dropdown affordability.
+//
+// Fixer errata: the 2-dot Social merit Fixer reduces the availability cost
+// of all items by 1. Applies in all usage and displays — dropdown, sheet
+// held-items, admin editor row labels (the admin editor BYPASSES the
+// affordability gate but still SHOWS the reduced number for consistency).
+//
+// Out of scope (Peter / Khepri): admin catalogue page (ECM-6) shows raw
+// catalogue availability; it is character-agnostic.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Resources cap = effective rating of the character's Resources merit, or 0
+ * if absent. Uses meritEffectiveRating so cp / xp / free / bonus channels
+ * compose correctly without re-walking the merit array.
+ *
+ * @param {object} c - character document
+ * @returns {number} resources rating (0-5)
+ */
+export function availabilityCap(c) {
+  if (!c) return 0;
+  const m = (c.merits || []).find(x => x?.name === 'Resources');
+  return m ? meritEffectiveRating(c, m) : 0;
+}
+
+/**
+ * Fixer reduction = 1 if the character has Fixer merit with effective rating
+ * >= 1, else 0. The Fixer merit is a fixed 2-dot Social merit per the rules,
+ * but we gate on the effective-rating check rather than mere presence so a
+ * suppressed / zeroed Fixer entry (edge case during merit editing) doesn't
+ * spuriously grant the reduction.
+ *
+ * @param {object} c - character document
+ * @returns {0 | 1} reduction magnitude
+ */
+export function fixerReduction(c) {
+  if (!c) return 0;
+  const m = (c.merits || []).find(x => x?.name === 'Fixer');
+  if (!m) return 0;
+  return meritEffectiveRating(c, m) >= 1 ? 1 : 0;
+}
+
+/**
+ * Effective availability of a catalogue item for a specific character:
+ *
+ *   effectiveAvailability(item, c) = max(0, item.availability - fixerReduction(c))
+ *
+ * Floored at 0 so a level-0 item with Fixer doesn't surface as -1; the
+ * floor lives here, no clamp needed at consumer sites (same single-floor
+ * discipline as ADR-006 Concern #9).
+ *
+ * `item` may be a catalogue entry (post-ECM-1 shape with `availability` int
+ * field) OR a partial; null/undefined item or missing availability defaults
+ * to 0.
+ *
+ * @param {object} item - catalogue entry
+ * @param {object} c - character document
+ * @returns {number} effective availability (0-5)
+ */
+export function effectiveAvailability(item, c) {
+  const raw = Number.isInteger(item?.availability) ? item.availability : 0;
+  return Math.max(0, raw - fixerReduction(c));
+}
+
+/**
+ * Convenience wrapper: is the item within the character's affordability gate?
+ *
+ *   isAffordable(item, c) = effectiveAvailability(item, c) <= availabilityCap(c)
+ *
+ * Used by the DT form dropdown to disable unaffordable options. The admin
+ * character editor explicitly BYPASSES this gate (ST override) but still
+ * displays the effective availability per Peter's dispatch.
+ *
+ * @param {object} item - catalogue entry
+ * @param {object} c - character document
+ * @returns {boolean}
+ */
+export function isAffordable(item, c) {
+  return effectiveAvailability(item, c) <= availabilityCap(c);
 }

--- a/public/js/editor/edit.js
+++ b/public/js/editor/edit.js
@@ -21,6 +21,10 @@ import { vmPool, vmUsed, investedPool, investedUsed, lorekeeperPool, lorekeeperU
 // alongside the server mirror; editor/sheet.js and suite/roll.js still
 // read from it via `getCatalogueEntry`.
 import { getCatalogueByBucket } from '../data/equipment-catalogue-cache.js';
+// #896: ST admin editor BYPASSES the availability filter (ST can assign any
+// item to any character) but still shows the per-character effective
+// availability in option labels for display consistency.
+import { effectiveAvailability } from '../data/equipment-derivation.js';
 import {
   shEditInflMerit, shEditContactSphere, shRemoveInflMerit, shAddInflMerit, shAddVMAllies, shAddLKMerit,
   shEditGenMerit, shRemoveGenMerit, shAddGenMerit,
@@ -1080,10 +1084,20 @@ export function shEquipBucketFilter() {
   const itemSel = document.getElementById('eq-add-item');
   if (!itemSel) return;
   const entries = bucket ? getCatalogueByBucket(bucket) : [];
+  // #896: append effective availability per the character being edited.
+  // ST admin BYPASSES the affordability gate — every option remains enabled
+  // regardless of whether the character could acquire it via DT — but the
+  // label still surfaces the effective number for consistency with player
+  // surfaces (sheet rows, DT dropdown).
+  const c = (state.editIdx != null && state.editIdx >= 0) ? state.chars[state.editIdx] : null;
   // ECM-5: option `value` is the catalogue ObjectId in 24-hex string form.
   // ECM-3's PUT/POST coercion hydrates it back to an ObjectId on the server.
   itemSel.innerHTML = '<option value="">-- select item --</option>'
-    + entries.map(e => `<option value="${String(e._id)}">${e.name}</option>`).join('');
+    + entries.map(e => {
+      const eff = (c && e.availability != null) ? effectiveAvailability(e, c) : null;
+      const availTag = eff != null ? ` (avail ${eff})` : '';
+      return `<option value="${String(e._id)}">${e.name}${availTag}</option>`;
+    }).join('');
 }
 
 export async function shAddEquip() {

--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -16,7 +16,7 @@ import { calcHealth, calcWillpowerMax, calcSize, calcSpeed, calcDefence } from '
 //
 // wornArmourCount drives the >1 worn armour editor hint (ADR-006 D2 + Concern
 // #8, wording locked).
-import { defenceForDisplay, wornArmourCount } from '../data/equipment-derivation.js';
+import { defenceForDisplay, wornArmourCount, effectiveAvailability } from '../data/equipment-derivation.js';
 import { xpToDots, xpEarned, xpSpent, xpLeft, xpStarting, xpHumanityDrop, xpOrdeals, xpGame, xpPT5, xpSpentAttrs, xpSpentSkills, xpSpentMerits, xpSpentPowers, xpSpentSpecial, setDevotionsDB, meritBdRow } from './xp.js';
 import { meritBase, meritDotCount, meritLookup, meritFixedRating, buildMeritOptions, buildSubCategoryMeritOptions, buildMCIGrantOptions, buildFThiefOptions, ensureMeritSync, meetsDevPrereqs, devPrereqStr, meetsPrereq, prereqLabel } from './merits.js';
 // N-1 (Concern #11): every read of m.attached_to goes through this normaliser.
@@ -2229,10 +2229,13 @@ export function shRenderEquipment(c, editMode) {
     h += '<div class="sh-sub-title">Weapons</div>';
     for (const { item, entry, idx } of byBucket.weapon) {
       const name  = entry.name || item.catalogue_id;
+      // #896: per-character effective availability (raw - Fixer reduction).
+      const eff = entry.availability != null ? effectiveAvailability(entry, c) : null;
       const parts = [
         entry.damage_mod != null ? `+${entry.damage_mod}` : null,
         DMGTYPE[entry.damage_type] || entry.damage_type || null,
         WPNTYPE[entry.weapon_type] || entry.weapon_type || null,
+        eff != null ? `avail ${eff}` : null,
       ].filter(Boolean);
       const qual   = parts.join(' · ');
       const rmBtn  = editMode ? `<button class="sk-spec-rm" style="float:right;margin-top:2px" onclick="shRemoveEquip(${idx})" title="Remove">× Remove</button>` : '';
@@ -2257,9 +2260,12 @@ export function shRenderEquipment(c, editMode) {
     const baseDefence = calcDefence(c);
     for (const { item, entry, idx } of byBucket.armour) {
       const name  = entry.name || item.catalogue_id;
+      // #896: per-character effective availability (raw - Fixer reduction).
+      const eff = entry.availability != null ? effectiveAvailability(entry, c) : null;
       const parts = [
         entry.armour_value    != null ? `AR ${entry.armour_value}` : null,
         entry.defence_penalty != null ? `Defence ${baseDefence}(${baseDefence - entry.defence_penalty})` : null,
+        eff != null ? `avail ${eff}` : null,
       ].filter(Boolean);
       const qual  = parts.join(' · ');
       const rmBtn = editMode ? `<button class="sk-spec-rm" style="float:right;margin-top:2px" onclick="shRemoveEquip(${idx})" title="Remove">× Remove</button>` : '';
@@ -2277,10 +2283,17 @@ export function shRenderEquipment(c, editMode) {
       const name  = entry.name || item.catalogue_id;
       const pool  = (entry.skill_domain && entry.bonus_dice != null)
         ? `${entry.skill_domain} +${entry.bonus_dice} dice` : '';
+      // #896: per-character effective availability (raw - Fixer reduction).
+      const eff = entry.availability != null ? effectiveAvailability(entry, c) : null;
+      const qualParts = [
+        pool || null,
+        eff != null ? `avail ${eff}` : null,
+      ].filter(Boolean);
+      const qual = qualParts.join(' · ');
       const rmBtn = editMode ? `<button class="sk-spec-rm" style="float:right;margin-top:2px" onclick="shRemoveEquip(${idx})" title="Remove">× Remove</button>` : '';
       h += `<div class="merit-plain"><div class="trait-row">` +
         `<div class="trait-main"><span class="trait-name">${esc(name)}</span><div class="trait-right">${stateChip(item.state)}${rmBtn}</div></div>` +
-        (pool || item.notes ? `<div class="trait-sub">${pool ? `<span class="trait-qual">${esc(pool)}</span>` : ''}${item.notes ? `<span class="trait-qual dim">${esc(item.notes)}</span>` : ''}</div>` : '') +
+        (qual || item.notes ? `<div class="trait-sub">${qual ? `<span class="trait-qual">${esc(qual)}</span>` : ''}${item.notes ? `<span class="trait-qual dim">${esc(item.notes)}</span>` : ''}</div>` : '') +
         `</div></div>`;
     }
   }

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -35,6 +35,11 @@ import { isMinimalComplete, missingMinimumPieces } from '../data/dt-completeness
 // synchronously here at render time. getCatalogueEntry resolves a
 // 24-hex catalogue_id → display name for the legacy-fallback path.
 import { getCatalogue, getCatalogueEntry } from '../data/equipment-catalogue-cache.js';
+// #896: availability filter + Fixer errata. Helpers gate which catalogue
+// items appear as enabled options for the active character; unaffordable
+// items render disabled with a tooltip explaining why. Item-request
+// textarea (ECM-9) is the escape valve.
+import { availabilityCap, fixerReduction, effectiveAvailability, isAffordable } from '../data/equipment-derivation.js';
 
 // Influence merit names that generate monthly influence
 const INFLUENCE_MERIT_NAMES = ['Allies', 'Retainer', 'Mentor', 'Resources', 'Staff', 'Contacts', 'Status'];
@@ -5437,6 +5442,14 @@ function renderEquipmentRow(n, saved) {
   const selectedId = saved[`equipment_${n}_catalogue_id`] || '';
   const legacyName = saved[`equipment_${n}_name`] || '';
 
+  // #896: per-character affordability gate. Resources rating is the cap
+  // for effective availability (raw - fixer reduction). The raw-availability
+  // max a character can afford is `cap + fixer` — that's the number we
+  // show in the tooltip + footnote (matches the dispatch's wording).
+  const cap   = availabilityCap(currentChar);
+  const fixer = fixerReduction(currentChar);
+  const rawMax = cap + fixer;
+
   let h = `<div class="dt-equipment-row" id="dt-equipment-row-${n}">`;
   h += `<div class="dt-equipment-row-fields">`;
   h += `<select id="dt-equipment_${n}_catalogue_id" class="qf-input dt-equip-cat">`;
@@ -5449,12 +5462,22 @@ function renderEquipmentRow(n, saved) {
     if (!arr || !arr.length) continue;
     h += `<optgroup label="${esc(bucket)}">`;
     for (const it of arr) {
-      const sel = String(it._id) === selectedId ? ' selected' : '';
-      h += `<option value="${esc(String(it._id))}"${sel}>${esc(it.name || '')}</option>`;
+      const sel       = String(it._id) === selectedId ? ' selected' : '';
+      const eff       = effectiveAvailability(it, currentChar);
+      const aff       = isAffordable(it, currentChar);
+      const disabled  = (!aff && !sel) ? ' disabled' : '';
+      const tooltip   = !aff
+        ? ` title="Above your effective availability (Resources ${cap} + Fixer ${fixer} = max ${rawMax}). Use the item request field below to ask the ST for it."`
+        : '';
+      const availTag  = (it.availability == null) ? '' : ` (avail ${eff})`;
+      h += `<option value="${esc(String(it._id))}"${sel}${disabled}${tooltip}>${esc(it.name || '')}${availTag}</option>`;
     }
     h += `</optgroup>`;
   }
   h += `</select>`;
+  // #896: footnote under the dropdown \u2014 surfaces the cap math so players
+  // see why some options are disabled without hovering each.
+  h += `<div class="dt-equipment-cap-note" style="font-size:0.8em;opacity:0.7;margin-top:2px;">Showing items you can acquire. Resources ${cap} + Fixer reduction ${fixer} = effective availability cap ${rawMax}.</div>`;
   h += `<input type="number" id="dt-equipment_${n}_qty" class="qf-input dt-equip-qty" placeholder="Qty" min="1" value="${esc(saved[`equipment_${n}_qty`] || '1')}">`;
   h += `<input type="text" id="dt-equipment_${n}_notes" class="qf-input dt-equip-notes" placeholder="Notes (optional)" value="${esc(saved[`equipment_${n}_notes`] || '')}">`;
   if (n > 1) h += `<button type="button" class="dt-sorcery-remove" data-remove-equipment="${n}" title="Remove">\u00D7</button>`;

--- a/server/tests/issue-896-availability-filter.test.js
+++ b/server/tests/issue-896-availability-filter.test.js
@@ -1,0 +1,266 @@
+/**
+ * Issue #896 — equipment availability filter + Fixer errata.
+ *
+ * Three slices:
+ *   1. Pure-helper unit tests for availabilityCap / fixerReduction /
+ *      effectiveAvailability / isAffordable. Behaviour contract directly
+ *      from the dispatch formula:
+ *        effective(item, c) = max(0, item.availability - fixerReduction(c))
+ *        affordable(item, c) = effective(item, c) <= availabilityCap(c)
+ *   2. Static-analysis on the DT form dropdown — disabled options, tooltip
+ *      copy, footnote, option label includes effective availability.
+ *   3. Static-analysis on the display sweep + admin editor bypass.
+ *
+ * Plus a tiny check that the reference JSON Fixer entry now reflects the
+ * errata (the small docs nudge per Peter).
+ *
+ * Behavioural slice imports equipment-derivation.js via dynamic import with
+ * a browser-globals stub (the module reaches the cache module → api.js
+ * which uses `location`). Same pattern ECM-1 / ECM-5 / ADR-006 use.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+function read(rel) { return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8'); }
+
+// Convenience character builders for the behavioural slice.
+function mkChar({ resources = 0, fixer = false } = {}) {
+  const merits = [];
+  if (resources > 0) merits.push({ name: 'Resources', category: 'general', cp: resources });
+  if (fixer)         merits.push({ name: 'Fixer',     category: 'general', cp: 2 });
+  return {
+    name: 'Fixture', merits,
+    attributes: {}, skills: {}, disciplines: {}, equipment: [],
+  };
+}
+
+function mkItem(availability) {
+  return { _id: 'item-' + availability, bucket: 'equipment', name: 'Item ' + availability, availability };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Slice 1 — pure helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#896 — availabilityCap', () => {
+  it('returns 0 when the character has no Resources merit', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    expect(mod.availabilityCap(mkChar())).toBe(0);
+  });
+
+  it('returns the Resources rating when present', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    expect(mod.availabilityCap(mkChar({ resources: 3 }))).toBe(3);
+  });
+
+  it('handles null character defensively', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    expect(mod.availabilityCap(null)).toBe(0);
+  });
+});
+
+describe('#896 — fixerReduction', () => {
+  it('returns 0 when the character has no Fixer merit', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    expect(mod.fixerReduction(mkChar())).toBe(0);
+  });
+
+  it('returns 1 when Fixer is present', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    expect(mod.fixerReduction(mkChar({ fixer: true }))).toBe(1);
+  });
+
+  it('returns 0 when Fixer entry is present but zeroed (edge case during merit editing)', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    const c = mkChar();
+    c.merits.push({ name: 'Fixer', category: 'general', cp: 0, xp: 0, free: 0 });
+    expect(mod.fixerReduction(c)).toBe(0);
+  });
+});
+
+describe('#896 — effectiveAvailability', () => {
+  it('returns raw item.availability when Fixer is absent', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    expect(mod.effectiveAvailability(mkItem(3), mkChar())).toBe(3);
+  });
+
+  it('returns (raw - 1) when Fixer is present', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    expect(mod.effectiveAvailability(mkItem(3), mkChar({ fixer: true }))).toBe(2);
+  });
+
+  it('floors at 0 — a level-0 item with Fixer does NOT surface as -1', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    expect(mod.effectiveAvailability(mkItem(0), mkChar({ fixer: true }))).toBe(0);
+  });
+
+  it('treats null/undefined/non-integer availability as 0', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    expect(mod.effectiveAvailability({ availability: null }, mkChar())).toBe(0);
+    expect(mod.effectiveAvailability({ availability: undefined }, mkChar())).toBe(0);
+    expect(mod.effectiveAvailability({ availability: 'bad' }, mkChar())).toBe(0);
+    expect(mod.effectiveAvailability(null, mkChar())).toBe(0);
+  });
+});
+
+describe('#896 — isAffordable', () => {
+  it('exactly at cap is affordable (<=, not strict less-than)', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    // Resources 2, raw availability 2 → effective = 2, cap = 2 → affordable.
+    expect(mod.isAffordable(mkItem(2), mkChar({ resources: 2 }))).toBe(true);
+  });
+
+  it('above cap is unaffordable', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    expect(mod.isAffordable(mkItem(3), mkChar({ resources: 2 }))).toBe(false);
+  });
+
+  it('Fixer lifts an out-of-reach item into affordability', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    // Resources 2: raw availability 3 → effective = 3, cap = 2 → unaffordable.
+    expect(mod.isAffordable(mkItem(3), mkChar({ resources: 2 }))).toBe(false);
+    // Resources 2 + Fixer: raw 3 → effective = 2, cap = 2 → affordable.
+    expect(mod.isAffordable(mkItem(3), mkChar({ resources: 2, fixer: true }))).toBe(true);
+  });
+
+  it('Resources 0 + Fixer still affords availability-1 items (the documented edge case)', async () => {
+    if (typeof globalThis.location === 'undefined') globalThis.location = { hostname: '' };
+    const mod = await import('../../public/js/data/equipment-derivation.js');
+    // No Resources, Fixer present: raw 1 → effective = 0, cap = 0 → affordable.
+    expect(mod.isAffordable(mkItem(1), mkChar({ fixer: true }))).toBe(true);
+    // Same character can't afford raw 2 (effective 1, cap 0 → false).
+    expect(mod.isAffordable(mkItem(2), mkChar({ fixer: true }))).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Slice 2 — DT form dropdown wiring
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#896 — DT form dropdown wires affordability gate', () => {
+  const src = read('public/js/tabs/downtime-form.js');
+
+  it('imports availabilityCap / fixerReduction / effectiveAvailability / isAffordable from the helper module', () => {
+    expect(src).toMatch(/import\s+\{\s*availabilityCap,\s*fixerReduction,\s*effectiveAvailability,\s*isAffordable\s*\}\s+from\s+['"]\.\.\/data\/equipment-derivation\.js['"]/);
+  });
+
+  it('renders unaffordable options as <option disabled> with the dispatch tooltip copy verbatim', () => {
+    // Tooltip wording: 'Above your effective availability (Resources ${cap} + Fixer ${fixer} = max ${rawMax}). Use the item request field below to ask the ST for it.'
+    expect(src).toMatch(/Above your effective availability \(Resources \$\{cap\} \+ Fixer \$\{fixer\} = max \$\{rawMax\}\)\. Use the item request field below to ask the ST for it\./);
+  });
+
+  it('appends `(avail X)` to each option label using the effective number', () => {
+    expect(src).toMatch(/const\s+eff\s*=\s*effectiveAvailability\(it,\s*currentChar\)/);
+    expect(src).toMatch(/\(avail \$\{eff\}\)/);
+  });
+
+  it('renders the footnote with cap + fixer math', () => {
+    expect(src).toMatch(/Showing items you can acquire\. Resources \$\{cap\} \+ Fixer reduction \$\{fixer\} = effective availability cap \$\{rawMax\}\./);
+  });
+
+  it('does NOT hide unaffordable items — they remain visible but disabled (per dispatch UX)', () => {
+    // The optgroup loop iterates EVERY item, then chooses disabled vs enabled.
+    // If items were hidden, the dispatch's "all options visible" guarantee would break.
+    const fnStart = src.indexOf('function renderEquipmentRow');
+    const fnEnd   = src.indexOf('\n}\n', fnStart);
+    const body    = src.slice(fnStart, fnEnd);
+    expect(body).not.toMatch(/if\s*\(\s*!aff\s*\)\s*continue/);
+  });
+
+  it('exempts the currently-selected option from being disabled (so existing in-flight selections remain visible)', () => {
+    // The conditional `(!aff && !sel)` means a currently-selected unaffordable
+    // item still renders enabled — silent-leave per the same backcompat
+    // discipline as ECM-4's legacy-name fallback.
+    expect(src).toMatch(/\(!aff\s*&&\s*!sel\)\s*\?/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Slice 3 — display sweep + admin editor bypass
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#896 — editor/sheet.js held-items display surfaces effective availability', () => {
+  const src = read('public/js/editor/sheet.js');
+
+  it('imports effectiveAvailability from the helper module', () => {
+    expect(src).toMatch(/import\s+\{[^}]*effectiveAvailability[^}]*\}\s+from\s+['"]\.\.\/data\/equipment-derivation\.js['"]/);
+  });
+
+  it('each per-bucket render computes effectiveAvailability(entry, c) and surfaces it in the trait-sub row', () => {
+    const matches = src.match(/effectiveAvailability\(entry,\s*c\)/g) || [];
+    // One per bucket-render path: weapons, armour, equipment (asset bucket has
+    // its own shape and no availability surfacing).
+    expect(matches.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('label uses the `avail X` substring so display is consistent across surfaces', () => {
+    expect(src).toMatch(/`avail \$\{eff\}`/);
+  });
+});
+
+describe('#896 — editor/edit.js admin add-equipment bypasses gate but shows effective availability', () => {
+  const src = read('public/js/editor/edit.js');
+
+  it('imports effectiveAvailability from the helper module', () => {
+    expect(src).toMatch(/import\s+\{[^}]*effectiveAvailability[^}]*\}\s+from\s+['"]\.\.\/data\/equipment-derivation\.js['"]/);
+  });
+
+  it('shEquipBucketFilter appends `(avail X)` to option labels for the character being edited', () => {
+    const fnStart = src.indexOf('export function shEquipBucketFilter');
+    const fnEnd   = src.indexOf('\n}\n', fnStart);
+    const body    = src.slice(fnStart, fnEnd);
+    expect(body).toMatch(/effectiveAvailability\(e,\s*c\)/);
+    expect(body).toMatch(/\(avail \$\{eff\}\)/);
+  });
+
+  it('does NOT mark any options disabled — ST admin BYPASSES the filter per dispatch', () => {
+    const fnStart = src.indexOf('export function shEquipBucketFilter');
+    const fnEnd   = src.indexOf('\n}\n', fnStart);
+    const body    = src.slice(fnStart, fnEnd);
+    // The dispatch said "ST can assign any item". The render emits `<option
+    // value="${...}">...</option>` per entry — never with the `disabled`
+    // attribute on the body.
+    expect(body).not.toMatch(/<option[^>]*disabled[^>]*>\$\{/);
+  });
+});
+
+describe('#896 — suite/sheet.js inherits the display sweep via shRenderEquipment', () => {
+  const src = read('public/js/suite/sheet.js');
+
+  it('delegates equipment rendering to shRenderEquipment from editor/sheet.js (no duplicate render path)', () => {
+    expect(src).toMatch(/shRenderEquipment\b/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Slice 4 — reference JSON nudge
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#896 — Fixer reference JSON reflects the errata', () => {
+  it('TM_rules_merit_2026-04-17.json Fixer description names the availability-cost-by-1 reduction', () => {
+    const src = read('data/reference/TM_rules_merit_2026-04-17.json');
+    // Find the Fixer entry's description field.
+    const fixerIdx = src.indexOf('"key": "fixer"');
+    expect(fixerIdx).toBeGreaterThan(-1);
+    const block = src.slice(fixerIdx, fixerIdx + 1500);
+    expect(block).toMatch(/Reduces the availability cost of all items by 1/);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #896. First post-ECM feature. Surfaces the catalogue dropdown's affordability gate per Peter's 2026-06-18 product call + the corrected Fixer mechanic across all displays.

## Math (single-floor invariant, ADR-006 Concern #9 discipline)

\`\`\`
availabilityCap(c)        = c.merits[name=Resources].rating (0 if absent)
fixerReduction(c)         = 1 if c has Fixer w/ effective rating >= 1, else 0
effectiveAvailability(item, c) = max(0, item.availability - fixerReduction(c))
isAffordable(item, c)     = effectiveAvailability(item, c) <= availabilityCap(c)
\`\`\`

The floor lives in \`effectiveAvailability\`; no clamps anywhere else. Equivalent to \`item.availability <= cap + fixer\` for the affordability check.

## What ships

| Layer | Change |
|---|---|
| **Helper module** (`public/js/data/equipment-derivation.js`) | Four pure helpers added next to ADR-006's defence helpers. Injectable-free; symmetric with the ADR-006 shape. |
| **DT form dropdown** (`public/js/tabs/downtime-form.js`) | All items visible. Unaffordable items render `<option disabled>` with tooltip copy verbatim per dispatch. Affordable items show `(avail N)` where N is the Fixer-reduced number. Footnote under the dropdown surfaces the cap math. Currently-selected unaffordable items exempt from disable (in-flight DT draft backcompat). |
| **Held-items display sweep** (`public/js/editor/sheet.js`) | Weapons / armour / equipment per-bucket renders append `avail N` to the qualifier row. `public/js/suite/sheet.js` inherits via `shRenderEquipment` — no duplicate render path. |
| **Admin character editor** (`public/js/editor/edit.js shEquipBucketFilter`) | ST BYPASSES the filter — every option enabled — but each label appends `(avail N)` per the character being edited, for display consistency. |
| **Reference JSON nudge** (`data/reference/TM_rules_merit_2026-04-17.json`) | Fixer description updated: _"Arrange illegal services and contacts. Reduces the availability cost of all items by 1."_ Small docs nudge. |
| **Out of scope** | Admin catalogue page (ECM-6) shows raw catalogue availability. Catalogue is character-agnostic. Untouched. |

## Tooltip + footnote wording (verbatim)

Tooltip on disabled options:
> Above your effective availability (Resources X + Fixer Y = max Z). Use the item request field below to ask the ST for it.

Footnote under the dropdown:
> Showing items you can acquire. Resources X + Fixer reduction Y = effective availability cap Z.

## Selected-item exemption

A currently-selected unaffordable item is rendered **enabled** rather than disabled — same silent-leave discipline as ECM-4's legacy-name fallback. Lets a player resume editing a DT draft whose selection was made under a higher Resources rating without the form refusing to display it. They can leave it or pick something else; the change-on-revisit is opt-in.

## Verification

\`\`\`
$ cd server && npx vitest run tests/issue-896-availability-filter.test.js
Tests  28 passed (28)

$ npx vitest run                       # full suite
Test Files  4 failed | 136 passed (140)
Tests  1816 passed (1816)
\`\`\`

The 4 file-failures are pre-existing 0-test suite-load failures on dev. 0 individual test failures.

Parse-check on all 4 touched JS files + the JSON: OK.

## Test plan

- [x] Vitest — 28 passes across pure helpers + DT form static + display sweep + admin bypass + reference JSON
- [x] \`node --check\` — parse OK on all touched JS files
- [x] Full suite — 0 new failures
- [ ] **Manual smoke (player)**: Resources 2 + no Fixer → DT form shows availability ≤ 2 items enabled, > 2 disabled with tooltip; footnote reads "cap 2"; sheet shows held items with `avail N` qualifier
- [ ] **Manual smoke (Fixer)**: same character + Fixer → availability ≤ 3 items enabled; option labels show effective number (raw − 1); footnote reads "cap 3"
- [ ] **Manual smoke (ST admin)**: open a character in admin edit mode, add-equipment dropdown shows ALL items as enabled but option labels still show the per-character effective availability