### PR TITLE
hotfix: strip c.derived from save paths (cycle-blocker)

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -948,10 +948,11 @@ const _LEGACY_FIELDS = new Set(['attr_creation', 'skill_creation', 'disc_creatio
 
 function buildSaveBody(c) {
   // Strip _id (goes in URL), all ephemeral _-prefixed runtime fields, legacy v2 fields,
-  // and c.current (tracker-state namespace set by spliceCurrent — not a schema field).
+  // c.current (tracker-state namespace set by spliceCurrent — not a schema field),
+  // and c.derived (render-time materialised cache from ADR-006; never stored).
   const body = {};
   for (const [k, v] of Object.entries(c)) {
-    if (k === '_id' || k.startsWith('_') || k === 'current' || _LEGACY_FIELDS.has(k)) continue;
+    if (k === '_id' || k.startsWith('_') || k === 'current' || k === 'derived' || _LEGACY_FIELDS.has(k)) continue;
     body[k] = v;
   }
   // N-1 (ADR-005 Rev 2, Concern #3): merit-level `_`-prefixed fields

--- a/public/js/editor/export.js
+++ b/public/js/editor/export.js
@@ -54,6 +54,10 @@ export function charsForSave() {
     // delete _st_mod_overlay + _st_mod_base. Pre-overlay characters
     // have no _st_mod_base; stripOverlay no-ops cleanly in that case.
     stripOverlay(copy);
+    // ADR-006: c.derived is the render-time materialised defence cache,
+    // never stored. Strip before localStorage stash so a fresh boot
+    // recomputes from base values without carrying stale derived state.
+    delete copy.derived;
     if (copy.merits) {
       for (let i = copy.merits.length - 1; i >= 0; i--) {
         if (copy.merits[i].derived) {


### PR DESCRIPTION
**URGENT** — character PUT broken in prod. AJV rejects payload with \`derived\` additionalProperty.

## Root cause

ADR-006 (#879) added \`materialiseDerivedDefence\` which writes \`c.derived.defence\` at render time as the armour-adjusted base for STM overlay composition. Both save paths missed adding \`derived\` to their strip lists:

- \`public/js/admin.js\` \`buildSaveBody\` — strips \`_id\`, \`_\`-prefixed, \`current\`, legacy v2 — but NOT \`derived\`.
- \`public/js/editor/export.js\` \`charsForSave\` — strips STM overlay + merit-level transient fields — but NOT \`copy.derived\`.

Result: any PUT against \`/api/characters/:id\` after a render carries \`derived: { defence: N }\` which AJV rejects under \`additionalProperties: false\`.

## Fix

Two-line strip additions. No schema change, no test additions in this PR (urgent — characters are unsaveable on prod). Tests follow in next opportunity.

- \`admin.js:954\` — add \`k === 'derived'\` to the buildSaveBody skip predicate.
- \`editor/export.js:56\` — \`delete copy.derived\` after \`stripOverlay\`.

## Verification

Local: stripped body matches character schema. No \`derived\` field round-trips.

## Why no tests this PR

Characters cannot save on prod. Filing a follow-up issue to add a static-analysis test asserting \`derived\` is in the buildSaveBody skip list + the charsForSave delete list — same pattern as the ADR-006 floor-count regression test.

— Khepri (SM, hotfixing directly per urgent framing; not pushed to main per CLAUDE.md HARD RULE — awaiting Peter's main-push authorisation explicitly)