### PR TITLE
hotfix: wire equipment functions in admin.js (pre-existing EQ-4 gap)

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -74,6 +74,7 @@ import {
   shEditMeritPt, shStepMeritRating, shEditXP, shAdjAttrBonus, shAdjMeritBonus, shAdjSkillBonus,
   shSetWhiteAntsTerritory,
   shSetTrapDoorAnchor,
+  shAddEquip, shRemoveEquip, shEquipBucketFilter, shAddAsset, shRemoveAsset,
   registerCallbacks as registerEditCallbacks,
   getDirtyPartners, clearDirtyPartners
 } from './editor/edit.js';
@@ -1386,6 +1387,7 @@ Object.assign(window, {
   shEditMeritPt, shStepMeritRating, shEditXP, shAdjAttrBonus, shAdjMeritBonus, shAdjSkillBonus,
   shSetWhiteAntsTerritory,
   shSetTrapDoorAnchor,
+  shAddEquip, shRemoveEquip, shEquipBucketFilter, shAddAsset, shRemoveAsset,
   clickAttrDot, adjAttrBonus, clickSkillDot, toggleNineAgain, adjSkillBonus, updSkillSpec,
   updField, updStatus,
   renderIdentityTab, renderAttrsTab,


### PR DESCRIPTION
**URGENT** — admin character editor equipment buttons broken with \`ReferenceError: shEquipBucketFilter is not defined\` on prod. Peter cannot add equipment to characters.

## Root cause

\`shEquipBucketFilter\`, \`shAddEquip\`, \`shRemoveEquip\`, \`shAddAsset\`, \`shRemoveAsset\` are defined and exported in \`public/js/editor/edit.js\`. \`public/js/app.js\` (the suite entry point) imports them and exposes via \`Object.assign(window, {...})\`. \`public/js/admin.js\` (the admin entry point) never did either.

The inline HTML handlers in \`public/js/editor/sheet.js\` (e.g. \`onchange="shEquipBucketFilter()"\`) run in global scope. Suite works; admin throws.

**Latent since EQ-4 (#665) shipped.** Surfaced 2026-06-19 when Peter tried to add equipment via the admin editor. Matches the \`feedback_listener_routing_static_blind_spot\` pattern — static review can't catch wiring placement; browser smoke is the only path.

## Fix

Two-line addition in \`public/js/admin.js\`:
- Add the 5 names to the \`./editor/edit.js\` import block.
- Add the same 5 to the \`Object.assign(window, {...})\` block.

No schema or behaviour change. Same shape as every other \`sh*\` wired in admin.js.

## Why no tests

Wiring-placement failures require browser smoke or a JSDOM harness, neither of which exists in this repo. Filing a follow-up to add a \`window.shEquipBucketFilter\` typeof-function check at admin.js boot (cheap and load-bearing) plus a JSDOM-based test slice that would catch the absence of any new \`sh*\` from the window registration.

— Khepri (SM, hotfixing directly per urgent framing)