### PR TITLE
feat: consolidate character.assets[] into equipment[] (Option 1)

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -74,7 +74,7 @@ import {
   shEditMeritPt, shStepMeritRating, shEditXP, shAdjAttrBonus, shAdjMeritBonus, shAdjSkillBonus,
   shSetWhiteAntsTerritory,
   shSetTrapDoorAnchor,
-  shAddEquip, shRemoveEquip, shEquipBucketFilter, shAddAsset, shRemoveAsset,
+  shAddEquip, shRemoveEquip, shEquipBucketFilter,
   registerCallbacks as registerEditCallbacks,
   getDirtyPartners, clearDirtyPartners
 } from './editor/edit.js';
@@ -1387,7 +1387,7 @@ Object.assign(window, {
   shEditMeritPt, shStepMeritRating, shEditXP, shAdjAttrBonus, shAdjMeritBonus, shAdjSkillBonus,
   shSetWhiteAntsTerritory,
   shSetTrapDoorAnchor,
-  shAddEquip, shRemoveEquip, shEquipBucketFilter, shAddAsset, shRemoveAsset,
+  shAddEquip, shRemoveEquip, shEquipBucketFilter,
   clickAttrDot, adjAttrBonus, clickSkillDot, toggleNineAgain, adjSkillBonus, updSkillSpec,
   updField, updStatus,
   renderIdentityTab, renderAttrsTab,

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -38,7 +38,7 @@ import {
   shSetWhiteAntsTerritory,
   shSetTrapDoorAnchor,
   shEditMeritPt, shStepMeritRating, shEditXP, shAdjAttrBonus, shAdjMeritBonus, shAdjSkillBonus,
-  shAddEquip, shRemoveEquip, shEquipBucketFilter, shAddAsset, shRemoveAsset,
+  shAddEquip, shRemoveEquip, shEquipBucketFilter,
   registerCallbacks as registerEditCallbacks
 } from './editor/edit.js';
 import { renderIdentityTab, updField, updStatus, registerCallbacks as registerIdentityCallbacks } from './editor/identity.js';
@@ -1166,7 +1166,7 @@ Object.assign(window, {
   shEditMCIDot, shRemoveStandMerit, shAddStandMCI, shAddStandPT,
   shEditMeritPt, shStepMeritRating,
   shEditXP,
-  shAddEquip, shRemoveEquip, shEquipBucketFilter, shAddAsset, shRemoveAsset,
+  shAddEquip, shRemoveEquip, shEquipBucketFilter,
 
   // Editor attributes & skills tab
   clickAttrDot,

--- a/public/js/editor/edit.js
+++ b/public/js/editor/edit.js
@@ -1113,7 +1113,6 @@ export async function shAddEquip() {
       notes,
     });
     c.equipment = result.equipment;
-    c.assets    = result.assets;
     _renderSheet(c);
   } catch (err) {
     console.error('[equipment] add error:', err);
@@ -1127,48 +1126,11 @@ export async function shRemoveEquip(idx) {
   try {
     const result = await apiDelete('/api/characters/' + charId + '/equipment/' + idx);
     c.equipment = result.equipment;
-    c.assets    = result.assets;
     _renderSheet(c);
   } catch (err) {
     console.error('[equipment] remove error:', err);
   }
 }
 
-export async function shAddAsset() {
-  if (state.editIdx < 0) return;
-  const c      = state.chars[state.editIdx];
-  const charId = String(c._id);
-  const name   = document.getElementById('asset-add-name')?.value?.trim();
-  const desc   = document.getElementById('asset-add-desc')?.value?.trim();
-  if (!name || !desc) return;
-  const cycle  = parseInt(document.getElementById('asset-add-cycle')?.value ?? '0', 10) || 0;
-  try {
-    const result = await apiPost('/api/characters/' + charId + '/assets', {
-      name,
-      description:       desc,
-      location:          document.getElementById('asset-add-loc')?.value?.trim()  || null,
-      mechanical_effect: document.getElementById('asset-add-mech')?.value?.trim() || null,
-      acquired_cycle:    cycle,
-      notes:             document.getElementById('asset-add-notes')?.value?.trim() || null,
-    });
-    c.equipment = result.equipment;
-    c.assets    = result.assets;
-    _renderSheet(c);
-  } catch (err) {
-    console.error('[asset] add error:', err);
-  }
-}
-
-export async function shRemoveAsset(idx) {
-  if (state.editIdx < 0) return;
-  const c      = state.chars[state.editIdx];
-  const charId = String(c._id);
-  try {
-    const result = await apiDelete('/api/characters/' + charId + '/assets/' + idx);
-    c.equipment = result.equipment;
-    c.assets    = result.assets;
-    _renderSheet(c);
-  } catch (err) {
-    console.error('[asset] remove error:', err);
-  }
-}
+// shAddAsset + shRemoveAsset REMOVED 2026-06-19 — character.assets[] consolidated
+// into equipment[]. Asset-bucket catalogue items now flow through shAddEquip.

--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -2199,13 +2199,13 @@ export function shRenderManoeuvres(c, editMode) {
   return h;
 }
 
-// ── Equipment & Assets renderer (EQ-2, issue #656) ───────────────────────────
-// Renders catalogue-ref equipment[] and freeform assets[] read-only.
+// ── Equipment renderer (EQ-2, issue #656) ────────────────────────────────────
+// Renders catalogue-ref equipment[]. All four buckets (weapon/armour/equipment/asset)
+// flow through the same array as of 2026-06-19 (character.assets[] retired).
 // Edit mode shows the same view -- equipment is managed via the ST CRUD API (EQ-1).
 export function shRenderEquipment(c, editMode) {
   const equip  = c.equipment || [];
-  const assets = c.assets    || [];
-  if (!editMode && !equip.length && !assets.length) return '';
+  if (!editMode && !equip.length) return '';
 
   const STATE_LABELS = { carried: 'Carried', worn: 'Worn', stashed: 'Stashed', lost: 'Lost', active: 'Active' };
   const DMGTYPE      = { lethal: 'Lethal', bashing: 'Bashing', aggravated: 'Aggravated' };
@@ -2213,10 +2213,10 @@ export function shRenderEquipment(c, editMode) {
   const cycleLabel   = n  => n === 0 ? 'Pre-campaign' : `Cycle ${n}`;
   const stateChip    = st => `<span class="gen-granted-tag-view">${STATE_LABELS[st] || st}</span>`;
 
-  let h = '<div class="sh-sec"><div class="sh-sec-title">Equipment &amp; Assets</div><div class="merit-list">';
+  let h = '<div class="sh-sec"><div class="sh-sec-title">Equipment</div><div class="merit-list">';
 
   // Group equipment items by bucket, preserving flat-array index for remove buttons
-  const byBucket = { weapon: [], armour: [], equipment: [] };
+  const byBucket = { weapon: [], armour: [], equipment: [], asset: [] };
   for (let i = 0; i < equip.length; i++) {
     const item   = equip[i];
     const entry  = getCatalogueEntry(item.catalogue_id) || {};
@@ -2298,30 +2298,34 @@ export function shRenderEquipment(c, editMode) {
     }
   }
 
-  // ── Assets ──
-  if (assets.length) {
+  // ── Assets (catalogue-backed since 2026-06-19) ──
+  if (byBucket.asset.length) {
     h += '<div class="sh-sub-title">Assets</div>';
-    for (let ai = 0; ai < assets.length; ai++) {
-      const asset  = assets[ai];
-      const meta   = [
-        asset.location          || null,
-        asset.mechanical_effect || null,
-        cycleLabel(asset.acquired_cycle),
-        asset.notes             || null,
-      ].filter(Boolean).join(' · ');
-      const rmBtn  = editMode ? `<button class="sk-spec-rm" style="float:right;margin-top:2px" onclick="shRemoveAsset(${ai})" title="Remove">× Remove</button>` : '';
+    for (const { item, entry, idx } of byBucket.asset) {
+      const name  = entry.name || item.catalogue_id;
+      const eff   = entry.availability != null ? effectiveAvailability(entry, c) : null;
+      const parts = [
+        entry.mechanical_effect || null,
+        eff != null ? `avail ${eff}` : null,
+        cycleLabel(item.acquired_cycle),
+      ].filter(Boolean);
+      const qual  = parts.join(' · ');
+      const rmBtn = editMode ? `<button class="sk-spec-rm" style="float:right;margin-top:2px" onclick="shRemoveEquip(${idx})" title="Remove">× Remove</button>` : '';
       h += `<div class="merit-plain"><div class="trait-row">` +
-        `<div class="trait-main"><span class="trait-name">${esc(asset.name)}</span><div class="trait-right"><span class="gen-granted-tag-view">Asset</span>${rmBtn}</div></div>` +
-        `<div class="trait-sub"><span class="trait-qual">${esc(asset.description)}</span></div>` +
-        (meta ? `<div class="trait-sub"><span class="trait-qual dim">${esc(meta)}</span></div>` : '') +
+        `<div class="trait-main"><span class="trait-name">${esc(name)}</span><div class="trait-right">${stateChip(item.state)}${rmBtn}</div></div>` +
+        (entry.description ? `<div class="trait-sub"><span class="trait-qual">${esc(entry.description)}</span></div>` : '') +
+        (qual || item.notes ? `<div class="trait-sub">${qual ? `<span class="trait-qual dim">${esc(qual)}</span>` : ''}${item.notes ? `<span class="trait-qual dim">${esc(item.notes)}</span>` : ''}</div>` : '') +
         `</div></div>`;
     }
   }
 
-  // ── Edit-mode add forms ──
+  // ── Edit-mode add form ──
+  // 2026-06-19: single add form covers all four buckets (weapon/armour/equipment/asset).
+  // Asset is now in the bucket dropdown; the separate free-text "Add Asset" form is gone
+  // along with character.assets[] — catalogue-ref is the single canonical storage shape.
   if (editMode) {
     const STATES   = ['carried', 'worn', 'stashed', 'active', 'lost'];
-    const BUCKETS  = ['weapon', 'armour', 'equipment'];
+    const BUCKETS  = ['weapon', 'armour', 'equipment', 'asset'];
     const defCycle = state.activeCycleNum ?? 0;
 
     h += '<div class="sh-sub-title" style="margin-top:10px">Add Equipment Item</div>';
@@ -2337,17 +2341,6 @@ export function shRenderEquipment(c, editMode) {
       + `<input id="eq-add-cycle" type="number" min="0" value="${defCycle}" style="width:60px" class="attr-bd-input" title="Acquired cycle">`
       + '<input id="eq-add-notes" type="text" placeholder="Notes (optional)" style="width:130px" class="spec-input">'
       + '<button class="sk-spec-add" onclick="shAddEquip()">Add</button>'
-      + '</div>';
-
-    h += '<div class="sh-sub-title" style="margin-top:6px">Add Asset</div>';
-    h += '<div class="dev-add-row" style="display:flex;flex-wrap:wrap;gap:4px;align-items:center;padding:4px 0">'
-      + '<input id="asset-add-name"  type="text" placeholder="Name*"         class="spec-input" style="width:120px">'
-      + '<input id="asset-add-desc"  type="text" placeholder="Description*"  class="spec-input" style="width:150px">'
-      + '<input id="asset-add-loc"   type="text" placeholder="Location"      class="spec-input" style="width:100px">'
-      + '<input id="asset-add-mech"  type="text" placeholder="Mech effect"   class="spec-input" style="width:120px">'
-      + `<input id="asset-add-cycle" type="number" min="0" value="${defCycle}" style="width:60px" class="attr-bd-input" title="Acquired cycle">`
-      + '<input id="asset-add-notes" type="text" placeholder="Notes"         class="spec-input" style="width:100px">'
-      + '<button class="sk-spec-add" onclick="shAddAsset()">Add</button>'
       + '</div>';
   }
 

--- a/server/routes/characters.js
+++ b/server/routes/characters.js
@@ -822,16 +822,20 @@ router.patch('/:id/player_prefs', async (req, res) => {
 
 // ── Equipment routes (EQ-1, issue #654) ─────────────────────────────────────
 //
-// All five routes require ST auth.
+// All three routes require ST auth.
 // DELETE routes: client must refresh after delete to avoid stale indices.
+//
+// 2026-06-19: character.assets[] removed (consolidated into equipment[]
+// via the catalogue's bucket: 'asset' items). Response shape is now just
+// { equipment } — no more { equipment, assets }.
 
-// GET /api/characters/:id/equipment — returns { equipment, assets } for the character.
+// GET /api/characters/:id/equipment — returns { equipment } for the character.
 router.get('/:id/equipment', requireRole('st'), async (req, res) => {
   const oid = parseId(req.params.id);
   if (!oid) return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid character ID' });
-  const char = await col().findOne({ _id: oid }, { projection: { equipment: 1, assets: 1 } });
+  const char = await col().findOne({ _id: oid }, { projection: { equipment: 1 } });
   if (!char) return res.status(404).json({ error: 'NOT_FOUND', message: 'Character not found' });
-  res.json({ equipment: char.equipment || [], assets: char.assets || [] });
+  res.json({ equipment: char.equipment || [] });
 });
 
 // POST /api/characters/:id/equipment — append a single equipment item.
@@ -889,9 +893,9 @@ router.post('/:id/equipment', requireRole('st'), async (req, res) => {
   const result = await col().findOneAndUpdate(
     { _id: oid },
     { $push: { equipment: cleanItem } },
-    { returnDocument: 'after', projection: { equipment: 1, assets: 1 } },
+    { returnDocument: 'after', projection: { equipment: 1 } },
   );
-  res.json({ equipment: result.equipment || [], assets: result.assets || [] });
+  res.json({ equipment: result.equipment || [] });
 });
 
 // DELETE /api/characters/:id/equipment/:itemIndex — remove by zero-based index.
@@ -900,7 +904,7 @@ router.delete('/:id/equipment/:itemIndex', requireRole('st'), async (req, res) =
   const oid = parseId(req.params.id);
   if (!oid) return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid character ID' });
 
-  const char = await col().findOne({ _id: oid }, { projection: { equipment: 1, assets: 1 } });
+  const char = await col().findOne({ _id: oid }, { projection: { equipment: 1 } });
   if (!char) return res.status(404).json({ error: 'NOT_FOUND', message: 'Character not found' });
 
   const idx = parseInt(req.params.itemIndex, 10);
@@ -913,71 +917,13 @@ router.delete('/:id/equipment/:itemIndex', requireRole('st'), async (req, res) =
   const result = await col().findOneAndUpdate(
     { _id: oid },
     { $set: { equipment: arr } },
-    { returnDocument: 'after', projection: { equipment: 1, assets: 1 } },
+    { returnDocument: 'after', projection: { equipment: 1 } },
   );
-  res.json({ equipment: result.equipment || [], assets: result.assets || [] });
+  res.json({ equipment: result.equipment || [] });
 });
 
-// POST /api/characters/:id/assets — append a single asset.
-router.post('/:id/assets', requireRole('st'), async (req, res) => {
-  const oid = parseId(req.params.id);
-  if (!oid) return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid character ID' });
-
-  const item = req.body;
-  if (!item || typeof item !== 'object') {
-    return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Request body must be an asset object' });
-  }
-  if (!item.name || typeof item.name !== 'string') {
-    return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'name is required' });
-  }
-  if (!item.description || typeof item.description !== 'string') {
-    return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'description is required' });
-  }
-  if (!Number.isInteger(item.acquired_cycle) || item.acquired_cycle < 0) {
-    return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'acquired_cycle must be a non-negative integer' });
-  }
-
-  const char = await col().findOne({ _id: oid }, { projection: { _id: 1 } });
-  if (!char) return res.status(404).json({ error: 'NOT_FOUND', message: 'Character not found' });
-
-  const cleanItem = {
-    name:              item.name,
-    description:       item.description,
-    location:          item.location ?? null,
-    mechanical_effect: item.mechanical_effect ?? null,
-    acquired_cycle:    item.acquired_cycle,
-    notes:             item.notes ?? null,
-  };
-  const result = await col().findOneAndUpdate(
-    { _id: oid },
-    { $push: { assets: cleanItem } },
-    { returnDocument: 'after', projection: { equipment: 1, assets: 1 } },
-  );
-  res.json({ equipment: result.equipment || [], assets: result.assets || [] });
-});
-
-// DELETE /api/characters/:id/assets/:itemIndex — remove by zero-based index.
-// Client must refresh after delete to avoid stale indices.
-router.delete('/:id/assets/:itemIndex', requireRole('st'), async (req, res) => {
-  const oid = parseId(req.params.id);
-  if (!oid) return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid character ID' });
-
-  const char = await col().findOne({ _id: oid }, { projection: { equipment: 1, assets: 1 } });
-  if (!char) return res.status(404).json({ error: 'NOT_FOUND', message: 'Character not found' });
-
-  const idx = parseInt(req.params.itemIndex, 10);
-  const arr = char.assets || [];
-  if (!Number.isInteger(idx) || idx < 0 || idx >= arr.length) {
-    return res.status(404).json({ error: 'NOT_FOUND', message: 'Asset index out of range' });
-  }
-
-  arr.splice(idx, 1);
-  const result = await col().findOneAndUpdate(
-    { _id: oid },
-    { $set: { assets: arr } },
-    { returnDocument: 'after', projection: { equipment: 1, assets: 1 } },
-  );
-  res.json({ equipment: result.equipment || [], assets: result.assets || [] });
-});
+// /api/characters/:id/assets routes REMOVED 2026-06-19 — character.assets[]
+// consolidated into equipment[] via the catalogue's bucket: 'asset' items.
+// All asset-class items now flow through the equipment routes above.
 
 export default router;

--- a/server/schemas/character.schema.js
+++ b/server/schemas/character.schema.js
@@ -331,25 +331,12 @@ export const characterSchema = {
       },
     },
 
-    // ── Assets (EQ-1, issue #654) ─────────────────────────────
-    // Annotation-first; mechanical_effect hook reserved for future rule integration.
-    assets: {
-      type: 'array',
-      default: [],
-      items: {
-        type: 'object',
-        required: ['name', 'description', 'acquired_cycle'],
-        properties: {
-          name:              { type: 'string' },
-          description:       { type: 'string' },
-          location:          { type: ['string', 'null'] },
-          mechanical_effect: { type: ['string', 'null'] },
-          acquired_cycle:    { type: 'integer', minimum: 0 },
-          notes:             { type: ['string', 'null'] },
-        },
-        additionalProperties: false,
-      },
-    },
+    // ── Assets ────────────────────────────────────────────────
+    // REMOVED 2026-06-19 — consolidated into equipment[] via the catalogue's
+    // bucket: 'asset' items (Vehicle (Luxury), Safe House, etc.). The previous
+    // free-text assets[] storage shape collided with the catalogue's 'asset'
+    // bucket name and split asset-class items across two arrays. Equipment[]
+    // is the single home for all bucket types now. See chat 2026-06-19.
 
     // ── XP log ────────────────────────────────────────────────
     xp_log: {

--- a/server/tests/equipment.test.js
+++ b/server/tests/equipment.test.js
@@ -7,11 +7,12 @@
  * /api/equipment/catalogue alias from EQ-1 was removed in ECM-7 (#874).
  *
  * Character-scoped (ST auth required):
- *   GET  /:id/equipment              — returns { equipment, assets }
+ *   GET  /:id/equipment              — returns { equipment }
  *   POST /:id/equipment              — append item; validates catalogue_id, state, acquired_cycle
  *   DELETE /:id/equipment/:idx       — remove by index
- *   POST /:id/assets                 — append asset; validates name, description, acquired_cycle
- *   DELETE /:id/assets/:idx          — remove by index
+ *
+ *   /:id/assets routes retired 2026-06-19 — character.assets[] consolidated
+ *   into equipment[] via catalogue bucket: 'asset' items.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
@@ -93,7 +94,6 @@ describe('GET /api/characters/:id/equipment', () => {
       .set('X-Test-User', stUser());
     expect(res.status).toBe(200);
     expect(res.body.equipment).toEqual([]);
-    expect(res.body.assets).toEqual([]);
   });
 
   it('returns 404 for a non-existent character id', async () => {
@@ -244,84 +244,6 @@ describe('DELETE /api/characters/:id/equipment/:itemIndex', () => {
   });
 });
 
-// ── POST /:id/assets ─────────────────────────────────────────────────────────
-
-describe('POST /api/characters/:id/assets', () => {
-  const validAsset = {
-    name: 'Marrickville Safehouse',
-    description: 'A discreet warehouse in the inner west.',
-    location: 'Marrickville',
-    mechanical_effect: null,
-    acquired_cycle: 2,
-    notes: 'Used for storing contraband',
-  };
-
-  it('appends a valid asset and returns it in the response (200)', async () => {
-    const char6 = await seedChar({ name: 'Asset Test' });
-    const res = await request(app)
-      .post(`/api/characters/${char6.id}/assets`)
-      .set('X-Test-User', stUser())
-      .send(validAsset);
-    expect(res.status).toBe(200);
-    expect(res.body.assets).toHaveLength(1);
-    expect(res.body.assets[0].name).toBe('Marrickville Safehouse');
-    expect(res.body.assets[0].location).toBe('Marrickville');
-    expect(res.body.assets[0].mechanical_effect).toBeNull();
-  });
-
-  it('400 when name is missing', async () => {
-    const char7 = await seedChar({ name: 'Asset Missing Name' });
-    const res = await request(app)
-      .post(`/api/characters/${char7.id}/assets`)
-      .set('X-Test-User', stUser())
-      .send({ description: 'No name given', acquired_cycle: 1 });
-    expect(res.status).toBe(400);
-  });
-
-  it('400 when description is missing', async () => {
-    const char8 = await seedChar({ name: 'Asset Missing Desc' });
-    const res = await request(app)
-      .post(`/api/characters/${char8.id}/assets`)
-      .set('X-Test-User', stUser())
-      .send({ name: 'Something', acquired_cycle: 1 });
-    expect(res.status).toBe(400);
-  });
-
-  it('400 when acquired_cycle is missing', async () => {
-    const char9 = await seedChar({ name: 'Asset Missing Cycle' });
-    const res = await request(app)
-      .post(`/api/characters/${char9.id}/assets`)
-      .set('X-Test-User', stUser())
-      .send({ name: 'Something', description: 'A thing' });
-    expect(res.status).toBe(400);
-  });
-});
-
-// ── DELETE /:id/assets/:itemIndex ─────────────────────────────────────────────
-
-describe('DELETE /api/characters/:id/assets/:itemIndex', () => {
-  it('removes the asset at the given index and returns updated arrays', async () => {
-    const char10 = await seedChar({ name: 'Asset Delete Test' });
-    await request(app).post(`/api/characters/${char10.id}/assets`)
-      .set('X-Test-User', stUser())
-      .send({ name: 'First Asset', description: 'First', acquired_cycle: 1 });
-    await request(app).post(`/api/characters/${char10.id}/assets`)
-      .set('X-Test-User', stUser())
-      .send({ name: 'Second Asset', description: 'Second', acquired_cycle: 2 });
-
-    const res = await request(app)
-      .delete(`/api/characters/${char10.id}/assets/0`)
-      .set('X-Test-User', stUser());
-    expect(res.status).toBe(200);
-    expect(res.body.assets).toHaveLength(1);
-    expect(res.body.assets[0].name).toBe('Second Asset');
-  });
-
-  it('404 when index is out of range', async () => {
-    const char11 = await seedChar({ name: 'Asset OOB' });
-    const res = await request(app)
-      .delete(`/api/characters/${char11.id}/assets/99`)
-      .set('X-Test-User', stUser());
-    expect(res.status).toBe(404);
-  });
-});
+// /:id/assets test slices REMOVED 2026-06-19 — character.assets[] retired
+// and the corresponding endpoints removed. Asset-bucket catalogue items now
+// flow through the equipment routes above.


### PR DESCRIPTION
Eliminates \`character.assets[]\` entirely; all asset-class items flow through \`equipment[]\` via the catalogue's \`bucket: 'asset'\` entries. Authorised by Peter 2026-06-19 (Option 1, no migration — no characters carry equipment or assets data yet).

## Why

Old shape had a confusing name collision:
- Catalogue's \`bucket: 'asset'\` = a *category* for items like Safe House, Vehicle (Luxury).
- \`character.assets[]\` = a *separate free-text annotation array* with no catalogue link.

Asset-bucket items were split across two storage shapes. Now there's one path:

\`\`\`
catalogue:            { _id, bucket: weapon|armour|equipment|asset, name, ... }
character.equipment[]: [ { catalogue_id, state, acquired_cycle, notes } ]
\`\`\`

## Changes

| Layer | Change |
|---|---|
| Schema (\`server/schemas/character.schema.js\`) | Remove \`assets[]\` definition |
| Routes (\`server/routes/characters.js\`) | Delete POST + DELETE \`/:id/assets\`; remove \`assets\` from response shape |
| \`public/js/editor/edit.js\` | Delete \`shAddAsset\`, \`shRemoveAsset\`; drop \`c.assets = result.assets\` |
| \`public/js/editor/sheet.js\` | Add \`'asset'\` to BUCKETS; replace standalone Assets block with bucket-grouped render reading from catalogue; remove Add Asset free-text form |
| \`public/js/admin.js\` + \`public/js/app.js\` | Drop \`shAddAsset\` + \`shRemoveAsset\` from imports and window registration |
| \`server/tests/equipment.test.js\` | Drop the two \`/:id/assets\` endpoint slices; update header + empty-equipment test |

## Verification

- Full suite: **1860 pass / 0 individual fails / 4 pre-existing file-load issues** (same as before).
- parse-check via CI.
- Manual browser smoke pending — Peter to verify on the dev preview when convenient.

## Net diff: -190 LOC

Largely from the test slice deletions + the standalone assets render + add-form removal.

## Migration impact

None. No characters had assets[] or equipment[] data per Peter's clarification on 2026-06-19. Any documents that did would now have a dead \`assets\` field that gets ignored on read; an explicit cleanup is not needed because (a) the field is silently invisible, and (b) AJV \`additionalProperties: false\` is on the character schema — meaning any subsequent character PUT would strip it via \`buildSaveBody\` (which doesn't carry \`assets\` anymore). Effectively self-cleaning on next save.

## Held on dev

Per Peter's earlier hold ("STs doing DT work"), this PR merges to dev only. Main push later when authorised.