### PR TITLE
feat: #907 — player merit summary shows submitted description

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -4580,6 +4580,12 @@ html:not([data-theme="dark"]) .sk-spec-row  span { color: var(--crim) !important
   font-family: var(--fl);
 }
 .merit-summary-text { color: var(--txt1); flex: 1; }
+.merit-summary-description {
+  display: block;
+  color: var(--txt3);
+  font-size: 12px;
+  margin-bottom: 2px;
+}
 
 
 

--- a/public/js/tabs/story-tab.js
+++ b/public/js/tabs/story-tab.js
@@ -570,6 +570,7 @@ function renderMeritSummarySection(sub) {
     groups[cat].push({
       meritLabel,
       actionLabel: cat === 'contacts' ? '' : (ACTION_TYPE_LABELS[a.action_type] || a.action_type || ''),
+      description: (a.description || '').trim(),
       summary,
     });
   });
@@ -586,7 +587,10 @@ function renderMeritSummarySection(sub) {
       h += `<div class="merit-summary-row">`;
       h += `<span class="merit-summary-merit">${esc(entry.meritLabel)}</span>`;
       if (entry.actionLabel) h += `<span class="merit-summary-action-type">${esc(entry.actionLabel)}</span>`;
-      h += `<span class="merit-summary-text">${esc(entry.summary)}</span>`;
+      h += `<div class="merit-summary-text">`;
+      if (entry.description) h += `<span class="merit-summary-description">${esc(entry.description)}</span>`;
+      h += esc(entry.summary);
+      h += `</div>`;
       h += `</div>`;
     }
     h += `</div>`;
@@ -615,45 +619,54 @@ function buildPlayerMeritActions(sub) {
       actions.push({
         merit_type:  resp[`sphere_${slot}_merit`] || '',
         action_type: entry.action_type || '',
+        description: entry.desired_outcome || resp[`sphere_${slot}_outcome`] || '',
       });
     });
   } else {
     for (let n = 1; n <= 5; n++) {
       const mt = resp[`sphere_${n}_merit`];
       if (!mt) continue;
-      actions.push({ merit_type: mt, action_type: resp[`sphere_${n}_action`] || '' });
+      actions.push({ merit_type: mt, action_type: resp[`sphere_${n}_action`] || '', description: resp[`sphere_${n}_outcome`] || '' });
     }
+  }
+
+  // Status / MCI — mirrors downtime-story.js:1997–2014; must follow spheres to preserve flat index order
+  for (let n = 1; n <= 5; n++) {
+    const mt = resp[`status_${n}_merit`];
+    const actionVal = resp[`status_${n}_action`];
+    if (!mt || !actionVal) continue;
+    actions.push({ merit_type: mt, action_type: actionVal, description: resp[`status_${n}_outcome`] || '' });
   }
 
   // Contacts
   const contactRaw = raw.contact_actions?.requests || [];
   if (contactRaw.length) {
-    contactRaw.forEach((_, idx) => {
+    contactRaw.forEach((c, idx) => {
       const n = idx + 1;
-      actions.push({ merit_type: resp[`contact_${n}_merit`] || resp[`contact_1_merit`] || 'Contacts', action_type: 'misc' });
+      actions.push({ merit_type: resp[`contact_${n}_merit`] || resp[`contact_1_merit`] || 'Contacts', action_type: 'misc', description: c.detail || c.description || '' });
     });
   } else {
     for (let n = 1; n <= 5; n++) {
       if (!resp[`contact_${n}_request`]) continue;
-      actions.push({ merit_type: resp[`contact_${n}_merit`] || 'Contacts', action_type: 'misc' });
+      actions.push({ merit_type: resp[`contact_${n}_merit`] || 'Contacts', action_type: 'misc', description: resp[`contact_${n}_request`] || '' });
     }
   }
 
   // Retainers
   const retainerRaw = raw.retainer_actions?.actions || [];
   if (retainerRaw.length) {
-    retainerRaw.forEach(() => actions.push({ merit_type: 'Retainer', action_type: 'misc' }));
+    retainerRaw.forEach(r => actions.push({ merit_type: r.merit || 'Retainer', action_type: 'misc', description: r.task || r.description || '' }));
   } else {
     for (let n = 1; n <= 4; n++) {
       if (!resp[`retainer_${n}_task`]) continue;
-      actions.push({ merit_type: 'Retainer', action_type: 'misc' });
+      actions.push({ merit_type: resp[`retainer_${n}_merit`] || 'Retainer', action_type: 'misc', description: resp[`retainer_${n}_task`] || '' });
     }
   }
 
   // Resources
   const resBlob = raw.acquisitions?.resource_acquisitions || resp['resources_acquisitions'] || '';
   if (resBlob.trim()) {
-    actions.push({ merit_type: 'Resources', action_type: 'acquisition' });
+    actions.push({ merit_type: 'Resources', action_type: 'acquisition', description: (resp['acq_description'] || resBlob).trim() });
   }
 
   // Skill Acquisitions (mirror ST-side buildMeritActions at downtime-story.js:2159-2188).
@@ -661,7 +674,7 @@ function buildPlayerMeritActions(sub) {
   // current single-acquisition-per-submission constraint (PR #187 context).
   const skillAcqBlob = raw.acquisitions?.skill_acquisitions || resp['skill_acquisitions'] || '';
   if (skillAcqBlob.trim()) {
-    actions.push({ merit_type: 'Skill Acquisition', action_type: 'acquisition' });
+    actions.push({ merit_type: 'Skill Acquisition', action_type: 'acquisition', description: skillAcqBlob.trim() });
   }
 
   return actions;

--- a/specs/stories/feat.907.dt-story-player-merit-description.story.md
+++ b/specs/stories/feat.907.dt-story-player-merit-description.story.md
@@ -1,0 +1,375 @@
+# feat.907 — DT Story: show player's submitted description before ST outcome
+
+```yaml
+issue: 907
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/907
+branch: ms/issue-907-player-merit-description
+status: review
+type: feature
+```
+
+## Story
+
+As a player, when I open my downtime story, I want to see my own submitted
+request or description alongside the ST's outcome in the Allies & Asset Summary,
+so I can understand what I asked for and what was delivered without having to
+go back to my original submission.
+
+## Acceptance criteria
+
+- [x] **AC-1** — Contacts action: the player's request text (`contact_${n}_request`)
+  appears before the ST outcome in the Allies & Asset Summary row
+- [x] **AC-2** — Allies/Status sphere action: the player's desired outcome
+  (`sphere_${n}_outcome` or `status_${n}_outcome`) appears before the ST outcome
+- [x] **AC-3** — Retainer action: the player's task description (`retainer_${n}_task`)
+  appears before the ST outcome
+- [x] **AC-4** — Skill Acquisition: the skill(s) text from the submission appears
+  before the ST outcome
+- [x] **AC-5** — When no description is available (blank field or old submission),
+  the row renders without a description element — no empty gap, no placeholder
+- [x] **AC-6** — When there is no ST outcome the row is already excluded from the
+  summary (existing gate unchanged — this criterion guards against regression)
+- [x] **AC-7** — Styling uses design-system tokens only; no inline `style=`, no
+  bare hex
+
+## Scope
+
+**In scope**
+- `public/js/tabs/story-tab.js` — `buildPlayerMeritActions` and
+  `renderMeritSummarySection`
+- `public/css/components.css` — new `.merit-summary-description` class
+
+**Out of scope**
+- Admin DT Story layout (`downtime-story.js`) — no changes
+- DT Processing panel — no changes
+- `renderMeritActionCards` (legacy fallback, not the summary ledger)
+
+---
+
+## Dev Notes
+
+### 1. The two functions to modify
+
+**`buildPlayerMeritActions`** (`story-tab.js:605–668`) reconstructs the ordered
+list of merit actions from `sub.responses` and `sub._raw`. It currently returns
+`{ merit_type, action_type }` per entry. This story adds a `description` field
+to each entry.
+
+**`renderMeritSummarySection`** (`story-tab.js:541–596`) builds category groups
+and renders the HTML rows. It currently passes `{ meritLabel, actionLabel, summary }`
+into each group. This story adds `description` and renders it before the outcome.
+
+### 2. `buildPlayerMeritActions` — exact changes
+
+Reference implementation: admin `buildMeritActions` at `downtime-story.js:1955–2141`,
+which already has `desired_outcome` and `description` per action.
+
+#### Spheres (Allies, etc.)
+
+**Raw path** — reading from `raw.sphere_actions`:
+```js
+// BEFORE
+actions.push({
+  merit_type:  resp[`sphere_${slot}_merit`] || '',
+  action_type: entry.action_type || '',
+});
+
+// AFTER
+actions.push({
+  merit_type:   resp[`sphere_${slot}_merit`] || '',
+  action_type:  entry.action_type || '',
+  description:  entry.desired_outcome || resp[`sphere_${slot}_outcome`] || '',
+});
+```
+
+**Form path** — reading from `resp` keys:
+```js
+// BEFORE
+actions.push({ merit_type: mt, action_type: resp[`sphere_${n}_action`] || '' });
+
+// AFTER
+actions.push({
+  merit_type:  mt,
+  action_type: resp[`sphere_${n}_action`] || '',
+  description: resp[`sphere_${n}_outcome`] || '',
+});
+```
+
+#### Status loop — currently MISSING in `buildPlayerMeritActions`
+
+**This is a pre-existing bug.** The admin `buildMeritActions` has a Status loop
+(lines 1997–2014) inserted after spheres and before contacts, matching the flat
+index order in `merit_actions_resolved`. Without it, any submission with Status
+actions misaligns contact/retainer outcomes.
+
+Add this loop **after the spheres block and before the contacts block** (around
+line 627 in the current file):
+
+```js
+// ── Status / MCI ── (mirrors downtime-story.js:1997–2014)
+for (let n = 1; n <= 5; n++) {
+  const mt = resp[`status_${n}_merit`];
+  const actionVal = resp[`status_${n}_action`];
+  if (!mt || !actionVal) continue;
+  actions.push({
+    merit_type:  mt,
+    action_type: actionVal,
+    description: resp[`status_${n}_outcome`] || '',
+  });
+}
+```
+
+#### Contacts
+
+**Raw path** (reading from `raw.contact_actions.requests`):
+```js
+// BEFORE
+contactRaw.forEach((_, idx) => {
+  const n = idx + 1;
+  actions.push({ merit_type: resp[`contact_${n}_merit`] || 'Contacts', action_type: 'misc' });
+});
+
+// AFTER
+contactRaw.forEach((c, idx) => {
+  const n = idx + 1;
+  actions.push({
+    merit_type:  resp[`contact_${n}_merit`] || 'Contacts',
+    action_type: 'misc',
+    description: c.detail || c.description || '',
+  });
+});
+```
+
+Note: `_` becomes `c` to read the raw object's description fields.
+
+**Form path** (reading from `resp` keys):
+```js
+// BEFORE
+actions.push({ merit_type: resp[`contact_${n}_merit`] || 'Contacts', action_type: 'misc' });
+
+// AFTER
+actions.push({
+  merit_type:  resp[`contact_${n}_merit`] || 'Contacts',
+  action_type: 'misc',
+  description: resp[`contact_${n}_request`] || '',
+});
+```
+
+#### Retainers
+
+**Raw path** (reading from `raw.retainer_actions.actions`):
+```js
+// BEFORE
+retainerRaw.forEach(() => actions.push({ merit_type: 'Retainer', action_type: 'misc' }));
+
+// AFTER
+retainerRaw.forEach(r => actions.push({
+  merit_type:  r.merit || 'Retainer',
+  action_type: 'misc',
+  description: r.task || r.description || '',
+}));
+```
+
+Note: `()` becomes `r` to read the raw object.
+
+**Form path**:
+```js
+// BEFORE
+actions.push({ merit_type: 'Retainer', action_type: 'misc' });
+
+// AFTER — `resp[retainer_${n}_task]` is already guarded by `if (!resp[...])` above
+actions.push({
+  merit_type:  resp[`retainer_${n}_merit`] || 'Retainer',
+  action_type: 'misc',
+  description: resp[`retainer_${n}_task`] || '',
+});
+```
+
+Note: The form path already has `if (!resp[\`retainer_${n}_task\`]) continue;`
+so `resp[\`retainer_${n}_task\`]` is guaranteed non-empty in that branch.
+Also, retrieve the merit name from `resp[\`retainer_${n}_merit\`]` rather than
+hardcoding `'Retainer'` (matches admin pattern).
+
+#### Resources
+
+```js
+// BEFORE
+actions.push({ merit_type: 'Resources', action_type: 'acquisition' });
+
+// AFTER
+actions.push({
+  merit_type:  'Resources',
+  action_type: 'acquisition',
+  description: (resp['acq_description'] || resAcqBlob).trim(),
+});
+```
+
+`resAcqBlob` is already computed just above; `resp['acq_description']` is the
+structured description from the form (same fields admin uses).
+
+#### Skill Acquisitions
+
+```js
+// BEFORE
+actions.push({ merit_type: 'Skill Acquisition', action_type: 'acquisition' });
+
+// AFTER
+actions.push({
+  merit_type:  'Skill Acquisition',
+  action_type: 'acquisition',
+  description: skillAcqBlob.trim(),
+});
+```
+
+`skillAcqBlob` is already computed just above.
+
+### 3. `renderMeritSummarySection` — group push
+
+At lines 569–574, the group push currently creates:
+```js
+groups[cat].push({
+  meritLabel,
+  actionLabel: cat === 'contacts' ? '' : (ACTION_TYPE_LABELS[a.action_type] || a.action_type || ''),
+  summary,
+});
+```
+
+Add `description`:
+```js
+groups[cat].push({
+  meritLabel,
+  actionLabel:  cat === 'contacts' ? '' : (ACTION_TYPE_LABELS[a.action_type] || a.action_type || ''),
+  description:  (a.description || '').trim(),
+  summary,
+});
+```
+
+### 4. `renderMeritSummarySection` — row render
+
+Current row render (lines 585–590):
+```js
+h += `<div class="merit-summary-row">`;
+h += `<span class="merit-summary-merit">${esc(entry.meritLabel)}</span>`;
+if (entry.actionLabel) h += `<span class="merit-summary-action-type">${esc(entry.actionLabel)}</span>`;
+h += `<span class="merit-summary-text">${esc(entry.summary)}</span>`;
+h += `</div>`;
+```
+
+After adding description. Change `.merit-summary-text` from `span` to `div`
+(it is a flex child of the row — `div` is valid and allows block children):
+```js
+h += `<div class="merit-summary-row">`;
+h += `<span class="merit-summary-merit">${esc(entry.meritLabel)}</span>`;
+if (entry.actionLabel) h += `<span class="merit-summary-action-type">${esc(entry.actionLabel)}</span>`;
+h += `<div class="merit-summary-text">`;
+if (entry.description) h += `<span class="merit-summary-description">${esc(entry.description)}</span>`;
+h += esc(entry.summary);
+h += `</div>`;
+h += `</div>`;
+```
+
+This stacks description above outcome within the flex-1 text column.
+
+### 5. CSS — `components.css`
+
+Add `.merit-summary-description` immediately after `.merit-summary-text`
+(line 4582 in current file). Use `display: block` so it stacks above the outcome
+text node within the `div.merit-summary-text` flex child.
+
+```css
+.merit-summary-text { color: var(--txt1); flex: 1; }
+.merit-summary-description {
+  display: block;
+  color: var(--txt3);
+  font-size: 12px;
+  margin-bottom: 2px;
+}
+```
+
+No bare hex. No inline style. Tokens only.
+
+`.merit-summary-text` itself needs no layout change — `flex: 1` already makes it
+fill available space; block children inside it stack naturally.
+
+### 6. `esc()` guard
+
+All player-submitted text goes through `esc()` (the HTML-escape helper already
+used in this file) before being rendered. This is the existing pattern — maintain
+it for `entry.description` too.
+
+### 7. Index alignment — why Status must go before Contacts
+
+`merit_actions_resolved` is an ordered array parallel to the actions array.
+The processing panel builds it in the same order as `buildMeritActions` in
+`downtime-story.js`: spheres → Status → contacts → retainers → skill/resource.
+The player's `buildPlayerMeritActions` must produce actions in the same order,
+otherwise `resolved[i]` maps to the wrong action.
+
+Currently `buildPlayerMeritActions` has no Status loop, so for any submission
+with Status actions and subsequent Contacts actions, contact outcomes are being
+read at wrong indices. Adding the Status loop in the correct position (after
+spheres, before contacts) both enables description display for Status and fixes
+the pre-existing index bug.
+
+### 8. Files to change
+
+| File | Change |
+|------|--------|
+| `public/js/tabs/story-tab.js` | `buildPlayerMeritActions`: add `description` field + Status loop; `renderMeritSummarySection`: include `description` in group push and row render |
+| `public/css/components.css` | Add `.merit-summary-description` after `.merit-summary-text` (~line 4583) |
+
+No server changes. No API changes. No admin-side changes.
+
+### 9. Preservation invariants
+
+- The `if (!summary) return;` gate at line 566 is unchanged. Rows without an
+  ST outcome are still excluded from the summary regardless of description.
+- `renderMeritActionCards` (legacy fallback) is untouched.
+- `hasOutcomeSummaries` guard (lines 547–549) is untouched.
+- The admin `downtime-story.js` is not touched.
+- `buildPlayerMeritActions` return shape gains a new `description` field —
+  `renderMeritActionCards` (the only other consumer) ignores extra fields, so
+  no regression.
+
+---
+
+## Testing
+
+Playwright E2E tests (following the fix.904 spec pattern at
+`tests/fix-904-merit-outcome-field-fallback.spec.js`). Create
+`tests/feat-907-player-merit-description.spec.js`.
+
+Player-side tests use `setupPlayerStory(page, [sub])` +
+`expandPastOutcome(page)` helpers (copy/adapt from the fix.904 spec).
+
+**Test fixtures needed** — each tests a different action type:
+
+| Test | Sub fixture shape | Assertion |
+|------|------------------|-----------|
+| AC-1 Contacts | `responses: { contact_1_request: 'Who runs the docks?', contact_1_merit: 'Contacts (Street)' }, merit_actions_resolved: [{ outcome: 'Mick Sullivan controls Pier 7.', outcome_confirmed: true }]` | `.merit-summary-description` contains `'Who runs the docks?'` |
+| AC-2 Sphere | `responses: { sphere_1_merit: 'Allies (Dockers)', sphere_1_action: 'misc', sphere_1_outcome: 'Send them to watch the harbour.' }, merit_actions_resolved: [{ outcome: 'Your allies deployed.', outcome_confirmed: true }]` | description contains `'Send them to watch the harbour.'` |
+| AC-3 Retainer | `responses: { retainer_1_merit: 'Retainer', retainer_1_task: 'Follow the red-haired man.' }, merit_actions_resolved: [{ outcome: 'Task complete.', outcome_confirmed: true }]` | description contains `'Follow the red-haired man.'` |
+| AC-4 Skill Acq | `responses: { skill_acquisitions: 'Athletics 3' }, acquisitions_resolved: [{ outcome_summary: 'Approved.' }]` | description contains `'Athletics 3'` |
+| AC-5 No description | `responses: { sphere_1_merit: 'Allies (X)', sphere_1_action: 'misc', sphere_1_outcome: '' }, merit_actions_resolved: [{ outcome: 'Some outcome.', outcome_confirmed: true }]` | no `.merit-summary-description` element present |
+
+All player-side tests: boot the app via the player `setupPlayerStory` helper,
+call `expandPastOutcome`, then assert on `.merit-summary-section` contents.
+
+---
+
+## Dev Agent Record
+
+### Files changed
+- `public/js/tabs/story-tab.js` — `buildPlayerMeritActions`: added `description` field to all six action types (spheres raw+form, Status loop added, contacts raw+form, retainers raw+form, resources, skill acquisitions); `renderMeritSummarySection`: group push includes `description`; row render emits `<span class="merit-summary-description">` inside `<div class="merit-summary-text">` when description non-empty
+- `public/css/components.css` — added `.merit-summary-description` class (`display: block; color: var(--txt3); font-size: 12px; margin-bottom: 2px`)
+- `tests/feat-907-player-merit-description.spec.js` — 7 new Playwright tests, all passing
+
+### Completion notes
+All 7 ACs satisfied. 7/7 tests pass in 24.3 s.
+Pre-existing bug fixed alongside: `buildPlayerMeritActions` had no Status loop, causing index misalignment for submissions with Status actions followed by Contacts. Status loop added in correct position (after spheres, before contacts) matching admin `buildMeritActions` order.
+
+### Change log
+- 2026-06-19: feat #907 — player merit summary now shows submitted description before ST outcome for all action types
+
+---
+_Story created from GitHub issue #907. Branch: `ms/issue-907-player-merit-description`_

--- a/tests/feat-907-player-merit-description.spec.js
+++ b/tests/feat-907-player-merit-description.spec.js
@@ -1,0 +1,279 @@
+/**
+ * E2E tests for feat #907 — player Allies & Asset Summary shows submitted
+ * description before ST outcome.
+ *
+ * `buildPlayerMeritActions` now returns a `description` field per action type:
+ *   - Contacts: contact_${n}_request
+ *   - Spheres (Allies/Status): sphere_${n}_outcome / status_${n}_outcome
+ *   - Retainers: retainer_${n}_task
+ *   - Skill Acquisitions: skill_acquisitions blob
+ *
+ * `renderMeritSummarySection` emits <span class="merit-summary-description">
+ * inside .merit-summary-text (before the ST outcome text) when description exists.
+ *
+ * AC-1: Contacts request appears as description
+ * AC-2: Sphere desired outcome appears as description
+ * AC-3: Retainer task appears as description
+ * AC-4: Skill Acquisition blob appears as description
+ * AC-5: Empty description → no .merit-summary-description element
+ * AC-6: No ST outcome → row absent (existing exclusion gate, regression guard)
+ * AC-7: Description span has no inline style= attribute (tokens only)
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Shared user fixtures ───────────────────────────────────────────────────────
+
+const PLAYER_USER = {
+  id: '987000907', username: 'test_player_907', global_name: 'Test Player 907',
+  avatar: null, role: 'player', player_id: 'p-907',
+  character_ids: ['char-907'], is_dual_role: false,
+};
+
+const CLOSED_CYCLE = {
+  _id: 'cycle-907', cycle_number: 4, status: 'closed',
+  deadline: new Date(Date.now() - 86400000).toISOString(),
+  confirmed_ambience: {}, narrative_notes: '',
+};
+
+const CHAR = {
+  _id: 'char-907',
+  name: 'Description Test', moniker: null, honorific: null,
+  clan: 'Daeva', covenant: 'Invictus', player: 'Test Player 907',
+  blood_potency: 2, humanity: 6, humanity_base: 7, court_title: null,
+  home_territory: null, retired: false,
+  status: { city: 1, clan: 1, covenant: { Invictus: 1 } },
+  attributes: {
+    Strength:     { dots: 2, bonus: 0 }, Dexterity:    { dots: 2, bonus: 0 }, Stamina:       { dots: 2, bonus: 0 },
+    Intelligence: { dots: 2, bonus: 0 }, Wits:         { dots: 2, bonus: 0 }, Resolve:       { dots: 2, bonus: 0 },
+    Presence:     { dots: 3, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure:     { dots: 2, bonus: 0 },
+  },
+  skills: {}, disciplines: {}, powers: [], ordeals: [],
+  merits: [
+    { name: 'Contacts', category: 'influence', rating: 2, qualifier: 'Street' },
+    { name: 'Allies',   category: 'influence', rating: 2, qualifier: 'Dockers' },
+    { name: 'Retainer', category: 'influence', rating: 2 },
+  ],
+};
+
+function baseSub(id) {
+  return {
+    _id: id,
+    cycle_id: 'cycle-907',
+    character_id: 'char-907',
+    character_name: 'Description Test',
+    player_name: 'Test Player 907',
+    status: 'submitted',
+    responses: {},
+    _raw: { sphere_actions: [], contact_actions: { requests: [] }, retainer_actions: { actions: [] } },
+    projects_resolved: [],
+    merit_actions_resolved: [],
+    acquisitions_resolved: [],
+    st_review: { outcome_text: '## Story Moment\n\nA quiet night.', outcome_visibility: 'published' },
+    published_outcome: '## Story Moment\n\nA quiet night.',
+    feeding_review: { pool_status: 'no_feed' },
+    st_narrative: { story_moment: { status: 'complete' } },
+  };
+}
+
+// ── Test submission fixtures ───────────────────────────────────────────────────
+
+// AC-1: Contacts — request text shown as description
+const SUB_CONTACTS = {
+  ...baseSub('sub-907-contacts'),
+  responses: {
+    contact_1_merit:   'Contacts (Street)',
+    contact_1_request: 'Who controls the docks?',
+  },
+  merit_actions_resolved: [
+    { pool_status: 'confirmed', outcome: 'Mick Sullivan controls Pier 7.', outcome_confirmed: true },
+  ],
+};
+
+// AC-2: Sphere (Allies) — desired outcome shown as description
+const SUB_SPHERE = {
+  ...baseSub('sub-907-sphere'),
+  responses: {
+    sphere_1_merit:    'Allies (Dockers)',
+    sphere_1_action:   'misc',
+    sphere_1_outcome:  'Send someone to watch the harbour entrance.',
+  },
+  merit_actions_resolved: [
+    { pool_status: 'confirmed', outcome: 'Your allies deployed as requested.', outcome_confirmed: true },
+  ],
+};
+
+// AC-3: Retainer — task text shown as description
+const SUB_RETAINER = {
+  ...baseSub('sub-907-retainer'),
+  responses: {
+    retainer_1_merit: 'Retainer',
+    retainer_1_task:  'Follow the red-haired man in the Elysium district.',
+  },
+  merit_actions_resolved: [
+    { pool_status: 'confirmed', outcome: 'Your retainer tailed him to a warehouse on Cork Street.', outcome_confirmed: true },
+  ],
+};
+
+// AC-4: Skill Acquisition — blob text shown as description
+const SUB_SKILL = {
+  ...baseSub('sub-907-skill'),
+  responses: {
+    skill_acquisitions: 'Athletics 3',
+  },
+  merit_actions_resolved: [],
+  acquisitions_resolved: [
+    { pool_status: 'confirmed', outcome_summary: 'Approved.' },
+  ],
+};
+
+// AC-5: No description (sphere_1_outcome empty) — no .merit-summary-description
+const SUB_NO_DESC = {
+  ...baseSub('sub-907-no-desc'),
+  responses: {
+    sphere_1_merit:   'Allies (Dockers)',
+    sphere_1_action:  'misc',
+    sphere_1_outcome: '',
+  },
+  merit_actions_resolved: [
+    { pool_status: 'confirmed', outcome: 'Outcome with no description.', outcome_confirmed: true },
+  ],
+};
+
+// AC-6: No ST outcome — row excluded entirely (regression guard)
+const SUB_NO_OUTCOME = {
+  ...baseSub('sub-907-no-outcome'),
+  responses: {
+    contact_1_merit:   'Contacts (Street)',
+    contact_1_request: 'Some request.',
+  },
+  merit_actions_resolved: [
+    { pool_status: 'confirmed' },
+  ],
+};
+
+// ── Setup helpers ──────────────────────────────────────────────────────────────
+
+async function setupPlayerStory(page, submissions) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'fake-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: PLAYER_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url    = route.request().url();
+    const method = route.request().method();
+    const ok = (body) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+    if (method === 'POST' || method === 'PUT' || method === 'PATCH') return ok({ ok: true });
+    if (url.includes('/api/auth/me'))             return ok(PLAYER_USER);
+    if (url.includes('/api/downtime_cycles'))      return ok([CLOSED_CYCLE]);
+    if (url.includes('/api/downtime_submissions')) return ok(submissions);
+    if (url.includes('/api/characters/names'))     return ok([{ _id: CHAR._id, name: CHAR.name, moniker: CHAR.moniker, honorific: CHAR.honorific }]);
+    if (url.includes('/api/characters'))           return ok([CHAR]);
+    if (url.includes('/api/territories'))          return ok([]);
+    if (url.includes('/api/game_sessions'))        return ok([]);
+    if (url.includes('/api/session_logs'))         return ok([]);
+    if (url.includes('/api/ordeal-responses'))     return ok([]);
+    if (url.includes('/api/st_mods'))              return ok([]);
+    return ok([]);
+  });
+
+  await page.goto('/');
+  await page.waitForSelector('#app', { state: 'visible', timeout: 15000 });
+  await page.waitForFunction(() => typeof window.goTab === 'function', { timeout: 8000 });
+  await page.evaluate(() => window.goTab('info'));
+  await page.waitForTimeout(800);
+}
+
+async function expandPastOutcome(page) {
+  await page.waitForSelector('#misc-past-outcomes .dt-history-row', { timeout: 5000 });
+  await page.evaluate(() => {
+    const row = document.querySelector('#misc-past-outcomes .dt-history-row');
+    if (row) row.open = true;
+  });
+  await page.waitForTimeout(200);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('feat.907: player merit summary shows submitted description', () => {
+
+  test('AC-1: Contacts — request text shown as description before ST outcome', async ({ page }) => {
+    await setupPlayerStory(page, [SUB_CONTACTS]);
+    await expandPastOutcome(page);
+    const meritSection = page.locator('.merit-summary-section');
+    await expect(meritSection).toBeVisible({ timeout: 5000 });
+    const desc = meritSection.locator('.merit-summary-description').first();
+    await expect(desc).toBeVisible();
+    await expect(desc).toContainText('Who controls the docks?');
+    await expect(meritSection).toContainText('Mick Sullivan controls Pier 7.');
+  });
+
+  test('AC-2: Sphere (Allies) — desired outcome shown as description before ST outcome', async ({ page }) => {
+    await setupPlayerStory(page, [SUB_SPHERE]);
+    await expandPastOutcome(page);
+    const meritSection = page.locator('.merit-summary-section');
+    await expect(meritSection).toBeVisible({ timeout: 5000 });
+    const desc = meritSection.locator('.merit-summary-description').first();
+    await expect(desc).toBeVisible();
+    await expect(desc).toContainText('Send someone to watch the harbour entrance.');
+    await expect(meritSection).toContainText('Your allies deployed as requested.');
+  });
+
+  test('AC-3: Retainer — task description shown before ST outcome', async ({ page }) => {
+    await setupPlayerStory(page, [SUB_RETAINER]);
+    await expandPastOutcome(page);
+    const meritSection = page.locator('.merit-summary-section');
+    await expect(meritSection).toBeVisible({ timeout: 5000 });
+    const desc = meritSection.locator('.merit-summary-description').first();
+    await expect(desc).toBeVisible();
+    await expect(desc).toContainText('Follow the red-haired man');
+    await expect(meritSection).toContainText('tailed him to a warehouse');
+  });
+
+  test('AC-4: Skill Acquisition — blob text shown as description before outcome', async ({ page }) => {
+    await setupPlayerStory(page, [SUB_SKILL]);
+    await expandPastOutcome(page);
+    const meritSection = page.locator('.merit-summary-section');
+    await expect(meritSection).toBeVisible({ timeout: 5000 });
+    const desc = meritSection.locator('.merit-summary-description').first();
+    await expect(desc).toBeVisible();
+    await expect(desc).toContainText('Athletics 3');
+    await expect(meritSection).toContainText('Approved.');
+  });
+
+  test('AC-5: Empty description → no .merit-summary-description element in row', async ({ page }) => {
+    await setupPlayerStory(page, [SUB_NO_DESC]);
+    await expandPastOutcome(page);
+    const meritSection = page.locator('.merit-summary-section');
+    await expect(meritSection).toBeVisible({ timeout: 5000 });
+    await expect(meritSection).toContainText('Outcome with no description.');
+    const descEls = meritSection.locator('.merit-summary-description');
+    await expect(descEls).toHaveCount(0);
+  });
+
+  test('AC-6: No ST outcome → row absent from summary (existing gate regression)', async ({ page }) => {
+    await setupPlayerStory(page, [SUB_NO_OUTCOME]);
+    await expandPastOutcome(page);
+    // Without an ST outcome the section may not render at all, or renders empty
+    const meritSection = page.locator('.merit-summary-section');
+    const isVisible = await meritSection.isVisible().catch(() => false);
+    if (isVisible) {
+      // If section renders, the specific row with no outcome must not appear
+      await expect(meritSection).not.toContainText('Some request.');
+    }
+  });
+
+  test('AC-7: Description span has no inline style= attribute (design-system tokens only)', async ({ page }) => {
+    await setupPlayerStory(page, [SUB_CONTACTS]);
+    await expandPastOutcome(page);
+    const meritSection = page.locator('.merit-summary-section');
+    await expect(meritSection).toBeVisible({ timeout: 5000 });
+    const desc = meritSection.locator('.merit-summary-description').first();
+    await expect(desc).toBeVisible();
+    const styleAttr = await desc.getAttribute('style');
+    expect(styleAttr).toBeNull();
+  });
+
+});

--- a/tests/feat-907-player-merit-description.spec.js
+++ b/tests/feat-907-player-merit-description.spec.js
@@ -103,6 +103,19 @@ const SUB_SPHERE = {
   ],
 };
 
+// AC-2b: Status — desired outcome shown as description
+const SUB_STATUS = {
+  ...baseSub('sub-907-status'),
+  responses: {
+    status_1_merit:   'Status (Invictus)',
+    status_1_action:  'misc',
+    status_1_outcome: 'Attend the Elysium and make an impression.',
+  },
+  merit_actions_resolved: [
+    { pool_status: 'confirmed', outcome: 'Your attendance was noted by several Priscii.', outcome_confirmed: true },
+  ],
+};
+
 // AC-3: Retainer — task text shown as description
 const SUB_RETAINER = {
   ...baseSub('sub-907-retainer'),
@@ -219,6 +232,17 @@ test.describe('feat.907: player merit summary shows submitted description', () =
     await expect(desc).toBeVisible();
     await expect(desc).toContainText('Send someone to watch the harbour entrance.');
     await expect(meritSection).toContainText('Your allies deployed as requested.');
+  });
+
+  test('AC-2b: Status — desired outcome shown as description before ST outcome', async ({ page }) => {
+    await setupPlayerStory(page, [SUB_STATUS]);
+    await expandPastOutcome(page);
+    const meritSection = page.locator('.merit-summary-section');
+    await expect(meritSection).toBeVisible({ timeout: 5000 });
+    const desc = meritSection.locator('.merit-summary-description').first();
+    await expect(desc).toBeVisible();
+    await expect(desc).toContainText('Attend the Elysium');
+    await expect(meritSection).toContainText('attendance was noted');
   });
 
   test('AC-3: Retainer — task description shown before ST outcome', async ({ page }) => {


### PR DESCRIPTION
## Summary

- Players now see their own submitted content (contact request, sphere desired
  outcome, retainer task, skill name) before the ST's outcome in the Allies &
  Asset Summary, mirroring what the admin DT Story already shows
- Fixes a latent index-alignment bug: `buildPlayerMeritActions` had no Status
  loop, so any submission with Status actions followed by Contacts misaligned
  resolved outcomes — Status loop added in the correct position
- New `.merit-summary-description` CSS class uses design-system tokens only
  (`var(--txt3)`) — no inline styles, no bare hex

## Closes

- Closes #907

## Story

- specs/stories/feat.907.dt-story-player-merit-description.story.md

## Test plan

- [x] 8/8 feat-907 Playwright tests pass (AC-1 through AC-7 + AC-2b Status path)
- [x] 7/7 fix-904 regression tests still pass — no regressions in merit summary
- [ ] Smoke: open a character's past downtime story on dev, expand past outcomes, confirm description text appears above ST outcome in Allies & Asset Summary

## Branch flow

- From: `ms/issue-907-player-merit-description`
- Into: `dev`