### PR TITLE
feat(#918): Cycle tab lifecycle management

### DIFF
--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -10384,3 +10384,113 @@ html:not([data-theme="dark"]) .rules-tbl tbody tr:hover            { background:
 .ec-form-msg--ok    { color: var(--green2); }
 .ec-form-msg--error { color: var(--crim); }
 .ec-form-msg--info  { color: var(--txt3); }
+
+/* ── Cycle tab (issue #918) ──────────────────────────────────────────────────
+   Engine → Cycle: status ribbon, chapters/cycles panels, inline edit,
+   toggleable phases, add/delete. All tokens from theme.css; no inline styles. */
+
+.cy-section { margin-bottom: 32px; }
+.cy-section-head { display: flex; align-items: center; gap: 12px; margin-bottom: 12px; }
+.cy-section-title {
+  margin: 0; font-family: var(--fh); font-size: 15px; letter-spacing: .04em;
+}
+.cy-muted { color: var(--txt3); font-size: 13px; }
+.cy-empty-cell { color: var(--txt3); padding: 8px; }
+
+.cy-error { color: var(--crim); font-size: 13px; margin: 4px 0 0; display: none; }
+.cy-error.is-visible { display: block; }
+.cy-error--inline.is-visible { display: inline; }
+
+/* Status ribbon */
+.cy-ribbon {
+  display: flex; flex-wrap: wrap; gap: 24px; align-items: center;
+  background: var(--surf1); border: 1px solid var(--bdr);
+  border-radius: 8px; padding: 12px 18px; margin-bottom: 24px;
+}
+.cy-ribbon-empty { color: var(--txt3); font-family: var(--ft); font-size: 14px; }
+.cy-ribbon-item { display: flex; flex-direction: column; gap: 4px; }
+.cy-ribbon-label {
+  font-family: var(--fl); font-size: 10px; font-weight: 600;
+  letter-spacing: .12em; text-transform: uppercase; color: var(--txt3);
+}
+.cy-ribbon-val { font-family: var(--fh); font-size: 15px; color: var(--txt); }
+.cy-ribbon-chip {
+  font-family: var(--fl); font-size: 11px; font-weight: 600;
+  letter-spacing: .08em; text-transform: uppercase;
+  padding: 4px 10px; border-radius: 4px; align-self: flex-start;
+  background: var(--surf2); border: 1px solid var(--bdr); color: var(--txt3);
+}
+.cy-phase--game       { background: var(--green-dk-bg);    color: var(--green-dk);    border-color: var(--green-dk-bdr); }
+.cy-phase--downtime   { background: var(--warn-orange-bg); color: var(--warn-orange); border-color: var(--warn-orange-bdr); }
+.cy-phase--processing { background: var(--accent-a8);      color: var(--accent);      border-color: var(--accent-a40); }
+.cy-phase--none       { background: transparent;           color: var(--txt3);        border-color: var(--bdr2); }
+
+/* Tables */
+.cy-table { width: 100%; margin-bottom: 8px; }
+.cy-col-num { width: 60px; }
+.cy-col-act { width: 80px; }
+.cy-col-phase { width: 240px; }
+.cy-col-chapter { width: 220px; }
+.cy-col-prep, .cy-col-pub, .cy-col-att { width: 110px; }
+.cy-col-del { width: 80px; }
+
+/* Buttons (extends .btn-sm) */
+.btn-danger { background: var(--crim); color: #fff; border-color: var(--crim); }
+.btn-danger:hover { background: var(--crim2); }
+.btn-muted { background: var(--surf2); color: var(--txt2); border-color: var(--bdr); }
+.btn-sm.is-active { border-color: var(--gold2); color: var(--gold2); }
+.btn-sm.is-hidden { display: none; }
+
+/* Inline add forms */
+.cy-inline-form { display: none; flex-wrap: wrap; gap: 8px; align-items: center; margin: 8px 0 4px; }
+.cy-inline-form.is-open { display: flex; }
+.cy-input-num { width: 90px; }
+.cy-input-grow { flex: 1; min-width: 220px; }
+
+/* Inline label edit */
+.cy-label-cell { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.cy-label-text { font-family: var(--ft); color: var(--txt); }
+.cy-label-input { min-width: 160px; }
+.cy-label-input.is-error { border-color: var(--crim); }
+.cy-icon-btn {
+  background: none; border: none; color: var(--txt3); cursor: pointer;
+  font-size: 13px; line-height: 1; padding: 2px 4px; border-radius: 3px;
+}
+.cy-icon-btn:hover { color: var(--accent); background: var(--surf2); }
+
+.cy-chapter-select { min-width: 180px; }
+
+/* Phase cell */
+.cy-phase-cell { white-space: nowrap; }
+.cy-phase-group { display: inline-flex; gap: 4px; }
+.cy-phase-btn {
+  font-size: 12px; padding: 4px 12px; border-radius: 4px; cursor: pointer;
+  background: var(--surf2); color: var(--accent); border: 1px solid var(--accent-a40);
+}
+.cy-phase-btn:hover { background: var(--surf3); }
+.cy-phase-btn.is-active { background: var(--accent-a8); border-color: var(--gold2); color: var(--gold2); font-weight: 600; }
+
+/* Detail rows (prep access / attendance) */
+.cy-detail-row.is-hidden { display: none; }
+.cy-detail-cell { padding: 4px 12px 12px; background: var(--surf2); }
+.cy-detail-scroll { padding: 8px 0 4px; max-height: 220px; overflow-y: auto; }
+.cy-check-label {
+  display: flex; align-items: center; gap: 8px; padding: 3px 0;
+  cursor: pointer; font-size: 13px;
+}
+
+/* Publish result text */
+.cy-publish-result { display: block; font-size: 11px; margin-top: 3px; color: var(--txt3); }
+.cy-publish-result.is-ok { color: var(--gold2); }
+.cy-publish-result.is-error { color: var(--crim); }
+
+/* Attendance */
+.cy-attend { padding: 8px 0 4px; }
+.cy-attend-head { display: flex; align-items: center; gap: 8px; margin-bottom: 10px; }
+.cy-attend-lbl { font-size: 13px; color: var(--txt2); }
+.cy-attend-select { padding: 3px 6px; font-size: 13px; }
+.cy-attend-table { width: 100%; font-size: 13px; }
+.cy-attend-empty { font-size: 13px; margin: 4px 0; }
+.cy-att-c { width: 60px; text-align: center; }
+.cy-att-xp { font-weight: 600; }
+.cy-att-total { font-weight: 700; border-top: 1px solid var(--bdr); }

--- a/public/js/admin/cycle-views.js
+++ b/public/js/admin/cycle-views.js
@@ -1,4 +1,5 @@
 import { apiGet, apiPost, apiDelete, apiPut } from '../data/api.js';
+import { createCycle, updateCycle, deleteCycle, deriveCycleStatus } from '../downtime/db.js';
 
 const PHASE_LABELS = {
   game:       'Game',
@@ -6,9 +7,18 @@ const PHASE_LABELS = {
   processing: 'Processing',
 };
 
+const PHASES = ['game', 'downtime', 'processing'];
+
+// Module-level view state so the status ribbon can refresh after any
+// label / chapter / phase / add / delete mutation without a full re-fetch.
+const view = { chapters: [], cycles: [], sessions: [], charList: [], ribbonEl: null };
+
+// _id is a creation-order proxy (cycle docs lack created_at) — newest first.
+function byIdDesc(a, b) { return String(b._id) > String(a._id) ? 1 : -1; }
+
 export async function initCycleView(charList) {
   const el = document.getElementById('cycle-content');
-  el.innerHTML = '<p style="padding:16px;color:var(--txt2)">Loading…</p>';
+  el.innerHTML = '<p class="placeholder">Loading…</p>';
 
   let chapters, cycles, sessions;
   try {
@@ -18,24 +28,94 @@ export async function initCycleView(charList) {
       apiGet('/api/game_sessions'),
     ]);
   } catch (err) {
-    el.innerHTML = `<p style="padding:16px;color:var(--crim)">Failed to load cycle data: ${err.message}</p>`;
+    el.innerHTML = `<p class="cy-error">Failed to load cycle data: ${err.message}</p>`;
     return;
   }
 
+  view.chapters = chapters;
+  view.cycles = cycles;
+  view.sessions = sessions;
+  view.charList = charList;
+
   el.innerHTML = '';
+  el.appendChild(buildRibbon());
   el.appendChild(buildChaptersPanel(chapters));
   el.appendChild(buildCyclesPanel(cycles, chapters, charList, sessions));
+}
+
+/** Re-fetch and rebuild the whole tab (used after add / delete). */
+async function refresh() {
+  await initCycleView(view.charList);
+}
+
+// ── Status ribbon ─────────────────────────────────────────────────────────────
+
+function buildRibbon() {
+  const el = document.createElement('div');
+  el.className = 'cy-ribbon';
+  view.ribbonEl = el;
+  renderRibbon();
+  return el;
+}
+
+/** Current cycle: the one in a set game phase, else newest non-closed. */
+function deriveCurrentCycle() {
+  const cycles = view.cycles || [];
+  const inGame = cycles.find(c => c.game_phase === 'game');
+  if (inGame) return inGame;
+  const anyPhase = cycles.filter(c => c.game_phase).sort(byIdDesc)[0];
+  if (anyPhase) return anyPhase;
+  const nonClosed = cycles.filter(c => deriveCycleStatus(c) !== 'closed').sort(byIdDesc)[0];
+  return nonClosed || null;
+}
+
+function renderRibbon() {
+  const el = view.ribbonEl;
+  if (!el) return;
+  const cy = deriveCurrentCycle();
+
+  if (!cy) {
+    el.innerHTML = '<span class="cy-ribbon-empty">No active cycle.</span>';
+    return;
+  }
+
+  const chapter = cy.chapter_id
+    ? view.chapters.find(ch => String(ch._id) === String(cy.chapter_id))
+    : null;
+  const chapterText = chapter ? `${chapter.number} — ${chapter.label}` : 'No chapter';
+  const phaseText = cy.game_phase ? PHASE_LABELS[cy.game_phase] : 'No phase set';
+  const phaseMod = cy.game_phase ? ` cy-phase--${cy.game_phase}` : ' cy-phase--none';
+
+  el.innerHTML = `
+    <div class="cy-ribbon-item">
+      <span class="cy-ribbon-label">Chapter</span>
+      <span class="cy-ribbon-val">${esc(chapterText)}</span>
+    </div>
+    <div class="cy-ribbon-item">
+      <span class="cy-ribbon-label">Game Cycle</span>
+      <span class="cy-ribbon-val">${esc(cy.label || String(cy._id))}</span>
+    </div>
+    <div class="cy-ribbon-item">
+      <span class="cy-ribbon-label">Phase</span>
+      <span class="cy-ribbon-chip${phaseMod}">${esc(phaseText)}</span>
+    </div>`;
+}
+
+function esc(s) {
+  return String(s ?? '').replace(/[&<>"']/g, c => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ));
 }
 
 // ── Chapters panel ──────────────────────────────────────────────────────────
 
 function buildChaptersPanel(chapters) {
   const wrap = document.createElement('div');
-  wrap.style.cssText = 'margin-bottom:32px';
+  wrap.className = 'cy-section';
 
   const header = document.createElement('div');
-  header.style.cssText = 'display:flex;align-items:center;gap:12px;margin-bottom:12px';
-  header.innerHTML = '<h3 style="margin:0;font-family:Cinzel,serif;font-size:15px;letter-spacing:.04em">Chapters</h3>';
+  header.className = 'cy-section-head';
+  header.innerHTML = '<h3 class="cy-section-title">Chapters</h3>';
 
   const addBtn = document.createElement('button');
   addBtn.className = 'btn-sm';
@@ -43,17 +123,16 @@ function buildChaptersPanel(chapters) {
   header.appendChild(addBtn);
 
   const errMsg = document.createElement('p');
-  errMsg.style.cssText = 'color:var(--crim);font-size:13px;margin:4px 0 0;display:none';
+  errMsg.className = 'cy-error cy-error--inline';
 
   wrap.appendChild(header);
 
   const table = document.createElement('table');
-  table.className = 'infl-table';
-  table.style.cssText = 'width:100%;margin-bottom:8px';
+  table.className = 'infl-table cy-table';
   table.innerHTML = `<thead><tr>
-    <th style="width:60px">#</th>
+    <th class="cy-col-num">#</th>
     <th>Label</th>
-    <th style="width:80px"></th>
+    <th class="cy-col-act"></th>
   </tr></thead>`;
   const tbody = document.createElement('tbody');
   table.appendChild(tbody);
@@ -63,27 +142,27 @@ function buildChaptersPanel(chapters) {
   function renderRows(list) {
     tbody.innerHTML = '';
     if (!list.length) {
-      tbody.innerHTML = '<tr><td colspan="3" style="color:var(--txt2);padding:8px">No chapters yet.</td></tr>';
+      tbody.innerHTML = '<tr><td colspan="3" class="cy-empty-cell">No chapters yet.</td></tr>';
       return;
     }
     list.forEach(ch => {
       const tr = document.createElement('tr');
       tr.innerHTML = `
         <td>${ch.number}</td>
-        <td>${ch.label}</td>
-        <td><button class="btn-sm" data-id="${ch._id}" style="background:var(--crim);border-color:var(--crim)">Delete</button></td>`;
+        <td>${esc(ch.label)}</td>
+        <td><button class="btn-sm btn-danger" data-id="${ch._id}">Delete</button></td>`;
       tr.querySelector('button').addEventListener('click', async () => {
-        errMsg.style.display = 'none';
+        errMsg.classList.remove('is-visible');
         try {
           await apiDelete(`/api/chapters/${ch._id}`);
           renderRows(list.filter(c => c._id !== ch._id));
         } catch (err) {
           if (err.message && err.message.includes('cycle')) {
-            errMsg.textContent = `Chapter is linked to cycle(s) — remove the link before deleting.`;
+            errMsg.textContent = 'Chapter is linked to cycle(s) — remove the link before deleting.';
           } else {
             errMsg.textContent = `Delete failed: ${err.message}`;
           }
-          errMsg.style.display = 'block';
+          errMsg.classList.add('is-visible');
         }
       });
       tbody.appendChild(tr);
@@ -94,26 +173,26 @@ function buildChaptersPanel(chapters) {
 
   // Inline new-chapter form
   const form = document.createElement('div');
-  form.style.cssText = 'display:none;flex-wrap:wrap;gap:8px;align-items:center;margin-top:8px';
+  form.className = 'cy-inline-form';
   form.innerHTML = `
-    <input id="new-ch-num" type="number" min="1" placeholder="Number" style="width:70px;padding:4px 6px;background:var(--surf);border:1px solid var(--bdr);color:var(--txt);border-radius:4px">
-    <input id="new-ch-label" type="text" placeholder="Label (e.g. Chapter Two: The Price of Power)" style="flex:1;min-width:200px;padding:4px 6px;background:var(--surf);border:1px solid var(--bdr);color:var(--txt);border-radius:4px">
+    <input id="new-ch-num" type="number" min="1" placeholder="Number" class="form-input cy-input-num">
+    <input id="new-ch-label" type="text" placeholder="Label (e.g. Chapter Two: The Price of Power)" class="form-input cy-input-grow">
     <button class="btn-sm" id="new-ch-save">Save</button>
-    <button class="btn-sm" id="new-ch-cancel" style="background:var(--surf2);border-color:var(--bdr)">Cancel</button>`;
+    <button class="btn-sm btn-muted" id="new-ch-cancel">Cancel</button>`;
   wrap.appendChild(form);
 
   addBtn.addEventListener('click', () => {
-    form.style.display = 'flex';
-    addBtn.style.display = 'none';
-    errMsg.style.display = 'none';
+    form.classList.add('is-open');
+    addBtn.classList.add('is-hidden');
+    errMsg.classList.remove('is-visible');
     form.querySelector('#new-ch-num').value = '';
     form.querySelector('#new-ch-label').value = '';
     form.querySelector('#new-ch-num').focus();
   });
 
   form.querySelector('#new-ch-cancel').addEventListener('click', () => {
-    form.style.display = 'none';
-    addBtn.style.display = '';
+    form.classList.remove('is-open');
+    addBtn.classList.remove('is-hidden');
   });
 
   form.querySelector('#new-ch-save').addEventListener('click', async () => {
@@ -121,19 +200,21 @@ function buildChaptersPanel(chapters) {
     const label  = form.querySelector('#new-ch-label').value.trim();
     if (!number || !label) {
       errMsg.textContent = 'Both Number and Label are required.';
-      errMsg.style.display = 'block';
+      errMsg.classList.add('is-visible');
       return;
     }
-    errMsg.style.display = 'none';
+    errMsg.classList.remove('is-visible');
     try {
       const created = await apiPost('/api/chapters', { number, label });
       chapters = [...chapters, created].sort((a, b) => a.number - b.number);
+      view.chapters = chapters;
       renderRows(chapters);
-      form.style.display = 'none';
-      addBtn.style.display = '';
+      form.classList.remove('is-open');
+      addBtn.classList.remove('is-hidden');
+      renderRibbon();
     } catch (err) {
       errMsg.textContent = `Save failed: ${err.message}`;
-      errMsg.style.display = 'block';
+      errMsg.classList.add('is-visible');
     }
   });
 
@@ -142,10 +223,11 @@ function buildChaptersPanel(chapters) {
 
 // ── Phase controls ───────────────────────────────────────────────────────────
 
-const PHASES = ['game', 'downtime', 'processing'];
-
-async function setGamePhase(cycleId, phase) {
-  if (phase === 'game') {
+// Write a phase to a cycle. `phaseOrNull === null` clears the phase (neutral).
+// Only entering Game phase resets the live tracker — clearing does NOT.
+// Returns false if the ST cancels the Game-phase confirmation.
+async function writePhase(cy, phaseOrNull) {
+  if (phaseOrNull === 'game') {
     if (!confirm('Setting to Game phase will reset the live tracker (all characters reload with default states). Continue?')) return false;
     try {
       await apiDelete('/api/tracker_state');
@@ -153,50 +235,51 @@ async function setGamePhase(cycleId, phase) {
       throw new Error('Tracker reset failed: ' + err.message);
     }
   }
-  await apiPut('/api/downtime_cycles/' + cycleId, { game_phase: phase });
+  await apiPut('/api/downtime_cycles/' + cy._id, { game_phase: phaseOrNull });
+  cy.game_phase = phaseOrNull;
   return true;
 }
 
 function buildPhaseCell(cy) {
   const td = document.createElement('td');
-  td.style.cssText = 'white-space:nowrap';
+  td.className = 'cy-phase-cell';
+
+  const group = document.createElement('div');
+  group.className = 'cy-phase-group';
+  td.appendChild(group);
 
   const errEl = document.createElement('span');
-  errEl.style.cssText = 'color:var(--crim);font-size:11px;display:none;margin-left:6px';
-  td.appendChild(errEl);
+  errEl.className = 'cy-error cy-error--inline';
 
   PHASES.forEach(phase => {
     const btn = document.createElement('button');
-    btn.className = 'btn-sm';
+    btn.className = 'cy-phase-btn' + (cy.game_phase === phase ? ' is-active' : '');
     btn.textContent = PHASE_LABELS[phase];
     btn.dataset.phase = phase;
-    btn.style.marginRight = '4px';
-    const isActive = cy.game_phase === phase;
-    if (isActive) {
-      btn.style.borderColor = 'var(--gold2)';
-      btn.style.color = 'var(--gold2)';
-      btn.disabled = true;
-    }
+    btn.title = cy.game_phase === phase ? 'Click to clear this phase' : `Set ${PHASE_LABELS[phase]} phase`;
+
     btn.addEventListener('click', async () => {
-      errEl.style.display = 'none';
+      errEl.classList.remove('is-visible');
+      // Active phase toggles OFF to neutral; otherwise switch to the clicked phase.
+      const target = (cy.game_phase === phase) ? null : phase;
       try {
-        const ok = await setGamePhase(cy._id, phase);
+        const ok = await writePhase(cy, target);
         if (!ok) return;
-        cy.game_phase = phase;
-        td.querySelectorAll('button[data-phase]').forEach(b => {
-          const active = b.dataset.phase === phase;
-          b.disabled = active;
-          b.style.borderColor = active ? 'var(--gold2)' : '';
-          b.style.color = active ? 'var(--gold2)' : '';
+        group.querySelectorAll('.cy-phase-btn').forEach(b => {
+          const active = b.dataset.phase === cy.game_phase;
+          b.classList.toggle('is-active', active);
+          b.title = active ? 'Click to clear this phase' : `Set ${PHASE_LABELS[b.dataset.phase]} phase`;
         });
+        renderRibbon();
       } catch (err) {
         errEl.textContent = 'Phase change failed: ' + err.message;
-        errEl.style.display = 'inline';
+        errEl.classList.add('is-visible');
       }
     });
-    td.insertBefore(btn, errEl);
+    group.appendChild(btn);
   });
 
+  td.appendChild(errEl);
   return td;
 }
 
@@ -204,7 +287,7 @@ function buildPhaseCell(cy) {
 
 function buildAccessSection(cy, charList) {
   const wrap = document.createElement('div');
-  wrap.style.cssText = 'padding:8px 0 4px;max-height:220px;overflow-y:auto';
+  wrap.className = 'cy-detail-scroll';
 
   const activeChars = charList
     .filter(c => !c.retired)
@@ -212,7 +295,7 @@ function buildAccessSection(cy, charList) {
 
   if (!activeChars.length) {
     wrap.textContent = 'No active characters.';
-    wrap.style.color = 'var(--txt2)';
+    wrap.classList.add('cy-muted');
     return wrap;
   }
 
@@ -221,7 +304,7 @@ function buildAccessSection(cy, charList) {
   activeChars.forEach(c => {
     const id = String(c._id);
     const label = document.createElement('label');
-    label.style.cssText = 'display:flex;align-items:center;gap:8px;padding:3px 0;cursor:pointer;font-size:13px';
+    label.className = 'cy-check-label';
 
     const cb = document.createElement('input');
     cb.type = 'checkbox';
@@ -254,17 +337,17 @@ function buildAccessSection(cy, charList) {
 
 function buildAttendanceSection(cy, sessions) {
   const wrap = document.createElement('div');
-  wrap.style.cssText = 'padding:8px 0 4px';
+  wrap.className = 'cy-attend';
 
   const selectWrap = document.createElement('div');
-  selectWrap.style.cssText = 'display:flex;align-items:center;gap:8px;margin-bottom:10px';
+  selectWrap.className = 'cy-attend-head';
 
   const lbl = document.createElement('label');
-  lbl.style.cssText = 'font-size:13px;color:var(--txt2)';
+  lbl.className = 'cy-attend-lbl';
   lbl.textContent = 'Linked Session:';
 
   const sel = document.createElement('select');
-  sel.style.cssText = 'background:var(--surf);border:1px solid var(--bdr);color:var(--txt);border-radius:4px;padding:3px 6px;font-size:13px';
+  sel.className = 'form-select cy-attend-select';
 
   const blank = document.createElement('option');
   blank.value = '';
@@ -285,7 +368,7 @@ function buildAttendanceSection(cy, sessions) {
   sel.value = cy.session_id || '';
 
   const errEl = document.createElement('span');
-  errEl.style.cssText = 'color:var(--crim);font-size:11px;display:none';
+  errEl.className = 'cy-error cy-error--inline';
 
   selectWrap.appendChild(lbl);
   selectWrap.appendChild(sel);
@@ -302,7 +385,7 @@ function buildAttendanceSection(cy, sessions) {
     const att = session.attendance || [];
     if (!att.length) {
       const msg = document.createElement('p');
-      msg.style.cssText = 'font-size:13px;color:var(--txt2);margin:4px 0';
+      msg.className = 'cy-muted cy-attend-empty';
       msg.textContent = 'No attendance recorded for this session.';
       tableWrap.appendChild(msg);
       return;
@@ -315,15 +398,14 @@ function buildAttendanceSection(cy, sessions) {
     });
 
     const table = document.createElement('table');
-    table.className = 'infl-table';
-    table.style.cssText = 'width:100%;font-size:13px';
+    table.className = 'infl-table cy-attend-table';
     table.innerHTML = `<thead><tr>
       <th>Character</th>
-      <th style="width:70px;text-align:center">Attend</th>
-      <th style="width:80px;text-align:center">Costuming</th>
-      <th style="width:50px;text-align:center">DT</th>
-      <th style="width:50px;text-align:center">Extra</th>
-      <th style="width:60px;text-align:center">XP</th>
+      <th class="cy-att-c">Attend</th>
+      <th class="cy-att-c">Costuming</th>
+      <th class="cy-att-c">DT</th>
+      <th class="cy-att-c">Extra</th>
+      <th class="cy-att-c">XP</th>
     </tr></thead>`;
 
     const tbody = document.createElement('tbody');
@@ -340,24 +422,24 @@ function buildAttendanceSection(cy, sessions) {
       const name = a.character_display || a.character_name || a.character_id || '?';
       const tr = document.createElement('tr');
       tr.innerHTML = `
-        <td>${name}</td>
-        <td style="text-align:center">${a.attended  ? '●' : '○'}</td>
-        <td style="text-align:center">${a.costuming ? '●' : '○'}</td>
-        <td style="text-align:center">${a.downtime  ? '●' : '○'}</td>
-        <td style="text-align:center">${a.extra || 0}</td>
-        <td style="text-align:center;font-weight:600">${xp}</td>`;
+        <td>${esc(name)}</td>
+        <td class="cy-att-c">${a.attended  ? '●' : '○'}</td>
+        <td class="cy-att-c">${a.costuming ? '●' : '○'}</td>
+        <td class="cy-att-c">${a.downtime  ? '●' : '○'}</td>
+        <td class="cy-att-c">${a.extra || 0}</td>
+        <td class="cy-att-c cy-att-xp">${xp}</td>`;
       tbody.appendChild(tr);
     });
 
     const totTr = document.createElement('tr');
-    totTr.style.cssText = 'font-weight:700;border-top:1px solid var(--bdr)';
+    totTr.className = 'cy-att-total';
     totTr.innerHTML = `
-      <td style="color:var(--txt2)">Total (${rows.length})</td>
-      <td style="text-align:center">${totAtt}</td>
-      <td style="text-align:center">${totCos}</td>
-      <td style="text-align:center">${totDT}</td>
-      <td style="text-align:center">${totExtra}</td>
-      <td style="text-align:center">${totXP}</td>`;
+      <td class="cy-muted">Total (${rows.length})</td>
+      <td class="cy-att-c">${totAtt}</td>
+      <td class="cy-att-c">${totCos}</td>
+      <td class="cy-att-c">${totDT}</td>
+      <td class="cy-att-c">${totExtra}</td>
+      <td class="cy-att-c">${totXP}</td>`;
     tbody.appendChild(totTr);
 
     table.appendChild(tbody);
@@ -367,7 +449,7 @@ function buildAttendanceSection(cy, sessions) {
   renderTable();
 
   sel.addEventListener('change', async () => {
-    errEl.style.display = 'none';
+    errEl.classList.remove('is-visible');
     const newId = sel.value || null;
     try {
       await apiPut('/api/downtime_cycles/' + cy._id, { session_id: newId });
@@ -376,7 +458,7 @@ function buildAttendanceSection(cy, sessions) {
     } catch (err) {
       sel.value = cy.session_id || '';
       errEl.textContent = 'Link failed: ' + err.message;
-      errEl.style.display = 'inline';
+      errEl.classList.add('is-visible');
     }
   });
 
@@ -385,53 +467,195 @@ function buildAttendanceSection(cy, sessions) {
 
 // ── Game Cycles panel ───────────────────────────────────────────────────────
 
+// Build a chapter <select>. Options-only; no persistence handler — used for
+// the add-cycle form (which has no cycle to write to yet).
+function buildChapterPicker(chapters, selectedId = '') {
+  const sel = document.createElement('select');
+  sel.className = 'form-select cy-chapter-select';
+  const none = document.createElement('option');
+  none.value = '';
+  none.textContent = '— none —';
+  sel.appendChild(none);
+  [...chapters].sort((a, b) => a.number - b.number).forEach(ch => {
+    const opt = document.createElement('option');
+    opt.value = String(ch._id);
+    opt.textContent = `${ch.number} — ${ch.label}`;
+    sel.appendChild(opt);
+  });
+  sel.value = selectedId ? String(selectedId) : '';
+  return sel;
+}
+
+// Row-level chapter select: persists chapter_id to an existing cycle on change.
+function buildChapterSelect(cy, chapters) {
+  const sel = buildChapterPicker(chapters, cy.chapter_id);
+  sel.addEventListener('change', async () => {
+    const val = sel.value || null;
+    try {
+      await updateCycle(cy._id, { chapter_id: val });
+      cy.chapter_id = val;
+      renderRibbon();
+    } catch (err) {
+      sel.value = cy.chapter_id ? String(cy.chapter_id) : '';
+    }
+  });
+  return sel;
+}
+
+function buildLabelCell(cy) {
+  const td = document.createElement('td');
+  td.className = 'cy-label-cell';
+
+  function renderView() {
+    td.innerHTML = '';
+    const span = document.createElement('span');
+    span.className = 'cy-label-text';
+    span.textContent = cy.label || String(cy._id);
+    const editBtn = document.createElement('button');
+    editBtn.className = 'cy-icon-btn';
+    editBtn.title = 'Edit label';
+    editBtn.textContent = '✎';
+    editBtn.addEventListener('click', renderEdit);
+    td.appendChild(span);
+    td.appendChild(editBtn);
+  }
+
+  function renderEdit() {
+    td.innerHTML = '';
+    const input = document.createElement('input');
+    input.type = 'text';
+    input.className = 'form-input cy-label-input';
+    input.value = cy.label || '';
+    const save = document.createElement('button');
+    save.className = 'btn-sm';
+    save.textContent = 'Save';
+    const cancel = document.createElement('button');
+    cancel.className = 'btn-sm btn-muted';
+    cancel.textContent = 'Cancel';
+
+    async function doSave() {
+      const newLabel = input.value.trim();
+      if (!newLabel) { input.focus(); return; }
+      try {
+        await updateCycle(cy._id, { label: newLabel });
+        cy.label = newLabel;
+        renderView();
+        renderRibbon();
+      } catch (_err) {
+        input.classList.add('is-error');
+      }
+    }
+    save.addEventListener('click', doSave);
+    cancel.addEventListener('click', renderView);
+    input.addEventListener('keydown', e => {
+      if (e.key === 'Enter') doSave();
+      else if (e.key === 'Escape') renderView();
+    });
+
+    td.appendChild(input);
+    td.appendChild(save);
+    td.appendChild(cancel);
+    input.focus();
+    input.select();
+  }
+
+  renderView();
+  return td;
+}
+
 function buildCyclesPanel(cycles, chapters, charList = [], sessions = []) {
   const sorted = [...cycles].sort((a, b) => (a.game_number ?? 0) - (b.game_number ?? 0));
-  const chapterMap = Object.fromEntries(chapters.map(c => [String(c._id), c]));
 
   const wrap = document.createElement('div');
+  wrap.className = 'cy-section';
 
-  const hdr = document.createElement('h3');
-  hdr.style.cssText = 'margin:0 0 12px;font-family:Cinzel,serif;font-size:15px;letter-spacing:.04em';
-  hdr.textContent = 'Game Cycles';
-  wrap.appendChild(hdr);
+  const header = document.createElement('div');
+  header.className = 'cy-section-head';
+  header.innerHTML = '<h3 class="cy-section-title">Game Cycles</h3>';
+
+  const addBtn = document.createElement('button');
+  addBtn.className = 'btn-sm';
+  addBtn.textContent = '+ New Cycle';
+  header.appendChild(addBtn);
+  wrap.appendChild(header);
+
+  const errMsg = document.createElement('p');
+  errMsg.className = 'cy-error cy-error--inline';
+
+  // Inline add-cycle form
+  const addForm = document.createElement('div');
+  addForm.className = 'cy-inline-form';
+  const nextGame = (sorted.reduce((mx, c) => Math.max(mx, c.game_number ?? 0), 0) || 0) + 1;
+  addForm.innerHTML = `
+    <input id="new-cy-num" type="number" min="1" placeholder="Game #" value="${nextGame}" class="form-input cy-input-num">
+    <input id="new-cy-label" type="text" placeholder="Label (e.g. Downtime 5)" class="form-input cy-input-grow">
+    <button class="btn-sm" id="new-cy-save">Save</button>
+    <button class="btn-sm btn-muted" id="new-cy-cancel">Cancel</button>`;
+  const chapterPick = buildChapterPicker(chapters);
+  chapterPick.id = 'new-cy-chapter';
+  addForm.insertBefore(chapterPick, addForm.querySelector('#new-cy-save'));
+  wrap.appendChild(addForm);
+
+  addBtn.addEventListener('click', () => {
+    addForm.classList.add('is-open');
+    addBtn.classList.add('is-hidden');
+    errMsg.classList.remove('is-visible');
+    addForm.querySelector('#new-cy-label').value = `Downtime ${nextGame}`;
+    addForm.querySelector('#new-cy-label').focus();
+  });
+  addForm.querySelector('#new-cy-cancel').addEventListener('click', () => {
+    addForm.classList.remove('is-open');
+    addBtn.classList.remove('is-hidden');
+  });
+  addForm.querySelector('#new-cy-save').addEventListener('click', async () => {
+    const num = parseInt(addForm.querySelector('#new-cy-num').value, 10);
+    const label = addForm.querySelector('#new-cy-label').value.trim();
+    const chapterId = addForm.querySelector('#new-cy-chapter').value || null;
+    if (!num || !label) {
+      errMsg.textContent = 'Game number and label are required.';
+      errMsg.classList.add('is-visible');
+      return;
+    }
+    errMsg.classList.remove('is-visible');
+    try {
+      await createCycle(num, { label, chapterId });
+      await refresh();
+    } catch (err) {
+      errMsg.textContent = `Create failed: ${err.message}`;
+      errMsg.classList.add('is-visible');
+    }
+  });
 
   if (!sorted.length) {
     const empty = document.createElement('p');
-    empty.style.cssText = 'color:var(--txt2);font-size:13px';
+    empty.className = 'cy-muted';
     empty.textContent = 'No downtime cycles found.';
+    wrap.appendChild(errMsg);
     wrap.appendChild(empty);
     return wrap;
   }
 
   const table = document.createElement('table');
-  table.className = 'infl-table';
-  table.style.width = '100%';
+  table.className = 'infl-table cy-table';
   table.innerHTML = `<thead><tr>
     <th>Label</th>
-    <th style="width:270px">Phase</th>
-    <th style="width:200px">Chapter</th>
-    <th style="width:110px">Prep Access</th>
-    <th style="width:130px">Publish</th>
-    <th style="width:110px">Attendance</th>
+    <th class="cy-col-phase">Phase</th>
+    <th class="cy-col-chapter">Chapter</th>
+    <th class="cy-col-prep">Prep Access</th>
+    <th class="cy-col-pub">Publish</th>
+    <th class="cy-col-att">Attendance</th>
+    <th class="cy-col-del"></th>
   </tr></thead>`;
   const tbody = document.createElement('tbody');
 
   sorted.forEach(cy => {
-    const chapter = cy.chapter_id ? chapterMap[cy.chapter_id] : null;
-    const chapterLabel = chapter ? `${chapter.number} — ${chapter.label}` : '—';
-
     const tr = document.createElement('tr');
 
-    const tdLabel = document.createElement('td');
-    tdLabel.textContent = cy.label || cy._id;
-    tr.appendChild(tdLabel);
-
+    tr.appendChild(buildLabelCell(cy));
     tr.appendChild(buildPhaseCell(cy));
 
     const tdChapter = document.createElement('td');
-    tdChapter.style.color = 'var(--txt2)';
-    tdChapter.textContent = chapterLabel;
+    tdChapter.appendChild(buildChapterSelect(cy, chapters));
     tr.appendChild(tdChapter);
 
     // Prep Access toggle
@@ -442,20 +666,18 @@ function buildCyclesPanel(cycles, chapters, charList = [], sessions = []) {
     tdAccess.appendChild(accessBtn);
     tr.appendChild(tdAccess);
 
-    // Detail row (hidden by default)
     const detailTr = document.createElement('tr');
-    detailTr.style.display = 'none';
+    detailTr.className = 'cy-detail-row is-hidden';
     const detailTd = document.createElement('td');
-    detailTd.colSpan = 6;
-    detailTd.style.cssText = 'padding:4px 12px 12px;background:var(--surf2)';
+    detailTd.colSpan = 7;
+    detailTd.className = 'cy-detail-cell';
     detailTd.appendChild(buildAccessSection(cy, charList));
     detailTr.appendChild(detailTd);
 
     accessBtn.addEventListener('click', () => {
-      const open = detailTr.style.display !== 'none';
-      detailTr.style.display = open ? 'none' : '';
-      accessBtn.style.borderColor = open ? '' : 'var(--gold2)';
-      accessBtn.style.color = open ? '' : 'var(--gold2)';
+      const open = !detailTr.classList.contains('is-hidden');
+      detailTr.classList.toggle('is-hidden', open);
+      accessBtn.classList.toggle('is-active', !open);
     });
 
     // Publish Reports button
@@ -464,25 +686,25 @@ function buildCyclesPanel(cycles, chapters, charList = [], sessions = []) {
     publishBtn.className = 'btn-sm';
     publishBtn.textContent = 'Publish Reports';
     const publishResult = document.createElement('span');
-    publishResult.style.cssText = 'display:block;font-size:11px;margin-top:3px;color:var(--txt2)';
+    publishResult.className = 'cy-publish-result';
     tdPublish.appendChild(publishBtn);
     tdPublish.appendChild(publishResult);
     tr.appendChild(tdPublish);
 
     publishBtn.addEventListener('click', async () => {
       publishBtn.disabled = true;
-      publishResult.style.color = 'var(--txt2)';
+      publishResult.className = 'cy-publish-result';
       publishResult.textContent = 'Publishing…';
       try {
         const result = await apiPost('/api/downtime_cycles/' + cy._id + '/publish', {});
         if (result.published === 0) {
           publishResult.textContent = 'No compiled reports found.';
         } else {
-          publishResult.style.color = 'var(--gold2)';
+          publishResult.classList.add('is-ok');
           publishResult.textContent = result.published + ' report' + (result.published === 1 ? '' : 's') + ' published.';
         }
       } catch (err) {
-        publishResult.style.color = 'var(--crim)';
+        publishResult.classList.add('is-error');
         publishResult.textContent = 'Publish failed: ' + err.message;
       } finally {
         publishBtn.disabled = false;
@@ -498,18 +720,40 @@ function buildCyclesPanel(cycles, chapters, charList = [], sessions = []) {
     tr.appendChild(tdAtt);
 
     const attendTr = document.createElement('tr');
-    attendTr.style.display = 'none';
+    attendTr.className = 'cy-detail-row is-hidden';
     const attendTd = document.createElement('td');
-    attendTd.colSpan = 6;
-    attendTd.style.cssText = 'padding:4px 12px 12px;background:var(--surf2)';
+    attendTd.colSpan = 7;
+    attendTd.className = 'cy-detail-cell';
     attendTd.appendChild(buildAttendanceSection(cy, sessions));
     attendTr.appendChild(attendTd);
 
     attBtn.addEventListener('click', () => {
-      const open = attendTr.style.display !== 'none';
-      attendTr.style.display = open ? 'none' : '';
-      attBtn.style.borderColor = open ? '' : 'var(--gold2)';
-      attBtn.style.color     = open ? '' : 'var(--gold2)';
+      const open = !attendTr.classList.contains('is-hidden');
+      attendTr.classList.toggle('is-hidden', open);
+      attBtn.classList.toggle('is-active', !open);
+    });
+
+    // Delete cycle
+    const tdDel = document.createElement('td');
+    const delBtn = document.createElement('button');
+    delBtn.className = 'btn-sm btn-danger';
+    delBtn.textContent = 'Delete';
+    tdDel.appendChild(delBtn);
+    tr.appendChild(tdDel);
+
+    delBtn.addEventListener('click', async () => {
+      if (!confirm(`Delete cycle "${cy.label || cy._id}"? This cannot be undone.`)) return;
+      errMsg.classList.remove('is-visible');
+      delBtn.disabled = true;
+      try {
+        await deleteCycle(cy._id);
+        await refresh();
+      } catch (err) {
+        delBtn.disabled = false;
+        // 409 CYCLE_HAS_SUBMISSIONS surfaces here with the server message.
+        errMsg.textContent = err.message || 'Delete failed.';
+        errMsg.classList.add('is-visible');
+      }
     });
 
     tbody.appendChild(tr);
@@ -518,6 +762,7 @@ function buildCyclesPanel(cycles, chapters, charList = [], sessions = []) {
   });
 
   table.appendChild(tbody);
+  wrap.appendChild(errMsg);
   wrap.appendChild(table);
   return wrap;
 }

--- a/public/js/downtime/db.js
+++ b/public/js/downtime/db.js
@@ -3,7 +3,7 @@
  * Replaces Peter's IndexedDB layer with HTTP calls to the Express API.
  */
 
-import { apiGet, apiPost, apiPut } from '../data/api.js';
+import { apiGet, apiPost, apiPut, apiDelete } from '../data/api.js';
 
 // ── Cycles ──────────────────────────────────────────────────────────────────
 
@@ -16,9 +16,9 @@ export async function getActiveCycle() {
   return cycles.find(c => c.status === 'active') || null;
 }
 
-export async function createCycle(gameNumber, { status = 'prep', deadlineAt = null } = {}) {
+export async function createCycle(gameNumber, { status = 'prep', deadlineAt = null, label = null, chapterId = null } = {}) {
   const body = {
-    label: 'Downtime ' + gameNumber,
+    label: label || ('Downtime ' + gameNumber),
     game_number: gameNumber,
     status,
     loaded_at: new Date().toISOString(),
@@ -26,7 +26,12 @@ export async function createCycle(gameNumber, { status = 'prep', deadlineAt = nu
     out_of_window_player_ids: [],
   };
   if (deadlineAt) body.deadline_at = deadlineAt;
+  if (chapterId) body.chapter_id = chapterId;
   return apiPost('/api/downtime_cycles', body);
+}
+
+export async function deleteCycle(id) {
+  return apiDelete('/api/downtime_cycles/' + id);
 }
 
 /** Derive the game number for a new cycle: closed cycle count + 1 for current, +1 for next. */

--- a/server/routes/downtime.js
+++ b/server/routes/downtime.js
@@ -554,6 +554,28 @@ cyclesRouter.put('/:id', requireRole('st'), async (req, res) => {
   res.json(result);
 });
 
+// DELETE /api/downtime_cycles/:id — ST only.
+// Hard-delete guarded by the submission count: a cycle that owns
+// downtime_submissions cannot be deleted (it would orphan player data).
+// Returns 409 CYCLE_HAS_SUBMISSIONS so the client can surface a clear message.
+// Empty cycles (e.g. the test-residue "Test Cycle" docs) delete cleanly.
+cyclesRouter.delete('/:id', requireRole('st'), async (req, res) => {
+  const oid = parseId(req.params.id);
+  if (!oid) return res.status(400).json({ error: 'VALIDATION_ERROR', message: 'Invalid cycle ID format' });
+
+  const subCount = await getCollection('downtime_submissions').countDocuments({ cycle_id: oid });
+  if (subCount > 0) {
+    return res.status(409).json({
+      error: 'CYCLE_HAS_SUBMISSIONS',
+      message: `Cycle has ${subCount} submission${subCount === 1 ? '' : 's'}; remove or reassign them before deleting.`,
+    });
+  }
+
+  const result = await cycles().deleteOne({ _id: oid });
+  if (result.deletedCount === 0) return res.status(404).json({ error: 'NOT_FOUND', message: 'Cycle not found' });
+  res.json({ deleted: true });
+});
+
 // POST /api/downtime_cycles/:id/publish — ST only; bulk-promote compiled DT reports
 cyclesRouter.post('/:id/publish', requireRole('st'), async (req, res) => {
   const cycleOid = parseId(req.params.id);

--- a/server/tests/issue-918-cycle-tab-management.test.js
+++ b/server/tests/issue-918-cycle-tab-management.test.js
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+
+const DOWNTIME = fs.readFileSync('../server/routes/downtime.js', 'utf8');
+const DB       = fs.readFileSync('../public/js/downtime/db.js', 'utf8');
+const VIEWS    = fs.readFileSync('../public/js/admin/cycle-views.js', 'utf8');
+const CSS      = fs.readFileSync('../public/css/admin-layout.css', 'utf8');
+
+// ── Server: DELETE /api/downtime_cycles/:id ──────────────────────────────────
+
+describe('issue-918 — cycle DELETE route', () => {
+  it('DELETE /:id requires ST role', () =>
+    expect(DOWNTIME).toMatch(/cyclesRouter\.delete\s*\(\s*'\/:id'\s*,\s*requireRole\s*\(\s*'st'\s*\)/));
+
+  it('validates the id format (400)', () =>
+    expect(DOWNTIME).toMatch(/cyclesRouter\.delete[\s\S]{0,400}VALIDATION_ERROR/));
+
+  it('guards against deleting a cycle with submissions (409)', () => {
+    expect(DOWNTIME).toContain('CYCLE_HAS_SUBMISSIONS');
+    expect(DOWNTIME).toMatch(/cyclesRouter\.delete[\s\S]{0,600}countDocuments\(\{\s*cycle_id:\s*oid/);
+    expect(DOWNTIME).toMatch(/cyclesRouter\.delete[\s\S]{0,600}status\(409\)/);
+  });
+
+  it('returns 404 when nothing was deleted', () =>
+    expect(DOWNTIME).toMatch(/cyclesRouter\.delete[\s\S]{0,800}deletedCount === 0[\s\S]{0,120}NOT_FOUND/));
+});
+
+// ── Client db.js helpers ─────────────────────────────────────────────────────
+
+describe('issue-918 — db.js cycle helpers', () => {
+  it('exports deleteCycle', () =>
+    expect(DB).toMatch(/export async function deleteCycle\(id\)/));
+
+  it('deleteCycle DELETEs the cycle endpoint', () =>
+    expect(DB).toMatch(/deleteCycle[\s\S]{0,120}apiDelete\('\/api\/downtime_cycles\/'\s*\+\s*id\)/));
+
+  it('imports apiDelete', () =>
+    expect(DB).toMatch(/import\s*\{[^}]*apiDelete[^}]*\}\s*from\s*'\.\.\/data\/api\.js'/));
+
+  it('createCycle accepts label and chapterId options', () => {
+    expect(DB).toMatch(/createCycle\(gameNumber,\s*\{[^}]*label/);
+    expect(DB).toContain('chapterId');
+    expect(DB).toMatch(/chapter_id = chapterId|body\.chapter_id = chapterId/);
+  });
+});
+
+// ── Client cycle-views.js ────────────────────────────────────────────────────
+
+describe('issue-918 — cycle-views.js wiring', () => {
+  it('imports cycle CRUD + status helper from db.js', () =>
+    expect(VIEWS).toMatch(/import\s*\{[^}]*createCycle[^}]*deleteCycle[^}]*deriveCycleStatus[^}]*\}\s*from\s*'\.\.\/downtime\/db\.js'/));
+
+  it('renders a status ribbon', () => {
+    expect(VIEWS).toContain('buildRibbon');
+    expect(VIEWS).toContain('renderRibbon');
+    expect(VIEWS).toContain('deriveCurrentCycle');
+    expect(VIEWS).toContain('cy-ribbon');
+  });
+
+  it('phase toggle clears to neutral (active phase → null)', () =>
+    expect(VIEWS).toMatch(/\(cy\.game_phase === phase\)\s*\?\s*null\s*:\s*phase/));
+
+  it('clearing a phase does NOT reset the tracker — tracker delete is gated behind game phase', () => {
+    const gameGuardIdx = VIEWS.indexOf("phaseOrNull === 'game'");
+    const trackerDelIdx = VIEWS.indexOf("apiDelete('/api/tracker_state')");
+    expect(gameGuardIdx).toBeGreaterThan(-1);
+    expect(trackerDelIdx).toBeGreaterThan(gameGuardIdx);
+  });
+
+  it('inline-edits the label via updateCycle', () => {
+    expect(VIEWS).toContain('buildLabelCell');
+    expect(VIEWS).toMatch(/updateCycle\(cy\._id,\s*\{\s*label/);
+  });
+
+  it('assigns chapter via a dropdown writing chapter_id', () => {
+    expect(VIEWS).toContain('buildChapterSelect');
+    expect(VIEWS).toMatch(/updateCycle\(cy\._id,\s*\{\s*chapter_id/);
+  });
+
+  it('adds a new cycle via createCycle', () => {
+    expect(VIEWS).toContain('new-cy-save');
+    expect(VIEWS).toMatch(/createCycle\(num,\s*\{\s*label,\s*chapterId/);
+  });
+
+  it('add-cycle form uses the handler-free chapter picker (no phantom updateCycle)', () => {
+    // Regression (QA #918): the add form must NOT reuse buildChapterSelect,
+    // whose change handler persists to an existing cycle id. With no cycle to
+    // write to, that fired updateCycle(undefined,...) and reverted the choice.
+    expect(VIEWS).toContain('buildChapterPicker(chapters)');
+    expect(VIEWS).not.toContain('buildChapterSelect({ chapter_id: null }');
+  });
+
+  it('deletes a cycle via deleteCycle with confirmation', () => {
+    expect(VIEWS).toContain('btn-danger');
+    expect(VIEWS).toMatch(/deleteCycle\(cy\._id\)/);
+    expect(VIEWS).toContain('confirm(');
+  });
+
+  it('uses normalised CSS — no inline styles in the rewritten view', () => {
+    expect(VIEWS).not.toContain('cssText');
+    expect(VIEWS).not.toContain('style="');
+  });
+});
+
+// ── CSS normalised classes ───────────────────────────────────────────────────
+
+describe('issue-918 — admin-layout.css cycle classes', () => {
+  it('defines the ribbon', () =>
+    expect(CSS).toContain('.cy-ribbon'));
+
+  it('defines the neutral phase chip', () =>
+    expect(CSS).toContain('.cy-phase--none'));
+
+  it('defines toggleable phase buttons', () => {
+    expect(CSS).toContain('.cy-phase-btn');
+    expect(CSS).toContain('.cy-phase-btn.is-active');
+  });
+});

--- a/specs/stories/issue-918-cycle-tab-management.story.md
+++ b/specs/stories/issue-918-cycle-tab-management.story.md
@@ -1,0 +1,160 @@
+# Issue #918: Cycle tab — edit/add/delete cycles, status ribbon, toggleable phases
+
+Status: review
+
+issue: 918
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/918
+branch: morningstar-issue-918-cycle-tab-edit-add-delete
+
+## Story
+
+As a Storyteller managing the campaign from the Engine → Cycle tab,
+I want full lifecycle control over Game Cycles — edit a cycle's label and chapter, add new cycles, delete redundant ones, freely toggle the phase (including back to neutral), and see at a glance where the campaign currently sits,
+so that I can run cycle setup (e.g. opening feeding for the next game) without hand-editing the database or being stuck with read-only rows.
+
+## Background / why now
+
+Raised while setting up Game 5. The Cycle tab can CRUD Chapters but Game Cycle rows are largely read-only: no label edit, no chapter assignment after creation, no add-cycle, no delete (two junk "Test Cycle" rows, `game_number: 99`, sit in the live list), and no indicator of current chapter/cycle/phase. The phase buttons also can't be toggled off — the active one is `disabled`.
+
+This is a single cohesive story (not an epic) because all five features overhaul the **same render module** (`public/js/admin/cycle-views.js`, primarily `buildCyclesPanel` / `buildPhaseCell`). Splitting tightly-coupled edits to one render function across separate stories/branches would create rebase fragility in shared code for no QA benefit. The only naturally-separable piece — the server `DELETE` route — belongs with the delete feature anyway.
+
+## Current behaviour (files read)
+
+**`public/js/admin/cycle-views.js`** (read in full):
+- `buildChaptersPanel` (L32-141) — Chapters have inline add-form (L96-138) and per-row Delete (L75-88). This is the **reuse pattern** for cycle add/edit/delete UI.
+- `buildCyclesPanel` (L388-523) — renders the cycle table. **Label** rendered as plain text `tdLabel.textContent` (L427). **Chapter** rendered as plain text `tdChapter.textContent` (L432-435). No add-cycle control, no delete control.
+- `buildPhaseCell` (L160-201) / `setGamePhase` (L147-158) — three buttons (Game/Downtime/Processing). Active phase button is `disabled` (L178); clicking Game first fires `confirm()` then `apiDelete('/api/tracker_state')` (L148-154) then `PUT { game_phase }`. No way to clear the phase.
+- Heavy use of inline `style=` throughout — **legacy tech-debt; do not propagate** (see CSS standards).
+
+**`public/js/downtime/db.js`** (read in full):
+- `createCycle(gameNumber, {status, deadlineAt})` (L19-30) — exists, **unwired in admin**. Builds `{ label: 'Downtime '+n, game_number, status, ... }`.
+- `updateCycle(id, updates)` (L42-44) — `PUT /api/downtime_cycles/:id`. Use for label/chapter/game_phase writes.
+- `deriveCycleStatus(cycle)` (L67-84) — maps `game_phase` → status: `game→game`, `downtime→active`, `processing→closed`; falls back to `phase_signoff` legacy derivation when `game_phase` is unset. **This is why clearing `game_phase` is safe**: it reverts to the legacy derivation.
+- `getGamePhaseCycle()` (L121-124) — `cycles.find(c => c.status === 'game')`. Drives whether the Feeding tab opens. A neutral cycle (no `game_phase`) is intentionally NOT picked up here.
+- No client-side delete helper exists.
+
+**`server/routes/downtime.js`** (relevant sections read):
+- `parseId(id)` (L24-30) — ObjectId parse, returns null on bad format.
+- `cyclesRouter.get('/')` (L76-79) — both roles; sorts `_id: -1` (cycles lack `created_at`).
+- `cyclesRouter.post('/')` (L82-87) — ST only, `validate(downtimeCycleSchema)`, inserts and returns the doc.
+- `cyclesRouter.put('/:id')` (L542-555) — ST only, strips `_id`, `$set` updates, returns updated doc or 404.
+- **No `DELETE` route exists** — must be added (see Task 6).
+- Auth: `requireRole('st')` from `../middleware/auth.js`. Schema: `downtimeCycleSchema` from `../schemas/downtime_submission.schema.js`.
+
+## Decisions (locked)
+
+- **Phase toggle includes a cleared/neutral state.** Clicking the currently-active phase button **unsets `game_phase`** (clears it). `deriveCycleStatus` then falls back to `phase_signoff`. The status ribbon must show "no phase set" in that state. This is the correct way to CLOSE feeding for a game without forcing the cycle into Processing/closed.
+
+## Open question (carry into implementation — decide before Task 6)
+
+- **Soft-delete vs hard-delete** for a cycle that has `downtime_submissions` referencing it. Hard delete would orphan submissions; the live DT1-4 cycles each have submissions. Recommendation: **hard-delete only when the cycle has zero submissions** (the two Test Cycles qualify); block deletion of cycles with submissions behind a hard error from the server, with the UI surfacing it. Defer a true archive/soft-delete model unless the ST needs to remove a cycle that has submissions. Confirm with Angelus during dev if a submission-bearing cycle must be deletable.
+
+## Acceptance Criteria
+
+1. A cycle row's **label** can be edited inline (reuse the chapters inline-edit pattern) and persists across reload via `PUT /api/downtime_cycles/:id`.
+2. A cycle can be **assigned/reassigned to a Chapter** (or cleared to none) from its row via a dropdown of existing chapters; persists `chapter_id`.
+3. A **status ribbon** at the top of the Cycle tab shows current **Chapter / Game Cycle / Phase**. "Current" = the cycle whose `game_phase` is set; if none, the newest non-closed cycle. Ribbon updates live when the phase changes, and shows "no phase set" when the current cycle has no `game_phase`.
+4. **All three phase buttons are interactive**; the active phase is visually distinct; switching phases still fires the existing Game-phase tracker-reset `confirm()` + `apiDelete('/api/tracker_state')`.
+5. **Clicking the active phase clears it** (`game_phase` unset); the ribbon reflects "no phase set" and `deriveCycleStatus` falls back to `phase_signoff`.
+6. A **"+ New Cycle"** control creates a cycle (label + game_number, optional chapter) that appears in the list without a full reload (mirror the chapters add-form flow).
+7. A cycle can be **deleted** from the UI; a cycle **with submissions cannot be deleted** without explicit confirmation (or is blocked per the resolved open question); the two "Test Cycle" rows can be removed.
+8. `DELETE /api/downtime_cycles/:id` exists, is **ST-only**, returns 404 for unknown id and a clear error for a guarded/blocked delete.
+9. **Styling uses design-system tokens and reuses existing component classes** — no inline `style=`, no bare hex/`rgba()`. New ribbon styling goes in `admin-layout.css` using `theme.css` tokens.
+
+## Tasks / Subtasks
+
+- [x] **Task 1 — Inline edit label (AC: 1).** `buildLabelCell` renders label text + a ✎ edit button; clicking swaps to an input with Save/Cancel (Enter saves, Esc cancels). Save via `updateCycle(cy._id, { label })`, mutate `cy.label`, re-render cell, refresh ribbon. No full reload.
+- [x] **Task 2 — Chapter assignment dropdown (AC: 2).** `buildChapterSelect` renders a `.form-select` of chapters (+ "none"). On change, `updateCycle(cy._id, { chapter_id })` (null clears); mutate `cy.chapter_id`, refresh ribbon; reverts the select on failure.
+- [x] **Task 3 — Status ribbon (AC: 3).** `buildRibbon`/`renderRibbon` at the top of `initCycleView`. `deriveCurrentCycle` = cycle in `game` phase → else newest with any phase → else newest non-closed (via `deriveCycleStatus`). Shows Chapter / Game Cycle / Phase, "No phase set" when unset. Module-level `view` state lets it refresh after any mutation without a re-fetch.
+- [x] **Task 4 — Toggleable phases incl. neutral (AC: 4, 5).** `buildPhaseCell` buttons are all interactive; active one carries `.is-active`. Clicking the active phase writes `{ game_phase: null }` (clears). `writePhase` keeps the Game-phase `confirm()` + `apiDelete('/api/tracker_state')` — and that reset is gated strictly inside the `phaseOrNull === 'game'` branch, so clearing never wipes the tracker. `null` via `$set` works because `deriveCycleStatus` uses strict `=== 'game'` etc. and falls through to the legacy branch.
+- [x] **Task 5 — Add new cycle (AC: 6).** "+ New Cycle" button toggles an inline form (game # prefilled to max+1, label, chapter `.form-select`). Save calls `createCycle(num, { label, chapterId })` (extended in db.js) then `refresh()`.
+- [x] **Task 6 — Delete cycle: server route (AC: 8) + client (AC: 7).** Resolved open question with the recommended default — **block hard-delete of submission-bearing cycles**.
+  - Server: `cyclesRouter.delete('/:id', requireRole('st'), ...)` — `parseId`→400; `countDocuments({ cycle_id: oid })`; if > 0 → **409 `CYCLE_HAS_SUBMISSIONS`** with a clear message; else `deleteOne`, 404 if nothing matched.
+  - Client: per-row Delete button (`.btn-danger`); `confirm()`; on success `refresh()`; the 409 message surfaces via the API client's thrown `Error.message`. `deleteCycle(id)` helper added to `db.js`.
+- [x] **Task 7 — CSS pass (AC: 9).** New `cy-*` block appended to `admin-layout.css`, all `theme.css` tokens, reusing `.btn-sm`/`.form-input`/`.form-select`. The rewrite removed ALL inline `style=`/`cssText` from the file (was previously ~50 inline styles); a test asserts neither string remains.
+- [x] **Task 8 — Smoke / contract.** `server/tests/issue-918-cycle-tab-management.test.js` — 20 source-contract cases (server route auth/guard/404, db.js helpers, view wiring incl. the tracker-reset-gating assertion, CSS classes). All pass. **Live click-through deferred**: the new `DELETE` route won't exist on `dev`'s proxied prod API until merged to `main`, and Angelus can't run a local API — so deleting the two Test Cycles must be verified post-merge.
+
+## Dev Notes
+
+- **Do NOT change `deriveCycleStatus`'s model** — out of scope. The neutral state relies on its existing fallback; just stop writing a `game_phase` value.
+- **Tracker reset is load-bearing.** The Game-phase confirm + `apiDelete('/api/tracker_state')` (cycle-views.js:147-154) wipes live vitae/WP/influence for all characters by design. Preserve it exactly; do not let the new "toggle off" path trigger it (clearing phase should NOT reset the tracker — only entering Game phase does).
+- **Cycles have no `created_at`** — order/"newest" must use `_id` (server already sorts `_id: -1`).
+- **`game_phase: null` vs `$unset`** — `deriveCycleStatus` checks `cycle?.game_phase === 'game'` etc. with strict equality, so a `null` value falls through to the legacy branch correctly. `null` via `$set` is simplest; only reach for `$unset` if a downstream reader treats `null` differently (none found). Flag if you change the server contract.
+- **British English** in any user-facing copy. **No em-dashes** in output text. Dots via `'●'.repeat(n)`.
+- **Server changes are NOT testable on `dev`** — `dev`'s frontend proxies `/api/*` to the production Render (built from `main`). The new `DELETE` route won't exist on the live API until merged to `main`. Plan QA accordingly (contract test locally; full delete verification post-merge or against a local API).
+- The two redundant cycles to delete: `Test Cycle` `game_number: 99` — ids `6a30b3a45aafa000cac30110` and `6a30b3fe8dc95c95e3f1b6f5`. Their *data* removal also overlaps with #823; this story delivers the *capability*.
+
+### Project Structure Notes
+
+- All client work in `public/js/admin/cycle-views.js` + a `deleteCycle` helper (and possibly a `createCycle` extension) in `public/js/downtime/db.js`.
+- Server: one new route in `server/routes/downtime.js` (cyclesRouter). No schema change expected (DELETE takes no body).
+- New CSS: `public/css/admin-layout.css` (ribbon class + any chip reuse), tokens from `public/css/theme.css`.
+
+### References
+
+- [Source: public/js/admin/cycle-views.js#buildCyclesPanel L388-523, buildPhaseCell L160-201, setGamePhase L147-158, buildChaptersPanel L32-141 (reuse pattern)]
+- [Source: public/js/downtime/db.js#createCycle L19, updateCycle L42, deriveCycleStatus L67, getGamePhaseCycle L121]
+- [Source: server/routes/downtime.js#parseId L24, post '/' L82, put '/:id' L542, requireOpenCycle L37 (submission-guard precedent)]
+- [Source: public/css/admin-layout.css#.btn-sm L195, .dl-status-chip L234, .terr-chip L861]
+- Prior art: specs/stories/feature.96.dt-status-ribbon.story.md, specs/stories/dtux-1-phase-ribbon-nav.story.md, specs/stories/issue-231-dt-prep-open-override.story.md (manual_open/phase model)
+- Related: #823 (data purge of Test Cycle docs); CYCLE epic #708 (introduced `game_phase`)
+- Standards: specs/project-context.md (critical CSS standards), specs/architecture/coding-standards.md (CSS Standards)
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-8 (bmad-dev-story)
+
+### Debug Log References
+
+- `npx vitest run tests/issue-918-cycle-tab-management.test.js` → 20/20 pass.
+- Regression: `epic.708.1`, `epic.708.2`, `derive-cycle-status`, `api-publish-cycle`, `api-chapters` → 82/82 pass.
+- `node --check` clean on `cycle-views.js`, `db.js`, `downtime.js`.
+
+### Completion Notes List
+
+- **Open question resolved (default):** submission-bearing cycles are blocked from deletion server-side (409 `CYCLE_HAS_SUBMISSIONS`). The two live "Test Cycle" docs have zero submissions and will delete cleanly. If Angelus later needs to delete a cycle that has submissions, that's a follow-up (soft-delete/archive or a force flag) — not built here.
+- **Tracker-reset safety is the load-bearing invariant.** The clear-to-neutral path deliberately does NOT reset the tracker; only entering Game phase does. A structural test pins `apiDelete('/api/tracker_state')` as occurring only inside the `phaseOrNull === 'game'` branch, so a future edit can't accidentally make "clear phase" wipe live vitae/WP/influence.
+- **Full inline-style removal.** The file was entirely inline-styled (`style.cssText` / `style="..."`). The rewrite moved all of it to a normalised `cy-*` CSS block; a test asserts neither `cssText` nor `style="` remains, enforcing AC9 going forward.
+- **Server change is not testable on `dev`** (dev proxies `/api/*` to prod Render built from `main`). Contract test covers the route's shape; the actual delete of the two Test Cycles needs verification after merge to `main`.
+- Em-dashes in dropdown placeholders ("— none —", "— not linked —") and `${n} — ${label}` were preserved verbatim from the pre-existing UI strings (not new prose).
+
+### File List
+
+- `public/js/admin/cycle-views.js` (rewritten) — ribbon, inline label edit, chapter dropdown, toggleable/neutral phases, add + delete cycle; all inline styles removed.
+- `public/js/downtime/db.js` (modified) — `createCycle` accepts `label`/`chapterId`; new `deleteCycle`; `apiDelete` import.
+- `server/routes/downtime.js` (modified) — new ST-only `DELETE /api/downtime_cycles/:id` with submission guard.
+- `public/css/admin-layout.css` (modified) — new `cy-*` normalised CSS block (ribbon, phase buttons, inline forms, tables) using theme tokens.
+- `server/tests/issue-918-cycle-tab-management.test.js` (new) — 20 source-contract cases.
+- `specs/stories/issue-918-cycle-tab-management.story.md` — this file.
+
+### Change Log
+
+- 2026-06-20 (DEV): Implemented #918 — Cycle tab full lifecycle management (edit label/chapter, status ribbon, toggleable phases incl. clear-to-neutral, add cycle, delete cycle + server DELETE route). 20 contract tests + 82 regression green.
+- 2026-06-20 (QA): Found + fixed High bug in add-cycle chapter picker; added regression test. 21 contract + 103 cycle-area regression green.
+
+## QA Review (Quinn)
+
+**Outcome: PASS (with 1 bug fixed during review).**
+
+### Fixed during QA
+
+- **[High] Add-cycle chapter picker was unusable.** The add form reused `buildChapterSelect({ chapter_id: null }, ...)`, whose change handler persists to an existing cycle via `updateCycle(cy._id, ...)`. With no real cycle, every chapter pick fired `updateCycle(undefined, ...)` → `PUT /api/downtime_cycles/undefined` → 400 → the `catch` reverted the dropdown to "none", so a chapter could never be chosen when adding a cycle (broke AC6). **Fix:** split `buildChapterPicker` (options-only, no handler — used by the add form) from `buildChapterSelect` (row-level, persists on change). Regression test added (`add-cycle form uses the handler-free chapter picker`).
+
+### Documented, not fixed (pre-existing data-hygiene, root cause is the junk Test Cycles — #823, removable via this story's own delete feature)
+
+- **[Low] Ribbon fallback can surface a Test Cycle.** When no cycle has a phase set (e.g. DT4 cleared to neutral), `deriveCurrentCycle`'s "newest non-closed by `_id`" picks a `Test Cycle` (higher `_id`, derives to `prep`). Spec-faithful behaviour; resolves when the two Test Cycle docs are deleted. Not patched with a `game_number===99` filter (hacky).
+- **[Low] Add-form Game # prefills to 100.** `max(game_number)+1` = 99+1 because of the Test Cycles. Field is editable; resolves on Test Cycle deletion.
+
+### AC verification
+
+All 9 ACs verified against the code: 1 label inline edit ✓, 2 chapter dropdown ✓ (post-fix), 3 ribbon ✓ (with caveat above), 4 interactive phases + Game confirm ✓, 5 clear-to-neutral + `deriveCycleStatus` fallback ✓, 6 add cycle ✓ (post-fix), 7 delete + submission guard ✓, 8 ST-only DELETE route + 404 + clear error ✓, 9 no inline styles (test-guarded) ✓.
+
+### Tracker-reset safety invariant
+
+Verified: `apiDelete('/api/tracker_state')` sits only inside the `phaseOrNull === 'game'` branch of `writePhase`; clearing a phase or switching to downtime/processing never resets the tracker. Pinned by a structural test.
+
+### Note on live verification
+
+The DELETE route and the live deletion of the two Test Cycles remain verifiable only after merge to `main` (dev proxies `/api/*` to prod). Recommend confirming the delete + the two Low findings clear in the same post-merge smoke.

--- a/specs/stories/sprint-status.yaml
+++ b/specs/stories/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-15
-# last_updated: 2026-06-07 (DI-3 ordeal parity audit complete — Verdict A, no XP gaps; history-ordeal type mismatch for 3 chars flagged for ST manual check)
+# last_updated: 2026-06-20 (issue-918 cycle-tab-management implemented, review)
 # project: TM Suite
 # project_key: NOKEY
 # tracking_system: file-system
@@ -877,3 +877,5 @@ development_status:
   proto-15-dt-processing-hide-protect-disc-consume: done          # Snapshot: _renderSnapshotHideProtect prefers hide_protect_disc structured field; text extraction remains fallback for legacy entries
 
   proto-16-dt-processing-st-review-touched-at: done               # Write-back: co-save st_review.st_review_touched_at ISO timestamp in every saveEntryReview call; atomic with source-specific update; D1 gap closure
+
+  issue-918-cycle-tab-management: review                          # Cycle tab: inline edit label/chapter, status ribbon, toggleable phases (incl. clear-to-neutral), add cycle, delete cycle + new server DELETE route


### PR DESCRIPTION
Closes #918.

## Summary

Full ST control over Game Cycles in Engine -> Cycle:
- **Edit** a cycle's label inline and assign/change/clear its Chapter via a dropdown.
- **Status ribbon** showing current Chapter / Game Cycle / Phase (updates live).
- **Toggleable phases** — all three buttons interactive; clicking the active one clears the phase to neutral (unset `game_phase`, falls back to legacy `deriveCycleStatus`).
- **Add** a new cycle from the tab.
- **Delete** a cycle, backed by a new ST-only `DELETE /api/downtime_cycles/:id` that returns 409 `CYCLE_HAS_SUBMISSIONS` when the cycle owns submissions (the two empty "Test Cycle" rows delete cleanly).

Rewrites `cycle-views.js` off inline styles onto a normalised `cy-*` CSS block (theme tokens). Clearing a phase never resets the live tracker — only entering Game phase does (pinned by a structural test).

## Story

`specs/stories/issue-918-cycle-tab-management.story.md` (includes the QA review).

## QA

- Fixed during QA: add-cycle chapter picker was unusable (reused the row-level persist handler against a non-existent cycle id). Split into a handler-free picker; regression test added.
- 21 source-contract cases + 103 cycle-area regression tests green.

## Test plan / post-merge smoke

- The `DELETE` route is only live once on `main` (dev proxies `/api/*` to prod). After deploy: delete the two `Test Cycle` (game_number 99) rows; confirm a submission-bearing cycle (DT1-4) is blocked with the 409 message.
- Verify the ribbon, inline edit, phase toggle incl. clear-to-neutral, and add-cycle on the live admin Cycle tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)