### PR TITLE
fix(#922): restore Territory Pulse for real-territory feeders

### DIFF
--- a/public/js/admin/downtime-story.js
+++ b/public/js/admin/downtime-story.js
@@ -3070,7 +3070,10 @@ function _feedTerrEntries(sub) {
   const raw = parseFeedingTerritories(sub)
     .filter(([, v]) => v && v !== 'none' && v !== 'Not feeding here')
     .map(([slug]) => {
-      const rawId = TERRITORY_SLUG_MAP[slug];
+      // #922: post-ADR-002 grid keys are Mongo _ids, absent from TERRITORY_SLUG_MAP;
+      // fall back to resolveTerrId (_id -> slug via _currentTerritories) so real
+      // territories don't collapse to The Barrens. Legacy slug keys still hit the map first.
+      const rawId = TERRITORY_SLUG_MAP[slug] || resolveTerrId(slug);
       return { slug, id: rawId || 'barrens', name: (rawId && TERRITORY_DISPLAY[rawId]) || 'The Barrens' };
     });
   // Deduplicate by id

--- a/specs/stories/fix.922.dt-story-feeding-territory-barrens.story.md
+++ b/specs/stories/fix.922.dt-story-feeding-territory-barrens.story.md
@@ -1,0 +1,183 @@
+---
+title: 'DT downtime report: Territory Pulse dropped for real-territory feeders (_feedTerrEntries _id keys)'
+type: 'fix'
+issue: 922
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/922
+branch: morningstar-issue-922-feeding-territory-barrens
+created: '2026-06-20'
+status: review
+recommended_model: 'haiku/sonnet — single one-line edit reusing the existing resolveTerrId() helper; no design decisions, no new code paths'
+context:
+  - public/js/admin/downtime-story.js
+---
+
+## Intent
+
+**Problem:** A player (Einar Solveig) reported their DT4 feeding report shows them feeding in **The Barrens** when they selected **The Second City**. Investigation of the DT4 export confirms the submission data is correct — `feeding_territories` holds the right territory `_id` (`69d9e54c00815d471503bea8` = The Second City) and `feeding_review.outcome` is the correct Second City narrative. The wrong "Barrens" is generated at render time, not stored.
+
+`_feedTerrEntries()` (`downtime-story.js:3069`) resolves each feeding-grid key via `TERRITORY_SLUG_MAP[slug]`. Post-migration (ADR-002) the grid keys are Mongo `_id`s (24-hex), which are **not** in `TERRITORY_SLUG_MAP` (that map is keyed by slugs and display-name variants). So `rawId` comes back `undefined` and the code falls through to its default `{ id: 'barrens', name: 'The Barrens' }`. Every real-territory feed therefore renders as The Barrens in the player-facing DT Story report.
+
+**Scope:** 24 of 29 DT4 submissions affected (every player who fed in a real territory). The 4 unaffected genuinely selected Barrens (Henry St. John, Carver, Anichka, Hazel); 1 is a draft with no feeding selection.
+
+**Secondary impact:** `buildTerritoryContext` suppresses co-residents, poachers, and the territory pulse when `id === 'barrens'` (`downtime-story.js:2990, 3002, 3254, 3569`), so the 24 mislabelled reports also drop their co-resident lists and per-territory pulse content. Fixing the resolver restores these automatically.
+
+**No data is corrupted.** No `territory_reports` or `published_outcome` are persisted on any submission (0 found across all 29) — the report is built live each render. A code fix corrects all 24 retroactively with no DB write.
+
+**Fix:** `_feedTerrEntries()` already lives in a module that holds `_currentTerritories` (the `GET /api/territories` cache) and exposes an existing helper `resolveTerrId(raw)` (`downtime-story.js:75-79`) that maps a 24-hex `_id` → territory `slug` via that cache. Fall back to it when `TERRITORY_SLUG_MAP[slug]` misses. This is the same migration-aware resolution already used by the sibling resolvers `_playerFeedTerrsText` (`downtime-views.js:11662`) and `_getSubFedTerrs` (`downtime-views.js:11711`); `_feedTerrEntries` was simply missed when those were hardened.
+
+**Approach:** One targeted edit, one file. Reuse the existing `resolveTerrId` helper — do **not** inline a new regex/territory lookup, and do **not** attempt the broader `normaliseTerritoryId()` consolidation (that is #816 / #496, out of scope here).
+
+## Boundaries & Constraints
+
+**Always:**
+- Reuse the existing `resolveTerrId(slug)` helper for the `_id` fallback. It returns the territory `slug` (or `null`) by matching `String(td._id) === raw` against `_currentTerritories`.
+- Preserve the existing order: try `TERRITORY_SLUG_MAP[slug]` first (handles legacy slug / display-name keys with zero behaviour change), then fall back to `resolveTerrId(slug)` only when the map misses.
+- Keep the Barrens default intact: a genuinely-Barrens key (`the_barrens_no_territory_` → `TERRITORY_SLUG_MAP` returns `null`, `resolveTerrId` returns `null`) must still resolve to `{ id: 'barrens', name: 'The Barrens' }`.
+- `name` continues to derive from `TERRITORY_DISPLAY[rawId]` (keyed by slug: `academy`, `harbour`, `dockyards`, `secondcity`, `northshore`).
+
+**Never:**
+- Do not write any data / migration script — submission data is already correct.
+- Do not change `TERRITORY_SLUG_MAP`, `TERRITORY_DISPLAY`, or `resolveTerrId`.
+- Do not touch the barrens-suppression branches in `buildTerritoryContext` — they become correct for free once the resolver returns real territory ids.
+- Do not refactor toward a shared `normaliseTerritoryId()` boundary (tracked separately in #816 / #496).
+- Do not modify the sibling resolvers in `downtime-views.js`; they already handle `_id` keys.
+
+## Code Map — One Fix Site
+
+### `_feedTerrEntries()` (`downtime-story.js:3069`)
+
+**Existing helper this fix reuses (`downtime-story.js:75-79`, unchanged):**
+```js
+function resolveTerrId(raw) {
+  if (!raw) return null;
+  const t = (_currentTerritories || []).find(td => String(td._id) === raw);
+  return t?.slug || null;
+}
+```
+
+**Current (broken):**
+```js
+function _feedTerrEntries(sub) {
+  const raw = parseFeedingTerritories(sub)
+    .filter(([, v]) => v && v !== 'none' && v !== 'Not feeding here')
+    .map(([slug]) => {
+      const rawId = TERRITORY_SLUG_MAP[slug];   // _id keys miss → undefined
+      return { slug, id: rawId || 'barrens', name: (rawId && TERRITORY_DISPLAY[rawId]) || 'The Barrens' };
+    });
+  // Deduplicate by id
+  const seen = new Set();
+  const deduped = raw.filter(t => { if (seen.has(t.id)) return false; seen.add(t.id); return true; });
+  // Every player gets at least a Barrens entry
+  return deduped.length ? deduped : [{ slug: 'the_barrens', id: 'barrens', name: 'The Barrens' }];
+}
+```
+
+**Fix (single changed line):**
+```js
+function _feedTerrEntries(sub) {
+  const raw = parseFeedingTerritories(sub)
+    .filter(([, v]) => v && v !== 'none' && v !== 'Not feeding here')
+    .map(([slug]) => {
+      const rawId = TERRITORY_SLUG_MAP[slug] || resolveTerrId(slug);   // _id keys resolve via _currentTerritories
+      return { slug, id: rawId || 'barrens', name: (rawId && TERRITORY_DISPLAY[rawId]) || 'The Barrens' };
+    });
+  // Deduplicate by id
+  const seen = new Set();
+  const deduped = raw.filter(t => { if (seen.has(t.id)) return false; seen.add(t.id); return true; });
+  // Every player gets at least a Barrens entry
+  return deduped.length ? deduped : [{ slug: 'the_barrens', id: 'barrens', name: 'The Barrens' }];
+}
+```
+
+Resolution walk for Einar's grid `{"69d9e54c00815d471503bea8":"feeding_rights", ...}`:
+- `TERRITORY_SLUG_MAP['69d9e54c00815d471503bea8']` → `undefined` (not a slug key)
+- `resolveTerrId('69d9e54c00815d471503bea8')` → finds the territory doc by `_id` → returns `'secondcity'`
+- `rawId = 'secondcity'` → `id: 'secondcity'`, `name: TERRITORY_DISPLAY['secondcity']` = `'The Second City'` ✓
+
+Genuine-Barrens walk for `{"the_barrens_no_territory_":"barrens"}`:
+- `TERRITORY_SLUG_MAP['the_barrens_no_territory_']` → `null` (explicit Barrens mapping in `downtime-constants.js:131`)
+- `resolveTerrId('the_barrens_no_territory_')` → `null` (not a 24-hex `_id`)
+- `rawId = null` → `id: 'barrens'`, `name: 'The Barrens'` ✓ (unchanged)
+
+## Tasks
+
+- [x] **T1 — `_feedTerrEntries` `_id` fallback** (`downtime-story.js:3073`)
+  - Change `const rawId = TERRITORY_SLUG_MAP[slug];` → `const rawId = TERRITORY_SLUG_MAP[slug] || resolveTerrId(slug);`
+  - No other lines in the function change.
+
+- [x] **T2 — Parse-check**
+  - Confirm `public/js/admin/downtime-story.js` parses cleanly (Node `new Function` / the repo `.githooks` parse-check).
+
+- [x] **T3 — Verification harness (QA)** — re-scoped to the live surface (Territory Pulse in `compilePushOutcome`)
+  - `tests/issue-922-dt-story-pulse-territory-resolve.spec.js` (3 tests, all pass; red-green verified).
+  - AC-1: real territory by `_id` key → `## Territory Pulse — The Second City` included in the pushed `st_review.outcome_text` (fails pre-fix).
+  - AC-2: genuine Barrens → no Territory Pulse heading (correctly skipped).
+  - AC-3: legacy slug key → pulse still resolves (no regression).
+  - Regression batch (territory/pulse area): `issue-922` + `fix-470` green (9/9). `fix-814` (1) and `issue-332` (4) show failures, but these are **pre-existing** — confirmed identical with the #922 change reverted (5 fail either way), so not introduced by this story. Flagged separately for triage; out of scope here.
+
+## Files to Change
+
+- `public/js/admin/downtime-story.js` — one line in `_feedTerrEntries`; no other files.
+
+## Files Changed
+
+- `public/js/admin/downtime-story.js` — one line in `_feedTerrEntries` (`_id` fallback via `resolveTerrId`); 3-line explanatory comment added above it.
+- `tests/issue-922-dt-story-pulse-territory-resolve.spec.js` — new QA spec (3 tests).
+
+## Dev Agent Record
+
+### Completion Notes
+
+**T1 — implemented.** `_feedTerrEntries` (`downtime-story.js:3073`) now resolves the grid key as `TERRITORY_SLUG_MAP[slug] || resolveTerrId(slug)`. Legacy slug / display-name keys still hit `TERRITORY_SLUG_MAP` first (zero behaviour change); post-ADR-002 `_id` keys, which are absent from that map, now fall back to the existing `resolveTerrId()` helper (`downtime-story.js:75-79`), which maps `_id` → territory `slug` via the module's `_currentTerritories` cache. Single line changed; the dedup and Barrens-default tail of the function are untouched. Reused the existing helper rather than inlining the regex/`cachedTerritories` lookup used by the sibling resolvers in `downtime-views.js`.
+
+**T2 — parse-check green.** `node --input-type=module --check < public/js/admin/downtime-story.js` → `parse OK` (matches the `.githooks/pre-commit` method).
+
+**Dev-side AC validation (logic simulation).** Replicated the fixed `map` step against all 29 DT4 grids from `backup_downtime_4_2026-06-18.json` using live-shaped territory docs (`{_id, slug}`). Result: **28 PASS / 0 FAIL** —
+- All 24 real-territory feeders resolve to their selected territory (Einar → The Second City; René/Casamir/Aleksei/Eve → The Second City; Margaret/Jack/Macheath/Ivana → The Academy; etc.).
+- The 4 genuine-Barrens characters (Henry St. John, Carver, Anichka, Hazel) still resolve to The Barrens.
+- Humongulus (draft, no feeding selection) → Barrens default (n/a — not a regression).
+
+Secondary impact resolves automatically: with real territory ids returned, `buildTerritoryContext`'s `id === 'barrens'` suppressions (`:2990, :3002, :3254, :3569`) no longer fire for these reports, restoring co-resident lists and territory-pulse content.
+
+### Debug Log
+
+- Confirmed the canonical territory field post-ADR-002 is `slug` (`server/schemas/territory.schema.js:30`; ADR-002 renamed legacy `id` → `slug`). `resolveTerrId` reads `t?.slug`, consistent with existing slug-dependent code in this module (territory-pulse injection `:3570`, `_terrGridVal` `:81`).
+
+### QA Notes
+
+**⚠️ Fixture trap for QA:** `data/dev-fixtures/territories.json` and the inline `TERRITORIES` in `public/js/dev-fixtures.js` are **stale** — they still carry the legacy pre-ADR-002 `id` field (`"id":"harbour"`) and have **no `slug`**. `resolveTerrId` keys off `slug`, so a Playwright/local run that feeds these fixtures as `_currentTerritories` will see `resolveTerrId` return `null` and the report will (wrongly) still show The Barrens — a false negative. QA must drive the harness with **live-shaped territory docs that include `slug`** (as in the dev simulation above). This staleness pre-dates and is orthogonal to this fix (it already breaks the territory-pulse path on localhost); flag separately if it warrants its own chore.
+
+T3 (Playwright verification harness) remains for the QA cycle — assert Einar's report renders "The Second City" with co-resident/pulse blocks, Anichka still "The Barrens" with co-residents suppressed, and a legacy slug-keyed fixture still resolves (no regression).
+
+### QA finding (Quinn, 2026-06-20) — BLOCKER: player-facing surface not reached in current code
+
+While building the harness I traced every live consumer of `_feedTerrEntries` and found the patched function's territory-name output does **not** reach a player in the current `main`/`dev` code. The fix is logically correct (re-confirmed: 28/29 sim PASS), but it appears **necessary-but-not-sufficient** for Einar's actual complaint:
+
+- `getApplicableSections` (`downtime-story.js:1148`) does **not** include `territory_reports`. `#886` ("drops redundant drafting layer", commit b64703d7) reworked the section list and the Territory Report section is no longer enumerated.
+- Therefore both name-emitting consumers are unreachable:
+  - `compilePushOutcome` `key === 'territory_reports'` branch (`:3601`, the `## ${terr.name}` heading the player reads) — **dead**: the loop iterates `getApplicableSections`.
+  - `renderTerritoryReports` (`:3216`, switch case `:1458`, save re-render `:4225`) — not rendered; `renderCharacterView` (`:1395`) and `renderProgressTracker` (`:1378`) both iterate `getApplicableSections`.
+- The only **live** `_feedTerrEntries` consumer is the Territory Pulse loop inside `feeding_validation` (`:3571`). It `continue`s when `terr.id === 'barrens'` (`:3572`). Pre-fix, real territories were misread as barrens and their pulse was **skipped**; post-fix they resolve and the pulse is emitted as `## Territory Pulse — The Second City`. This is a genuine improvement, but it never prints the literal "feeding in the barrens" Einar reported.
+- `public/js/tabs/story-tab.js` (player Story tab) holds no territory logic — it renders the compiled markdown only.
+
+**Conclusion:** no current live path prints a feeding-territory heading to the player, so Einar's literal "feeding in the barrens" is not reproducible against current `main`. Open question for Angelus: **which surface/environment did Einar see it on?** (a) a report delivered/cached under pre-#886 code where `territory_reports` was still published; (b) the Territory Pulse reading wrong/absent; (c) an untraced surface (portal readback / email digest). The answer decides whether this story also needs `territory_reports` restored to `getApplicableSections`, or whether the fix should instead be verified via the Territory Pulse output.
+
+**T3 harness deferred** pending that decision — writing an E2E now would either assert against a dead path (false green) or omit Einar's real surface. Status left at `review`.
+
+### QA resolution (Quinn, 2026-06-20) — surface identified; ticket mis-scoped
+
+Angelus confirmed the player's surface: the **feeding tab** (roll calculator / player feeding view), not the DT Story report. That is `public/js/tabs/feeding-tab.js` → `computeVitateTally` (`:498`), whose ambience block defaults to `ambience_territory = 'Barrens'` (`:527-528`) and resolves the territory from `feeding_territories`.
+
+**That function is already fixed by Peter's #920** ("feeding tab territory lookup uses _id post-migration", commit `5406f0a2`), which is **on `origin/main`/production**. `feeding-tab.js:536` now matches `(t._id && t._id === tid) || String(t.slug) === tid`; the caller passes live territory docs (`:193, :240`). So Einar's "feeding in the barrens" is resolved on production — his 11:04 report predates the deploy / a refresh.
+
+**Implication for #922:** this story patched a *different* function (`_feedTerrEntries` in `downtime-story.js`) — same root-cause class, but **not** the surface the player saw. The `_feedTerrEntries` fix is still valid and worth keeping for one **live** reason: in `compilePushOutcome` the Territory Pulse loop (`:3571-3572`) does `continue` when `terr.id === 'barrens'`, so pre-fix every real-territory feeder had their **Territory Pulse silently dropped** from the published downtime report; post-fix it resolves and the pulse is included. The `territory_reports` publish branch (`:3601`) is dead (incidental). The original AC ("player report shows The Second City not The Barrens") was wrong about the surface and should be re-pointed.
+
+**Recommendation:** re-scope #922 to "Territory Pulse dropped for real-territory feeders (`_feedTerrEntries` `_id` resolution)", keep the one-line fix, and verify via the Territory Pulse output in `compilePushOutcome`. Close the player-facing "feeding tab Barrens" concern as fixed-by-#920 (ask Einar to refresh). Decision is Angelus's.
+
+## Change Log
+
+| Date | Version | Description | Author |
+|------|---------|-------------|--------|
+| 2026-06-20 | 1.0 | Story authored from player report + DT4 export investigation and code inspection | Claude (SM) |
+| 2026-06-20 | 1.1 | T1 implemented (one-line `resolveTerrId` fallback in `_feedTerrEntries`); T2 parse-check green; dev-side AC simulation 28/29 PASS (4 genuine-Barrens preserved, 1 draft n/a). Status → review | Claude (Dev) |
+| 2026-06-20 | 1.2 | QA: surface re-scoped — Einar's feeding-tab complaint already fixed by #920 on main; this story now fixes the live Territory Pulse drop in `compilePushOutcome`. Added `tests/issue-922-...spec.js` (3/3 pass, red-green verified). Issue #922 retitled + comment added | Claude (QA) |

--- a/specs/stories/sprint-status.yaml
+++ b/specs/stories/sprint-status.yaml
@@ -1,5 +1,5 @@
 # generated: 2026-04-15
-# last_updated: 2026-06-20 (issue-918 cycle-tab-management implemented, review)
+# last_updated: 2026-06-20 (issue-922 dt-story-feeding-territory-barrens implemented, review)
 # project: TM Suite
 # project_key: NOKEY
 # tracking_system: file-system
@@ -879,3 +879,5 @@ development_status:
   proto-16-dt-processing-st-review-touched-at: done               # Write-back: co-save st_review.st_review_touched_at ISO timestamp in every saveEntryReview call; atomic with source-specific update; D1 gap closure
 
   issue-918-cycle-tab-management: review                          # Cycle tab: inline edit label/chapter, status ribbon, toggleable phases (incl. clear-to-neutral), add cycle, delete cycle + new server DELETE route
+
+  issue-922-dt-story-feeding-territory-barrens: review             # RE-SCOPED post-QA: Einar's feeding-tab complaint already fixed by #920 on main. This fixes the live Territory Pulse drop in compilePushOutcome (_feedTerrEntries _id keys collapsed real territories to barrens → pulse skipped). One-line resolveTerrId fallback; QA spec 3/3 pass red-green

--- a/tests/issue-922-dt-story-pulse-territory-resolve.spec.js
+++ b/tests/issue-922-dt-story-pulse-territory-resolve.spec.js
@@ -1,0 +1,177 @@
+/**
+ * issue-922: DT Story push — Territory Pulse dropped for real-territory feeders.
+ *
+ * Root cause: `_feedTerrEntries()` (downtime-story.js) resolved feeding-grid keys
+ * via `TERRITORY_SLUG_MAP[slug]` only. Post-ADR-002 the keys are Mongo _ids (24-hex),
+ * absent from that map, so every real-territory feed collapsed to `{ id: 'barrens' }`.
+ *
+ * Live consequence (the player-facing bug this story actually fixes): in
+ * `compilePushOutcome` the Territory Pulse loop does `continue` when
+ * `terr.id === 'barrens'` (downtime-story.js:3572). So pre-fix, every real-territory
+ * feeder had their Territory Pulse silently dropped from the pushed downtime report.
+ *
+ * Fix: `_feedTerrEntries` falls back to the existing `resolveTerrId(slug)` helper
+ * (_id -> slug via _currentTerritories) when the slug map misses.
+ *
+ * NOTE: Einar's original "feeding tab says Barrens" complaint is a SEPARATE surface
+ * (public/js/tabs/feeding-tab.js computeVitateTally) already fixed by #920 on main.
+ * This spec covers the downtime-story.js pulse path only.
+ *
+ * AC-1: Real territory by _id key — Territory Pulse for that territory is included in the push.
+ * AC-2: Genuine Barrens — no Territory Pulse heading (correctly skipped).
+ * AC-3: Legacy slug key — still resolves; pulse included (no regression).
+ *
+ * Run with: npx playwright test tests/issue-922-dt-story-pulse-territory-resolve.spec.js
+ */
+
+const { test, expect } = require('@playwright/test');
+
+// ── Identity ────────────────────────────────────────────────────────────────
+
+const ST_USER = {
+  id: '922000001', username: 'test_st_922', global_name: 'Test ST 922',
+  avatar: null, role: 'st', player_id: 'p-922', character_ids: [], is_dual_role: false,
+};
+
+// ── Territories (live shape: _id + slug) ─────────────────────────────────────
+
+const TERR_SECOND_CITY = {
+  _id: '69d9e54c00815d471503bea8', slug: 'secondcity', name: 'The Second City',
+  ambience: 'Curated', ambienceMod: 3, regent_id: null,
+};
+const ALL_TERRS = [TERR_SECOND_CITY];
+
+// ── Characters ───────────────────────────────────────────────────────────────
+
+function mkChar(id, name) {
+  return {
+    _id: id, name, moniker: null, honorific: null,
+    clan: 'Ventrue', covenant: 'Carthian Movement', player: 'Test Player',
+    blood_potency: 2, humanity: 6, humanity_base: 7, court_title: null, retired: false,
+    status: { city: 0, clan: 0, covenant: { 'Carthian Movement': 0, 'Circle of the Crone': 0, 'Invictus': 0, 'Lancea et Sanctum': 0, 'Ordo Dracul': 0 } },
+    attributes: {
+      Strength: { dots: 2, bonus: 0 }, Dexterity: { dots: 2, bonus: 0 }, Stamina: { dots: 2, bonus: 0 },
+      Intelligence: { dots: 2, bonus: 0 }, Wits: { dots: 2, bonus: 0 }, Resolve: { dots: 2, bonus: 0 },
+      Presence: { dots: 2, bonus: 0 }, Manipulation: { dots: 2, bonus: 0 }, Composure: { dots: 2, bonus: 0 },
+    },
+    skills: {}, disciplines: {}, merits: [], powers: [], ordeals: [],
+  };
+}
+
+const CHAR_EINAR    = mkChar('char-922-einar',    'Einar Solveig');
+const CHAR_ANICHKA  = mkChar('char-922-anichka',  'Anichka Test');
+const CHAR_MACHEATH = mkChar('char-922-macheath', 'Macheath Test');
+const ALL_CHARS = [CHAR_EINAR, CHAR_ANICHKA, CHAR_MACHEATH];
+
+// Cycle carries a Territory Pulse draft keyed by the Second City _id (post-ADR-002 shape).
+const CYCLE_922 = {
+  _id: 'cycle-922', cycle_number: 4, status: 'active', label: 'Downtime 4',
+  confirmed_ambience: {}, narrative_notes: '', phase_signoff: {}, deadline_at: null,
+  territory_pulse: {
+    '69d9e54c00815d471503bea8': { draft: 'The Second City hums with quiet industry this cycle.' },
+  },
+};
+
+function mkSub(id, char, feedingTerritories) {
+  return {
+    _id: id,
+    cycle_id: CYCLE_922._id,
+    character_name: char.name,
+    character_id: char._id,
+    player_name: char.player,
+    submitted_at: '2026-06-15T00:00:00Z',
+    _raw: { projects: [], feeding: null, sphere_actions: [], contact_actions: { requests: [] }, retainer_actions: { actions: [] } },
+    responses: { feeding_territories: JSON.stringify(feedingTerritories) },
+    projects_resolved: [],
+    // feeding outcome present so compilePushOutcome has content and the pulse loop runs.
+    feeding_review: { pool_status: 'validated', outcome: 'You feed where the crowds are thickest.', player_facing_note: '' },
+    merit_actions_resolved: [],
+    st_narrative: {},
+    st_review: { territory_overrides: {} },
+  };
+}
+
+// Einar — real territory by ObjectID key (the bug scenario).
+const SUB_EINAR    = mkSub('sub-922-einar',    CHAR_EINAR,    { '69d9e54c00815d471503bea8': 'feeding_rights' });
+// Anichka — genuine Barrens.
+const SUB_ANICHKA  = mkSub('sub-922-anichka',  CHAR_ANICHKA,  { the_barrens_no_territory_: 'barrens' });
+// Macheath — legacy slug key (regression; resolves via TERRITORY_SLUG_MAP).
+const SUB_MACHEATH = mkSub('sub-922-macheath', CHAR_MACHEATH, { the_second_city: 'feeding_rights' });
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+async function setup(page, submissions) {
+  await page.addInitScript(({ user }) => {
+    localStorage.setItem('tm_auth_token', 'local-test-token');
+    localStorage.setItem('tm_auth_expires', String(Date.now() + 3600000));
+    localStorage.setItem('tm_auth_user', JSON.stringify(user));
+  }, { user: ST_USER });
+
+  await page.route('http://localhost:3000/**', route => {
+    const url = route.request().url();
+    const method = route.request().method();
+    const ok = body => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+    if (['PUT', 'PATCH', 'POST'].includes(method)) return ok({ ok: true });
+    if (url.includes('/api/downtime_submissions')) return ok(submissions);
+    if (url.includes('/api/downtime_cycles'))      return ok([CYCLE_922]);
+    if (url.includes('/api/territories'))          return ok(ALL_TERRS);
+    if (url.includes('/api/characters/names'))     return ok(ALL_CHARS.map(c => ({ _id: c._id, name: c.name, moniker: c.moniker, honorific: c.honorific })));
+    if (url.includes('/api/characters'))           return ok(ALL_CHARS);
+    if (url.includes('/api/game_sessions'))        return ok([]);
+    if (url.includes('/api/session_logs'))         return ok([]);
+    return ok([]);
+  });
+
+  await page.goto('/admin.html');
+  await page.waitForSelector('#admin-app', { state: 'visible', timeout: 10000 });
+  await page.click('[data-domain="downtime"]');
+  await page.waitForSelector('#dt-phase-ribbon', { state: 'visible', timeout: 8000 });
+  await page.click('#dt-phase-ribbon .pr-tab[data-phase="story"]');
+  await page.waitForSelector('#dt-story-panel', { state: 'visible', timeout: 5000 });
+  await page.waitForFunction(() => {
+    const rail = document.getElementById('dt-story-nav-rail');
+    return rail && rail.innerHTML.length > 0;
+  }, { timeout: 5000 });
+}
+
+/** Click a character's Push button and return the compiled outcome_text from the PUT body. */
+async function pushAndCaptureOutcome(page, subId) {
+  const putPromise = page.waitForRequest(
+    req => req.method() === 'PUT' && req.url().includes(`/api/downtime_submissions/${subId}`),
+    { timeout: 8000 },
+  );
+  await page.click(`.dt-story-push-btn[data-sub-id="${subId}"]`);
+  const req = await putPromise;
+  return req.postDataJSON()['st_review.outcome_text'] || '';
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('issue-922: Territory Pulse resolves real territory in pushed outcome', () => {
+
+  // AC-1 ──────────────────────────────────────────────────────────────────────
+  test('AC-1: real territory by _id key — Territory Pulse included in push', async ({ page }) => {
+    await setup(page, [SUB_EINAR]);
+    const md = await pushAndCaptureOutcome(page, 'sub-922-einar');
+    // The fix: real territory resolves, so its pulse is emitted (pre-fix it was skipped as Barrens).
+    expect(md).toContain('## Territory Pulse — The Second City');
+    expect(md).toContain('hums with quiet industry');
+    // And it must not have collapsed to a Barrens label.
+    expect(md).not.toContain('The Barrens');
+  });
+
+  // AC-2 ──────────────────────────────────────────────────────────────────────
+  test('AC-2: genuine Barrens — no Territory Pulse heading (correctly skipped)', async ({ page }) => {
+    await setup(page, [SUB_ANICHKA]);
+    const md = await pushAndCaptureOutcome(page, 'sub-922-anichka');
+    expect(md).not.toContain('Territory Pulse');
+  });
+
+  // AC-3 ──────────────────────────────────────────────────────────────────────
+  test('AC-3: legacy slug key — pulse still resolves (no regression)', async ({ page }) => {
+    await setup(page, [SUB_MACHEATH]);
+    const md = await pushAndCaptureOutcome(page, 'sub-922-macheath');
+    expect(md).toContain('## Territory Pulse — The Second City');
+  });
+
+});


### PR DESCRIPTION
## Summary

- `_feedTerrEntries` resolved feeding-grid keys via `TERRITORY_SLUG_MAP` only, so post-ADR-002 Mongo `_id` keys collapsed to `barrens`.
- In `compilePushOutcome`, the Territory Pulse loop `continue`s on `id === 'barrens'`, so every real-territory feeder had their Territory Pulse silently dropped from the pushed downtime report.
- One-line fix: `|| resolveTerrId(slug)` fallback (reuses the existing helper) so `_id` keys resolve; legacy slug keys unchanged.
- The player's original feeding-tab "Barrens" complaint is a **separate** surface already fixed by #920 — this PR fixes the distinct pulse-drop bug found while diagnosing.

## Closes

- Closes #922

## Story

- specs/stories/fix.922.dt-story-feeding-territory-barrens.story.md

## Test plan

- [ ] `npx playwright test tests/issue-922-dt-story-pulse-territory-resolve.spec.js` (3/3; red-green verified — AC-1 fails without the fix)
- [ ] CI green
- [ ] Manual: push a downtime report for a real-territory feeder; confirm the Territory Pulse section appears for their territory

## Branch flow

- From: `morningstar-issue-922-feeding-territory-barrens`
- Into: `dev`