### PR TITLE
fix: rename or-result-close → or-result-near (follow-up to #924)

### DIFF
--- a/public/css/admin-layout.css
+++ b/public/css/admin-layout.css
@@ -3687,7 +3687,7 @@ body {
   overflow: hidden;
 }
 .or-qa-row.or-result-yes     { border-left: 3px solid var(--result-succ); }
-.or-qa-row.or-result-close   { border-left: 3px solid var(--accent); }
+.or-qa-row.or-result-near    { border-left: 3px solid var(--accent); }
 .or-qa-row.or-result-no      { border-left: 3px solid var(--crim); }
 
 .or-qa-cell {

--- a/public/css/player-layout.css
+++ b/public/css/player-layout.css
@@ -734,7 +734,7 @@ body {
   padding: 7px 10px;
 }
 .ordeal-fb-item.or-result-yes   { border-left-color: var(--green2); }
-.ordeal-fb-item.or-result-close { border-left-color: var(--accent); }
+.ordeal-fb-item.or-result-near { border-left-color: var(--accent); }
 .ordeal-fb-item.or-result-no    { border-left-color: var(--crim); }
 
 .ordeal-fb-q {
@@ -756,7 +756,7 @@ body {
   color: var(--txt3);
 }
 .or-result-yes  .ordeal-fb-result { background: var(--result-succ-bg); color: var(--green2); }
-.or-result-close .ordeal-fb-result { background: var(--accent-a8); color: var(--accent); }
+.or-result-near .ordeal-fb-result { background: var(--accent-a8); color: var(--accent); }
 .or-result-no   .ordeal-fb-result { background: var(--crim-a22); color: var(--result-pend); }
 
 .ordeal-fb-text {

--- a/public/css/suite.css
+++ b/public/css/suite.css
@@ -2475,10 +2475,10 @@ body.desktop-mode.sidebar-collapsed .sb-collapse-btn { width: 100%; justify-cont
 .ordeal-fb-overall{font-size:13px;color:var(--txt2);font-style:italic;line-height:1.5;}
 .ordeal-fb-answers{display:flex;flex-direction:column;gap:6px;}
 .ordeal-fb-item{background:var(--surf);border-left:3px solid var(--bdr);border-radius:0 4px 4px 0;padding:7px 10px;}
-.ordeal-fb-item.or-result-yes{border-left-color:var(--green2);}.ordeal-fb-item.or-result-close{border-left-color:var(--accent);}.ordeal-fb-item.or-result-no{border-left-color:var(--crim);}
+.ordeal-fb-item.or-result-yes{border-left-color:var(--green2);}.ordeal-fb-item.or-result-near{border-left-color:var(--accent);}.ordeal-fb-item.or-result-no{border-left-color:var(--crim);}
 .ordeal-fb-q{font-size:12px;color:var(--txt3);margin-bottom:3px;line-height:1.4;}
 .ordeal-fb-result{display:inline-block;font-size:10px;font-weight:600;padding:1px 5px;border-radius:3px;margin-left:6px;vertical-align:middle;background:rgba(255,255,255,.06);color:var(--txt3);}
-.or-result-yes .ordeal-fb-result{background:var(--result-succ-bg);color:var(--green2);}.or-result-close .ordeal-fb-result{background:var(--accent-a8);color:var(--accent);}.or-result-no .ordeal-fb-result{background:var(--crim-a22);color:var(--result-pend);}
+.or-result-yes .ordeal-fb-result{background:var(--result-succ-bg);color:var(--green2);}.or-result-near .ordeal-fb-result{background:var(--accent-a8);color:var(--accent);}.or-result-no .ordeal-fb-result{background:var(--crim-a22);color:var(--result-pend);}
 .ordeal-fb-text{font-size:13px;color:var(--txt2);line-height:1.5;}
 
 /* ── Split sheet tabs ── */

--- a/public/js/admin/ordeals-admin.js
+++ b/public/js/admin/ordeals-admin.js
@@ -248,7 +248,7 @@ function renderRight() {
     if (!isComplete) {
       h += `<div class="or-qa-mark-row">`;
       h += `<div class="or-ync-btns" data-sub-id="${esc(sub._id)}" data-idx="${i}">`;
-      for (const [val, label] of [['yes', 'Yes'], ['close', 'Close'], ['no', 'No']]) {
+      for (const [val, label] of [['yes', 'Yes'], ['near', 'Near'], ['no', 'No']]) {
         h += `<button class="or-ync-btn${result === val ? ' active' : ''}" data-result="${val}">${label}</button>`;
       }
       h += '</div>';


### PR DESCRIPTION
## Summary

- CSS class `or-result-close` renamed to `or-result-near` in `admin-layout.css`, `player-layout.css`, and `suite.css`
- Button val/label `'close'`/`'Close'` → `'near'`/`'Near'` in `ordeals-admin.js`

These were left uncommitted when #924 was merged. Aligns the CSS class names and admin button values with the canonical `near` result enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)