### PR TITLE
fix(ordeals): use running counter qi to pair verdicts to form questions

### DIFF
--- a/public/js/tabs/ordeal-form.js
+++ b/public/js/tabs/ordeal-form.js
@@ -170,6 +170,10 @@ function renderForm(container) {
   }
 
   // Sections
+  // qi = flat 0-based question index across all sections; matches rubric question_index exactly
+  // (rubric indices are assigned per question in form order, including split sub-questions like
+  // Q10a/Q10b). Incrementing at the TOP of the loop keeps it in sync even when `continue` fires.
+  let qi = -1;
   for (const section of currentSections) {
     h += '<div class="qf-section">';
     h += `<h4 class="qf-section-title">${esc(section.title)}</h4>`;
@@ -178,14 +182,10 @@ function renderForm(container) {
     }
 
     for (const q of section.questions) {
+      qi++;
       if (readOnly) {
         const val = saved[q.key] || '';
-        // Issue #930: pair the verdict/feedback to this question by its OWN number — on real data the
-        // marking's question_index is (question number - 1) (Q1 -> 0). An unnumbered label (a bonus
-        // question) is ungraded, so it gets no verdict; never pair by raw position (it could collide with a
-        // real graded answer's index).
-        const n = parseInt((String(q.label).match(/^\s*(\d+)/) || [])[1], 10);
-        const mark = (graded && Number.isInteger(n)) ? markAnswers.find(a => a.question_index === n - 1) : null;
+        const mark = graded ? markAnswers.find(a => a.question_index === qi) : null;
         if (!val && !mark) continue;
         h += `<div class="qf-field">`;
         h += `<label class="qf-label">${esc(q.label)}</label>`;


### PR DESCRIPTION
## Summary

- Replaces `n-1` label-integer extraction in `ordeal-form.js` read-only rendering with a flat 0-based running counter `qi` that matches rubric `question_index` exactly
- Fixes Rules Mastery verdict display: Q10a and Q10b both extracted `n=10`, causing Q10b to display Q10a's verdict and shifting all verdicts from Q11 onward by −1
- Also sets up correct pairing for the Lore Q27-Q44 fix once the unlabelled rubric entry at index 26 is removed (tracked in #933)

## Root cause

`ordeal-form.js:188` (introduced in #930) extracted the leading integer from each question label and used `question_index === n - 1`. This breaks for Q10a/Q10b because both labels start with "10", producing the same `n` value for two distinct rubric entries. The running counter avoids any label parsing — it simply increments once per form question in traversal order, which is identical to how the cockpit assigns `question_index` values.

## Test plan

- [ ] Log in as a player with a Rules Mastery ordeal in `in_progress` / graded state
- [ ] Open the ordeal view — confirm Q10a and Q10b each show their own distinct verdict
- [ ] Confirm Q13 near shows feedback about out-of-clan Disciplines (was showing under Q14 before this fix)
- [ ] Confirm Q14 shows "Yes" (was blank / shifted before)
- [ ] Confirm no regression on Q1-Q9 verdicts
- [ ] Lore ordeal: Q1-Q26 verdicts unaffected; Q27+ remains misaligned until #933's DB fix

Closes: partial — Rules display fixed here; Lore tracked in #933.

🤖 Generated with [Claude Code](https://claude.com/claude-code)