### PR TITLE
hotfix: strip c.assets from save paths (cycle-blocker)

### DIFF
--- a/public/js/admin.js
+++ b/public/js/admin.js
@@ -959,7 +959,7 @@ function buildSaveBody(c) {
   // namespace), and c.derived (render-time materialised cache from ADR-006; never stored).
   const body = {};
   for (const [k, v] of Object.entries(c)) {
-    if (k === '_id' || k.startsWith('_') || k === 'current' || k === 'derived'
+    if (k === '_id' || k.startsWith('_') || k === 'current' || k === 'derived' || k === 'assets'
         || _LEGACY_FIELDS.has(k) || _DEPRECATED_FIELDS.has(k)) continue;
     body[k] = v;
   }

--- a/public/js/editor/export.js
+++ b/public/js/editor/export.js
@@ -58,6 +58,11 @@ export function charsForSave() {
     // never stored. Strip before localStorage stash so a fresh boot
     // recomputes from base values without carrying stale derived state.
     delete copy.derived;
+    // PR #902 (2026-06-19): character.assets[] removed from the schema,
+    // consolidated into equipment[]. Existing prod docs may still carry
+    // an assets field — strip it on save so a stale field doesn't fail
+    // additionalProperties: false on the next PUT round-trip.
+    delete copy.assets;
     if (copy.merits) {
       for (let i = copy.merits.length - 1; i >= 0; i--) {
         if (copy.merits[i].derived) {


### PR DESCRIPTION
**URGENT** — character save broken with AJV `additionalProperty: assets` rejection after adding equipment. Yusuf cannot save.

## Root cause

PR #902 (2026-06-19) removed `character.assets[]` from the schema and routes (consolidated into `equipment[]` via catalogue bucket: 'asset'). Existing prod character docs still carry the old `assets` field on disk. When client GETs a character, the field comes through; client modifies + PUTs back; schema rejects under `additionalProperties: false`.

Same shape as the `c.derived` hotfix #898 — schema removed a field but save body wasn't taught to strip it.

## Fix

Two-line strip:
- `admin.js` `buildSaveBody`: add `k === 'assets'` to the skip predicate.
- `editor/export.js` `charsForSave`: `delete copy.assets` after `stripOverlay`.

## Verification

Local: stripped body matches the post-#902 character schema. No `assets` field round-trips.

## Follow-up debt

Issue #900 already tracks adding static-analysis test for `derived` strip; widening to include `assets` after merge. A small one-shot cleanup script can drop the stale `assets` field from every character doc in prod — same pattern as the `xp_total` / `xp_spent` cleanup. Filing as a follow-up after this hotfix lands; not blocking tonight.

Per CLAUDE.md HARD RULE — not pushed to main yet. Awaiting per-message main promotion authorisation. — Khepri (SM)