### PR TITLE
Make Personal Story optional; clarify Vamping text (#939)

### DIFF
--- a/public/js/data/dt-completeness.js
+++ b/public/js/data/dt-completeness.js
@@ -35,24 +35,10 @@ function _hasAnyGameRecount(responses) {
   return isNonEmptyString(responses.game_recount);
 }
 
-function _hasPersonalStory(responses) {
-  // dt-form.18 (HALT-DAR-A option 2 — lenient): both shapes pass.
-  //   - New canonical (post-#18): `personal_story_kind` (touchstone |
-  //     correspondence) + `personal_story_text`.
-  //   - Legacy ADVANCED: free-text NPC name/id + interaction note. Pre-
-  //     redesign drafts pass without re-engaging the new binary UI.
-  // ADR §Q1 makes ADVANCED a superset of MINIMAL. Either shape is a valid
-  // signal that the player has filled in their Personal Story for the cycle.
-  const hasMinimalKind = isNonEmptyString(responses.personal_story_kind);
-  const hasMinimalText = isNonEmptyString(responses.personal_story_text);
-  const hasLegacyWho   = isNonEmptyString(responses.personal_story_npc_name)
-                      || isNonEmptyString(responses.personal_story_npc_id);
-  const hasLegacyWhat  = isNonEmptyString(responses.personal_story_note)
-                      || isNonEmptyString(responses.story_moment_note)
-                      || isNonEmptyString(responses.osl_moment)
-                      || isNonEmptyString(responses.correspondence);
-  return (hasMinimalKind && hasMinimalText) || (hasLegacyWho && hasLegacyWhat);
-}
+// Issue #939: Personal Story (Off-Screen Life) is now OPTIONAL. It was
+// previously gated by a _hasPersonalStory() check here; that helper and its
+// callers (isMinimalComplete + missingMinimumPieces) were removed so a blank
+// Personal Story no longer holds a player's downtime XP credit.
 
 function _hasFeedingTerritory(responses) {
   // feeding_territories is a JSON-stringified map of slug → state. Any slug
@@ -105,7 +91,7 @@ export function isMinimalComplete(responses, ctx = {}) {
   const { isRegent = false, regencyConfirmed = false, attended = true } = ctx;
 
   if (attended && !_hasAnyGameRecount(responses)) return false;
-  if (!_hasPersonalStory(responses)) return false;
+  // Issue #939: Personal Story no longer gates minimum-complete (optional).
   if (!_hasFeedingComplete(responses)) return false;
   if (!_hasFirstProject(responses)) return false;
   if (isRegent && !regencyConfirmed) return false;
@@ -123,7 +109,6 @@ export function missingMinimumPieces(responses, ctx = {}) {
   const out = [];
   if (!responses || typeof responses !== 'object') {
     out.push({ section: 'court', label: 'Fill in your game recount' });
-    out.push({ section: 'personal_story', label: 'Personal Story: pick Touchstone or Correspondence and describe it' });
     out.push({ section: 'feeding', label: 'Pick a feeding territory, method, blood type, and Kiss/Violent toggle' });
     out.push({ section: 'projects', label: 'Pick an action for Project 1' });
     return out;
@@ -133,9 +118,7 @@ export function missingMinimumPieces(responses, ctx = {}) {
   if (attended && !_hasAnyGameRecount(responses)) {
     out.push({ section: 'court', label: 'Game Recount: add at least one highlight from last session' });
   }
-  if (!_hasPersonalStory(responses)) {
-    out.push({ section: 'personal_story', label: 'Personal Story: pick Touchstone or Correspondence and describe it' });
-  }
+  // Issue #939: Personal Story is optional — not listed as a missing piece.
   if (!_hasFeedingTerritory(responses)) {
     out.push({ section: 'feeding', label: 'Feeding: pick a territory to hunt in' });
   }

--- a/public/js/tabs/downtime-data.js
+++ b/public/js/tabs/downtime-data.js
@@ -242,7 +242,7 @@ export const DOWNTIME_SECTIONS = [
   // historically lived). Rendered by the custom personal-story renderer.
   {
     key: 'personal_story',
-    title: 'Personal Story: Off-Screen Life',
+    title: 'Personal Story: Off-Screen Life (optional)',
     gate: null,
     intro: null,
     questions: [
@@ -400,7 +400,7 @@ export const DOWNTIME_SECTIONS = [
         label: 'Anything you want the STs to know about the other things your character gets up to?',
         type: 'textarea',
         required: false,
-        desc: 'Soft RP, general flavour, non-mechanical activities, personal habits, quirks, or fun. This section won\'t generate rolls but informs ST narration and may influence ongoing plots.\n\nExample: "Konstantin spends most nights at the casino, cultivating his image as a wealthy eccentric. He\'s been composing a letter to his sire that he never sends."',
+        desc: 'This is just to let the STs know what your character gets up to: soft RP, general flavour, non-mechanical activities, personal habits, quirks, or fun. It is informational only. It will not generate rolls, and you will not get content or a written response back from the STs about it. It may quietly inform ST narration and ongoing plots.\n\nExample: "Konstantin spends most nights at the casino, cultivating his image as a wealthy eccentric. He\'s been composing a letter to his sire that he never sends."',
       },
       {
         key: 'aspirations',

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -539,9 +539,9 @@ function collectResponses() {
   // name. Collect writes `_kind` + `_text` + `_npc_name`. Does NOT write
   // `_npc_id` (no picker = no DB ID) nor legacy `_note` / `_direction`
   // (the new `_text` replaces the note; the rich-UI direction radios are
-  // gone). Pre-redesign drafts retain the old keys via the spread base, so
-  // isMinimalComplete's lenient gate (dt-completeness.js _hasPersonalStory)
-  // keeps recognising them.
+  // gone). Pre-redesign drafts retain the old keys via the spread base for
+  // ST admin views. (Issue #939: Personal Story no longer gates
+  // minimum-complete — it is optional.)
   const psKindEl = document.querySelector('input[name="dt-personal_story_kind"]:checked');
   const psNpcEl  = document.getElementById('dt-personal_story_npc_name');
   const psTextEl = document.getElementById('dt-personal_story_text');
@@ -4528,7 +4528,7 @@ function renderPersonalStorySection(saved) {
   let h = '<div class="qf-section collapsed" data-section-key="personal_story">';
   h += `<h4 class="qf-section-title">${esc(section.title)}<span class="qf-section-tick">✔</span></h4>`;
   h += '<div class="qf-section-body">';
-  h += '<p class="qf-section-intro">Pick one personal-story beat for this cycle: a touchstone moment that anchors your humanity, or a correspondence with someone off-screen.</p>';
+  h += '<p class="qf-section-intro">Optional. If you like, add one personal-story beat for this cycle: a touchstone moment that anchors your humanity, or a correspondence with someone off-screen. You can leave this blank and still submit your downtime.</p>';
 
   h += '<div class="qf-field">';
   h += '<div class="qf-radio-group" role="radiogroup" aria-label="Personal Story kind">';
@@ -6851,8 +6851,10 @@ function updateSectionTicks(container) {
       return;
     }
 
-    // #637: personal_story — match the submit gate (_hasPersonalStory = kind && text). The
-    // generic "all qf-fields filled" fallback would wrongly require the OPTIONAL NPC name too.
+    // #637 / #939: personal_story tick is cosmetic only — Personal Story is now
+    // OPTIONAL and no longer gates submission. The tick still lights when kind +
+    // text are filled; the generic "all qf-fields filled" fallback would wrongly
+    // require the OPTIONAL NPC name too, so this explicit rule stays.
     if (key === 'personal_story') {
       const kindChecked = !!body.querySelector('input[name="dt-personal_story_kind"]:checked');
       const textEl = document.getElementById('dt-personal_story_text');

--- a/server/tests/issue-939-personal-story-optional.test.js
+++ b/server/tests/issue-939-personal-story-optional.test.js
@@ -1,0 +1,65 @@
+/**
+ * Unit tests — issue #939: Personal Story (Off-Screen Life) is no longer part
+ * of the minimum-complete gate. A submission with a blank Personal Story must
+ * still be minimum-complete (so its XP credit is not held), and Personal Story
+ * must never appear in missingMinimumPieces. The other minimum rules (game
+ * recount, feeding, project 1, regency-if-regent) must still gate.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { isMinimalComplete, missingMinimumPieces } from '../../public/js/data/dt-completeness.js';
+
+// A responses bag that satisfies every minimum rule EXCEPT Personal Story.
+function completeMinusPersonalStory() {
+  return {
+    game_recount_1: 'Confronted the Prince at Elysium.',
+    feeding_territories: JSON.stringify({ 'kings-cross': 'open' }),
+    _feed_method: 'hunt',
+    _feed_blood_types: JSON.stringify(['mortal']),
+    feed_violence: 'kiss',
+    project_1_action: 'investigate',
+  };
+}
+
+describe('dt-completeness — Personal Story optional (issue #939)', () => {
+  it('isMinimalComplete is true with a blank Personal Story when other pieces are present', () => {
+    expect(isMinimalComplete(completeMinusPersonalStory())).toBe(true);
+  });
+
+  it('missingMinimumPieces does not list personal_story (live branch)', () => {
+    const missing = missingMinimumPieces(completeMinusPersonalStory());
+    expect(missing.some(p => p.section === 'personal_story')).toBe(false);
+  });
+
+  it('missingMinimumPieces does not list personal_story (null-responses fallback)', () => {
+    const missing = missingMinimumPieces(null);
+    expect(missing.some(p => p.section === 'personal_story')).toBe(false);
+  });
+
+  // Regression — the OTHER minimum rules must still gate.
+  it('still requires a game recount', () => {
+    const r = completeMinusPersonalStory();
+    delete r.game_recount_1;
+    expect(isMinimalComplete(r)).toBe(false);
+    expect(missingMinimumPieces(r).some(p => p.section === 'court')).toBe(true);
+  });
+
+  it('still requires feeding to be complete', () => {
+    const r = completeMinusPersonalStory();
+    delete r.feed_violence;
+    expect(isMinimalComplete(r)).toBe(false);
+    expect(missingMinimumPieces(r).some(p => p.section === 'feeding')).toBe(true);
+  });
+
+  it('still requires project 1', () => {
+    const r = completeMinusPersonalStory();
+    delete r.project_1_action;
+    expect(isMinimalComplete(r)).toBe(false);
+    expect(missingMinimumPieces(r).some(p => p.section === 'projects')).toBe(true);
+  });
+
+  it('still requires regency confirmation for a regent', () => {
+    expect(isMinimalComplete(completeMinusPersonalStory(), { isRegent: true, regencyConfirmed: false })).toBe(false);
+    expect(isMinimalComplete(completeMinusPersonalStory(), { isRegent: true, regencyConfirmed: true })).toBe(true);
+  });
+});

--- a/specs/stories/issue-939-personal-story-optional.story.md
+++ b/specs/stories/issue-939-personal-story-optional.story.md
@@ -1,0 +1,137 @@
+# Issue #939: Make Personal Story (Off-Screen Life) optional; clarify Vamping text
+
+Status: review
+<!-- Implemented + verified headless (node --check x3, dt-completeness unit suite 7/7, hold-flag + territory suites green; no spec asserts the changed copy). Open gate: in-browser smoke on dev (Angelus cannot test locally). -->
+
+issue: 939
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/939
+branch: ms/issue-939-personal-story-optional
+
+## Story
+
+As a player submitting a downtime,
+I want Personal Story (Off-Screen Life) to be optional — and the Vamping section to clearly say it's informational-only —
+so that I'm not forced to write an off-screen beat to keep my downtime XP credit, and I understand Vamping won't get a reply from the STs.
+
+## Background / why now
+
+Personal Story (Off-Screen Life) is currently part of the **minimum-complete** gate: leave it blank and the form shows "your downtime XP credit is on hold." The ST (Angelus) wants it optional. Separately, the Vamping section's help text doesn't make clear that it's informational-only — players read it as something the STs will respond to, when in fact STs only take note (no content returned).
+
+Single cohesive story (two small, related edits to the same downtime-form surface): one logic change (drop Personal Story from the completeness gate) plus copy changes to two section texts.
+
+## Current behaviour (files read)
+
+**`public/js/data/dt-completeness.js`** (read in full) — the single source of truth for "minimum-complete":
+- `_hasPersonalStory(responses)` (L38-55) — true when `personal_story_kind` + `personal_story_text` present, OR a legacy who+what pair.
+- `isMinimalComplete` (L103-113) — **L108 `if (!_hasPersonalStory(responses)) return false;`** is the mandatory gate.
+- `missingMinimumPieces` (L122-158) — pushes a `personal_story` entry in the null-responses fallback (**L126**) and in the live branch (**L136-138**). This list drives the "XP credit on hold" banner's missing-pieces UI.
+- `_hasPersonalStory` is module-local; its ONLY callers are L108 and L136. Removing both makes it dead → remove the function too.
+
+**`public/js/tabs/downtime-form.js`** (read):
+- Personal Story render: section open L4528, intro **L4531** ("Pick one personal-story beat for this cycle: a touchstone moment that anchors your humanity, or a correspondence with someone off-screen."), kind radios L4534-4541, optional NPC name L4549-4550, textarea label L4554 + textarea L4557.
+- Min-complete banner L2022-2069 — consumes `missingMinimumPieces` (so removing the gate auto-removes it from the banner).
+- Section-tick gate L6854-6861 — independently lights the green tick when `personal_story_kind` + text are set. This is cosmetic (not a submit block); leave as-is (an optional section can still show a tick when filled).
+
+**`public/js/tabs/downtime-data.js`** (read):
+- Personal Story section title L245 "Personal Story: Off-Screen Life".
+- Vamping section L390-413: title "Vamping: Fever for the Flavour" (L394); main field L399-404 label "Anything you want the STs to know about the other things your character gets up to?" with desc (L403) "Soft RP, general flavour, non-mechanical activities, personal habits, quirks, or fun. This section won't generate rolls but informs ST narration and may influence ongoing plots." — does NOT say the player gets nothing back.
+
+**Other consumers to verify (don't break):**
+- `public/js/data/dt-hold-flag.js` — computes the XP-hold flag from completeness. Confirm it relies on `isMinimalComplete`/`missingMinimumPieces` and needs no separate personal_story reference.
+- `server/schemas/downtime_submission.schema.js` — grep hit; confirm it does NOT server-side-enforce personal_story (the module is currently client-only per its header comment).
+- Existing specs/tests that may assert the old mandatory behaviour: `tests/issue-24-story-freetext.spec.js`, `server/tests/dt-form-territory-fresh-fetch.test.js`. Update any assertion that requires Personal Story for completeness.
+
+## Decisions (locked)
+
+1. Personal Story stays **visible and fully usable** — it just no longer gates minimum-complete.
+2. Direction: remove the `_hasPersonalStory` checks from the completeness gate (not a feature-flag).
+3. Vamping behaviour is unchanged (already `required:false`, non-mechanical); only its help text changes.
+4. UI copy reuses existing classes (`.qf-section-intro`, `.qf-label`, `.qf-textarea`); no inline `style=`, no new CSS, British/Australian spelling, no em-dashes.
+
+## Acceptance Criteria
+
+1. Given a submission with no Personal Story (no `personal_story_kind`/`personal_story_text` and no legacy pair), `isMinimalComplete(responses, ctx)` returns true when the other minimum pieces (game recount, feeding, project 1, regency-if-regent) are present.
+2. `missingMinimumPieces` never returns a `personal_story` entry (neither the null-responses fallback nor the live branch).
+3. The "downtime XP credit is on hold" banner does not appear solely because Personal Story is blank.
+4. The Personal Story section text explicitly states it is **optional**.
+5. The Vamping section text explicitly states it is **informational-only** and that the player will **not** receive content / a written response back from the STs.
+6. No regression to the other minimum-complete rules (court/feeding/projects/regency) or to Personal Story rendering when it IS filled.
+7. Copy uses design-system classes and tokens (no inline `style=`, no bare hex). British/Australian spelling, no em-dashes.
+
+## Tasks / Subtasks
+
+- [x] **Task 1 — Drop Personal Story from the completeness gate (AC: 1,2,3,6).**
+  - [x] `dt-completeness.js`: removed the `_hasPersonalStory` check from `isMinimalComplete`; removed the `personal_story` push from `missingMinimumPieces` (null-responses fallback + live branch); removed the now-dead `_hasPersonalStory` helper (replaced with a #939 note).
+  - [x] Added `server/tests/issue-939-personal-story-optional.test.js` — 7/7 green: blank Personal Story is now complete; personal_story never in `missingMinimumPieces`; game-recount / feeding / project-1 / regency still gate.
+  - [x] Verified consumers: `dt-hold-flag.js` reads the server `/hold-flags` map (no PS ref); the server endpoint (`downtime.js:710-741`) only READS the stored `responses._has_minimum`; the client writes `_has_minimum = isMinimalComplete(...)` (`downtime-form.js:1156-1157`), so the gate change propagates to the persisted flag on next save. Schema declares `personal_story` as an allowed (not required) field. No test asserted the old mandatory behaviour (`dt-form-territory-fresh-fetch` stubs the module; `issue-24` checks rendering/tick only).
+- [x] **Task 2 — Personal Story text says optional (AC: 4,7).**
+  - [x] Reworded the intro (`downtime-form.js:4531`) to lead with "Optional." and "You can leave this blank and still submit your downtime"; added "(optional)" to the section title (`downtime-data.js:245`). Reuses `.qf-section-intro`/`.qf-section-title`. Also tidied a stale `_hasPersonalStory` comment at `downtime-form.js:543`.
+- [x] **Task 3 — Vamping text says informational-only (AC: 5,7).**
+  - [x] Reworded the Vamping field desc (`downtime-data.js:403`) to state it is just to let the STs know what the character gets up to, that it is informational only, and that the player will not get content or a written response back. Example retained.
+- [x] **Task 4 — Verify (AC: 6).** `node --check` clean on all 3 frontend files; `dt-completeness` suite 7/7; `dt-form-territory-fresh-fetch` + `api-downtime-hold-flags` green (19 tests total); no spec asserts the changed copy. In-browser smoke on `dev` is the open gate (cannot test locally).
+
+## Dev Notes
+
+- The gate is the ONLY hard enforcement. The section-tick (downtime-form.js:6856) is cosmetic — safe to leave; an optional section showing a tick when filled is fine.
+- `dt-completeness.js` is pure ESM (no DOM) and unit-testable directly — that's where the headless test belongs.
+- Keep the legacy-shape tolerance out of scope: since the whole personal_story check is removed from the gate, the legacy who/what branch in `_hasPersonalStory` goes away with the function. No data migration.
+- Copy: British/Australian spelling, no em-dashes (project conventions). Vamping wording should be unambiguous that STs take note but do not reply with content.
+
+### Project Structure Notes
+
+- Frontend-only. No server route or schema changes (verify the schema grep hit is not an enforcement). No DB writes.
+
+### References
+
+- `public/js/data/dt-completeness.js` — `_hasPersonalStory` L38-55, `isMinimalComplete` L108, `missingMinimumPieces` L126 + L136-138
+- `public/js/tabs/downtime-form.js` — Personal Story intro L4531 (render L4528-4557), min-complete banner L2022-2069, section-tick L6854-6861
+- `public/js/tabs/downtime-data.js` — Personal Story title L245, Vamping section L390-413 (desc L403)
+- Consumers: `public/js/data/dt-hold-flag.js`, `server/schemas/downtime_submission.schema.js`
+- Issue: https://github.com/angelusvmorningstar/TerraMortis/issues/939
+
+## QA Results (Quinn, 2026-06-27)
+
+**Gate: PASS** (headless) — clear to deploy to `dev`. In-browser smoke is the only remaining confirmation (deploy-gated).
+
+**Regression:** 103 tests green across 9 suites touching the changed modules / hold path — including the DB-backed `api-downtime-hold-flags` and `epic.708.6-attendance-xp-absorption`. `node --check` clean on all changed files. New `dt-completeness` unit suite 7/7.
+
+**Edge cases reviewed:**
+- Gate now = game-recount (if attended) + feeding + project 1 + regency-if-regent; Personal Story removed from both `isMinimalComplete` and `missingMinimumPieces` (incl. the null-responses fallback). Other rules verified still gating (negative tests).
+- No live code references the removed `_hasPersonalStory` — only comments remained; the stale ones (`downtime-form.js:543` and the section-tick comment `:6854`) were tidied. Cosmetic section-tick behaviour unchanged (lights when filled; an optional section showing a tick is fine).
+- Hold path: `_has_minimum` is written client-side from `isMinimalComplete` and only read back by the server `/hold-flags` endpoint — so the change correctly lifts the XP hold on save. Schema declares `personal_story` allowed (not required) — no server enforcement.
+- Copy: British/Australian spelling retained ("flavour"), no em-dashes; reuses existing component classes.
+
+**Low-severity note (non-blocking):**
+1. `_has_minimum` is a save-time snapshot. Submissions already on hold *solely* because Personal Story was blank will not auto-flip to "not on hold" until the player re-opens and saves the form (recomputing the flag). For a live cycle this is self-healing on next save; a one-off backfill is only needed if STs want existing holds cleared without a player re-save.
+
+**Smoke for `dev` (open gate):** submit a downtime with the other minimum pieces present but Personal Story blank → confirm no "downtime credit on hold" and that the optional/Vamping wording reads correctly.
+
+## Dev Agent Record
+
+### Agent Model Used
+
+claude-opus-4-8 (BMAD dev-story, Amelia)
+
+### Debug Log References
+
+- `dt-completeness` test: RED 4 fail / 3 pass → GREEN 7/7 (`server/tests/issue-939-personal-story-optional.test.js`).
+- `node --check` clean on `dt-completeness.js`, `downtime-form.js`, `downtime-data.js`.
+- Verify run: `issue-939` + `dt-form-territory-fresh-fetch` + `api-downtime-hold-flags` → 19/19 green.
+
+### Completion Notes List
+
+- **Architecture confirmed:** `_has_minimum` is computed client-side via `isMinimalComplete` (`downtime-form.js:1156-1157`) and persisted on the submission; the server `/hold-flags` endpoint only reads the stored boolean. So `dt-completeness.js` is the single correct seam — the change lifts the XP hold on the player's next save and removes Personal Story from the on-hold banner's missing-pieces list.
+- Personal Story remains visible and fully usable; only its gating + copy changed. The cosmetic section-tick still lights when filled (left as-is).
+- British/Australian spelling, no em-dashes; copy reuses existing component classes (no new CSS, no new inline styles introduced).
+- No DB writes, no server route/schema changes, no new dependencies.
+
+### File List
+
+- `public/js/data/dt-completeness.js` (modified) — removed Personal Story from `isMinimalComplete` + `missingMinimumPieces`; removed dead `_hasPersonalStory`
+- `public/js/tabs/downtime-form.js` (modified) — Personal Story intro reworded to "optional"; tidied stale comment
+- `public/js/tabs/downtime-data.js` (modified) — Personal Story title "(optional)"; Vamping desc reworded to informational-only / no content back
+- `server/tests/issue-939-personal-story-optional.test.js` (new) — completeness unit tests
+
+### Change Log
+
+- 2026-06-27: Personal Story (Off-Screen Life) made optional (removed from minimum-complete gate); Personal Story + Vamping help text clarified. Frontend + pure completeness module only; no server/DB changes. Unit tests 7/7; verify suite 19/19. In-browser smoke pending dev deploy.

--- a/specs/stories/sprint-status.yaml
+++ b/specs/stories/sprint-status.yaml
@@ -32,7 +32,7 @@
 # - DT Fixes: new epic — bugs, quick features, feeding panel parity, DT Story pill fix
 
 generated: 2026-04-15
-last_updated: 2026-06-27 (issue-937 implemented, review; manoeuvres-in-downtime resolved out of scope (option a); in-browser smoke on dev is the open gate)
+last_updated: 2026-06-27 (issue-939 implemented + verified, review; in-browser smoke on dev is the open gate)
 project: TM Suite
 project_key: NOKEY
 tracking_system: file-system
@@ -888,4 +888,6 @@ development_status:
 
   fix-933-lore-rubric-index26: done                         # DB migration script: remove unlabelled scored:false entry at index 26 from ordeal_rubrics.lore_mastery (retired Q20 duplicate), decrement question_index >= 27 in all ordeal_responses lore markings by 1. Fixes Q27-Q44 verdict pairing in player lore ordeal view. Script written by Angelus, executed by Peter. No suite code changes (ordeal-form.js qi fix landed in PR #934).
 
-  issue-937-merit-dropdown-fighting-styles: review        # Surface fighting styles + manoeuvres in the Merit dropdown (sheet) and downtime XP picker (under Merit category), routed to fighting_styles/fighting_picks (Direction A, storage unchanged); un-hide the 13 parent:'Style' merits; fix prereq.js merit-leaf to read c.fighting_styles by effective dots (unblocks Iron Skin). Decisions locked: both styles+manoeuvres, un-hide here, within Merit category. Frontend + shared prereq engine; no DB/server changes.
+  issue-937-merit-dropdown-fighting-styles: review
+
+  issue-939-personal-story-optional: review              # Make Personal Story (Off-Screen Life) optional: drop _hasPersonalStory from the minimum-complete gate in dt-completeness.js (isMinimalComplete L108 + missingMinimumPieces L126/L136-138); reword Personal Story intro to say optional; reword Vamping desc to say informational-only (no content back from STs). Frontend-only, no DB/server changes.        # Surface fighting styles + manoeuvres in the Merit dropdown (sheet) and downtime XP picker (under Merit category), routed to fighting_styles/fighting_picks (Direction A, storage unchanged); un-hide the 13 parent:'Style' merits; fix prereq.js merit-leaf to read c.fighting_styles by effective dots (unblocks Iron Skin). Decisions locked: both styles+manoeuvres, un-hide here, within Merit category. Frontend + shared prereq engine; no DB/server changes.


### PR DESCRIPTION
Closes #939.

## What

- **Personal Story (Off-Screen Life) is now optional** — removed from the minimum-complete gate, so a blank Personal Story no longer holds a player's downtime XP credit or appears in the "credit on hold" missing-pieces banner.
- **Clarified copy:** Personal Story intro/title now say it's optional; the **Vamping** help text now states it is informational-only and that the player will not get content or a written response back from the STs.

## Changes

- `public/js/data/dt-completeness.js` — drop `_hasPersonalStory` from `isMinimalComplete` + `missingMinimumPieces`; remove the now-dead helper.
- `public/js/tabs/downtime-form.js` — Personal Story intro reworded to "optional"; tidy stale `_hasPersonalStory` comments (the section-tick is cosmetic now).
- `public/js/tabs/downtime-data.js` — section title "(optional)"; Vamping desc reworded.
- `server/tests/issue-939-personal-story-optional.test.js` — new unit tests.

The persisted `_has_minimum` is computed client-side via `isMinimalComplete` and only read back by the server `/hold-flags` endpoint, so the gate change lifts the XP hold on the player's next save. No server/schema/DB changes.

## Test plan

- New `dt-completeness` unit suite: 7/7 (blank Personal Story is complete; never in missing-pieces; recount / feeding / project-1 / regency still gate).
- Regression: 103 tests green across 9 suites touching the changed modules + hold path (incl. DB-backed `api-downtime-hold-flags`, attendance-XP). `node --check` clean.
- **In-browser smoke (deploy-gated):** submit a downtime with the other minimum pieces but Personal Story blank → confirm no "downtime credit on hold"; check the optional + Vamping wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)