### PR TITLE
hotfix: surface Carthian Law merits in XP-spend + sheet pickers

### DIFF
--- a/public/js/editor/merits.js
+++ b/public/js/editor/merits.js
@@ -314,7 +314,11 @@ export function buildMeritOptions(c, currentName) {
       if (rule.sub_category && rule.sub_category !== 'general') continue;
       if (INFLUENCE_MERIT_TYPES.includes(rule.name)) continue;
       // Issue #937: 'Style'-parent merits are plain merits — surface them.
-      if (rule.parent && ['Invictus Oath', 'Carthian Law'].includes(rule.parent)) continue;
+      // 2026-06-30: 'Carthian Law' also removed. Carthian Laws are merits with
+      // status-based prereqs and belong in the regular picker; the Pacts UI
+      // continues to list them too as an alternate path. See parallel change
+      // in downtime-form.js so DT XP-spend and sheet pickers stay aligned.
+      if (rule.parent && ['Invictus Oath'].includes(rule.parent)) continue;
       if (!meritPrereqOK(c, rule)) continue;
       const excl = _isExcluded(c, rule.name);
       if (excl && rule.name.toLowerCase() !== (currentName || '').toLowerCase()) continue;

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -4189,9 +4189,14 @@ function getItemsForCategory(category) {
         for (const rule of meritRules) {
           // Issue #937: 'Style'-parent merits (Body As Weapon, Survivalist, etc.)
           // are ordinary 1 XP/dot merits — surface them. Fighting STYLES proper
-          // (Street Fighting etc.) are injected after this loop. Invictus Oath /
-          // Carthian Law remain sub-system-managed and stay excluded.
-          if (rule.parent && ['Invictus Oath', 'Carthian Law'].includes(rule.parent)) continue;
+          // (Street Fighting etc.) are injected after this loop.
+          // 2026-06-30: 'Carthian Law' also removed from this exclusion list.
+          // Carthian Laws are merits with status-based prereqs (per VtR 2e) and
+          // belong in the regular XP-purchase picker. The Pacts UI in sheet
+          // edit-mode still lists them too, but DT XP-spend has no Pacts category
+          // — without this fix Carthian Laws were entirely unreachable via XP.
+          // Invictus Oath stays excluded (pact UI handles its mutual-bond mechanics).
+          if (rule.parent && ['Invictus Oath'].includes(rule.parent)) continue;
           if (rule.sub_category === 'standing') continue;
           if (!meetsPrereq(c, rule.prereq)) continue;
           const name = rule.name;


### PR DESCRIPTION
**Cycle-blocker reported by Peter 2026-06-30.** Yusuf cannot buy Establish Precedent (Carthian Law merit, prereq Carthian Status 4) via DT XP-spend even though he has Carthian Status 5.

## Root cause

Not a prereq evaluator bug. Yusuf's data + the rule prereq both validate correctly:
- Yusuf `status.covenant['Carthian Movement'] = 5`
- Establish Precedent prereq: `{ type: 'status', qualifier: 'Carthian', dots: 4 }`
- `_getStatus` in `public/js/data/prereq.js:21` maps `'Carthian'` → `'Carthian Movement'` via COV_FULL[] → returns 5 → prereq passes.

The DT XP-spend `case 'merit'` picker at `public/js/tabs/downtime-form.js:4194` explicitly skips any rule with `parent === 'Carthian Law'` on the assumption a dedicated UI handles them. The sheet edit-mode Pacts section does list Carthian Laws — but **DT XP-spend has no Pacts category**, so Carthian Laws are entirely unreachable via XP from the player-facing flow.

Same exclusion in the sheet's regular merit picker at `editor/merits.js:317`.

## Verified against prod

- 11 `purchasable_powers` docs with `parent='Carthian Law'`, all with `type='status'` `qualifier='Carthian'` prereqs.
- The existing meetsPrereq evaluator gates them correctly.

## Fix

Drop `'Carthian Law'` from the parent-exclusion list at both surfaces. Prereq filter on the next line gates them.

- `downtime-form.js` case 'merit' picker.
- `editor/merits.js` buildMeritOptions.

Left untouched:
- `buildMCIGrantOptions` — MCI is a separate sub-system; Carthian Laws aren't natural MCI grants.
- Pacts UI in sheet.js — keeps Carthian Laws as a parallel path. Storage-shape ambiguity (Pacts → `c.powers[]`, merit picker → `c.merits[]`) is a known wrinkle for follow-up.

`'Invictus Oath'` stays excluded — those have mutual-bond mechanics the Pacts UI handles specifically.

— Khepri (SM, hotfixing per Peter's urgent framing; awaiting per-message main-promotion authorisation)