### PR TITLE
hotfix: Carthian Law merits in XP-spend + sheet pickers

### DIFF
--- a/public/js/editor/merits.js
+++ b/public/js/editor/merits.js
@@ -314,7 +314,11 @@ export function buildMeritOptions(c, currentName) {
       if (rule.sub_category && rule.sub_category !== 'general') continue;
       if (INFLUENCE_MERIT_TYPES.includes(rule.name)) continue;
       // Issue #937: 'Style'-parent merits are plain merits — surface them.
-      if (rule.parent && ['Invictus Oath', 'Carthian Law'].includes(rule.parent)) continue;
+      // 2026-06-30: 'Carthian Law' also removed. Carthian Laws are merits with
+      // status-based prereqs and belong in the regular picker; the Pacts UI
+      // continues to list them too as an alternate path. See parallel change
+      // in downtime-form.js so DT XP-spend and sheet pickers stay aligned.
+      if (rule.parent && ['Invictus Oath'].includes(rule.parent)) continue;
       if (!meritPrereqOK(c, rule)) continue;
       const excl = _isExcluded(c, rule.name);
       if (excl && rule.name.toLowerCase() !== (currentName || '').toLowerCase()) continue;

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -4189,9 +4189,14 @@ function getItemsForCategory(category) {
         for (const rule of meritRules) {
           // Issue #937: 'Style'-parent merits (Body As Weapon, Survivalist, etc.)
           // are ordinary 1 XP/dot merits — surface them. Fighting STYLES proper
-          // (Street Fighting etc.) are injected after this loop. Invictus Oath /
-          // Carthian Law remain sub-system-managed and stay excluded.
-          if (rule.parent && ['Invictus Oath', 'Carthian Law'].includes(rule.parent)) continue;
+          // (Street Fighting etc.) are injected after this loop.
+          // 2026-06-30: 'Carthian Law' also removed from this exclusion list.
+          // Carthian Laws are merits with status-based prereqs (per VtR 2e) and
+          // belong in the regular XP-purchase picker. The Pacts UI in sheet
+          // edit-mode still lists them too, but DT XP-spend has no Pacts category
+          // — without this fix Carthian Laws were entirely unreachable via XP.
+          // Invictus Oath stays excluded (pact UI handles its mutual-bond mechanics).
+          if (rule.parent && ['Invictus Oath'].includes(rule.parent)) continue;
           if (rule.sub_category === 'standing') continue;
           if (!meetsPrereq(c, rule.prereq)) continue;
           const name = rule.name;


### PR DESCRIPTION
Promotes #941 to main per Peter 2026-06-30.

## What ships

**#941** — drop `'Carthian Law'` from the parent-exclusion list at `downtime-form.js:4194` and `editor/merits.js:317`. Carthian Law merits (Establish Precedent et al.) become reachable via the regular XP-spend merit picker and the sheet merit picker. Prereq filter on the next line gates them by Carthian Status.

## Authorisation

Per Peter "push to main" 2026-06-30. Per-message authorisation per CLAUDE.md HARD RULE.

— Khepri (SM)