### PR TITLE
fix(#821): game-xp attendance id-first matching (audit-finding)

### DIFF
--- a/public/js/admin/attendance.js
+++ b/public/js/admin/attendance.js
@@ -53,6 +53,7 @@ export async function initAttendance(charList) {
 
 function getEligibleChars() {
   if (!activeSession) return [];
+  // character_id and c._id are both JSON strings; Set.has uses SameValueZero (safe)
   const presentIds = new Set(activeSession.attendance.map(a => a.character_id));
   return chars
     .filter(c => !presentIds.has(c._id))
@@ -95,7 +96,9 @@ function hideAddForm() {
 async function confirmAddCharacter() {
   const sel = document.getElementById('att-add-sel');
   if (!sel || !sel.value) return;
-  const c = chars.find(ch => ch._id === sel.value);
+  // #821: string-coerce for defence-in-depth; both sides are strings in current writes but coerce is cheap.
+  // sel.value is seeded from c._id at render time (both strings); String() is defensive.
+  const c = chars.find(ch => String(ch._id) === String(sel.value));
   if (!c) return;
 
   const entry = {
@@ -202,7 +205,19 @@ function renderGrid() {
   const att = activeSession.attendance || [];
 
   const sorted = att.map((a, i) => {
-    const c = chars.find(ch => ch._id === a.character_id || ch.name === a.character_name || ch.name === a.name);
+    // #821: two-phase find — id first, name fallback only for legacy rows missing character_id.
+    // Note: renderGrid intentionally omits the displayName fallback present in loadGameXP;
+    // this asymmetry is deliberate — render-grid parity is out of scope per issue #821.
+    let c = null;
+    if (a.character_id) {
+      c = chars.find(ch => String(ch._id) === String(a.character_id));
+      if (!c) {
+        console.warn(`[attendance] attendance row with character_id=${a.character_id} matched no character — display may be incomplete`);
+      }
+    }
+    if (!c && !a.character_id) {
+      c = chars.find(ch => ch.name === a.character_name || ch.name === a.name);
+    }
     const player = resolvePlayerName(a, c);
     return { a, i, c, player };
   });

--- a/public/js/data/game-xp.js
+++ b/public/js/data/game-xp.js
@@ -29,12 +29,26 @@ export async function loadGameXP(chars, isST = true) {
         const xp = (a.attended ? 1 : 0) + (a.costuming ? 1 : 0) + (a.downtime ? 1 : 0) + (a.extra || 0);
         if (xp === 0) continue;
 
-        const c = chars.find(ch =>
-          (a.character_id && ch._id === a.character_id) ||
-          ch.name === a.character_name ||
-          ch.name === a.name ||
-          displayName(ch) === (a.display_name || a.character_display)
-        );
+        // Phase 1: id match (authoritative). Coerce both sides — both are JSON strings
+        // in practice, but guard against any path that supplies a non-string ObjectId.
+        // #821: id-first, silent-drop + warn on id-present-no-match (prod audit 2026-07-03
+        // confirmed 0 rows in that state; warn is diagnostic surface for future corner cases).
+        let c = null;
+        if (a.character_id) {
+          c = chars.find(ch => String(ch._id) === String(a.character_id));
+          if (!c) {
+            console.warn(`[game-xp] attendance row with character_id=${a.character_id} matched no character — XP unattributed`);
+          }
+        }
+        // Phase 2: name fallback — only for legacy rows that genuinely lack character_id.
+        // Rows with a character_id that fails to match stay unattributed (signal to backfill).
+        if (!c && !a.character_id) {
+          c = chars.find(ch =>
+            ch.name === a.character_name ||
+            ch.name === a.name ||
+            displayName(ch) === (a.display_name || a.character_display)
+          );
+        }
         if (c) {
           c._gameXP += xp;
           c._gameXPDetail.push({

--- a/server/tests/fix.821.game-xp-attendance-id-match.test.js
+++ b/server/tests/fix.821.game-xp-attendance-id-match.test.js
@@ -1,0 +1,412 @@
+/**
+ * Fix #821 — game-xp attendance id-first matching + string-coerce hardening.
+ *
+ * Static-analysis mirror-tests verifying:
+ *   1. game-xp.js uses two-phase id-first / name-fallback pattern.
+ *   2. attendance.js renderGrid uses the same two-phase pattern.
+ *   3. attendance.js confirmAddCharacter uses String() coercion on the id comparison.
+ *
+ * Inline logic tests (no DOM / browser module imports):
+ *   - Duplicate display name: id wins over name collision.
+ *   - String-coerce edge: ObjectId-like objects stringify correctly.
+ *   - Legacy row (no character_id): name fallback runs only when id absent.
+ *   - Id-present-no-match: console.warn is called; row is unattributed.
+ *   - Regression: mixed fixture with 10 rows reproduces expected per-character XP.
+ *
+ * Pattern follows fix.943.retireStripDerived.test.js (REPO_ROOT + read helper).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+function read(rel) { return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8'); }
+
+const gameXpSrc = read('public/js/data/game-xp.js');
+const attendanceSrc = read('public/js/admin/attendance.js');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Static-analysis: game-xp.js
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#821 — static: game-xp.js two-phase pattern', () => {
+  it('contains String(ch._id) === String(a.character_id) id-first shape', () => {
+    expect(gameXpSrc).toContain('String(ch._id) === String(a.character_id)');
+  });
+
+  it('contains if (a.character_id) guard before Phase 1', () => {
+    expect(gameXpSrc).toMatch(/if\s*\(\s*a\.character_id\s*\)/);
+  });
+
+  it('contains console.warn with [game-xp] prefix', () => {
+    expect(gameXpSrc).toContain('console.warn(`[game-xp]');
+  });
+
+  it('contains if (!c && !a.character_id) guard for Phase 2 name fallback', () => {
+    expect(gameXpSrc).toMatch(/if\s*\(\s*!c\s*&&\s*!a\.character_id\s*\)/);
+  });
+
+  it('Phase 2 is inside the !a.character_id guard (name fallback not reachable when id present)', () => {
+    // Find Phase 2 guard and check the displayName fallback is inside it
+    const phase2Idx = gameXpSrc.indexOf('if (!c && !a.character_id)');
+    expect(phase2Idx).toBeGreaterThan(-1);
+    const displayNameIdx = gameXpSrc.indexOf('displayName(ch)', phase2Idx);
+    expect(displayNameIdx).toBeGreaterThan(phase2Idx);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Static-analysis: attendance.js
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#821 — static: attendance.js renderGrid two-phase pattern', () => {
+  it('renderGrid area contains String(ch._id) === String(a.character_id)', () => {
+    expect(attendanceSrc).toContain('String(ch._id) === String(a.character_id)');
+  });
+
+  it('renderGrid area contains two-phase guard if (!c && !a.character_id)', () => {
+    expect(attendanceSrc).toMatch(/if\s*\(\s*!c\s*&&\s*!a\.character_id\s*\)/);
+  });
+
+  it('renderGrid console.warn for id-present-no-match', () => {
+    expect(attendanceSrc).toContain('console.warn(`[attendance]');
+  });
+
+  it('confirmAddCharacter uses String() coercion on id comparison', () => {
+    expect(attendanceSrc).toContain('String(ch._id) === String(sel.value)');
+  });
+
+  it('getEligibleChars has annotation comment about SameValueZero safety', () => {
+    expect(attendanceSrc).toContain('Set.has uses SameValueZero');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Inline two-phase matching logic (pure functions, no DOM)
+// Mirrors the fixed loadGameXP logic for unit testing.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Minimal displayName stand-in for tests — mirrors helpers.js logic.
+ * honorific + (moniker || name)
+ */
+function displayName(c) {
+  const parts = [];
+  if (c.honorific) parts.push(c.honorific);
+  parts.push(c.moniker || c.name);
+  return parts.join(' ');
+}
+
+/**
+ * Two-phase match — mirrors the fixed game-xp.js logic.
+ * Returns the matched char object or null (never undefined).
+ */
+function twoPhaseMatch(chars, a) {
+  let c = null;
+  if (a.character_id) {
+    c = chars.find(ch => String(ch._id) === String(a.character_id)) ?? null;
+  }
+  if (!c && !a.character_id) {
+    c = chars.find(ch =>
+      ch.name === a.character_name ||
+      ch.name === a.name ||
+      displayName(ch) === (a.display_name || a.character_display)
+    ) ?? null;
+  }
+  return c;
+}
+
+/**
+ * Simulate loadGameXP logic over a set of sessions.
+ * Returns a Map of char._id -> accumulated XP.
+ */
+function simulateLoadGameXP(chars, gameSessions) {
+  const xpMap = new Map(chars.map(c => [c._id, 0]));
+  for (const s of gameSessions) {
+    for (const a of s.attendance || []) {
+      const xp = (a.attended ? 1 : 0) + (a.costuming ? 1 : 0) + (a.downtime ? 1 : 0) + (a.extra || 0);
+      if (xp === 0) continue;
+      const c = twoPhaseMatch(chars, a);
+      if (c) {
+        xpMap.set(c._id, (xpMap.get(c._id) || 0) + xp);
+      }
+    }
+  }
+  return xpMap;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Suite 1: two-phase id/name logic (unit)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#821 — two-phase match unit tests', () => {
+  const chars = [
+    { _id: 'aaa111', name: 'Alice', honorific: null, moniker: null },
+    { _id: 'bbb222', name: 'Bob',   honorific: null, moniker: null },
+    { _id: 'ccc333', name: 'James', honorific: null, moniker: null },
+    { _id: 'ddd444', name: 'James', honorific: null, moniker: null }, // duplicate name
+  ];
+
+  it('id present, unique name — resolves correct character by id', () => {
+    const a = { character_id: 'aaa111', character_name: 'Alice' };
+    expect(twoPhaseMatch(chars, a)?._id).toBe('aaa111');
+  });
+
+  it('id present, duplicate name, correct id wins — bbb222 row goes to bbb222 not first-in-array', () => {
+    // Two chars named "James": ccc333 and ddd444. Row's character_id points at ddd444.
+    const a = { character_id: 'ddd444', character_name: 'James' };
+    const result = twoPhaseMatch(chars, a);
+    expect(result?._id).toBe('ddd444');
+    expect(result?._id).not.toBe('ccc333');
+  });
+
+  it('id absent, unique name — falls through to name-phase, resolves correct character', () => {
+    const a = { character_id: null, character_name: 'Bob' };
+    expect(twoPhaseMatch(chars, a)?._id).toBe('bbb222');
+  });
+
+  it('id absent, duplicate name — resolves to first match in array (documented behaviour)', () => {
+    // Both ccc333 and ddd444 are named "James"; first in array wins
+    const a = { character_id: null, character_name: 'James' };
+    expect(twoPhaseMatch(chars, a)?._id).toBe('ccc333');
+  });
+
+  it('id present, no match — returns null, XP unattributed', () => {
+    const a = { character_id: 'xyz999', character_name: 'Alice' };
+    expect(twoPhaseMatch(chars, a)).toBeNull();
+  });
+
+  it('id absent, no name match — returns null', () => {
+    const a = { character_id: null, character_name: 'Nobody' };
+    expect(twoPhaseMatch(chars, a)).toBeNull();
+  });
+
+  it('name fallback does NOT run when character_id is present and matched', () => {
+    // Give Alice a unique id but wrong character_name; id-match wins, name is irrelevant
+    const a = { character_id: 'aaa111', character_name: 'Bob' };
+    expect(twoPhaseMatch(chars, a)?._id).toBe('aaa111');
+  });
+
+  it('name fallback does NOT run when character_id is present and unmatched', () => {
+    // character_id present but stale; name would match Alice. Must not fall through.
+    const a = { character_id: 'stale-id', character_name: 'Alice' };
+    expect(twoPhaseMatch(chars, a)).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Suite 2: String-coerce edge cases
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#821 — String() coercion edge cases', () => {
+  it('char._id as string "abc123" matches row character_id as string "abc123"', () => {
+    const chars = [{ _id: 'abc123', name: 'Test', honorific: null, moniker: null }];
+    const a = { character_id: 'abc123', character_name: 'Test' };
+    expect(twoPhaseMatch(chars, a)?._id).toBe('abc123');
+  });
+
+  it('char._id as object with .toString() "abc123" matches string character_id "abc123"', () => {
+    // Simulates MongoDB ObjectId behaviour if a non-serialised id is in the chars array
+    const objectId = { toString: () => 'abc123', valueOf: () => 'abc123' };
+    // String(objectId) calls .toString() => 'abc123'
+    const chars = [{ _id: objectId, name: 'Test', honorific: null, moniker: null }];
+    const a = { character_id: 'abc123', character_name: 'Test' };
+    const result = twoPhaseMatch(chars, a);
+    expect(result).not.toBeNull();
+    expect(String(result?._id)).toBe('abc123');
+  });
+
+  it('does not match when string ids differ despite same name', () => {
+    const chars = [{ _id: 'aaa', name: 'Alice', honorific: null, moniker: null }];
+    const a = { character_id: 'bbb', character_name: 'Alice' };
+    expect(twoPhaseMatch(chars, a)).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Suite 3: console.warn emitted for id-present-no-match
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#821 — warn on id-present-no-match', () => {
+  let warnSpy;
+  beforeEach(() => { warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {}); });
+  afterEach(() => { warnSpy.mockRestore(); });
+
+  /**
+   * Two-phase match with warn — mirrors the actual game-xp.js path including the warn call.
+   */
+  function twoPhaseMatchWithWarn(chars, a) {
+    let c = null;
+    if (a.character_id) {
+      c = chars.find(ch => String(ch._id) === String(a.character_id)) ?? null;
+      if (!c) {
+        console.warn(`[game-xp] attendance row with character_id=${a.character_id} matched no character — XP unattributed`);
+      }
+    }
+    if (!c && !a.character_id) {
+      c = chars.find(ch =>
+        ch.name === a.character_name ||
+        ch.name === a.name ||
+        displayName(ch) === (a.display_name || a.character_display)
+      ) ?? null;
+    }
+    return c;
+  }
+
+  it('emits console.warn when character_id present but no char matches', () => {
+    const chars = [{ _id: 'abc', name: 'Alice', honorific: null, moniker: null }];
+    const a = { character_id: 'xyz', character_name: 'Alice' };
+    const result = twoPhaseMatchWithWarn(chars, a);
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalledOnce();
+    expect(warnSpy.mock.calls[0][0]).toContain('[game-xp]');
+    expect(warnSpy.mock.calls[0][0]).toContain('xyz');
+  });
+
+  it('does NOT warn when character_id absent (name-fallback path)', () => {
+    const chars = [{ _id: 'abc', name: 'Alice', honorific: null, moniker: null }];
+    const a = { character_id: null, character_name: 'Alice' };
+    twoPhaseMatchWithWarn(chars, a);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('does NOT warn when character_id present and matches', () => {
+    const chars = [{ _id: 'abc', name: 'Alice', honorific: null, moniker: null }];
+    const a = { character_id: 'abc', character_name: 'Alice' };
+    twoPhaseMatchWithWarn(chars, a);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Suite 4: Regression — XP totals over mixed fixture
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#821 — XP totals regression (mixed fixture)', () => {
+  // 5 chars with unique names (no collision risk in this regression suite)
+  const chars = [
+    { _id: 'c1', name: 'Valerius',  honorific: null, moniker: null },
+    { _id: 'c2', name: 'Seraphina', honorific: null, moniker: null },
+    { _id: 'c3', name: 'Mordecai',  honorific: null, moniker: null },
+    { _id: 'c4', name: 'Isadora',   honorific: null, moniker: null },
+    { _id: 'c5', name: 'Theron',    honorific: null, moniker: null },
+  ];
+
+  // 10 attendance rows: 7 with character_id, 3 without (name-fallback)
+  // Hand-computed expected XP:
+  //   c1: attended(1) + costuming(1) + downtime(1) = 3
+  //   c2: attended(1) = 1  [row has character_id]
+  //   c3: attended(1) + extra(2) = 3  [row has character_id]
+  //   c4: attended(1) + costuming(1) = 2  [two rows, both have character_id]
+  //   c5: attended(1) = 1  [no character_id, name match]
+  //   c1 also gets 1 more from a name-only legacy row: attended(1) = 1 => c1 total = 4
+  // unmatched: 1 row with stale character_id 'stale' => 0 XP attributed
+
+  const gameSessions = [
+    {
+      title: 'Game 1',
+      session_date: '2025-01-01',
+      attendance: [
+        { character_id: 'c1', character_name: 'Valerius',  attended: true,  costuming: true,  downtime: true,  extra: 0 },
+        { character_id: 'c2', character_name: 'Seraphina', attended: true,  costuming: false, downtime: false, extra: 0 },
+        { character_id: 'c3', character_name: 'Mordecai',  attended: true,  costuming: false, downtime: false, extra: 2 },
+        { character_id: 'c4', character_name: 'Isadora',   attended: true,  costuming: true,  downtime: false, extra: 0 },
+        { character_id: 'c4', character_name: 'Isadora',   attended: false, costuming: false, downtime: false, extra: 0 }, // xp=0, skip
+      ],
+    },
+    {
+      title: 'Game 2',
+      session_date: '2025-02-01',
+      attendance: [
+        // Legacy rows (no character_id)
+        { character_id: null, character_name: 'Theron',    attended: true,  costuming: false, downtime: false, extra: 0 },
+        { character_id: null, character_name: 'Valerius',  attended: true,  costuming: false, downtime: false, extra: 0 },
+        // Row with stale character_id — should be unattributed
+        { character_id: 'stale-id-xyz', character_name: 'Seraphina', attended: true, costuming: false, downtime: false, extra: 0 },
+        // Three more id-rows
+        { character_id: 'c3', character_name: 'Mordecai',  attended: false, costuming: false, downtime: false, extra: 0 }, // xp=0, skip
+        { character_id: 'c5', character_name: 'Theron',    attended: false, costuming: false, downtime: false, extra: 0 }, // xp=0, skip
+      ],
+    },
+  ];
+
+  it('c1 (Valerius) accumulates 4 XP: 3 from Game 1 + 1 legacy row Game 2', () => {
+    const xpMap = simulateLoadGameXP(chars, gameSessions);
+    expect(xpMap.get('c1')).toBe(4);
+  });
+
+  it('c2 (Seraphina) accumulates 1 XP from Game 1 id-row; stale-id row is unattributed', () => {
+    const xpMap = simulateLoadGameXP(chars, gameSessions);
+    expect(xpMap.get('c2')).toBe(1);
+  });
+
+  it('c3 (Mordecai) accumulates 3 XP from Game 1 (extra=2 + attended)', () => {
+    const xpMap = simulateLoadGameXP(chars, gameSessions);
+    expect(xpMap.get('c3')).toBe(3);
+  });
+
+  it('c4 (Isadora) accumulates 2 XP from Game 1 (attended + costuming; second row xp=0 skipped)', () => {
+    const xpMap = simulateLoadGameXP(chars, gameSessions);
+    expect(xpMap.get('c4')).toBe(2);
+  });
+
+  it('c5 (Theron) accumulates 1 XP from Game 2 legacy row (no character_id)', () => {
+    const xpMap = simulateLoadGameXP(chars, gameSessions);
+    expect(xpMap.get('c5')).toBe(1);
+  });
+
+  it('total attributed XP across all chars equals 11 (stale row unattributed)', () => {
+    const xpMap = simulateLoadGameXP(chars, gameSessions);
+    const total = [...xpMap.values()].reduce((s, v) => s + v, 0);
+    expect(total).toBe(11); // 3+1+3+2+1+1 = 11; stale row (1 XP) is dropped
+  });
+
+  it('no character absorbs XP from more rows than legitimately belong to it', () => {
+    const xpMap = simulateLoadGameXP(chars, gameSessions);
+    // The maximum any single char can earn in these two sessions is bounded by their rows
+    expect(xpMap.get('c1')).toBeLessThanOrEqual(4);
+    expect(xpMap.get('c2')).toBeLessThanOrEqual(1);
+    expect(xpMap.get('c3')).toBeLessThanOrEqual(3);
+    expect(xpMap.get('c4')).toBeLessThanOrEqual(2);
+    expect(xpMap.get('c5')).toBeLessThanOrEqual(1);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Suite 5: Duplicate display name (synthetic fixture per story spec)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#821 — duplicate display name synthetic fixture', () => {
+  // Two chars with identical name "James"
+  const chars = [
+    { _id: 'aaa111', name: 'James', honorific: null, moniker: null },
+    { _id: 'bbb222', name: 'James', honorific: null, moniker: null },
+  ];
+
+  it('row with character_id=bbb222 resolves to bbb222 regardless of array order', () => {
+    const a = { character_id: 'bbb222', character_name: 'James', attended: true };
+    expect(twoPhaseMatch(chars, a)?._id).toBe('bbb222');
+  });
+
+  it('row without character_id resolves to aaa111 (first in array by name)', () => {
+    const a = { character_id: null, character_name: 'James', attended: true };
+    expect(twoPhaseMatch(chars, a)?._id).toBe('aaa111');
+  });
+
+  it('XP totals: each "James" gets exactly 1 XP from their respective rows', () => {
+    const gameSessions = [{
+      title: 'Game 1',
+      session_date: '2025-01-01',
+      attendance: [
+        { character_id: 'bbb222', character_name: 'James', attended: true, costuming: false, downtime: false, extra: 0 },
+        { character_id: null,    character_name: 'James', attended: true, costuming: false, downtime: false, extra: 0 },
+      ],
+    }];
+    const xpMap = simulateLoadGameXP(chars, gameSessions);
+    expect(xpMap.get('aaa111')).toBe(1);
+    expect(xpMap.get('bbb222')).toBe(1);
+  });
+});

--- a/specs/stories/821-game-xp-attendance-id-match.story.md
+++ b/specs/stories/821-game-xp-attendance-id-match.story.md
@@ -1,0 +1,361 @@
+---
+issue: 821
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/821
+branch: piatra/issue-821-game-xp-attendance-id-match
+---
+
+# Story 821: Game-XP attendance name fallbacks mis-attribute XP for rows without `character_id`
+
+**Story ID:** fix.821
+**Status:** To Do
+**Date:** 2026-07-03
+**Issue:** [#821](https://github.com/angelusvmorningstar/TerraMortis/issues/821)
+**Branch:** `piatra/issue-821-game-xp-attendance-id-match`
+
+---
+
+## User Story
+
+As an ST reviewing XP totals,
+I want attendance rows matched to characters by `character_id` first and name only as a last
+resort for legacy rows,
+so that XP attribution is stable and correct even when two characters share the same display name.
+
+---
+
+## Background
+
+`loadGameXP()` in `public/js/data/game-xp.js:32-37` locates each attendance row's character
+using a single OR chain:
+
+```js
+const c = chars.find(ch =>
+  (a.character_id && ch._id === a.character_id) ||
+  ch.name === a.character_name ||
+  ch.name === a.name ||
+  displayName(ch) === (a.display_name || a.character_display)
+);
+```
+
+The three name fallbacks run unconditionally — even when `character_id` is present.
+Because `Array.find` returns the first match, a name collision between two characters
+can cause the wrong character to absorb XP for a row that has a perfectly good
+`character_id` on it.
+
+For legacy rows that genuinely lack `character_id` (CLAUDE.md: "Game 2 XP: attendance data
+partially entered"), name matching is the only available path and must be retained. The fix
+is to restructure from a flat OR-chain into a two-phase find so the intent is explicit:
+id-first, name only as fallback.
+
+The companion issue in `public/js/admin/attendance.js` is that the renderGrid id comparison
+at line 205 also chains name fallbacks without any `character_id` presence guard, and the
+id comparisons at lines 56/58 and 98 use uncoerced `===` across potentially mixed-type
+values.
+
+---
+
+## Acceptance Criteria
+
+- [ ] Attendance rows with `character_id` match by id only, using
+      `String(ch._id) === String(a.character_id)`
+- [ ] Name matching is retained only as a fallback for rows missing `character_id`
+- [ ] A character sharing a display name with another is attributed the correct
+      attendance/XP
+- [ ] No regression to `xpEarned`/game-XP totals for current rows
+
+---
+
+## Design Decision: Two-Phase Find
+
+Replace the single OR-chain with an explicit two-pass lookup in `loadGameXP`. The shape:
+
+```js
+// Phase 1: match by id (authoritative; coerce both sides for type safety)
+let c = a.character_id
+  ? chars.find(ch => String(ch._id) === String(a.character_id))
+  : null;
+
+// Phase 2: name fallback only for legacy rows that have no character_id
+if (!c && !a.character_id) {
+  c = chars.find(ch =>
+    ch.name === a.character_name ||
+    ch.name === a.name ||
+    displayName(ch) === (a.display_name || a.character_display)
+  );
+}
+```
+
+Rationale:
+
+- The two-phase structure makes the "id-first, name as exception path" policy readable in
+  code, not implied by short-circuit evaluation order in a flat OR.
+- Phase 2 runs only when `a.character_id` is absent (`!a.character_id` guard), so a row
+  with a bad/mistyped id still fails cleanly rather than silently falling through to name
+  matching. If a row has `character_id` set but no character matches, `c` stays `null` and
+  the row's XP goes unattributed — which is the correct observable signal that the id is
+  stale and needs remediation (rather than silently attributing to a name-match that may
+  be wrong).
+- `String()` coercion on both sides is defensive: JSON parse always yields strings for
+  these values, but if any server path ever returns an ObjectId object rather than a
+  serialised string, the coercion prevents a silent `false`.
+
+Apply the same two-phase structure to `renderGrid` in `attendance.js` at line 205 (see
+String-Coercion Sweep below).
+
+---
+
+## String-Coercion Sweep: `attendance.js` Call Sites
+
+The issue references four line numbers in `public/js/admin/attendance.js`. Exact analysis
+against the current file:
+
+| Line | Current code | Action |
+|------|-------------|--------|
+| 56 | `activeSession.attendance.map(a => a.character_id)` — builds a `Set` of id values | No comparison here; value is a bare string extraction. **No change needed.** Add a comment: `// character_id values are always strings from JSON; Set membership via ===` |
+| 58 | `!presentIds.has(c._id)` — `Set.has` uses SameValueZero, works for strings | Both sides are client-side character `_id` strings. **Low-risk; no-op change.** Verify with a comment and leave; do not alter. |
+| 98 | `chars.find(ch => ch._id === sel.value)` | `sel.value` is populated from `c._id` at line 76 via `esc(c._id)` (HTML attribute round-trip). Both sides are strings from the same source. **Low-risk; add `String()` coercion for consistency:** `String(ch._id) === String(sel.value)` |
+| 205 | `ch._id === a.character_id \|\| ch.name === a.character_name \|\| ch.name === a.name` | **Primary fix site.** Replace with a two-phase find matching the `loadGameXP` pattern (see Design Decision above). `a.character_id` presence guards the name fallback. Apply `String()` coercion on the id-path. |
+
+Summary: one genuine fix (line 205), one defensive coercion (line 98), two annotated
+no-ops (lines 56, 58).
+
+---
+
+## Duplicate-Name Test Fixture
+
+The AC requires a test for "a character sharing a display name with another." There are no
+known duplicate `name` or `displayName` values among the 31 active characters in
+production. Use a **synthetic fixture** in the Vitest test file:
+
+```js
+const chars = [
+  { _id: 'aaa111', name: 'James', honorific: null, moniker: null },
+  { _id: 'bbb222', name: 'James', honorific: null, moniker: null }, // duplicate name
+];
+const session = {
+  attendance: [
+    // Row with character_id — must resolve to bbb222 regardless of name order
+    { character_id: 'bbb222', character_name: 'James', attended: true },
+    // Row without character_id — must resolve to aaa111 (first-match by name)
+    { character_id: null,    character_name: 'James', attended: true },
+  ]
+};
+```
+
+Assert:
+- Row 0 resolves to `bbb222` (id-phase match).
+- Row 1 resolves to `aaa111` (name-phase match, first in array).
+- `chars[1]._gameXP === 1` and `chars[0]._gameXP === 1` — each gets exactly one row, not
+  two.
+
+This fixture does not require a real duplicate on prod. The synthetic case is sufficient to
+prove the two-phase logic is correct.
+
+---
+
+## Regression Coverage
+
+AC: "no regression to `xpEarned`/game-XP totals for current rows."
+
+Test approach:
+
+1. Construct a mixed attendance fixture with:
+   - Rows that have `character_id` set (simulates current/new rows).
+   - Rows that lack `character_id` but have `character_name` (simulates Game 2 legacy rows).
+2. Run the matching logic for both old (OR-chain) and new (two-phase) implementations as
+   pure functions in the test, operating on the same `chars` array and fixture.
+3. Assert:
+   - For rows WITH `character_id`: resolved character is identical under old and new logic.
+     These are the "no regression" rows.
+   - For rows WITHOUT `character_id` where name is unique: resolved character is identical
+     under old and new logic.
+   - For rows WITHOUT `character_id` where the name is a duplicate: surfaced in test output
+     as a "correction" — the new logic may resolve differently (or not at all) compared to
+     the old OR-chain, and that is the **intentional fix**, not a regression.
+
+Implement this as a Vitest mirror-test at
+`server/tests/fix.821.game-xp-attendance-id-match.test.js`. Extract the matching predicate
+from `loadGameXP` into a standalone function (or inline-replicate it in the test as a pure
+function) so the test does not need DOM or ES module browser imports.
+
+---
+
+## Implementation
+
+### Pre-flight: confirm base branch
+
+Branch `piatra/issue-821-game-xp-attendance-id-match` should already be off `dev`. Verify:
+
+```bash
+git log HEAD..origin/dev --oneline
+```
+
+Merge any outstanding `dev` commits before starting.
+
+---
+
+### Change 1 — `public/js/data/game-xp.js` (lines 32-37)
+
+**Current:**
+
+```js
+const c = chars.find(ch =>
+  (a.character_id && ch._id === a.character_id) ||
+  ch.name === a.character_name ||
+  ch.name === a.name ||
+  displayName(ch) === (a.display_name || a.character_display)
+);
+```
+
+**New:**
+
+```js
+// Phase 1: id match (authoritative). Coerce both sides — both are JSON strings
+// in practice, but guard against any path that supplies a non-string ObjectId.
+let c = a.character_id
+  ? chars.find(ch => String(ch._id) === String(a.character_id))
+  : null;
+
+// Phase 2: name fallback — only for legacy rows that genuinely lack character_id.
+// Rows with a character_id that fails to match stay unattributed (signal to backfill).
+if (!c && !a.character_id) {
+  c = chars.find(ch =>
+    ch.name === a.character_name ||
+    ch.name === a.name ||
+    displayName(ch) === (a.display_name || a.character_display)
+  );
+}
+```
+
+---
+
+### Change 2 — `public/js/admin/attendance.js` · `renderGrid` (line 205)
+
+**Current:**
+
+```js
+const c = chars.find(ch => ch._id === a.character_id || ch.name === a.character_name || ch.name === a.name);
+```
+
+**New (same two-phase pattern):**
+
+```js
+// Phase 1: id match
+let c = a.character_id
+  ? chars.find(ch => String(ch._id) === String(a.character_id))
+  : null;
+// Phase 2: name fallback for legacy rows only
+if (!c && !a.character_id) {
+  c = chars.find(ch => ch.name === a.character_name || ch.name === a.name);
+}
+```
+
+Note: `renderGrid` does not use the `displayName` fallback branch that `loadGameXP` uses.
+Retain parity with the existing behaviour (no `displayName` fallback in `renderGrid`) —
+do not add it.
+
+---
+
+### Change 3 — `public/js/admin/attendance.js` · `confirmAddCharacter` (line 98) — defensive coercion
+
+**Current:**
+
+```js
+const c = chars.find(ch => ch._id === sel.value);
+```
+
+**New:**
+
+```js
+const c = chars.find(ch => String(ch._id) === String(sel.value));
+```
+
+Both sides are strings from a controlled path (option value seeded from `c._id`). This is
+a defensive no-op coercion for consistency. Add a comment:
+
+```js
+// sel.value is seeded from c._id at render time (both strings); String() is defensive
+const c = chars.find(ch => String(ch._id) === String(sel.value));
+```
+
+---
+
+### Change 4 — `public/js/admin/attendance.js` · `getEligibleChars` (lines 56/58) — annotate as verified no-op
+
+Lines 56 and 58:
+
+```js
+const presentIds = new Set(activeSession.attendance.map(a => a.character_id));
+return chars
+  .filter(c => !presentIds.has(c._id))
+```
+
+Both `a.character_id` and `c._id` are JSON-derived strings. `Set.has` uses SameValueZero,
+which is equivalent to `===` for strings. This is correct as written.
+
+**Action:** Add an inline comment only — do not change the logic:
+
+```js
+// character_id and c._id are both JSON strings; Set.has uses SameValueZero (safe)
+const presentIds = new Set(activeSession.attendance.map(a => a.character_id));
+```
+
+---
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `public/js/data/game-xp.js` | Lines 32-37: replace OR-chain with two-phase find + `String()` coercion |
+| `public/js/admin/attendance.js` | Line 205: two-phase find (renderGrid) |
+| `public/js/admin/attendance.js` | Line 98: `String()` coercion (confirmAddCharacter) |
+| `public/js/admin/attendance.js` | Lines 56/58: add no-op comment (getEligibleChars) |
+| `server/tests/fix.821.game-xp-attendance-id-match.test.js` | New Vitest mirror-tests (see Testing below) |
+
+No schema changes. No API route changes. No CSS changes.
+
+---
+
+## Testing
+
+Write `server/tests/fix.821.game-xp-attendance-id-match.test.js` as a Vitest mirror-test.
+No DOM, no browser module imports. Copy the matching predicate logic inline.
+
+### Test cases
+
+**Suite 1: two-phase id/name logic (unit)**
+
+- `id present, unique name` — resolves correct character by id.
+- `id present, duplicate name, correct id wins` — the synthetic "James/James" fixture above;
+  the row with `character_id: 'bbb222'` resolves to `bbb222`, not `aaa111`.
+- `id absent, unique name` — falls through to name-phase, resolves correct character.
+- `id absent, duplicate name` — resolves to the first match by name (array order); this is
+  documented behaviour, not a fix target.
+- `id present, no match` — `c` stays `null`; XP goes unattributed.
+- `id absent, no name match` — `c` stays `null`; XP goes unattributed.
+
+**Suite 2: XP totals regression (mixed fixture)**
+
+Construct a `chars` array and a `gameSessions` array with:
+
+- 3 rows with `character_id` set (names may be non-unique).
+- 2 rows with no `character_id`, unique names.
+
+Run the new two-phase logic. Assert:
+- Each `character._gameXP` matches the expected value.
+- Total XP attributed across all characters equals the sum for all rows that resolved.
+- No character has absorbed XP from more than the rows that legitimately belong to it.
+
+Rows that legitimately differ from old-logic (e.g. duplicate-name collision) are NOT
+present in this regression suite — the regression suite only covers rows where old and new
+logic should agree.
+
+---
+
+## Dev Agent Record
+
+_(To be completed by dev agent on implementation.)_
+
+### Files Changed
+
+### Completion Notes


### PR DESCRIPTION
## Summary

- Replaces the flat OR-chain in `loadGameXP` (`game-xp.js:32-37`) with an explicit two-phase find: Phase 1 matches by `character_id` using `String()`-coerced comparison; Phase 2 (name fallback) runs only when `character_id` is absent. Emits `console.warn` when `character_id` is present but no character matches.
- Applies the same two-phase pattern to `renderGrid` in `attendance.js` (was a flat OR-chain without an id-presence guard). Intentional asymmetry: `renderGrid` omits the `displayName` fallback branch; noted in comment.
- Wraps `confirmAddCharacter`'s id comparison with `String()` coercion (defensive no-op; both sides are strings). Annotates `getEligibleChars` lines 56/58 as verified no-ops (`Set.has` + SameValueZero).
- Prod audit 2026-07-03: 149/149 rows have `character_id`, 0 legacy. Name-fallback retained as defensive code only; no backfill needed.

## Test plan

- [ ] `server/tests/fix.821.game-xp-attendance-id-match.test.js` — 34 tests, all passing
  - Static assertions on `game-xp.js` two-phase shape, `attendance.js` two-phase shape, `String()` coercion at confirmAddCharacter, `SameValueZero` comment at getEligibleChars
  - Unit tests: id present/unique, id present/duplicate-name (James fixture), id absent/unique, id absent/duplicate, id present/no-match (returns null), id absent/no-name-match (returns null), fallback blocked when id present-and-unmatched
  - String-coerce edge cases including ObjectId-like object
  - `console.warn` emitted on id-present-no-match; not emitted on clean match or name-only path
  - 10-row mixed regression fixture verifying per-character XP totals (c1=4, c2=1, c3=3, c4=2, c5=1, total=11; stale-id row correctly unattributed)
  - Duplicate-name synthetic fixture: bbb222 row -> bbb222, null-id row -> aaa111, each gets exactly 1 XP
- [ ] Full test suite: 1975 passing, 4 pre-existing failures (`epic.708.3` ×3, `n7-n9-allocator-readers` ×1) — no new failures

Closes #821