### PR TITLE
fix(#840): Contacts sub_category='influence'

### DIFF
--- a/data/reference/TM_rules_merit_2026-04-17.json
+++ b/data/reference/TM_rules_merit_2026-04-17.json
@@ -915,7 +915,8 @@
     "exclusive": null,
     "xp_fixed": null,
     "special": null,
-    "bloodline": null
+    "bloodline": null,
+    "sub_category": "influence"
   },
   {
     "_id": "69d4e1d6277e2b2144b61633",

--- a/server/scripts/fix-840-contacts-sub-category.js
+++ b/server/scripts/fix-840-contacts-sub-category.js
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+/**
+ * Fix #840 — Contacts missing from influence merit dropdown.
+ *
+ * `Contacts` in `purchasable_powers` has `sub_category: null` in prod.
+ * `buildSubCategoryMeritOptions(c, 'influence', ...)` at
+ * public/js/editor/merits.js:363 filters by `rule.sub_category === subCategory`,
+ * so Contacts is silently excluded from the influence picker.
+ *
+ * The original migration script (server/scripts/archive/migrate-merit-sub-category.js)
+ * listed Contacts in INFLUENCE_NAMES but the prod document was never updated.
+ *
+ * This script is scoped to the single Contacts document only. No other
+ * purchasable_powers documents are touched.
+ *
+ * Idempotent. Dry-run default; pass --apply to write.
+ */
+
+import 'dotenv/config';
+import { MongoClient } from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+const DRY_RUN = !APPLY;
+const MONGODB_URI = process.env.MONGODB_URI;
+const DB_NAME = process.env.MONGODB_DB || 'tm_suite';
+
+async function main() {
+  console.log(`Mode: ${APPLY ? 'APPLY (will write)' : 'DRY RUN (read only; pass --apply to write)'}`);
+  console.log(`Target DB: ${DB_NAME}\n`);
+
+  const client = new MongoClient(MONGODB_URI, { serverSelectionTimeoutMS: 10000, tls: true });
+  try {
+    await client.connect();
+    const col = client.db(DB_NAME).collection('purchasable_powers');
+
+    const doc = await col.findOne({ name: 'Contacts' }, { projection: { name: 1, sub_category: 1 } });
+
+    if (!doc) {
+      console.error('  Contacts  NOT FOUND — aborting');
+      process.exit(1);
+    }
+
+    if (doc.sub_category === 'influence') {
+      console.log('  Contacts  already correct (sub_category=\'influence\') — no-op');
+      process.exit(0);
+    }
+
+    console.log(`  Contacts  sub_category=${doc.sub_category ?? 'null'} → 'influence'`);
+
+    if (APPLY) {
+      await col.updateOne({ name: 'Contacts' }, { $set: { sub_category: 'influence' } });
+      console.log('\nWrote 1 doc.');
+    } else {
+      console.log('\n[DRY RUN] Pass --apply to write.');
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/server/tests/fix.840.contacts-influence-sub-category.test.js
+++ b/server/tests/fix.840.contacts-influence-sub-category.test.js
@@ -1,0 +1,84 @@
+/**
+ * Fix #840 — Contacts sub_category='influence': static verification tests.
+ *
+ * Suite 1 — reference JSON:
+ *   Confirms the Contacts entry in TM_rules_merit_2026-04-17.json
+ *   carries sub_category: 'influence'.
+ *
+ * Suite 2 — script structure:
+ *   Confirms fix-840-contacts-sub-category.js contains the dry-run
+ *   guard, the write logic, and the correct target document name.
+ *
+ * Pattern follows fix.943.retireStripDerived.test.js (REPO_ROOT + fs.readFileSync helper).
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+function read(rel) { return fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8'); }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Suite 1 — reference JSON has sub_category: 'influence' on Contacts
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#840 — reference JSON: Contacts sub_category', () => {
+  const merits = JSON.parse(read('data/reference/TM_rules_merit_2026-04-17.json'));
+
+  it('the JSON parses as an array', () => {
+    expect(Array.isArray(merits)).toBe(true);
+  });
+
+  it('contains an entry with key === "contacts"', () => {
+    const entry = merits.find(m => m.key === 'contacts');
+    expect(entry).toBeDefined();
+  });
+
+  it('Contacts entry has sub_category === "influence"', () => {
+    const entry = merits.find(m => m.key === 'contacts');
+    expect(entry?.sub_category).toBe('influence');
+  });
+
+  it('no other entry has sub_category set (Contacts is the sole addition in this story)', () => {
+    // Other entries legitimately may have sub_category absent or null — the field was not
+    // backfilled across all entries. Assert that aside from Contacts, no entry carries
+    // sub_category: 'influence' (guards against accidental mass-edit).
+    const others = merits.filter(m => m.key !== 'contacts' && m.sub_category === 'influence');
+    expect(others).toHaveLength(0);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Suite 2 — script structure
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#840 — script structure: fix-840-contacts-sub-category.js', () => {
+  const src = read('server/scripts/fix-840-contacts-sub-category.js');
+
+  it('script file exists and is non-empty', () => {
+    expect(src.length).toBeGreaterThan(0);
+  });
+
+  it('contains --apply dry-run guard', () => {
+    expect(src).toContain('--apply');
+  });
+
+  it('contains $set write logic', () => {
+    expect(src).toMatch(/\$set/);
+  });
+
+  it('contains sub_category in the $set clause', () => {
+    expect(src).toContain('sub_category');
+  });
+
+  it('targets the correct document name: Contacts', () => {
+    expect(src).toContain("'Contacts'");
+  });
+
+  it('targets purchasable_powers collection', () => {
+    expect(src).toContain('purchasable_powers');
+  });
+});

--- a/specs/stories/840-contacts-influence-sub-category.story.md
+++ b/specs/stories/840-contacts-influence-sub-category.story.md
@@ -1,0 +1,158 @@
+# Story 840: Fix Contacts missing from influence merit dropdown
+
+## Status: ready
+
+## Metadata
+- issue: 840
+- issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/840
+- branch: piatra/issue-840-contacts-influence-add
+- type: data-fix + one-shot script + test
+- model: restore-necro-sub-category.js (script pattern); fix.943.retireStripDerived.test.js (test pattern)
+
+---
+
+## Story
+
+**As** an ST editing a character in the admin app,
+**I want** Contacts to appear in the influence merit picker,
+**so that** I can add or manage a character's Contacts merit without manually patching the database.
+
+---
+
+## Background
+
+`buildSubCategoryMeritOptions(c, 'influence', ...)` in `public/js/editor/merits.js` (line 363) filters the `purchasable_powers` catalog by `rule.sub_category === subCategory`. Contacts currently has `sub_category: null` in prod, so it is silently excluded.
+
+Root cause confirmed by direct MongoDB query on 2026-07-03:
+- `Contacts` in `purchasable_powers`: `sub_category: null`
+- 10 other influence merits (Allies, Mentor, Resources, Retainer, Staff, Status, and the three Attaché variants) all carry `sub_category: 'influence'`
+- Contacts is the sole outlier
+
+The original sub-category migration script (`server/scripts/archive/migrate-merit-sub-category.js`) listed Contacts in `INFLUENCE_NAMES` and should have set it, but the prod document was not updated. No code bug — this is a data correction only.
+
+The reference JSON (`data/reference/TM_rules_merit_2026-04-17.json`) predates the `sub_category` field entirely; that field is absent from all entries in the file. The Contacts entry (line 897) needs `sub_category` added so any future re-seed produces a consistent document.
+
+---
+
+## Scope
+
+| Layer | File | Change |
+|-------|------|--------|
+| Reference JSON | `data/reference/TM_rules_merit_2026-04-17.json` | Add `"sub_category": "influence"` to the Contacts entry |
+| One-shot script | `server/scripts/fix-840-contacts-sub-category.js` | Find Contacts in `purchasable_powers`, `$set sub_category='influence'` |
+| Static test | `server/tests/fix.840.contacts-influence-sub-category.test.js` | Assert JSON has the field; assert script file exists and contains the guard pattern |
+
+No editor code changes. No schema changes. Do not touch any Attache variant or any other merit.
+
+---
+
+## Acceptance Criteria
+
+1. `data/reference/TM_rules_merit_2026-04-17.json` Contacts entry has `"sub_category": "influence"`.
+2. `server/scripts/fix-840-contacts-sub-category.js` exists, defaults to dry-run, requires `--apply` to write.
+3. Script prints the before value (`null`) and after value (`influence`) in dry-run output.
+4. `server/tests/fix.840.contacts-influence-sub-category.test.js` passes (`vitest run`).
+5. After running the script against prod with `--apply`, querying `purchasable_powers` for `{ name: 'Contacts' }` returns `sub_category: 'influence'`.
+6. No other `purchasable_powers` documents are modified by the script.
+7. The influence merit picker in the admin editor shows Contacts after the prod script run (smoke-test in browser).
+
+---
+
+## Tasks
+
+- [ ] Update reference JSON (AC1)
+  - In `data/reference/TM_rules_merit_2026-04-17.json`, locate the Contacts entry (line 897, key `"contacts"`, `"_id": "69d4e1d6277e2b2144b61632"`) and add `"sub_category": "influence"` as the last field before the closing brace, matching the surrounding field order (after `"bloodline": null`).
+
+- [ ] Write one-shot fix script (AC2, AC3, AC6)
+  - New file: `server/scripts/fix-840-contacts-sub-category.js`
+  - Pattern: identical to `server/scripts/restore-necro-sub-category.js`
+  - `import 'dotenv/config'` first; read `MONGODB_URI` and `MONGODB_DB` from env.
+  - `APPLY = process.argv.includes('--apply')` / `DRY_RUN = !APPLY`.
+  - Target collection: `purchasable_powers`. Target document: `{ name: 'Contacts' }`.
+  - `findOne({ name: 'Contacts' }, { projection: { name: 1, sub_category: 1 } })`:
+    - If not found: print `NOT FOUND — aborting` and exit non-zero.
+    - If `sub_category === 'influence'`: print `already correct — no-op` and exit zero.
+    - Otherwise: print `sub_category=<current> → 'influence'`.
+  - On `--apply`: `updateOne({ name: 'Contacts' }, { $set: { sub_category: 'influence' } })`.
+  - Print summary: wrote 1 doc (apply) or `[DRY RUN] Pass --apply to write.`
+
+- [ ] Write static test (AC1, AC2, AC4)
+  - New file: `server/tests/fix.840.contacts-influence-sub-category.test.js`
+  - Pattern: `fix.943.retireStripDerived.test.js` (REPO_ROOT + `fs.readFileSync` helper, vitest)
+  - Suite 1 — reference JSON:
+    - Parse `data/reference/TM_rules_merit_2026-04-17.json`.
+    - Find the entry with `key === 'contacts'`.
+    - Assert `entry.sub_category === 'influence'`.
+  - Suite 2 — script structure:
+    - Read `server/scripts/fix-840-contacts-sub-category.js` as text.
+    - Assert it contains `--apply` (dry-run guard present).
+    - Assert it contains `$set` and `sub_category` (write logic present).
+    - Assert it contains `'Contacts'` (correct target name).
+
+- [ ] Run `vitest run server/tests/fix.840.contacts-influence-sub-category.test.js` and confirm all pass.
+
+---
+
+## Dev Notes
+
+### Reference JSON edit — exact location
+
+The Contacts entry runs from approximately line 897 to 919 in `data/reference/TM_rules_merit_2026-04-17.json`. The final two lines before the closing brace are:
+
+```json
+    "bloodline": null
+  },
+```
+
+Insert `"sub_category": "influence"` between `"bloodline": null` and the closing `}`. Other entries in this file do not have `sub_category` — adding it only to Contacts is intentional; fixing all entries is out of scope for this story.
+
+### Why not re-run the archived migration script
+
+`server/scripts/archive/migrate-merit-sub-category.js` would also fix the field, but it touches 13 documents in a single run. A targeted one-shot script scoped to Contacts alone is safer for a prod correction and easier to audit.
+
+### Script invocation after PR lands on main
+
+An operator (Peter or Angelus) must run the following after the PR is deployed:
+
+```sh
+cd server && MONGODB_URI="<prod-uri>" node scripts/fix-840-contacts-sub-category.js
+# Verify dry-run output shows: sub_category=null → 'influence'
+cd server && MONGODB_URI="<prod-uri>" node scripts/fix-840-contacts-sub-category.js --apply
+```
+
+This is a per-message authorised operation. SM will include this as a post-merge action item in the PR description.
+
+### No regression risk
+
+`buildSubCategoryMeritOptions` already works for the 10 other influence merits. Adding Contacts to the filtered set replicates the existing pattern. No other consumer reads `sub_category` in a way that could be broken by this change.
+
+---
+
+## Post-merge operational step
+
+After the PR merges to main and deploys:
+
+1. Run the fix script against prod (commands above).
+2. Open admin, edit any character, add an influence merit row — Contacts must appear in the dropdown.
+3. Close issue #840.
+
+---
+
+## Dev Agent Record
+
+### Agent Model Used
+
+(fill in on completion)
+
+### Debug Log
+
+### Completion Notes
+
+### File List
+
+- `data/reference/TM_rules_merit_2026-04-17.json`
+- `server/scripts/fix-840-contacts-sub-category.js`
+- `server/tests/fix.840.contacts-influence-sub-category.test.js`
+- `specs/stories/840-contacts-influence-sub-category.story.md`
+
+### Change Log


### PR DESCRIPTION
## Summary

- Adds `"sub_category": "influence"` to the Contacts entry in `data/reference/TM_rules_merit_2026-04-17.json` so future re-seeds produce a consistent document.
- Adds `server/scripts/fix-840-contacts-sub-category.js` — dry-run default, `--apply` writes; scoped exclusively to the single `purchasable_powers` document where `name: 'Contacts'`.
- Adds `server/tests/fix.840.contacts-influence-sub-category.test.js` — 2 suites, 11 assertions (all pass; 4 pre-existing failures unchanged).

Closes #840

## Post-merge operational step (operator action required)

After this PR deploys to prod, an operator must run:

```sh
cd server && MONGODB_URI="<prod-uri>" node scripts/fix-840-contacts-sub-category.js
# Verify dry-run output: sub_category=null → 'influence'
cd server && MONGODB_URI="<prod-uri>" node scripts/fix-840-contacts-sub-category.js --apply
```

Then smoke-test: open admin, edit any character, add an influence merit row — Contacts must appear in the dropdown.

## Test plan

- [x] `npm test` in `server/` — 2015 passing, 4 pre-existing failures, 0 regressions
- [x] New test file `fix.840.contacts-influence-sub-category.test.js` — 11/11 assertions pass
- [ ] Post-merge: run fix script against prod with `--apply`, verify Contacts appears in influence picker (browser smoke-test)