### PR TITLE
fix(#865): retainer/mentor action-type override

### DIFF
--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -3413,13 +3413,17 @@ function buildProcessingQueue(subs) {
     });
 
     retainers.forEach((task, idx) => {
+      const _retResolved_A = (sub.merit_actions_resolved || [])[meritFlatIdx] || {};
+      const _retOrigType_A = 'resources_retainers';
+      const _retActionType_A = _retResolved_A.action_type_override || _retOrigType_A;
       queue.push({
         key: `${sub._id}:merit:${meritFlatIdx}`,
         subId: sub._id,
         charName,
-        phase: PHASE_NUM_TO_LABEL[PHASE_MISC],
-        phaseNum: PHASE_MISC,
-        actionType: 'resources_retainers',
+        phase: PHASE_NUM_TO_LABEL[PHASE_ORDER[_retActionType_A] ?? PHASE_MISC],
+        phaseNum: PHASE_ORDER[_retActionType_A] ?? PHASE_MISC,
+        actionType: _retActionType_A,
+        originalActionType: _retOrigType_A,
         label: 'Retainer: Directed Action',
         description: task,
         source: 'merit',
@@ -3452,13 +3456,17 @@ function buildProcessingQueue(subs) {
       const target  = resp[`mentor_${n}_target`];
       const meritLb = resp[`mentor_${n}_merit`];
       if (!task && !target) continue;
+      const _mentResolved = (sub.merit_actions_resolved || [])[meritFlatIdx] || {};
+      const _mentOrigType = 'resources_retainers';
+      const _mentActionType = _mentResolved.action_type_override || _mentOrigType;
       queue.push({
         key: `${sub._id}:merit:${meritFlatIdx}`,
         subId: sub._id,
         charName,
-        phase: PHASE_NUM_TO_LABEL[PHASE_MISC],
-        phaseNum: PHASE_MISC,
-        actionType: 'resources_retainers',
+        phase: PHASE_NUM_TO_LABEL[PHASE_ORDER[_mentActionType] ?? PHASE_MISC],
+        phaseNum: PHASE_ORDER[_mentActionType] ?? PHASE_MISC,
+        actionType: _mentActionType,
+        originalActionType: _mentOrigType,
         label: 'Mentor: Directed Action',
         description: _composeDirectedDesc(meritLb, _resolveTargetName(target), task || ''),
         source: 'merit',
@@ -3497,13 +3505,17 @@ function buildProcessingQueue(subs) {
       const type    = resp[`retainer_${n}_type`];
       const meritLb = resp[`retainer_${n}_merit`];
       if (!task && !type) continue;
+      const _retResolved_C = (sub.merit_actions_resolved || [])[meritFlatIdx] || {};
+      const _retOrigType_C = 'resources_retainers';
+      const _retActionType_C = _retResolved_C.action_type_override || _retOrigType_C;
       queue.push({
         key: `${sub._id}:merit:${meritFlatIdx}`,
         subId: sub._id,
         charName,
-        phase: PHASE_NUM_TO_LABEL[PHASE_MISC],
-        phaseNum: PHASE_MISC,
-        actionType: 'resources_retainers',
+        phase: PHASE_NUM_TO_LABEL[PHASE_ORDER[_retActionType_C] ?? PHASE_MISC],
+        phaseNum: PHASE_ORDER[_retActionType_C] ?? PHASE_MISC,
+        actionType: _retActionType_C,
+        originalActionType: _retOrigType_C,
         label: meritLb ? `${meritLb}: Directed Action` : 'Retainer: Directed Action',
         description: _composeDirectedDesc(meritLb, type || '', task || ''),
         source: 'merit',
@@ -5009,7 +5021,7 @@ function renderProcessingMode(container) {
       const entry = _getQueueEntry(key);
       if (!entry) return;
       // Clear override if ST selects the original player-submitted type
-      const patch = { action_type_override: newType === entry.originalActionType ? null : newType };
+      const patch = { action_type_override: (!newType || newType === entry.originalActionType) ? null : newType };
       // Maintenance auto-resolves as no-roll
       if (newType === 'maintenance') patch.pool_status = 'maintenance';
       await saveEntryReview(entry, patch);
@@ -8535,6 +8547,7 @@ function _renderActionTypeRow(entry, rev, char, opts = {}) {
     h += `<span class="proc-merit-cat-chip proc-action-type-rote">Rote Feed</span>`;
   } else {
     h += `<select class="proc-recat-select" data-proc-key="${esc(key)}">`;
+    h += `<option value=""${!actionType ? ' selected' : ''}>— Select action type —</option>`;
     for (const [val, lbl] of Object.entries(ACTION_TYPE_LABELS)) {
       h += `<option value="${esc(val)}"${actionType === val ? ' selected' : ''}>${esc(lbl)}</option>`;
     }

--- a/server/tests/fix.865.retainer-mentor-override.test.js
+++ b/server/tests/fix.865.retainer-mentor-override.test.js
@@ -1,0 +1,162 @@
+/**
+ * fix.865 — DT processing: retainer/mentor action-type override ignored.
+ *
+ * Three queue-build blocks hardcoded actionType: 'resources_retainers' without
+ * reading action_type_override from merit_actions_resolved. The sphere/allies
+ * path already applied the override correctly; these blocks now mirror that
+ * pattern. Also adds originalActionType to each push, a placeholder option to
+ * _renderActionTypeRow, and tightens the recat handler null-condition.
+ *
+ * AC-T1 — Block A (retainers.forEach) reads action_type_override
+ * AC-T2 — Block B (mentor for-loop) reads action_type_override
+ * AC-T3 — Block C (app-form retainer for-loop) reads action_type_override
+ * AC-T4 — Block A pushes originalActionType
+ * AC-T5 — Block B pushes originalActionType
+ * AC-T6 — Block C pushes originalActionType
+ * AC-T7 — No bare 'resources_retainers' without override read survives in A/B/C
+ * AC-T8 — _renderActionTypeRow emits placeholder option
+ * AC-T9 — Recat handler guards on !newType as well as originalActionType match
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const root = resolve(import.meta.dirname, '../..');
+const src  = readFileSync(resolve(root, 'public/js/admin/downtime-views.js'), 'utf8');
+
+// ── Block anchors ─────────────────────────────────────────────────────────────
+// Block A: retainers.forEach CSV path
+// Anchor from retainers.forEach (unique function call) so the override read
+// that precedes the queue.push label is included in the slice.
+const blockAStart = src.indexOf('retainers.forEach');
+const blockAEnd   = src.indexOf('meritFlatIdx++;', blockAStart) + 'meritFlatIdx++;'.length;
+
+// Block B: mentor for-loop — anchor from mentor_${n}_task key read
+const blockBStart = src.indexOf('`mentor_${n}_task`');
+const blockBEnd   = src.indexOf('meritFlatIdx++;', blockBStart) + 'meritFlatIdx++;'.length;
+
+// Block C: app-form retainer for-loop — retainer_${n}_task is unique discriminator
+const blockCStart = src.indexOf('`retainer_${n}_task`');
+const blockCEnd   = src.indexOf('meritFlatIdx++;', blockCStart) + 'meritFlatIdx++;'.length;
+
+// Recat handler anchor
+const recatHandlerStart = src.indexOf('Clear override if ST selects the original player-submitted type');
+
+// _renderActionTypeRow anchor
+const renderActionTypeRowStart = src.indexOf('proc-recat-row');
+
+// ── Sanity: anchors found ─────────────────────────────────────────────────────
+describe('anchors found', () => {
+  it('Block A anchor is present', () => { expect(blockAStart).toBeGreaterThan(0); });
+  it('Block B anchor is present', () => { expect(blockBStart).toBeGreaterThan(0); });
+  it('Block C anchor is present', () => { expect(blockCStart).toBeGreaterThan(0); });
+  it('recat handler anchor is present', () => { expect(recatHandlerStart).toBeGreaterThan(0); });
+  it('_renderActionTypeRow anchor is present', () => { expect(renderActionTypeRowStart).toBeGreaterThan(0); });
+});
+
+// ── AC-T1: Block A reads action_type_override ────────────────────────────────
+describe('AC-T1 — Block A reads action_type_override', () => {
+  it('contains action_type_override read in retainers.forEach block', () => {
+    const blockA = src.slice(blockAStart, blockAEnd);
+    expect(blockA).toContain('action_type_override');
+  });
+});
+
+// ── AC-T2: Block B reads action_type_override ────────────────────────────────
+describe('AC-T2 — Block B reads action_type_override', () => {
+  it('contains action_type_override read in mentor for-loop block', () => {
+    const blockB = src.slice(blockBStart, blockBEnd);
+    expect(blockB).toContain('action_type_override');
+  });
+});
+
+// ── AC-T3: Block C reads action_type_override ────────────────────────────────
+describe('AC-T3 — Block C reads action_type_override', () => {
+  it('contains action_type_override read in app-form retainer for-loop block', () => {
+    const blockC = src.slice(blockCStart, blockCEnd);
+    expect(blockC).toContain('action_type_override');
+  });
+});
+
+// ── AC-T4: Block A pushes originalActionType ─────────────────────────────────
+describe('AC-T4 — Block A pushes originalActionType', () => {
+  it('originalActionType appears in retainers.forEach queue.push', () => {
+    const pushStart = src.indexOf('queue.push({', blockAStart);
+    const pushEnd   = blockAEnd;
+    const pushSlice = src.slice(pushStart, pushEnd);
+    expect(pushSlice).toContain('originalActionType:');
+  });
+});
+
+// ── AC-T5: Block B pushes originalActionType ─────────────────────────────────
+describe('AC-T5 — Block B pushes originalActionType', () => {
+  it('originalActionType appears in mentor for-loop queue.push', () => {
+    const pushStart = src.indexOf('queue.push({', blockBStart);
+    const pushEnd   = blockBEnd;
+    const pushSlice = src.slice(pushStart, pushEnd);
+    expect(pushSlice).toContain('originalActionType:');
+  });
+});
+
+// ── AC-T6: Block C pushes originalActionType ─────────────────────────────────
+describe('AC-T6 — Block C pushes originalActionType', () => {
+  it('originalActionType appears in app-form retainer for-loop queue.push', () => {
+    const pushStart = src.indexOf('queue.push({', blockCStart);
+    const pushEnd   = blockCEnd;
+    const pushSlice = src.slice(pushStart, pushEnd);
+    expect(pushSlice).toContain('originalActionType:');
+  });
+});
+
+// ── AC-T7: No bare 'resources_retainers' assignment without override read ─────
+describe('AC-T7 — No bare resources_retainers actionType without override read', () => {
+  it('Block A does not contain bare actionType: resources_retainers', () => {
+    // Widen to include the full retainers.forEach closure
+    const retainerForEachStart = src.indexOf('retainers.forEach');
+    const retainerForEachEnd   = src.indexOf('meritFlatIdx++;', retainerForEachStart) + 'meritFlatIdx++;'.length;
+    const blockAFull = src.slice(retainerForEachStart, retainerForEachEnd);
+    // The bare assignment should not exist — the dynamic variable must be used instead
+    expect(blockAFull).not.toContain("actionType: 'resources_retainers'");
+  });
+
+  it('Block B does not contain bare actionType: resources_retainers', () => {
+    const blockB = src.slice(blockBStart, blockBEnd);
+    expect(blockB).not.toContain("actionType: 'resources_retainers'");
+  });
+
+  it('Block C does not contain bare actionType: resources_retainers', () => {
+    const blockC = src.slice(blockCStart, blockCEnd);
+    expect(blockC).not.toContain("actionType: 'resources_retainers'");
+  });
+});
+
+// ── AC-T8: _renderActionTypeRow emits placeholder option ─────────────────────
+describe('AC-T8 — _renderActionTypeRow emits placeholder option', () => {
+  it('placeholder option is present in select render', () => {
+    const selectStart = src.indexOf('proc-recat-select', renderActionTypeRowStart);
+    // Read enough to capture the placeholder option line.
+    // In the JS source the template literal uses escaped quotes: value=\"\"
+    const selectSlice = src.slice(selectStart, selectStart + 400);
+    // The source contains the placeholder option for empty/unset action type
+    expect(selectSlice).toContain('Select action type');
+    // value="" in the source — the template literal uses plain double-quotes
+    expect(selectSlice).toContain('value=""');
+  });
+});
+
+// ── AC-T9: Recat handler guards on !newType ───────────────────────────────────
+describe('AC-T9 — Recat handler patch line guards on !newType', () => {
+  it('patch line contains !newType condition', () => {
+    const patchIdx = src.indexOf('action_type_override:', recatHandlerStart);
+    expect(patchIdx).toBeGreaterThan(recatHandlerStart);
+    const patchLine = src.slice(patchIdx, patchIdx + 120);
+    expect(patchLine).toContain('!newType');
+  });
+
+  it('patch line also guards originalActionType match', () => {
+    const patchIdx = src.indexOf('action_type_override:', recatHandlerStart);
+    const patchLine = src.slice(patchIdx, patchIdx + 120);
+    expect(patchLine).toContain('entry.originalActionType');
+  });
+});

--- a/specs/stories/fix.865.retainer-mentor-action-type-override.story.md
+++ b/specs/stories/fix.865.retainer-mentor-action-type-override.story.md
@@ -1,0 +1,257 @@
+# fix.865 — DT processing: retainer/mentor action-type selection reverts (override ignored)
+
+```yaml
+issue: 865
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/865
+branch: piatra/issue-865-retainer-mentor-action-type-override
+status: draft
+type: bug
+```
+
+## Story
+
+As an ST resolving a Retainer or Mentor directed action in DT Processing, I want the
+action-type dropdown selection to persist across re-renders and reloads, so that I can
+classify these actions (Support, Patrol/Scout, Investigate, etc.) and have the chosen
+type drive the merit matrix lookup.
+
+## Background
+
+The retainer/mentor queue-build blocks hardcode `actionType: 'resources_retainers'`
+and never read `action_type_override` from `merit_actions_resolved`. Because
+`'resources_retainers'` is not a key in `ACTION_TYPE_LABELS`, the action-type
+`<select>` has no matching `<option>` and the browser falls back to displaying its
+first option — "Ambience Increase" — regardless of what the ST previously selected.
+
+The recat-select `change` handler (`:5008-5016`) does save `action_type_override`
+to `merit_actions_resolved[entry.actionIdx]` correctly. But each subsequent
+`renderProcessingMode` re-runs the queue-build, re-hardcoding `'resources_retainers'`,
+so the selection is lost on every re-render.
+
+The sphere/allies/status loop already applies the override correctly at line 3315:
+
+```js
+// downtime-views.js:3314-3315
+const meritResolved = (sub.merit_actions_resolved || [])[meritFlatIdx] || {};
+const actionType = meritResolved.action_type_override || originalActionType;
+```
+
+The three retainer/mentor blocks simply lack this read.
+
+There are **three** affected blocks (the issue body identified two; the third was
+added by #344 for app-form submissions):
+
+| Block | Line | Label |
+|---|---|---|
+| A | 3415 | `retainers.forEach` — CSV import path |
+| B | 3450 | `for n = 1..10` — mentor (app-form) |
+| C | 3495 | `for n = 1..10` — retainer (app-form, added by #344) |
+
+The recat-select handler also reads `entry.originalActionType` to decide whether to
+null the override (`newType === entry.originalActionType ? null : newType`, line 5012).
+The retainer/mentor blocks do not currently push `originalActionType` into the queue
+entry, so clearing an override after the fact would never null it. Each block must
+also push `originalActionType`.
+
+**SM-resolved open question:** when no override is set, default to `''` (empty
+string) and render a `— Select action type —` placeholder option as the first
+option in the `<select>`. This makes unclassified state explicit rather than
+defaulting to the misleading "Ambience Increase" fallback.
+
+## Acceptance criteria
+
+- [ ] **AC1** — Selecting a different action type on a Retainer directed action
+  (CSV-import block) persists: survives re-render and page reload without reverting
+  to "Ambience Increase".
+- [ ] **AC2** — Same for a Mentor directed action (app-form block).
+- [ ] **AC3** — Same for a Retainer directed action submitted via the app form
+  (the `retainer_${n}_task` block added by #344).
+- [ ] **AC4** — When no override is set, the action-type `<select>` shows
+  `— Select action type —` as the selected option (not "Ambience Increase").
+- [ ] **AC5** — After an ST selects an action type, the entry's phase and merit
+  matrix lookup use the chosen type (same behaviour as the sphere/allies path).
+- [ ] **AC6** — Sphere/allies/status/contacts/staff action paths are unaffected.
+- [ ] **AC7** — Clearing an override (re-selecting `''`) correctly nulls
+  `action_type_override` in the saved review.
+
+---
+
+## Dev Notes
+
+### Files
+
+- `public/js/admin/downtime-views.js` — only file that changes.
+
+### Pattern to mirror (sphere loop, already correct)
+
+```js
+// downtime-views.js:3313-3315
+const meritResolved = (sub.merit_actions_resolved || [])[meritFlatIdx] || {};
+const actionType = meritResolved.action_type_override || originalActionType;
+```
+
+### Block A — retainers.forEach, CSV import path (lines 3415-3430)
+
+Replace the hardcoded `actionType: 'resources_retainers'` with the override-aware
+pattern. Also push `originalActionType` so the recat handler can compare correctly.
+
+```js
+// BEFORE (line 3422):
+actionType: 'resources_retainers',
+
+// AFTER — insert before queue.push:
+const _retResolved_A = (sub.merit_actions_resolved || [])[meritFlatIdx] || {};
+const _retOrigType_A = 'resources_retainers';
+const _retActionType_A = _retResolved_A.action_type_override || _retOrigType_A;
+
+// In the queue.push object:
+actionType: _retActionType_A,
+originalActionType: _retOrigType_A,
+```
+
+### Block B — mentor for-loop (lines 3450-3470)
+
+Same pattern. The existing `actionType: 'resources_retainers'` on line 3461 becomes:
+
+```js
+const _mentResolved = (sub.merit_actions_resolved || [])[meritFlatIdx] || {};
+const _mentOrigType = 'resources_retainers';
+const _mentActionType = _mentResolved.action_type_override || _mentOrigType;
+
+// In queue.push:
+actionType: _mentActionType,
+originalActionType: _mentOrigType,
+```
+
+### Block C — retainer for-loop, app-form path (lines 3495-3514)
+
+Same pattern. The existing `actionType: 'resources_retainers'` on line 3506 becomes:
+
+```js
+const _retResolved_C = (sub.merit_actions_resolved || [])[meritFlatIdx] || {};
+const _retOrigType_C = 'resources_retainers';
+const _retActionType_C = _retResolved_C.action_type_override || _retOrigType_C;
+
+// In queue.push:
+actionType: _retActionType_C,
+originalActionType: _retOrigType_C,
+```
+
+### Placeholder option (AC4) — action-type `<select>` render
+
+Location: `_renderActionTypeRow`, lines 8537-8541.
+
+When `actionType` is `''` (no override set for a retainer/mentor block), the
+existing `for...of Object.entries(ACTION_TYPE_LABELS)` loop will produce no
+`selected` match and the browser will auto-select the first option. Add a
+placeholder as the first option, unconditionally — it is harmless for all other
+action types since any real type will match and become selected:
+
+```js
+// BEFORE (line 8537):
+h += `<select class="proc-recat-select" data-proc-key="${esc(key)}">`;
+for (const [val, lbl] of Object.entries(ACTION_TYPE_LABELS)) {
+  h += `<option value="${esc(val)}"${actionType === val ? ' selected' : ''}>${esc(lbl)}</option>`;
+}
+h += `</select>`;
+
+// AFTER:
+h += `<select class="proc-recat-select" data-proc-key="${esc(key)}">`;
+h += `<option value=""${!actionType ? ' selected' : ''}>— Select action type —</option>`;
+for (const [val, lbl] of Object.entries(ACTION_TYPE_LABELS)) {
+  h += `<option value="${esc(val)}"${actionType === val ? ' selected' : ''}>${esc(lbl)}</option>`;
+}
+h += `</select>`;
+```
+
+The recat handler already saves `action_type_override: null` when
+`newType === entry.originalActionType` (line 5012). With the placeholder,
+when the ST selects `''`, `newType` will be `''` which does not equal
+`'resources_retainers'` — so the handler would save `action_type_override: ''`
+(a falsy string, but not null). The handler should treat `''` the same as
+selecting the original type, nulling the override. Update the guard at line 5012:
+
+```js
+// BEFORE:
+const patch = { action_type_override: newType === entry.originalActionType ? null : newType };
+
+// AFTER:
+const patch = { action_type_override: (!newType || newType === entry.originalActionType) ? null : newType };
+```
+
+This ensures selecting `''` (or clearing back to the original type) both null the
+stored override cleanly.
+
+### Phase assignment for retainer/mentor entries
+
+Blocks A, B, and C currently hardcode `phaseNum: PHASE_MISC`. Once `actionType`
+is dynamic, the phase should be derived from the selected type (same as the sphere
+loop at lines 3316-3327). Apply `PHASE_ORDER[actionType] ?? PHASE_MISC`:
+
+```js
+phase: PHASE_NUM_TO_LABEL[PHASE_ORDER[_retActionType_A] ?? PHASE_MISC],
+phaseNum: PHASE_ORDER[_retActionType_A] ?? PHASE_MISC,
+```
+
+Do this for all three blocks. Do not change the contacts/staff phase assignments.
+
+### What NOT to change
+
+- The sphere/allies/status/contacts/staff blocks — already correct, out of scope.
+- `downtime-constants.js` — no new labels, no new entries in `ACTION_TYPE_LABELS`.
+- Server routes, MongoDB schema — no changes.
+- `originalActionType` field name — must be consistent with line 5012 and line 8546
+  (`entry.originalActionType`) which are already wired.
+
+### Label for retainer/mentor entries
+
+The sphere block builds its label from `ACTION_TYPE_LABELS[actionType]` at line
+3375. The retainer/mentor blocks use fixed string labels (`'Retainer: Directed
+Action'`, `'Mentor: Directed Action'`). Leave the fixed labels — they already
+identify the source clearly. No change needed to the label field.
+
+---
+
+## Testing
+
+`server/tests/fix.865.retainer-mentor-override.test.js` — static-analysis against
+`public/js/admin/downtime-views.js`.
+
+**Anchors to use (grep for these literal strings to position each block):**
+
+- Block A: `'retainers.forEach'` or the label `'Retainer: Directed Action'` on
+  line 3423 (use `src.indexOf("label: 'Retainer: Directed Action'")` — this
+  string is unique to Block A).
+- Block B: `'Mentor: Directed Action'` (unique to Block B).
+- Block C: `` 'retainer_${n}_task' `` as the loop discriminator, or the label
+  template string `` '${meritLb}: Directed Action' `` (line 3507 area, unique to
+  Block C).
+- Recat handler: `'Clear override if ST selects the original player-submitted type'`
+  comment on line 5011.
+- `_renderActionTypeRow`: `'proc-recat-row'` (line 8532).
+
+**AC tests to implement:**
+
+```
+AC-T1 — Block A (retainers.forEach) contains action_type_override read
+AC-T2 — Block B (mentor for-loop) contains action_type_override read
+AC-T3 — Block C (app-form retainer for-loop) contains action_type_override read
+AC-T4 — Block A pushes originalActionType into the queue entry
+AC-T5 — Block B pushes originalActionType into the queue entry
+AC-T6 — Block C pushes originalActionType into the queue entry
+AC-T7 — No bare actionType: 'resources_retainers' (without an override read in the
+         same block) survives in any of the three blocks
+AC-T8 — _renderActionTypeRow emits the placeholder option
+         '<option value="">— Select action type —</option>'
+AC-T9 — Recat handler patch line guards on !newType as well as originalActionType
+         match (i.e., the null-coerce condition)
+```
+
+Test implementation approach: `fs.readFileSync` the source, use
+`src.indexOf(anchorString)` to bound each block, then `src.indexOf(needle, blockStart)`
+within that range. Follow the pattern in
+`server/tests/fix.797.dt-proc-confirm-outcome-revert.test.js`.
+
+---
+
+_Story created by SM from GitHub issue #865. Branch: `piatra/issue-865-retainer-mentor-action-type-override`_


### PR DESCRIPTION
## Summary

- Three queue-build blocks in `renderProcessingMode` hardcoded `actionType: 'resources_retainers'` without reading `action_type_override` from `merit_actions_resolved`, causing the action-type dropdown to silently revert to the default on every re-render.
- Blocks A (retainers.forEach CSV path), B (mentor for-loop), and C (app-form retainer for-loop) now mirror the sphere/allies override-read pattern (`meritResolved.action_type_override || originalActionType`).
- Each block now pushes `originalActionType` so the recat handler can correctly null the override when the ST re-selects it.
- Phase is now derived from `PHASE_ORDER[actionType] ?? PHASE_MISC` instead of being hardcoded to `PHASE_MISC`.
- `_renderActionTypeRow` gains a `— Select action type —` placeholder as the first `<option>`, making unclassified state explicit instead of defaulting to the misleading "Ambience Increase".
- Recat handler null-condition tightened: `(!newType || newType === entry.originalActionType) ? null : newType` so selecting `''` (placeholder) also clears the stored override.

## Test plan

- `server/tests/fix.865.retainer-mentor-override.test.js` — 17 static-analysis tests, all passing.
- Full suite: 2035 passing, 4 pre-existing failures (epic.708.3 × 3, n7-n9 × 1) — unchanged.

Closes #865