### PR TITLE
feat(#994): expandable Full rules (rules_text) in sheet drawers + dice modal

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -785,6 +785,19 @@ html:not([data-theme="dark"]) .edit-icon {
 .disc-power-effect{font-family:var(--ft);font-size:11px;color:var(--label-secondary);line-height:1.55;}
 .disc-sub-head{font-family:var(--fl);font-size:9px;font-weight:900;letter-spacing:.14em;text-transform:uppercase;color:var(--label-tertiary);padding:7px 12px 3px;}
 
+/* ── Rules text expander (issue #994) ── */
+.rules-expander{margin-top:6px;}
+.rules-expander-toggle{display:flex;align-items:center;gap:4px;width:100%;background:none;border:none;padding:4px 0;font-family:var(--fl);font-size:10px;font-weight:700;font-variant:small-caps;letter-spacing:.05em;color:var(--label-secondary);cursor:pointer;user-select:none;text-align:left;}
+.rules-expander-toggle:hover{color:var(--accent);}
+.rules-expander-arr{font-size:10px;color:var(--txt3);transition:transform .15s;flex-shrink:0;}
+.rules-expander-toggle.open .rules-expander-arr{transform:rotate(90deg);}
+.rules-expander-body{display:none;margin-top:4px;padding:8px 10px;background:var(--surf2);border:0.5px solid var(--bdr);border-radius:4px;font-family:var(--ft);font-size:11px;color:var(--label-secondary);line-height:1.6;max-height:320px;overflow-y:auto;overflow-wrap:anywhere;}
+.rules-expander-body.visible{display:block;}
+.rules-text-p{margin:0 0 8px 0;}
+.rules-text-p:last-child{margin-bottom:0;}
+.rules-text-hr{border-top:0.5px solid var(--bdr);margin:10px 0;}
+.rules-text-source{margin-top:8px;font-style:italic;color:var(--txt3);font-size:10px;}
+
 /* ── Rite badges ── */
 .rite-free-badge,.rite-xp-badge{font-family:var(--fl);font-size:9px;letter-spacing:.1em;text-transform:uppercase;border:1px solid;border-radius:3px;padding:1px 5px;cursor:pointer;transition:background .15s,color .15s;}
 .rite-free-badge{background:var(--accent-a8);color:var(--accent);border-color:var(--accent);}

--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -37,6 +37,7 @@ import { auditCharacter } from '../data/audit.js';
 import { powersForDisc } from '../suite/sheet-helpers.js';
 import { markerFor } from './st-mod-popover.js';
 import { getCatalogueEntry } from '../data/equipment-catalogue-cache.js';
+import { renderRulesExpander } from '../shared/rules-text.js';
 
 // Build legacy-format shims from rules cache for remaining deep consumers.
 // These produce arrays/objects in the old DEVOTIONS_DB/MERITS_DB/MAN_DB shape.
@@ -52,7 +53,10 @@ function _devDB() {
 function _meritDB() {
   const db = {};
   for (const r of getRulesByCategory('merit')) {
-    db[r.name.toLowerCase()] = { desc: r.description, prereq: r.prereq, prereqStr: r.prereq ? prereqLabel(r.prereq) : null, rating: r.rating_range ? `${r.rating_range[0]}–${r.rating_range[1]}` : null, type: r.parent, sub_category: r.sub_category };
+    // Issue #994: carry rules_text/rules_source through so pact/oath drawers
+    // (the only consumer of this map for power-style rules-text display)
+    // can offer a "Full rules" expander.
+    db[r.name.toLowerCase()] = { desc: r.description, prereq: r.prereq, prereqStr: r.prereq ? prereqLabel(r.prereq) : null, rating: r.rating_range ? `${r.rating_range[0]}–${r.rating_range[1]}` : null, type: r.parent, sub_category: r.sub_category, rules_text: r.rules_text || null, rules_source: r.rules_source || null };
   }
   return db;
 }
@@ -845,6 +849,8 @@ export function shRenderDisciplines(c, editMode) {
           + '<div class="disc-drawer" id="disc-drawer-' + gid + '"><div class="disc-power">'
           + (p.stats ? '<div class="disc-power-stats">' + esc(p.stats) + '</div>' : '')
           + '<div class="disc-power-effect">' + esc(effect) + '</div>'
+          // Issue #994: "Full rules" expander from the oath/law rules doc.
+          + (dbEntry && dbEntry.rules_text ? renderRulesExpander('rte-' + gid, dbEntry.rules_text, dbEntry.rules_source) : '')
           + '</div></div>';
       }
     });
@@ -2401,7 +2407,12 @@ export function shRenderMeritRow(m, idPrefix, i, dotHtml, chipHtml) {
   const _inner = (hasArr) => '<div class="trait-row"><div class="trait-main"><span class="trait-name">' + esc(mn) + '</span><div class="trait-right">' + (dt || '') + '<span class="exp-arr' + (hasArr ? '' : ' trait-arr-hidden') + '">\u203A</span></div></div>' + ((sn || chipHtml) ? '<div class="trait-sub">' + (chipHtml || '') + (sn ? '<span class="trait-qual">' + esc(sn) + '</span>' : '') + '</div>' : '') + '</div>';
   if (db && db.desc) {
     const id2 = idPrefix + i, pqStr = db.prereq ? prereqLabel(db.prereq) : '', body = '<div>' + esc(db.desc) + '</div>' + (pqStr ? '<div style="margin-top:5px;font-style:italic;color:var(--txt3)">Prerequisite: ' + esc(pqStr) + '</div>' : '');
-    return '<div class="exp-row" id="exp-row-' + id2 + '" onclick="toggleExp(\'' + id2 + '\')">' + _inner(true) + '</div><div class="exp-body" id="exp-body-' + id2 + '">' + body + '</div>';
+    // Issue #994: "Full rules" expander from the merit's rules doc (meritLookup
+    // carries the full rule via db._rule). Reused by both the editor sheet and
+    // the suite sheet (shRenderInfluenceMerits/shRenderGeneralMerits etc. delegate here).
+    const _ruleDoc = db._rule || null;
+    const rulesExp = _ruleDoc && _ruleDoc.rules_text ? renderRulesExpander('rte-' + id2, _ruleDoc.rules_text, _ruleDoc.rules_source) : '';
+    return '<div class="exp-row" id="exp-row-' + id2 + '" onclick="toggleExp(\'' + id2 + '\')">' + _inner(true) + '</div><div class="exp-body" id="exp-body-' + id2 + '">' + body + rulesExp + '</div>';
   }
   return '<div class="merit-plain">' + _inner(false) + '</div>';
 }

--- a/public/js/shared/pools.js
+++ b/public/js/shared/pools.js
@@ -34,7 +34,14 @@ export function getPool(char, raw) {
   const rule = getRuleByKey(slug) || getRuleByKey('rite-' + slug) || getRuleByKey('devotion-' + slug);
   if (rule) {
     const p = rule.pool;
-    if (!p || (!p.attr && !p.skill)) return { noRoll: true, info: { d: rule.parent, c: rule.cost, ac: rule.action, du: rule.duration, ef: rule.description } };
+    // Issue #994: pass rules_text/rules_source through so the dice modal
+    // can render a "Rules" expander without a second rules-cache query.
+    if (!p || (!p.attr && !p.skill)) return {
+      noRoll: true,
+      info: { d: rule.parent, c: rule.cost, ac: rule.action, du: rule.duration, ef: rule.description },
+      rules_text: rule.rules_text || null,
+      rules_source: rule.rules_source || null,
+    };
     const attrV  = p.attr  ? getAttrEffective(char, p.attr) : 0;
     const skillV = p.skill ? skTotal(char, p.skill)         : 0;
     const unskilled = (p.skill && skillV === 0) ? unskilledPenalty(p.skill) : 0;
@@ -51,6 +58,8 @@ export function getPool(char, raw) {
       duration: rule.duration || null,
       effect: rule.description || null,
       isRitual: rule.action === 'Ritual',
+      rules_text: rule.rules_text || null,
+      rules_source: rule.rules_source || null,
       info: { d: rule.parent, a: p.attr, s: p.skill, r: rule.resistance, c: rule.cost, ac: rule.action, du: rule.duration, ef: rule.description }
     };
   }

--- a/public/js/shared/rules-text.js
+++ b/public/js/shared/rules-text.js
@@ -1,0 +1,109 @@
+/**
+ * Shared rules_text renderer + collapsed-expander builder.
+ *
+ * Issue #994: `purchasable_powers.rules_text` (markdown-lite, from #992's
+ * uplift) is displayed at three call sites — suite sheet Powers drawers,
+ * editor sheet drawers (pacts + generic merit row), and the dice modal.
+ * This module is the single source of truth for turning rules_text into
+ * safe HTML and for the collapsed toggle markup so all three sites stay
+ * byte-identical and XSS-safe.
+ *
+ * Format contract (per #992): paragraphs separated by blank lines;
+ * `**bold**` markers; an optional standalone `---` line ahead of a
+ * `**TM Errata:**` section. No other markdown.
+ */
+import { esc } from '../data/helpers.js';
+
+/**
+ * Render rules_text (+ rules_source provenance) to safe HTML.
+ * Escapes the ENTIRE input first via esc(), then applies exactly three
+ * transforms against the already-escaped string: `**...**` -> <strong>,
+ * blank-line breaks -> <p> paragraphs, a standalone `---` line -> a
+ * tokenised horizontal-rule div. Returns '' for empty input.
+ */
+export function renderRulesText(rulesText, rulesSource) {
+  const raw = (rulesText == null ? '' : String(rulesText));
+  if (!raw.trim()) return '';
+
+  const escaped = esc(raw);
+  const lines = escaped.split('\n');
+
+  let html = '';
+  let para = [];
+  const flushPara = () => {
+    if (!para.length) return;
+    const joined = para.join('<br>').replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+    html += `<p class="rules-text-p">${joined}</p>`;
+    para = [];
+  };
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === '---') {
+      flushPara();
+      html += '<div class="rules-text-hr"></div>';
+    } else if (trimmed === '') {
+      flushPara();
+    } else {
+      para.push(line);
+    }
+  }
+  flushPara();
+
+  if (rulesSource) {
+    html += `<div class="rules-text-source">Source: ${esc(rulesSource)}</div>`;
+  }
+  return html;
+}
+
+let _autoSeq = 0;
+
+/**
+ * Build a collapsed expander block (toggle button + hidden body). Returns
+ * '' when rulesText is empty so call sites can splice the result in
+ * unconditionally without an extra branch.
+ *
+ * @param {string} id - caller-supplied unique id fragment (alnum only recommended)
+ * @param {string} rulesText
+ * @param {string} [rulesSource]
+ * @param {{label?: string}} [opts] - label defaults to "Full rules"
+ */
+export function renderRulesExpander(id, rulesText, rulesSource, opts = {}) {
+  const text = (rulesText == null ? '' : String(rulesText));
+  if (!text.trim()) return '';
+  const label = opts.label || 'Full rules';
+  const safeId = esc(String(id || ('rt-auto-' + (_autoSeq++))));
+  const body = renderRulesText(text, rulesSource);
+  return '<div class="rules-expander">'
+    + '<button type="button" class="rules-expander-toggle" onclick="event.stopPropagation();toggleRulesText(\'' + safeId + '\')">'
+    + '<span class="rules-expander-arr">›</span><span>' + esc(label) + '</span>'
+    + '</button>'
+    + '<div class="rules-expander-body" id="rules-body-' + safeId + '">' + body + '</div>'
+    + '</div>';
+}
+
+/**
+ * Toggle a rendered expander open/closed. Wired as a real click handler
+ * (inline onclick on the <button>, never inside a `change` listener — see
+ * the repo's listener-routing blind-spot precedent). Stateless per-id DOM
+ * toggle — safe to share a single global across suite + editor + dice
+ * modal since it never touches module-level "currently open" state.
+ */
+export function toggleRulesText(id) {
+  const body = document.getElementById('rules-body-' + id);
+  if (!body) return;
+  const isOpen = body.classList.contains('visible');
+  body.classList.toggle('visible', !isOpen);
+  const toggleBtn = body.previousElementSibling;
+  if (toggleBtn && toggleBtn.classList.contains('rules-expander-toggle')) {
+    toggleBtn.classList.toggle('open', !isOpen);
+  }
+}
+
+// Rendered HTML uses an inline onclick="toggleRulesText(...)" attribute, so
+// the handler must be reachable as a bare global regardless of which module
+// (suite/sheet.js, editor/sheet.js, suite/dice-modal.js) happened to import
+// this file first.
+if (typeof window !== 'undefined') {
+  window.toggleRulesText = toggleRulesText;
+}

--- a/public/js/suite/dice-modal.js
+++ b/public/js/suite/dice-modal.js
@@ -10,6 +10,7 @@ import { getAttrEffective, skTotal, skNineAgain, skSpecs, getSkillObj } from '..
 import { hasAoE, displayName } from '../data/helpers.js';
 import { parseResistance, getResistTokenVal } from '../shared/resist.js';
 import { SKILLS_MENTAL, SKILLS_PHYSICAL, SKILLS_SOCIAL, ALL_SKILLS } from '../data/constants.js';
+import { renderRulesExpander } from '../shared/rules-text.js';
 import state from './data.js';   // only for reading rollChar / sheetChar
 
 // Attribute groups by category
@@ -312,6 +313,8 @@ export function openDiceModal(type, name, char) {
       if (pi.discName && pi.discV) info += ' + ' + pi.discName + ' ' + pi.discV;
       if (pi.cost) info += ' <span class="dm-info-dim">\u00B7 ' + pi.cost + '</span>';
       if (pi.resistance) info += ' <span class="dm-info-dim">\u00B7 vs ' + pi.resistance + '</span>';
+      // Issue #994: collapsed "Rules" expander beneath the cost line.
+      if (pi.rules_text) info += renderRulesExpander('dm-rules', pi.rules_text, pi.rules_source, { label: 'Rules' });
       infoEl.innerHTML = info;
     } else {
       // No-roll power
@@ -319,6 +322,7 @@ export function openDiceModal(type, name, char) {
       _ms.ps = 0;
       infoEl.innerHTML = '<span class="dm-info-dim">No dice pool \u2014 adjust manually</span>';
       if (pi?.info?.c) infoEl.innerHTML += ' <span class="dm-info-dim">\u00B7 Cost: ' + pi.info.c + '</span>';
+      if (pi?.rules_text) infoEl.innerHTML += renderRulesExpander('dm-rules', pi.rules_text, pi.rules_source, { label: 'Rules' });
     }
   } else if (type === 'skill') {
     // Bare skill roll — default attribute + skill selectors

--- a/public/js/suite/sheet-helpers.js
+++ b/public/js/suite/sheet-helpers.js
@@ -122,6 +122,10 @@ export function powersForDisc(powers, discName, dots) {
       stats: fmtRuleStats(r),
       effect: r.description || '',
       rank: r.rank,
+      // Issue #994: carry the full-rules text through so drawer renderers
+      // can offer a "Full rules" expander without a second lookup.
+      rules_text: r.rules_text || null,
+      rules_source: r.rules_source || null,
     }));
   }
   // Fallback: stored powers on the character (legacy / homebrew). Match by

--- a/public/js/suite/sheet.js
+++ b/public/js/suite/sheet.js
@@ -32,6 +32,8 @@ import { calcTotalInfluence, influenceBreakdown } from '../editor/domain.js';
 import { shRenderInfluenceMerits, shRenderDomainMerits, shRenderGeneralMerits, shRenderManoeuvres, shRenderEquipment } from '../editor/sheet.js';
 import { DICE_ICON_SVG, canRollDice } from './dice-modal.js';
 import { getPool } from '../shared/pools.js';
+import { renderRulesExpander } from '../shared/rules-text.js';
+import { getRulesByCategory } from '../data/loader.js';
 
 // ── STM display helpers (issue #425) ──
 // Mirror the editor sheet's wiring (public/js/editor/sheet.js) so modded
@@ -524,6 +526,10 @@ export function renderSheet() {
       + '</span>';
   }
 
+  // Issue #994: alnum-only id fragment for the rules-text expander toggle.
+  const _slugId = s => String(s || '').replace(/[^a-zA-Z0-9]/g, '');
+  const _charSlug = c.name.replace(/[^a-z]/gi, '');
+
   if (c.disciplines && Object.keys(c.disciplines).length) {
 
     function renderDiscRow(d, r, nameClass) {
@@ -536,10 +542,12 @@ export function renderSheet() {
         const _pPool = p.name ? getPool(c, p.name) : null;
         const _pHasRoll = _pPool && !_pPool.noRoll && _pPool.total !== undefined;
         const _pDice = (_showDice && _pHasRoll) ? `<span class="disc-power-dice" onclick="event.stopPropagation();openDiceModal('power','${_pName}')" title="Roll ${_pName}">${DICE_ICON_SVG}</span>` : '';
+        const _pRulesExp = p.rules_text ? renderRulesExpander('rt-' + _charSlug + _slugId(p.name), p.rules_text, p.rules_source) : '';
         drawerHtml += `<div class="disc-power">
           <div class="disc-power-name">${p.name || ''}${_pDice}</div>
           ${p.stats ? `<div class="disc-power-stats">${p.stats}</div>` : ''}
           <div class="disc-power-effect">${p.effect || ''}</div>
+          ${_pRulesExp}
         </div>`;
       });
       if (d === 'Auspex' && r >= 1) {
@@ -578,11 +586,14 @@ export function renderSheet() {
         const _devPool = p.name ? getPool(c, p.name) : null;
         const _devHasRoll = _devPool && !_devPool.noRoll && _devPool.total !== undefined;
         const _devDice = (_showDice && _devHasRoll) ? `<span class="disc-power-dice" onclick="event.stopPropagation();openDiceModal('power','${_devName}')" title="Roll ${_devName}">${DICE_ICON_SVG}</span>` : '';
+        const _devRule = getRulesByCategory('devotion').find(r => r.name === p.name);
+        const _devRulesExp = _devRule?.rules_text ? renderRulesExpander('rt-' + gid, _devRule.rules_text, _devRule.rules_source) : '';
         const inner = `<div class="trait-row"><div class="trait-main"><span class="trait-name secondary">${p.name || ''}</span>${_devDice}<div class="trait-right"><span class="disc-tap-arr">\u203A</span></div></div></div>`;
         html += `<div class="disc-tap-row" id="disc-row-${gid}" onclick="suiteToggleDisc('${gid}')">${inner}</div>
           <div class="disc-drawer" id="disc-drawer-${gid}"><div class="disc-power">
             ${p.stats ? `<div class="disc-power-stats">${p.stats}</div>` : ''}
             <div class="disc-power-effect">${p.effect || ''}</div>
+            ${_devRulesExp}
           </div></div>`;
       });
       html += `</div></div>`;
@@ -608,11 +619,14 @@ export function renderSheet() {
         const levelDots = p.level ? `<span class="trait-dots">${dots(p.level)}</span>` : '';
         const mgChip = p.mandragora_parked ? `<span class="rite-mg-tag" title="Permanently sustained by Mandragora Garden">MG</span>` : '';
         const tradSub = (p.tradition || mgChip) ? `<div class="trait-sub"><span class="trait-qual dim">${p.tradition || ''}</span>${mgChip}</div>` : '';
+        const _riteRule = getRulesByCategory('rite').find(r => r.name === p.name);
+        const _riteRulesExp = _riteRule?.rules_text ? renderRulesExpander('rt-' + gid, _riteRule.rules_text, _riteRule.rules_source) : '';
         const inner = `<div class="trait-row"><div class="trait-main"><span class="trait-name secondary">${p.name}</span>${_riteDice}<div class="trait-right">${levelDots}<span class="disc-tap-arr">\u203A</span></div></div>${tradSub}</div>`;
         html += `<div class="disc-tap-row" id="disc-row-${gid}" onclick="suiteToggleDisc('${gid}')">${inner}</div>
           <div class="disc-drawer" id="disc-drawer-${gid}"><div class="disc-power">
             ${p.stats ? `<div class="disc-power-stats">${p.stats}</div>` : ''}
             <div class="disc-power-effect">${p.effect || ''}</div>
+            ${_riteRulesExp}
           </div></div>`;
       });
       html += `</div></div>`;
@@ -628,11 +642,17 @@ export function renderSheet() {
         const _pactPool = p.name ? getPool(c, p.name) : null;
         const _pactHasRoll = _pactPool && !_pactPool.noRoll && _pactPool.total !== undefined;
         const _pactDice = (_showDice && _pactHasRoll) ? `<span class="disc-power-dice" onclick="event.stopPropagation();openDiceModal('power','${_pactName}')" title="Roll ${_pactName}">${DICE_ICON_SVG}</span>` : '';
+        // Issue #994: pacts (Invictus Oaths / Carthian Law) live in purchasable_powers
+        // as category "merit" (matches editor/sheet.js's _oathDB derivation).
+        // Match case-insensitively since stored power names vary in casing.
+        const _pactRule = getRulesByCategory('merit').find(r => (r.name || '').toLowerCase() === (p.name || '').toLowerCase());
+        const _pactRulesExp = _pactRule?.rules_text ? renderRulesExpander('rt-' + gid, _pactRule.rules_text, _pactRule.rules_source) : '';
         const inner = `<div class="trait-row"><div class="trait-main"><span class="trait-name secondary">${p.name}</span>${_pactDice}<div class="trait-right"><span class="disc-tap-arr">\u203A</span></div></div></div>`;
         html += `<div class="disc-tap-row" id="disc-row-${gid}" onclick="suiteToggleDisc('${gid}')">${inner}</div>
           <div class="disc-drawer" id="disc-drawer-${gid}"><div class="disc-power">
             ${p.stats ? `<div class="disc-power-stats">${p.stats}</div>` : ''}
             <div class="disc-power-effect">${p.effect || ''}</div>
+            ${_pactRulesExp}
           </div></div>`;
       });
       html += `</div></div>`;

--- a/specs/stories/994-rules-text-display.story.md
+++ b/specs/stories/994-rules-text-display.story.md
@@ -1,0 +1,71 @@
+---
+issue: 994
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/994
+branch: piatra/issue-994-rules-text-display
+---
+
+# Story 994: Display power `rules_text` in sheet drawers and dice modal
+
+**Story ID:** feat.994
+**Status:** Draft
+**Date:** 2026-07-15
+**Issue:** [#994](https://github.com/angelusvmorningstar/TerraMortis/issues/994)
+**Branch:** `piatra/issue-994-rules-text-display`
+
+---
+
+## User Story
+
+As a player on game day,
+I want to expand a power's full, errata-corrected rules right where the power is shown (sheet drawer, dice modal),
+so that I never have to open a PDF mid-scene.
+
+---
+
+## Background
+
+- #992 (merged, PR #993) added `rules_text` (full rulebook text, markdown-lite) and `rules_source` (provenance, e.g. "VtR 2e Rulebook + TM Errata") to 312 of 619 `purchasable_powers` docs in prod.
+- `/api/rules` (`server/routes/rules.js:27,43`) has **no projection** — full docs already flow to the client and into the `tm_rules_db` localStorage cache via `public/js/data/loader.js`. **No server change needed.** (Payload grows ~600-700KB; acceptable, note in PR.)
+- `rules_text` format: paragraphs separated by blank lines; `**bold**` markers (`**Cost:**`, `**Dice Pool:**`, `**Dramatic Failure:**` etc.); optionally a `---` line followed by `**TM Errata:**` section. No other markdown.
+- Display sites (verified):
+  1. **Suite sheet Powers section** — `public/js/suite/sheet.js` builds `powersHtml` (~:517-739); power rows/drawers show the one-line desc. Find where each discipline power / devotion / rite row renders its expandable body.
+  2. **Editor/legacy sheet drawers** — `public/js/editor/sheet.js`: rules-db map built at `:55` (`db[name] = { desc: r.description, ... }`); drawer bodies render `db.desc` at ~`:783` and ~`:2402`. The `:55` map must also carry `rules_text`/`rules_source`.
+  3. **Dice modal** — `public/js/suite/dice-modal.js` `#dm-pool-info` populated ~`:296-321` (shows pool breakdown + cost line).
+- CSS: tokens in `public/css/theme.css`; reuse existing drawer/expander component classes (`components.css`, `suite.css` — see `.disc-tap-row`/`.disc-drawer` pattern). NO bare hex, NO inline `style=`.
+- British English. No em-dashes in UI copy.
+
+---
+
+## Acceptance Criteria
+
+- [ ] AC1: A shared helper (suggest `public/js/shared/rules-text.js`) exports `renderRulesText(rulesText, rulesSource)` returning safe HTML: escape ALL input first (use existing `esc` helper), then transform exactly three markers — `**...**` → `<strong>`, blank-line paragraph breaks → `<p>`/`<br>`, a line consisting of `---` → `<hr>`-equivalent (tokenised class). Muted provenance line from `rules_source` at the end.
+- [ ] AC2: Suite sheet Powers section — every power row whose rules doc has non-empty `rules_text` gets a collapsed "Full rules" expander inside its drawer; tapping toggles it. Powers without `rules_text` render exactly as today.
+- [ ] AC3: Editor sheet drawers (both `:783`-area and `:2402`-area render paths) — same expander, same helper.
+- [ ] AC4: Dice modal — when the seeded pool has a matching rules doc with `rules_text`, `#dm-pool-info` gains a collapsed "Rules" expander beneath the cost line. Rolling is unaffected.
+- [ ] AC5: XSS-safe — a `rules_text` containing `<script>` or `<img onerror=...>` renders inert (test with a poisoned fixture).
+- [ ] AC6: Usable at 360px — expanded text wraps, scrolls vertically within the drawer if long, never causes horizontal page overflow.
+- [ ] AC7: All styling via theme tokens / existing classes; enforcement grep clean (no bare hex, no inline styles).
+- [ ] AC8: No server/schema changes; no admin-surface changes; edit-mode entry (stripOverlay path) untouched.
+
+## Design notes
+
+- Match key: the rules cache is keyed by name/key depending on site — editor/sheet.js keys `db` by `r.name.toLowerCase()` (`:55`); suite sheet + dice modal resolve powers via `powersForDisc`/`getPool` — pass the rules doc (or its `rules_text`) through the existing lookups rather than re-querying.
+- Lazy render is fine (build expander HTML on first toggle) but not required — 2-4KB strings are cheap.
+- Keep the expander label small-caps muted per existing drawer affordances; reuse an existing chevron/toggle class if one exists rather than inventing one.
+- The `**TM Errata:**` section after the `<hr>` should read as visually distinct via the hr + bold label only — no special colour needed.
+
+## Test Plan
+
+No test framework for client JS — browser smoke (per repo convention) + the AC5 poisoned-fixture check via a temporary console harness:
+1. Boot suite locally (`npx http-server public -p 8080` + `cd server && npm run dev`), pick a character with Animalism (Feral Whispers = book-only) and one with an errata-append power (Raise the Familiar).
+2. Sheet Powers drawer: expander present, toggles, renders bold/paragraphs/hr, provenance line shows.
+3. Power without rules_text (any Auspex power, any devotion): no expander, renders as today.
+4. Dice modal from a discipline row: Rules expander present and collapsed by default.
+5. 360px viewport: no horizontal overflow with the longest matched power.
+6. AC5: temporarily stub a poisoned rules_text in console; verify inert.
+7. Listener-routing check (repo blind spot): verify the toggle works via an actual click in-browser, not just code review — click handlers registered inside `change` listeners silently no-op.
+
+## Dev Notes
+
+- Do not push/PR/merge/commit — SM handles git after verification.
+- Unrelated uncommitted specs exist in the working tree — do not stage or modify them.


### PR DESCRIPTION
## Summary
Displays #992's uplifted `rules_text` as a collapsed 'Full rules' expander in the suite sheet Powers subsections (disciplines/devotions/rites/pacts), the shared merit drawers (suite + editor sheets), and the dice modal pool info. Shared XSS-safe renderer (esc-first; bold/paragraph/hr markers only) with `rules_source` provenance line. Closes #994 (manual close — dev-base PR).

## Test plan
Parse-check all six JS files; CSS-standards grep clean (tokens only, no inline styles); poisoned-fixture XSS harness; Playwright real-click toggle smoke at 360px (no horizontal overflow, drawer scrolls). Peter's live-data browser smoke passed 2026-07-15 (book-only, errata-append, and no-rules_text powers all render correctly).

Story: `specs/stories/994-rules-text-display.story.md`