### PR TITLE
Release: power rules-text uplift (#992) + Full rules display (#994)

### DIFF
--- a/public/css/components.css
+++ b/public/css/components.css
@@ -785,6 +785,19 @@ html:not([data-theme="dark"]) .edit-icon {
 .disc-power-effect{font-family:var(--ft);font-size:11px;color:var(--label-secondary);line-height:1.55;}
 .disc-sub-head{font-family:var(--fl);font-size:9px;font-weight:900;letter-spacing:.14em;text-transform:uppercase;color:var(--label-tertiary);padding:7px 12px 3px;}
 
+/* ── Rules text expander (issue #994) ── */
+.rules-expander{margin-top:6px;}
+.rules-expander-toggle{display:flex;align-items:center;gap:4px;width:100%;background:none;border:none;padding:4px 0;font-family:var(--fl);font-size:10px;font-weight:700;font-variant:small-caps;letter-spacing:.05em;color:var(--label-secondary);cursor:pointer;user-select:none;text-align:left;}
+.rules-expander-toggle:hover{color:var(--accent);}
+.rules-expander-arr{font-size:10px;color:var(--txt3);transition:transform .15s;flex-shrink:0;}
+.rules-expander-toggle.open .rules-expander-arr{transform:rotate(90deg);}
+.rules-expander-body{display:none;margin-top:4px;padding:8px 10px;background:var(--surf2);border:0.5px solid var(--bdr);border-radius:4px;font-family:var(--ft);font-size:11px;color:var(--label-secondary);line-height:1.6;max-height:320px;overflow-y:auto;overflow-wrap:anywhere;}
+.rules-expander-body.visible{display:block;}
+.rules-text-p{margin:0 0 8px 0;}
+.rules-text-p:last-child{margin-bottom:0;}
+.rules-text-hr{border-top:0.5px solid var(--bdr);margin:10px 0;}
+.rules-text-source{margin-top:8px;font-style:italic;color:var(--txt3);font-size:10px;}
+
 /* ── Rite badges ── */
 .rite-free-badge,.rite-xp-badge{font-family:var(--fl);font-size:9px;letter-spacing:.1em;text-transform:uppercase;border:1px solid;border-radius:3px;padding:1px 5px;cursor:pointer;transition:background .15s,color .15s;}
 .rite-free-badge{background:var(--accent-a8);color:var(--accent);border-color:var(--accent);}

--- a/public/js/editor/sheet.js
+++ b/public/js/editor/sheet.js
@@ -37,6 +37,7 @@ import { auditCharacter } from '../data/audit.js';
 import { powersForDisc } from '../suite/sheet-helpers.js';
 import { markerFor } from './st-mod-popover.js';
 import { getCatalogueEntry } from '../data/equipment-catalogue-cache.js';
+import { renderRulesExpander } from '../shared/rules-text.js';
 
 // Build legacy-format shims from rules cache for remaining deep consumers.
 // These produce arrays/objects in the old DEVOTIONS_DB/MERITS_DB/MAN_DB shape.
@@ -52,7 +53,10 @@ function _devDB() {
 function _meritDB() {
   const db = {};
   for (const r of getRulesByCategory('merit')) {
-    db[r.name.toLowerCase()] = { desc: r.description, prereq: r.prereq, prereqStr: r.prereq ? prereqLabel(r.prereq) : null, rating: r.rating_range ? `${r.rating_range[0]}–${r.rating_range[1]}` : null, type: r.parent, sub_category: r.sub_category };
+    // Issue #994: carry rules_text/rules_source through so pact/oath drawers
+    // (the only consumer of this map for power-style rules-text display)
+    // can offer a "Full rules" expander.
+    db[r.name.toLowerCase()] = { desc: r.description, prereq: r.prereq, prereqStr: r.prereq ? prereqLabel(r.prereq) : null, rating: r.rating_range ? `${r.rating_range[0]}–${r.rating_range[1]}` : null, type: r.parent, sub_category: r.sub_category, rules_text: r.rules_text || null, rules_source: r.rules_source || null };
   }
   return db;
 }
@@ -845,6 +849,8 @@ export function shRenderDisciplines(c, editMode) {
           + '<div class="disc-drawer" id="disc-drawer-' + gid + '"><div class="disc-power">'
           + (p.stats ? '<div class="disc-power-stats">' + esc(p.stats) + '</div>' : '')
           + '<div class="disc-power-effect">' + esc(effect) + '</div>'
+          // Issue #994: "Full rules" expander from the oath/law rules doc.
+          + (dbEntry && dbEntry.rules_text ? renderRulesExpander('rte-' + gid, dbEntry.rules_text, dbEntry.rules_source) : '')
           + '</div></div>';
       }
     });
@@ -2401,7 +2407,12 @@ export function shRenderMeritRow(m, idPrefix, i, dotHtml, chipHtml) {
   const _inner = (hasArr) => '<div class="trait-row"><div class="trait-main"><span class="trait-name">' + esc(mn) + '</span><div class="trait-right">' + (dt || '') + '<span class="exp-arr' + (hasArr ? '' : ' trait-arr-hidden') + '">\u203A</span></div></div>' + ((sn || chipHtml) ? '<div class="trait-sub">' + (chipHtml || '') + (sn ? '<span class="trait-qual">' + esc(sn) + '</span>' : '') + '</div>' : '') + '</div>';
   if (db && db.desc) {
     const id2 = idPrefix + i, pqStr = db.prereq ? prereqLabel(db.prereq) : '', body = '<div>' + esc(db.desc) + '</div>' + (pqStr ? '<div style="margin-top:5px;font-style:italic;color:var(--txt3)">Prerequisite: ' + esc(pqStr) + '</div>' : '');
-    return '<div class="exp-row" id="exp-row-' + id2 + '" onclick="toggleExp(\'' + id2 + '\')">' + _inner(true) + '</div><div class="exp-body" id="exp-body-' + id2 + '">' + body + '</div>';
+    // Issue #994: "Full rules" expander from the merit's rules doc (meritLookup
+    // carries the full rule via db._rule). Reused by both the editor sheet and
+    // the suite sheet (shRenderInfluenceMerits/shRenderGeneralMerits etc. delegate here).
+    const _ruleDoc = db._rule || null;
+    const rulesExp = _ruleDoc && _ruleDoc.rules_text ? renderRulesExpander('rte-' + id2, _ruleDoc.rules_text, _ruleDoc.rules_source) : '';
+    return '<div class="exp-row" id="exp-row-' + id2 + '" onclick="toggleExp(\'' + id2 + '\')">' + _inner(true) + '</div><div class="exp-body" id="exp-body-' + id2 + '">' + body + rulesExp + '</div>';
   }
   return '<div class="merit-plain">' + _inner(false) + '</div>';
 }

--- a/public/js/shared/pools.js
+++ b/public/js/shared/pools.js
@@ -34,7 +34,14 @@ export function getPool(char, raw) {
   const rule = getRuleByKey(slug) || getRuleByKey('rite-' + slug) || getRuleByKey('devotion-' + slug);
   if (rule) {
     const p = rule.pool;
-    if (!p || (!p.attr && !p.skill)) return { noRoll: true, info: { d: rule.parent, c: rule.cost, ac: rule.action, du: rule.duration, ef: rule.description } };
+    // Issue #994: pass rules_text/rules_source through so the dice modal
+    // can render a "Rules" expander without a second rules-cache query.
+    if (!p || (!p.attr && !p.skill)) return {
+      noRoll: true,
+      info: { d: rule.parent, c: rule.cost, ac: rule.action, du: rule.duration, ef: rule.description },
+      rules_text: rule.rules_text || null,
+      rules_source: rule.rules_source || null,
+    };
     const attrV  = p.attr  ? getAttrEffective(char, p.attr) : 0;
     const skillV = p.skill ? skTotal(char, p.skill)         : 0;
     const unskilled = (p.skill && skillV === 0) ? unskilledPenalty(p.skill) : 0;
@@ -51,6 +58,8 @@ export function getPool(char, raw) {
       duration: rule.duration || null,
       effect: rule.description || null,
       isRitual: rule.action === 'Ritual',
+      rules_text: rule.rules_text || null,
+      rules_source: rule.rules_source || null,
       info: { d: rule.parent, a: p.attr, s: p.skill, r: rule.resistance, c: rule.cost, ac: rule.action, du: rule.duration, ef: rule.description }
     };
   }

--- a/public/js/shared/rules-text.js
+++ b/public/js/shared/rules-text.js
@@ -1,0 +1,109 @@
+/**
+ * Shared rules_text renderer + collapsed-expander builder.
+ *
+ * Issue #994: `purchasable_powers.rules_text` (markdown-lite, from #992's
+ * uplift) is displayed at three call sites — suite sheet Powers drawers,
+ * editor sheet drawers (pacts + generic merit row), and the dice modal.
+ * This module is the single source of truth for turning rules_text into
+ * safe HTML and for the collapsed toggle markup so all three sites stay
+ * byte-identical and XSS-safe.
+ *
+ * Format contract (per #992): paragraphs separated by blank lines;
+ * `**bold**` markers; an optional standalone `---` line ahead of a
+ * `**TM Errata:**` section. No other markdown.
+ */
+import { esc } from '../data/helpers.js';
+
+/**
+ * Render rules_text (+ rules_source provenance) to safe HTML.
+ * Escapes the ENTIRE input first via esc(), then applies exactly three
+ * transforms against the already-escaped string: `**...**` -> <strong>,
+ * blank-line breaks -> <p> paragraphs, a standalone `---` line -> a
+ * tokenised horizontal-rule div. Returns '' for empty input.
+ */
+export function renderRulesText(rulesText, rulesSource) {
+  const raw = (rulesText == null ? '' : String(rulesText));
+  if (!raw.trim()) return '';
+
+  const escaped = esc(raw);
+  const lines = escaped.split('\n');
+
+  let html = '';
+  let para = [];
+  const flushPara = () => {
+    if (!para.length) return;
+    const joined = para.join('<br>').replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+    html += `<p class="rules-text-p">${joined}</p>`;
+    para = [];
+  };
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed === '---') {
+      flushPara();
+      html += '<div class="rules-text-hr"></div>';
+    } else if (trimmed === '') {
+      flushPara();
+    } else {
+      para.push(line);
+    }
+  }
+  flushPara();
+
+  if (rulesSource) {
+    html += `<div class="rules-text-source">Source: ${esc(rulesSource)}</div>`;
+  }
+  return html;
+}
+
+let _autoSeq = 0;
+
+/**
+ * Build a collapsed expander block (toggle button + hidden body). Returns
+ * '' when rulesText is empty so call sites can splice the result in
+ * unconditionally without an extra branch.
+ *
+ * @param {string} id - caller-supplied unique id fragment (alnum only recommended)
+ * @param {string} rulesText
+ * @param {string} [rulesSource]
+ * @param {{label?: string}} [opts] - label defaults to "Full rules"
+ */
+export function renderRulesExpander(id, rulesText, rulesSource, opts = {}) {
+  const text = (rulesText == null ? '' : String(rulesText));
+  if (!text.trim()) return '';
+  const label = opts.label || 'Full rules';
+  const safeId = esc(String(id || ('rt-auto-' + (_autoSeq++))));
+  const body = renderRulesText(text, rulesSource);
+  return '<div class="rules-expander">'
+    + '<button type="button" class="rules-expander-toggle" onclick="event.stopPropagation();toggleRulesText(\'' + safeId + '\')">'
+    + '<span class="rules-expander-arr">›</span><span>' + esc(label) + '</span>'
+    + '</button>'
+    + '<div class="rules-expander-body" id="rules-body-' + safeId + '">' + body + '</div>'
+    + '</div>';
+}
+
+/**
+ * Toggle a rendered expander open/closed. Wired as a real click handler
+ * (inline onclick on the <button>, never inside a `change` listener — see
+ * the repo's listener-routing blind-spot precedent). Stateless per-id DOM
+ * toggle — safe to share a single global across suite + editor + dice
+ * modal since it never touches module-level "currently open" state.
+ */
+export function toggleRulesText(id) {
+  const body = document.getElementById('rules-body-' + id);
+  if (!body) return;
+  const isOpen = body.classList.contains('visible');
+  body.classList.toggle('visible', !isOpen);
+  const toggleBtn = body.previousElementSibling;
+  if (toggleBtn && toggleBtn.classList.contains('rules-expander-toggle')) {
+    toggleBtn.classList.toggle('open', !isOpen);
+  }
+}
+
+// Rendered HTML uses an inline onclick="toggleRulesText(...)" attribute, so
+// the handler must be reachable as a bare global regardless of which module
+// (suite/sheet.js, editor/sheet.js, suite/dice-modal.js) happened to import
+// this file first.
+if (typeof window !== 'undefined') {
+  window.toggleRulesText = toggleRulesText;
+}

--- a/public/js/suite/dice-modal.js
+++ b/public/js/suite/dice-modal.js
@@ -10,6 +10,7 @@ import { getAttrEffective, skTotal, skNineAgain, skSpecs, getSkillObj } from '..
 import { hasAoE, displayName } from '../data/helpers.js';
 import { parseResistance, getResistTokenVal } from '../shared/resist.js';
 import { SKILLS_MENTAL, SKILLS_PHYSICAL, SKILLS_SOCIAL, ALL_SKILLS } from '../data/constants.js';
+import { renderRulesExpander } from '../shared/rules-text.js';
 import state from './data.js';   // only for reading rollChar / sheetChar
 
 // Attribute groups by category
@@ -312,6 +313,8 @@ export function openDiceModal(type, name, char) {
       if (pi.discName && pi.discV) info += ' + ' + pi.discName + ' ' + pi.discV;
       if (pi.cost) info += ' <span class="dm-info-dim">\u00B7 ' + pi.cost + '</span>';
       if (pi.resistance) info += ' <span class="dm-info-dim">\u00B7 vs ' + pi.resistance + '</span>';
+      // Issue #994: collapsed "Rules" expander beneath the cost line.
+      if (pi.rules_text) info += renderRulesExpander('dm-rules', pi.rules_text, pi.rules_source, { label: 'Rules' });
       infoEl.innerHTML = info;
     } else {
       // No-roll power
@@ -319,6 +322,7 @@ export function openDiceModal(type, name, char) {
       _ms.ps = 0;
       infoEl.innerHTML = '<span class="dm-info-dim">No dice pool \u2014 adjust manually</span>';
       if (pi?.info?.c) infoEl.innerHTML += ' <span class="dm-info-dim">\u00B7 Cost: ' + pi.info.c + '</span>';
+      if (pi?.rules_text) infoEl.innerHTML += renderRulesExpander('dm-rules', pi.rules_text, pi.rules_source, { label: 'Rules' });
     }
   } else if (type === 'skill') {
     // Bare skill roll — default attribute + skill selectors

--- a/public/js/suite/sheet-helpers.js
+++ b/public/js/suite/sheet-helpers.js
@@ -122,6 +122,10 @@ export function powersForDisc(powers, discName, dots) {
       stats: fmtRuleStats(r),
       effect: r.description || '',
       rank: r.rank,
+      // Issue #994: carry the full-rules text through so drawer renderers
+      // can offer a "Full rules" expander without a second lookup.
+      rules_text: r.rules_text || null,
+      rules_source: r.rules_source || null,
     }));
   }
   // Fallback: stored powers on the character (legacy / homebrew). Match by

--- a/public/js/suite/sheet.js
+++ b/public/js/suite/sheet.js
@@ -32,6 +32,8 @@ import { calcTotalInfluence, influenceBreakdown } from '../editor/domain.js';
 import { shRenderInfluenceMerits, shRenderDomainMerits, shRenderGeneralMerits, shRenderManoeuvres, shRenderEquipment } from '../editor/sheet.js';
 import { DICE_ICON_SVG, canRollDice } from './dice-modal.js';
 import { getPool } from '../shared/pools.js';
+import { renderRulesExpander } from '../shared/rules-text.js';
+import { getRulesByCategory } from '../data/loader.js';
 
 // ── STM display helpers (issue #425) ──
 // Mirror the editor sheet's wiring (public/js/editor/sheet.js) so modded
@@ -524,6 +526,10 @@ export function renderSheet() {
       + '</span>';
   }
 
+  // Issue #994: alnum-only id fragment for the rules-text expander toggle.
+  const _slugId = s => String(s || '').replace(/[^a-zA-Z0-9]/g, '');
+  const _charSlug = c.name.replace(/[^a-z]/gi, '');
+
   if (c.disciplines && Object.keys(c.disciplines).length) {
 
     function renderDiscRow(d, r, nameClass) {
@@ -536,10 +542,12 @@ export function renderSheet() {
         const _pPool = p.name ? getPool(c, p.name) : null;
         const _pHasRoll = _pPool && !_pPool.noRoll && _pPool.total !== undefined;
         const _pDice = (_showDice && _pHasRoll) ? `<span class="disc-power-dice" onclick="event.stopPropagation();openDiceModal('power','${_pName}')" title="Roll ${_pName}">${DICE_ICON_SVG}</span>` : '';
+        const _pRulesExp = p.rules_text ? renderRulesExpander('rt-' + _charSlug + _slugId(p.name), p.rules_text, p.rules_source) : '';
         drawerHtml += `<div class="disc-power">
           <div class="disc-power-name">${p.name || ''}${_pDice}</div>
           ${p.stats ? `<div class="disc-power-stats">${p.stats}</div>` : ''}
           <div class="disc-power-effect">${p.effect || ''}</div>
+          ${_pRulesExp}
         </div>`;
       });
       if (d === 'Auspex' && r >= 1) {
@@ -578,11 +586,14 @@ export function renderSheet() {
         const _devPool = p.name ? getPool(c, p.name) : null;
         const _devHasRoll = _devPool && !_devPool.noRoll && _devPool.total !== undefined;
         const _devDice = (_showDice && _devHasRoll) ? `<span class="disc-power-dice" onclick="event.stopPropagation();openDiceModal('power','${_devName}')" title="Roll ${_devName}">${DICE_ICON_SVG}</span>` : '';
+        const _devRule = getRulesByCategory('devotion').find(r => r.name === p.name);
+        const _devRulesExp = _devRule?.rules_text ? renderRulesExpander('rt-' + gid, _devRule.rules_text, _devRule.rules_source) : '';
         const inner = `<div class="trait-row"><div class="trait-main"><span class="trait-name secondary">${p.name || ''}</span>${_devDice}<div class="trait-right"><span class="disc-tap-arr">\u203A</span></div></div></div>`;
         html += `<div class="disc-tap-row" id="disc-row-${gid}" onclick="suiteToggleDisc('${gid}')">${inner}</div>
           <div class="disc-drawer" id="disc-drawer-${gid}"><div class="disc-power">
             ${p.stats ? `<div class="disc-power-stats">${p.stats}</div>` : ''}
             <div class="disc-power-effect">${p.effect || ''}</div>
+            ${_devRulesExp}
           </div></div>`;
       });
       html += `</div></div>`;
@@ -608,11 +619,14 @@ export function renderSheet() {
         const levelDots = p.level ? `<span class="trait-dots">${dots(p.level)}</span>` : '';
         const mgChip = p.mandragora_parked ? `<span class="rite-mg-tag" title="Permanently sustained by Mandragora Garden">MG</span>` : '';
         const tradSub = (p.tradition || mgChip) ? `<div class="trait-sub"><span class="trait-qual dim">${p.tradition || ''}</span>${mgChip}</div>` : '';
+        const _riteRule = getRulesByCategory('rite').find(r => r.name === p.name);
+        const _riteRulesExp = _riteRule?.rules_text ? renderRulesExpander('rt-' + gid, _riteRule.rules_text, _riteRule.rules_source) : '';
         const inner = `<div class="trait-row"><div class="trait-main"><span class="trait-name secondary">${p.name}</span>${_riteDice}<div class="trait-right">${levelDots}<span class="disc-tap-arr">\u203A</span></div></div>${tradSub}</div>`;
         html += `<div class="disc-tap-row" id="disc-row-${gid}" onclick="suiteToggleDisc('${gid}')">${inner}</div>
           <div class="disc-drawer" id="disc-drawer-${gid}"><div class="disc-power">
             ${p.stats ? `<div class="disc-power-stats">${p.stats}</div>` : ''}
             <div class="disc-power-effect">${p.effect || ''}</div>
+            ${_riteRulesExp}
           </div></div>`;
       });
       html += `</div></div>`;
@@ -628,11 +642,17 @@ export function renderSheet() {
         const _pactPool = p.name ? getPool(c, p.name) : null;
         const _pactHasRoll = _pactPool && !_pactPool.noRoll && _pactPool.total !== undefined;
         const _pactDice = (_showDice && _pactHasRoll) ? `<span class="disc-power-dice" onclick="event.stopPropagation();openDiceModal('power','${_pactName}')" title="Roll ${_pactName}">${DICE_ICON_SVG}</span>` : '';
+        // Issue #994: pacts (Invictus Oaths / Carthian Law) live in purchasable_powers
+        // as category "merit" (matches editor/sheet.js's _oathDB derivation).
+        // Match case-insensitively since stored power names vary in casing.
+        const _pactRule = getRulesByCategory('merit').find(r => (r.name || '').toLowerCase() === (p.name || '').toLowerCase());
+        const _pactRulesExp = _pactRule?.rules_text ? renderRulesExpander('rt-' + gid, _pactRule.rules_text, _pactRule.rules_source) : '';
         const inner = `<div class="trait-row"><div class="trait-main"><span class="trait-name secondary">${p.name}</span>${_pactDice}<div class="trait-right"><span class="disc-tap-arr">\u203A</span></div></div></div>`;
         html += `<div class="disc-tap-row" id="disc-row-${gid}" onclick="suiteToggleDisc('${gid}')">${inner}</div>
           <div class="disc-drawer" id="disc-drawer-${gid}"><div class="disc-power">
             ${p.stats ? `<div class="disc-power-stats">${p.stats}</div>` : ''}
             <div class="disc-power-effect">${p.effect || ''}</div>
+            ${_pactRulesExp}
           </div></div>`;
       });
       html += `</div></div>`;

--- a/server/schemas/purchasable_power.schema.js
+++ b/server/schemas/purchasable_power.schema.js
@@ -90,6 +90,13 @@ export const purchasablePowerSchema = {
 
     // Mechanics
     description: { type: 'string' },
+    // Issue #992: full rulebook text uplift. Optional — populated by
+    // server/scripts/uplift-power-rules-text.js. `description` (above)
+    // remains the untouched one-line summary; `rules_text` is the full
+    // parsed rules body, `rules_source` records provenance (e.g.
+    // "VtR 2e Rulebook" or "VtR 2e Rulebook + TM Errata").
+    rules_text:   { type: 'string' },
+    rules_source: { type: 'string' },
     pool: {
       oneOf: [
         {

--- a/server/scripts/reports/992-costs-extract.json
+++ b/server/scripts/reports/992-costs-extract.json
@@ -1,0 +1,67 @@
+[
+  {
+    "key": "feral-whispers",
+    "name": "Feral Whispers",
+    "cost_raw": "None"
+  },
+  {
+    "key": "lay-open-the-mind",
+    "name": "Lay Open the Mind",
+    "cost_raw": "1 Vitae"
+  },
+  {
+    "key": "iron-edict",
+    "name": "Iron Edict",
+    "cost_raw": "1 Vitae; none if victim is in Vinculum with the vampire"
+  },
+  {
+    "key": "awe",
+    "name": "Awe",
+    "cost_raw": "None"
+  },
+  {
+    "key": "confidant",
+    "name": "Confidant",
+    "cost_raw": "None"
+  },
+  {
+    "key": "loyalty",
+    "name": "Loyalty",
+    "cost_raw": "2 Vitae"
+  },
+  {
+    "key": "dread-presence",
+    "name": "Dread Presence",
+    "cost_raw": "None"
+  },
+  {
+    "key": "face-of-the-beast",
+    "name": "Face of the Beast",
+    "cost_raw": "1 Vitae **136** **Vampire: the Requiem**"
+  },
+  {
+    "key": "grand-delusion",
+    "name": "Grand Delusion",
+    "cost_raw": "2 Vitae"
+  },
+  {
+    "key": "waking-nightmare",
+    "name": "Waking Nightmare",
+    "cost_raw": "1 Vitae"
+  },
+  {
+    "key": "beasts-skin",
+    "name": "Beast's Skin",
+    "cost_raw": "2 Vitae"
+  },
+  {
+    "key": "predatory-aspect",
+    "name": "Predatory Aspect",
+    "cost_raw": "1 Vitae"
+  },
+  {
+    "key": "unmarked-grave",
+    "name": "Unmarked Grave",
+    "cost_raw": "Varies; 0 for soil or earth, otherwise Vitae equal to the Durability of the material."
+  }
+]

--- a/server/scripts/reports/992-costs-extract.json
+++ b/server/scripts/reports/992-costs-extract.json
@@ -5,11 +5,6 @@
     "cost_raw": "None"
   },
   {
-    "key": "lay-open-the-mind",
-    "name": "Lay Open the Mind",
-    "cost_raw": "1 Vitae"
-  },
-  {
     "key": "iron-edict",
     "name": "Iron Edict",
     "cost_raw": "1 Vitae; none if victim is in Vinculum with the vampire"

--- a/server/scripts/reports/992-uplift-report.json
+++ b/server/scripts/reports/992-uplift-report.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-14T13:16:01.621Z",
+  "generated_at": "2026-07-15T03:43:21.626Z",
   "book_status": [
     {
       "file": "Vampire the Requiem 2e Rulebook.md",
@@ -48,46 +48,54 @@
     }
   ],
   "totals": {
-    "matched": 317,
+    "matched": 312,
     "ambiguous": 19,
     "unmatched": 283,
+    "skipped_auspex": 5,
     "total": 619
   },
   "by_category": {
     "attribute": {
       "matched": 0,
       "unmatched": 9,
-      "ambiguous": 0
+      "ambiguous": 0,
+      "skipped_auspex": 0
     },
     "skill": {
       "matched": 0,
       "unmatched": 24,
-      "ambiguous": 0
+      "ambiguous": 0,
+      "skipped_auspex": 0
     },
     "discipline": {
-      "matched": 29,
+      "matched": 24,
       "unmatched": 16,
-      "ambiguous": 5
+      "ambiguous": 5,
+      "skipped_auspex": 5
     },
     "merit": {
       "matched": 126,
       "unmatched": 42,
-      "ambiguous": 13
+      "ambiguous": 13,
+      "skipped_auspex": 0
     },
     "devotion": {
       "matched": 0,
       "unmatched": 45,
-      "ambiguous": 0
+      "ambiguous": 0,
+      "skipped_auspex": 0
     },
     "manoeuvre": {
       "matched": 144,
       "unmatched": 33,
-      "ambiguous": 1
+      "ambiguous": 1,
+      "skipped_auspex": 0
     },
     "rite": {
       "matched": 18,
       "unmatched": 114,
-      "ambiguous": 0
+      "ambiguous": 0,
+      "skipped_auspex": 0
     }
   },
   "matches": [
@@ -106,53 +114,8 @@
       "category": "discipline",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 44,
-      "after_len": 149,
-      "preview": "Maintained familiars must be purchased as Retainers and impose a –1 Vitae from the character's starting Vitae pool each game. _Source: VTR 2e pg 121_"
-    },
-    {
-      "key": "beasts-hackles",
-      "name": "Beast's Hackles",
-      "category": "discipline",
-      "source": "VtR 2e Rulebook + TM Errata",
-      "before_len": 45,
-      "after_len": 419,
-      "preview": "**Clarification:** All questions at this level must be related to weakness or danger. If the Storyteller cannot determine the answer to a player's que"
-    },
-    {
-      "key": "lay-open-the-mind",
-      "name": "Lay Open the Mind",
-      "category": "discipline",
-      "source": "VtR 2e Rulebook",
-      "before_len": 46,
-      "after_len": 2012,
-      "preview": "The Mekhet focuses on bringing her thoughts in line with her victim. He begins to think like her, and soon hears her thoughts in his mind. By concentr"
-    },
-    {
-      "key": "spirits-touch",
-      "name": "Spirit's Touch",
-      "category": "discipline",
-      "source": "VtR 2e Rulebook + TM Errata",
-      "before_len": 53,
-      "after_len": 920,
-      "preview": "**Cost** is now: Varies, as the Discipline is slightly tiring; the first use in a scene is free, but subsequent uses in the same scene cost 1 Vitae ea"
-    },
-    {
-      "key": "twilight-projection",
-      "name": "Twilight Projection",
-      "category": "discipline",
-      "source": "VtR 2e Rulebook + TM Errata",
-      "before_len": 33,
-      "after_len": 515,
-      "preview": "A vampire in Twilight Projection can use Auspex 1–3 once per scene, but may not spend blood for additional uses. _Source: VTR 2e pg 125_  **CELERITY:*"
-    },
-    {
-      "key": "uncanny-perception",
-      "name": "Uncanny Perception",
-      "category": "discipline",
-      "source": "VtR 2e Rulebook + TM Errata",
-      "before_len": 56,
-      "after_len": 284,
-      "preview": "This power must be used on a single creature that can currently be perceived. This power can be used to initiate a Clash of Wills against any objects "
+      "after_len": 2527,
+      "preview": "True beasts cannot be Embraced. They have never had the necessary Humanity. With this power, though, the vampire can complete the process halfway. By "
     },
     {
       "key": "iron-edict",
@@ -169,8 +132,8 @@
       "category": "discipline",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 22,
-      "after_len": 281,
-      "preview": "Resistance to Possession is now – victim's Resolve + Supernatural Tolerance. Possession only allows the possessor to walk in the sun without consequen"
+      "after_len": 3050,
+      "preview": "Controlling a victim’s memories and actions is one thing, but for some vampires the truest expression of control comes from suppressing the victim’s w"
     },
     {
       "key": "awe",
@@ -196,8 +159,8 @@
       "category": "discipline",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 65,
-      "after_len": 665,
-      "preview": "**Clarification:** Green Eyes has two different uses. The first is to change emotional state and requires no action; the second is to make requests. O"
+      "after_len": 2408,
+      "preview": "To a victim of this level of Majesty, the vampire’s attention feels so good that it’s addictive. His inner circle craves his attention like a crackhea"
     },
     {
       "key": "idol",
@@ -205,8 +168,8 @@
       "category": "discipline",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 71,
-      "after_len": 163,
-      "preview": "**Clarification:** A successful reflexive roll to resist Idol only allows for one action before the check must be made again. _Source: VTR 2e pg 139_ "
+      "after_len": 2323,
+      "preview": "More than just a celebrity, a vampire who can play with people’s desires becomes a king or a star, the kind of person who wouldn’t ever be so crass as"
     },
     {
       "key": "loyalty",
@@ -250,8 +213,8 @@
       "category": "discipline",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 54,
-      "after_len": 324,
-      "preview": "Resistance to Mortal Terror is now – victim's Composure + Supernatural Tolerance. Full lethal damage is applied to vampires. Composure damage on vampi"
+      "after_len": 2768,
+      "preview": "The Nosferatu can summon horrific visions from the depths of a victim’s soul. She twists everything around her victim to **Chapter Three: Laws of the "
     },
     {
       "key": "waking-nightmare",
@@ -268,8 +231,8 @@
       "category": "discipline",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 17,
-      "after_len": 174,
-      "preview": "When using Cloak of Night to leave active combat they have participated in, it will initiate an automatic Clash of Wills against anyone with Auspex 2."
+      "after_len": 1862,
+      "preview": "With but a thought, the vampire slips from both sight and mind. He doesn’t just fade into the background, he vanishes entirely. He leaves no scent and"
     },
     {
       "key": "face-in-the-crowd",
@@ -277,8 +240,8 @@
       "category": "discipline",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 71,
-      "after_len": 541,
-      "preview": "When using Face in the Crowd to leave active combat they have participated in, onlookers can make a reflexive Wits + Composure – Obfuscate to still no"
+      "after_len": 2216,
+      "preview": "The vampire can turn his predatory aura inwards, walking through crowds of people who pay him no heed. As long as he doesn’t do anything to obviously "
     },
     {
       "key": "oubliette",
@@ -286,8 +249,8 @@
       "category": "discipline",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 87,
-      "after_len": 186,
-      "preview": "This power has no cost and is always considered active on a character's Haven/Safe Place. Further uses of this power can occur for the standard cost. "
+      "after_len": 3155,
+      "preview": "The vampire creates a realm of his own, hiding a place from mundane senses and scrambling the perceptions of everyone within. He can turn an alleyway "
     },
     {
       "key": "the-familiar-stranger",
@@ -295,8 +258,8 @@
       "category": "discipline",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 43,
-      "after_len": 291,
-      "preview": "As per Touch of Shadow, can be used at no cost for an unlimited duration on inanimate objects carried or worn by the vampire to reskin. However, no eq"
+      "after_len": 1913,
+      "preview": "Rather than removing himself from the perceptions of other people, the vampire can instead adjust how they see him. He can either appear as a subjecti"
     },
     {
       "key": "touch-of-shadow",
@@ -304,8 +267,8 @@
       "category": "discipline",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 43,
-      "after_len": 224,
-      "preview": "The effects of Touch of Shadow can be used at no cost for an unlimited duration on inanimate objects carried or worn by the vampire, so long as the ch"
+      "after_len": 2602,
+      "preview": "With just a touch, the vampire can extend the muted attentions of Face in the Crowd to an object or animal, rather than himself. His subject fades out"
     },
     {
       "key": "beasts-skin",
@@ -331,8 +294,8 @@
       "category": "discipline",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 21,
-      "after_len": 1459,
-      "preview": "Feeding on a vampire's open wounds shares all the same drawbacks as drinking Vitae. Kindred cannot be fed from if they have no open wounds. _Source: V"
+      "after_len": 53627,
+      "preview": "The Beast bursts out from the vampire’s body, dissolving it into a cloud of hungry smoke. Occasionally, her victims can see **Chapter Three: Laws of t"
     },
     {
       "key": "unmarked-grave",
@@ -349,8 +312,8 @@
       "category": "discipline",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 25,
-      "after_len": 94,
-      "preview": "**Adaptations:** ● **Barbed Hands:** Damage is not lethal to vampires. _Source: VTR 2e pg 147_"
+      "after_len": 2348,
+      "preview": "With her Beast boiling in her blood, the pathetic shell of the vampire’s human or animal form cannot contain it. Her flesh warps, twisting and crackin"
     },
     {
       "key": "acute-senses",
@@ -367,8 +330,8 @@
       "category": "merit",
       "source": "Secrets of the Covenants + TM Errata",
       "before_len": 69,
-      "after_len": 437,
-      "preview": "Merit now reads:  **Prerequisites:** Carthian Status •, Athletics ••, Stealth ••, Streetwise •• **Effect:** Carthians are the vampires most intimately"
+      "after_len": 1229,
+      "preview": "**Prerequisites:** Athletics ••, Stealth ••, Streetwise •• Carthians are the vampires most intimately familiar with the city streets. A Carthian with "
     },
     {
       "key": "allies",
@@ -376,8 +339,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 102,
-      "after_len": 631,
-      "preview": "Each instance represents one area of influence: Bureaucracy, Church, Finance, Health, High Society, Industry, Legal, Military, Media, Occult, Police, "
+      "after_len": 3972,
+      "preview": "**Effect:** Allies help your character. They might be friends, employees, associates, or people your character has blackmailed. Each instance of this "
     },
     {
       "key": "altar",
@@ -385,8 +348,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 104,
-      "after_len": 567,
-      "preview": "Merit now reads:  **Prerequisite:** Circle of the Crone Status • **Effect:** You've contributed to attuning a blood altar. In the presence of the alta"
+      "after_len": 1556,
+      "preview": "**Prerequisites**: Circle of the Crone Status •  **Effect:** Your character is attuned to a mystical, bloody altar. She may have crafted it herself, o"
     },
     {
       "key": "ambidextrous",
@@ -394,8 +357,8 @@
       "category": "merit",
       "source": "CofD Rulebook + TM Errata",
       "before_len": 36,
-      "after_len": 58,
-      "preview": "Cost reduced from 3 dots to 2 dots. _Source: CoD 2e pg 49_"
+      "after_len": 238,
+      "preview": "**Effect:** Your character does not suffer the -2 penalty for using his off hand in combat or to perform other actions. _Available only at character c"
     },
     {
       "key": "anointed",
@@ -430,8 +393,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 52,
-      "after_len": 57,
-      "preview": "Cost reduced from 2 dots to 1 dot. _Source: CoD 2e pg 50_"
+      "after_len": 409,
+      "preview": "**Prerequisite:** Socialize •• **Effect:** Your character is a natural in the Rack and can procure an open invitation wherever she wishes. Whereas mos"
     },
     {
       "key": "bloodhound",
@@ -439,8 +402,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 49,
-      "after_len": 58,
-      "preview": "Cost reduced from 2 dots to 1 dot. _Source: VTR 2e pg 110_"
+      "after_len": 352,
+      "preview": "**Prerequisites:** Wits ••• **Effect:** Your character can discern the intricacies of blood by smelling it, as if he had tasted it. When using his Kin"
     },
     {
       "key": "breaking-the-chains",
@@ -457,8 +420,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 61,
-      "after_len": 74,
-      "preview": "Only level 1 is available at character creation. _Source: VTR 2e_ _pg 110_"
+      "after_len": 1365,
+      "preview": "**Prerequisite:** City Status • **Effect:** You have your finger on the pulse of the Kindred underground. You’re adept with the codes and cants that a"
     },
     {
       "key": "carthian-pull",
@@ -475,8 +438,8 @@
       "category": "merit",
       "source": "Secrets of the Covenants + TM Errata",
       "before_len": 68,
-      "after_len": 56,
-      "preview": "Cost reduced from 2 dots to 1 dot. _Source: SotC pg 178_"
+      "after_len": 980,
+      "preview": "**Prerequisites:** **Not** a member of the Carthian Movement While your character is not a member of the Carthian Movement, she spends enough time aro"
     },
     {
       "key": "cease-fire",
@@ -484,8 +447,8 @@
       "category": "merit",
       "source": "Secrets of the Covenants + TM Errata",
       "before_len": 53,
-      "after_len": 82,
-      "preview": "Talk to Storytellers about how a Cease Fire can be declared. _Source: SotC pg 180_"
+      "after_len": 1648,
+      "preview": "**Prerequisites:** Carthian Status ••••• Law, at its heart, boasts the ability to bring peace. Cease Fire is a Carthian Law built on that principle, e"
     },
     {
       "key": "cheap-shot",
@@ -502,8 +465,8 @@
       "category": "merit",
       "source": "Secrets of the Covenants + TM Errata",
       "before_len": 65,
-      "after_len": 206,
-      "preview": "Changed mechanics. Cost reduced from 2 dots to 1 dot. Ability to purchase Crúac (first dot), rituals, and Circle Merits removed to maintain parity wit"
+      "after_len": 1090,
+      "preview": "**Prerequisites:** **Not** a member of the Circle of the Crone Your character is not a member of the Circle of the Crone, but is close enough that she"
     },
     {
       "key": "claws-of-the-unholy",
@@ -511,8 +474,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 119,
-      "after_len": 83,
-      "preview": "Now does +2 Aggravated Damage. Only ignores mundane armour. _Source: VTR 2e pg 110_"
+      "after_len": 759,
+      "preview": "**Prerequisite:** Protean •••• **Effect:** A Gangrel’s claws are deadly and bestial; yours are downright unnatural. The vampire allows the Beast out o"
     },
     {
       "key": "clipping",
@@ -529,8 +492,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 40,
-      "after_len": 128,
-      "preview": "Removed drawback \"cannot spend Willpower for bonus dice in scenes where blood sympathy has been felt\". _Source: VTR_ _2e pg 111_"
+      "after_len": 642,
+      "preview": "**Effect:** Your character feels blood sympathy more keenly than most of her kind. Add +1 to all blood sympathy bonuses, and apply the 8-again quality"
     },
     {
       "key": "closed-book",
@@ -556,8 +519,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 40,
-      "after_len": 519,
-      "preview": "**Effect:** Each dot represents an area of influence for gathering information: Bureaucracy, Church, Finance, Health, High Society, Industry, Legal, M"
+      "after_len": 1856,
+      "preview": "**Effect:** Contacts provide your character with information. This Merit can be taken multiple times; each instance represents a sphere or organizatio"
     },
     {
       "key": "court-jester",
@@ -565,8 +528,8 @@
       "category": "merit",
       "source": "Secrets of the Covenants + TM Errata",
       "before_len": 86,
-      "after_len": 193,
-      "preview": "There can only be one Jester per domain. To become the Jester if one is already present, you must convince them to give up the title, kill them, or pu"
+      "after_len": 1390,
+      "preview": "**Prerequisites:** City Status ••, Politics •• Many domains refuse to take Carthian members seriously, since members of the Movement point out the fai"
     },
     {
       "key": "crowdsourcing",
@@ -610,8 +573,8 @@
       "category": "merit",
       "source": "Secrets of the Covenants + TM Errata",
       "before_len": 64,
-      "after_len": 109,
-      "preview": "Experience cost reduction and teaching Beat removed. Cost reduced from 2 dots to 1 dot. _Source: SotC pg 178_"
+      "after_len": 879,
+      "preview": "**Prerequisites:** Carthian Status ••, Science •• Since, in many cities, the Carthian Movement has the fewest elders of any covenant, some Carthians s"
     },
     {
       "key": "distinguished-palate",
@@ -619,8 +582,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 82,
-      "after_len": 58,
-      "preview": "Cost reduced from 2 dots to 1 dot. _Source: VTR 2e pg 111_"
+      "after_len": 615,
+      "preview": "**Effect:** Your character can discern the subtle nuances in blood and Vitae. Consider any Taste of Blood roll (see p. 91) an exceptional success with"
     },
     {
       "key": "double-jointed",
@@ -628,8 +591,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 56,
-      "after_len": 245,
-      "preview": "Benefit of Double Jointed applies when already grappled and defending an overpower, or when attacking if she declares her intention to Break Free on a"
+      "after_len": 645,
+      "preview": "**Prerequisite:** Dexterity ••• **Effect:** Your character might have been a contortionist or spent time practicing yoga. She can dislodge joints when"
     },
     {
       "key": "dream-visions",
@@ -646,8 +609,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 87,
-      "after_len": 161,
-      "preview": "This Merit is now free and given in game by Storyteller on request. New Kid now applies to any Kindred Status. Exemplar has been removed. _Source: VTR"
+      "after_len": 647,
+      "preview": "**Prerequisite:** Clan Status • **Effect:** Your character claims membership to a long-standing dynasty of Kindred. Her clan and city know her family’"
     },
     {
       "key": "eidetic-memory",
@@ -655,8 +618,8 @@
       "category": "merit",
       "source": "CofD Rulebook + TM Errata",
       "before_len": 38,
-      "after_len": 57,
-      "preview": "Cost reduced from 2 dots to 1 dot. _Source: CoD 2e pg 46_"
+      "after_len": 365,
+      "preview": "**Effect:** Your character recalls events and details with pinpoint accuracy. You do not have to make rolls for your character to remember past experi"
     },
     {
       "key": "empower-judiciary",
@@ -691,8 +654,8 @@
       "category": "merit",
       "source": "Secrets of the Covenants + TM Errata",
       "before_len": 49,
-      "after_len": 736,
-      "preview": "Merit now reads:  **Prerequisite:** Carthian Status •••• **Effect:** Must be publicly announced on the same night a law is established. Invest 1 Willp"
+      "after_len": 2315,
+      "preview": "**Prerequisites:** Carthian Status •••• This Carthian Law forces an enforced law upon on all others to whom it applies. On the surface, this breeds an"
     },
     {
       "key": "eye-for-the-strange",
@@ -709,8 +672,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 158,
-      "after_len": 137,
-      "preview": "Allows the use of Disciplines up to Merit rating without risking Dramatic Failure on Start of Game Hunting Rolls. _Source: VTR 2e pg 112_"
+      "after_len": 600,
+      "preview": "**Effect:** Your character has fertile feeding grounds, whether officially granted or not. Dots in this Merit represent the ease of hunting in that te"
     },
     {
       "key": "fighting-finesse",
@@ -727,8 +690,8 @@
       "category": "merit",
       "source": "CofD Rulebook + TM Errata",
       "before_len": 38,
-      "after_len": 96,
-      "preview": "Now reduces all availability costs by one on anything, not just Services. _Source: CoD 2e pg 51_"
+      "after_len": 424,
+      "preview": "**Prerequisite:** Contacts ••, Wits ••• **Effect:** Your character is people that knows people. She can not only get in touch with the right people to"
     },
     {
       "key": "flock",
@@ -745,8 +708,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 114,
-      "after_len": 212,
-      "preview": "Once per Chapter, you may use dots equal to your Invictus Status as dots in Mortal Status for areas you do not already possess. Drawback: Other Invict"
+      "after_len": 999,
+      "preview": "**Prerequisites:** Invictus Status • **Effect:** The Invictus have their fingers in a lot of pies…but any one vampire only has so many fingers. So the"
     },
     {
       "key": "fucking-thief",
@@ -763,8 +726,8 @@
       "category": "merit",
       "source": "CofD Rulebook + TM Errata",
       "before_len": 47,
-      "after_len": 81,
-      "preview": "Available only at character creation and must be costumed. _Source: CoD 2e pg 49_"
+      "after_len": 375,
+      "preview": "**Effect:** Your character is massive. She’s well over six feet tall, and crowds part when she approaches. She’s Size 6, and gains +1 Health. _Availab"
     },
     {
       "key": "haven",
@@ -781,8 +744,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 60,
-      "after_len": 75,
-      "preview": "Herd provides one-for-one Vitae at start of game. _Source:_ _VTR 2e pg 112_"
+      "after_len": 580,
+      "preview": "**Effect:** Your character cultivates cliques of mortals willing and eager for the Kiss. Each week, you can draw on a number of Vitae equal to twice t"
     },
     {
       "key": "honey-trap",
@@ -835,8 +798,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 80,
-      "after_len": 133,
-      "preview": "Cost reduced from 2 dots to 1 dot. _Source: CoD 2e pg 51_ Iron Will does not apply to resisting or contesting supernatural influence."
+      "after_len": 426,
+      "preview": "**Prerequisite:** Resolve •••• **Effect:** Your character’s resolve is unwavering. When spending Willpower to contest or resist in a Social interactio"
     },
     {
       "key": "jack-booted-thug",
@@ -880,8 +843,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 49,
-      "after_len": 80,
-      "preview": "Use of Merit can be loaned for mundane extended actions. _Source: VTR 2e pg 120_"
+      "after_len": 492,
+      "preview": "**Effect:** Your character has access to a plethora of information about a given topic. When purchasing this Merit, choose a Mental Skill. The Library"
     },
     {
       "key": "lorekeeper",
@@ -898,8 +861,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 40,
-      "after_len": 108,
-      "preview": "Status requirement increased from 5 to 15 dots of Status per Blood Potency stripped. _Source: VTR 2e pg 116_"
+      "after_len": 1415,
+      "preview": "**Prerequisites:** Carthian Status ••••• **Effect:** Carthians wield consensus the way a cop wields a baton. With the power of the Movement behind her"
     },
     {
       "key": "mandragora-garden",
@@ -907,8 +870,8 @@
       "category": "merit",
       "source": "Secrets of the Covenants + TM Errata",
       "before_len": 160,
-      "after_len": 1416,
-      "preview": "Merit now reads:  **Prerequisites:** Circle Status •, Safe Place (equal level), Crúac • **Effect:** Your character cultivates and maintains a ghouled "
+      "after_len": 4455,
+      "preview": "**Prerequisites:** Safe Place (same level), Crúac • Your character maintains a garden of ghouled plants. They move and act on their own in slow, almos"
     },
     {
       "key": "mentor",
@@ -916,8 +879,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 93,
-      "after_len": 222,
-      "preview": "Rather than levels of favours, the use of a Mentor requires the sacrifice of downtime action, potentially more depending on Storyteller discretion. Ge"
+      "after_len": 1857,
+      "preview": "**Effect:** This Merit gives your character a teacher who provides advice and guidance. He acts on your character’s behalf, often in the background an"
     },
     {
       "key": "moderator",
@@ -925,8 +888,8 @@
       "category": "merit",
       "source": "Secrets of the Covenants + TM Errata",
       "before_len": 76,
-      "after_len": 89,
-      "preview": "Now once per chapter, not once per story, and all dots may be used. _Source: SotC pg 187_"
+      "after_len": 172,
+      "preview": "**Prerequisites:** Computer •••, Contacts • (Online), Invictus  --- **TM Errata:** Now once per chapter, not once per story, and all dots may be used."
     },
     {
       "key": "mortal-status",
@@ -952,8 +915,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 47,
-      "after_len": 189,
-      "preview": "Benefits can only be mundane. Can have Status in multiple Mystery Cults, but can only receive membership dot benefits from one instance of each level "
+      "after_len": 2291,
+      "preview": "Cults are far more common than the people of the World of Darkness would like to admit. Mystery cult is the catch-all term for a phenomenon ranging fr"
     },
     {
       "key": "night-doctor-surgery",
@@ -970,8 +933,8 @@
       "category": "merit",
       "source": "Secrets of the Covenants + TM Errata",
       "before_len": 37,
-      "after_len": 56,
-      "preview": "Cost reduced from 3 dots to 1 dot. _Source: SotC pg 188_"
+      "after_len": 791,
+      "preview": "**Prerequisites:** City Status ••• Some Invictus lead because they’re power hungry. Your character leads because she feels it’s her inherent responsib"
     },
     {
       "key": "notary",
@@ -979,8 +942,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 62,
-      "after_len": 59,
-      "preview": "Cost reduced from 3 dots to 2 dots. _Source: VTR 2e pg 116_"
+      "after_len": 819,
+      "preview": "**Prerequisites:** Invictus Status ••• **Effect:** The Invictus appointed your character a Notary, a scholar of Oaths. She presides over Oath agreemen"
     },
     {
       "key": "oath-of-abstinence",
@@ -997,8 +960,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 45,
-      "after_len": 72,
-      "preview": "The timeframe is now one Story, not one month. _Source:_ _VTR 2e pg 117_"
+      "after_len": 1003,
+      "preview": "**Effect:** With this Oath, a vassal swears to perform a service to his liege. The service must be a difficult task with definite criteria for accompl"
     },
     {
       "key": "oath-of-fealty",
@@ -1024,8 +987,8 @@
       "category": "merit",
       "source": "Secrets of the Covenants + TM Errata",
       "before_len": 54,
-      "after_len": 145,
-      "preview": "Cost reduced from 3 dots to 1 dot. Ending this Oath can only be done by losing this position or release by Liege or Notary. _Source: SotC pg 191_"
+      "after_len": 1091,
+      "preview": "**Prerequisites:** City Status or Invictus Status ••• This Oath seals an Invictus into an official position. She vows to uphold the duties of office, "
     },
     {
       "key": "oath-of-penance",
@@ -1060,8 +1023,8 @@
       "category": "merit",
       "source": "Secrets of the Covenants + TM Errata",
       "before_len": 413,
-      "after_len": 109,
-      "preview": "Oath now also provides Friends in High Places (•), as Invictus Status is not purchased. _Source: SotC pg 189_"
+      "after_len": 2397,
+      "preview": "**Prerequisites:** No Invictus Status Not every Invictus Oath comes down from on high. The Invictus is an inclusive organization, full of some of the "
     },
     {
       "key": "oath-of-the-model-prisoner",
@@ -1105,8 +1068,8 @@
       "category": "merit",
       "source": "Secrets of the Covenants + TM Errata",
       "before_len": 47,
-      "after_len": 352,
-      "preview": "Clarification:  **Drawback:** Cannot be woken from torpor by being fed blood whilst under this Oath, and Vitae from any source cannot be consumed. _So"
+      "after_len": 4123,
+      "preview": "**Prerequisites:** Invictus Status •• This Oath binds an Unconquered into service as a knight, tasked with defending the Invictus as a whole. She beco"
     },
     {
       "key": "one-foot-in-the-door",
@@ -1114,8 +1077,8 @@
       "category": "merit",
       "source": "Secrets of the Covenants + TM Errata",
       "before_len": 68,
-      "after_len": 56,
-      "preview": "Cost reduced from 2 dots to 1 dot. _Source: SotC pg 187_"
+      "after_len": 796,
+      "preview": "**Prerequisites:** **Not** a member of the Invictus ![](./assets/output_13_1.jpeg) **188** **Secrets of the Covenants:** Your character is not a membe"
     },
     {
       "key": "pack-alpha",
@@ -1141,8 +1104,8 @@
       "category": "merit",
       "source": "Secrets of the Covenants + TM Errata",
       "before_len": 71,
-      "after_len": 114,
-      "preview": "Prerequisites changed to: Invictus Status •, In-game sire with a Kindred Status 4 or higher. _Source: SotC pg 188_"
+      "after_len": 918,
+      "preview": "**Prerequisites:** Mentor •••• Invictus favor merit, but often, the concept of merit flows from sire to childe; a prestigious sire would clearly choos"
     },
     {
       "key": "primal-creation",
@@ -1159,8 +1122,8 @@
       "category": "merit",
       "source": "CofD Rulebook + TM Errata",
       "before_len": 67,
-      "after_len": 132,
-      "preview": "••••• The Routine: The Rote mechanic has been changed. See Dice Rolls / Dice Variations. _Source: CoD 2e pg 48_  **PHYSICAL MERITS**"
+      "after_len": 1697,
+      "preview": "**Effect:** Your character has extensive training in a particular profession, which offers distinct advantages in a handful of fields. When choosing t"
     },
     {
       "key": "pusher",
@@ -1177,8 +1140,8 @@
       "category": "merit",
       "source": "CofD Rulebook + TM Errata",
       "before_len": 41,
-      "after_len": 104,
-      "preview": "Any bonuses to initiative only apply if the character attempts to use the weapon. _Source: CoD 2e pg 49_"
+      "after_len": 506,
+      "preview": "**Prerequisites:** Wits •••, a Specialty in the weapon or fighting style chosen **Effect:** Choose a Specialty in Weaponry or Firearms when you purcha"
     },
     {
       "key": "resources",
@@ -1186,8 +1149,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 29,
-      "after_len": 88,
-      "preview": "Generates 1 Influence at Resources 3; 2 Influence at Resources 5. _Source: CoD 2e pg 53_"
+      "after_len": 1365,
+      "preview": "**Effect:** This Merit reflects your character’s disposable income. She might live in an upscale condo, but if her income is tied up in the mortgage a"
     },
     {
       "key": "retainer",
@@ -1195,8 +1158,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 28,
-      "after_len": 208,
-      "preview": "For Retainers that will come into direct contact with PCs (e.g. combat), the Storytellers will develop a relevant sheet. Generates 1 Influence at Reta"
+      "after_len": 1289,
+      "preview": "**Effect:** Your character has an assistant, sycophant, servant, or follower on whom she can rely. Establish who this companion is and how he was acqu"
     },
     {
       "key": "right-of-return",
@@ -1204,8 +1167,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 31,
-      "after_len": 298,
-      "preview": "Replace the sentence: \"In any Social Maneuvering with members of a covenant she claims Status in, treat her impressions as one step better.\" With: \"In"
+      "after_len": 1376,
+      "preview": "**Prerequisites:** Carthian Status ••, City Status • **Effect:** This somewhat rare Merit allows a Carthian to work within another covenant without fe"
     },
     {
       "key": "safe-place",
@@ -1213,8 +1176,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 28,
-      "after_len": 138,
-      "preview": "Safe Place also adds rounds of preparation equal to Merit rating when Safe Place is under threat where appropriate. _Source: CoD 2e pg 53_"
+      "after_len": 1426,
+      "preview": "**Effect:** Your character has somewhere she can go where she can feel secure. While she may have enemies that could attack her there, she’s prepared "
     },
     {
       "key": "sanctuary",
@@ -1222,8 +1185,8 @@
       "category": "merit",
       "source": "Secrets of the Covenants + TM Errata",
       "before_len": 82,
-      "after_len": 120,
-      "preview": "Prerequisites now read: Lancea et Sanctum Status ••, City Status •••, Safe Place equal or greater. _Source: SotC pg 193_"
+      "after_len": 853,
+      "preview": "**Prerequisites:** City Status ••, Lancea et Sanctum Status ••, Safe Place • Because of your character’s exalted status in the city and in the church,"
     },
     {
       "key": "sell-out",
@@ -1267,8 +1230,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 61,
-      "after_len": 70,
-      "preview": "Discuss with Storytellers before purchasing. _Source: VTR 2e_ _pg 114_"
+      "after_len": 798,
+      "preview": "**Prerequisite:** Dynasty Membership •, Invictus Status • **Effect:** Any Kindred may be part of a dynastic house, but the Invictus take dynasty membe"
     },
     {
       "key": "staff",
@@ -1276,8 +1239,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 95,
-      "after_len": 80,
-      "preview": "Generates 1 Influence at Staff 3; 2 Influence at Staff 5. _Source: CoD 2e pg 54_"
+      "after_len": 716,
+      "preview": "**Effect:** Your character has a crew of workers or assistants at her disposal. They may be housekeepers, designers, research assistants, animators, g"
     },
     {
       "key": "stigmata",
@@ -1285,8 +1248,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 109,
-      "after_len": 128,
-      "preview": "Prerequisites now read: Lancea et Sanctum Status •, Humanity 3 + Merit rating, or mortal. _Source: SotC pg 193_ **CRÚAC STYLES**"
+      "after_len": 617,
+      "preview": "**Target number of successes:** 5 **Resisted by:** Stamina **Sacrament:** a crucifix The ritualist curses his victim — who must be present for the rit"
     },
     {
       "key": "strength-of-resolution",
@@ -1321,8 +1284,8 @@
       "category": "merit",
       "source": "Secrets of the Covenants + TM Errata",
       "before_len": 94,
-      "after_len": 132,
-      "preview": "Merit now usable once per Chapter and cannot grant 9- again to combat equipment. _Source: SotC pg 189_  **LANCEA ET SANCTUM MERITS**"
+      "after_len": 972,
+      "preview": "**Prerequisites:** Computer ••, Crafts ••, Science •, Resources • Invictus members pride themselves in utilizing the best tools humanity has to offer."
     },
     {
       "key": "the-mother-daughter-bond",
@@ -1330,8 +1293,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 261,
-      "after_len": 371,
-      "preview": "Merit now reads:  **Prerequisite:** Circle of the Crone Status • **Effect:** Strong mentorship defines the Circle. When purchasing Mentor, take additi"
+      "after_len": 1037,
+      "preview": "**Prerequisites:** Circle of the Crone Status • **Effect**: The Circle exists through tribulation and mentorship. Without tight-knit bonds, the Circle"
     },
     {
       "key": "toss-that-shit-right-back",
@@ -1357,8 +1320,8 @@
       "category": "merit",
       "source": "VtR 2e Rulebook + TM Errata",
       "before_len": 77,
-      "after_len": 139,
-      "preview": "This Merit can be purchased by any Crone, embodying the feminine power of creation. Bleeding from relevant orifice. _Source: VTR 2e pg 115_"
+      "after_len": 1075,
+      "preview": "**Effect:** Throughout history, various cultures attributed mystical significance to the menstrual cycle. Many of these Multiple Touchstones **Touchst"
     },
     {
       "key": "unsettling-gaze",
@@ -1384,8 +1347,8 @@
       "category": "merit",
       "source": "Secrets of the Covenants + TM Errata",
       "before_len": 71,
-      "after_len": 400,
-      "preview": "Merit now reads:  **Prerequisites:** Circle Status •, Crúac •• **Effect:** Performing Crúac rituals enhances your standing within the Circle. Once per"
+      "after_len": 24633,
+      "preview": "Prerequisites: Crúac •• Members of the Circle of the Crone favor action. Acts of faith, acts of sacrifice, and acts of creation. The very act of perfo"
     },
     {
       "key": "where-the-bodies-are-buried",
@@ -1681,8 +1644,8 @@
       "category": "manoeuvre",
       "source": "CofD Rulebook + TM Errata",
       "before_len": 109,
-      "after_len": 19,
-      "preview": "Bashing to Kindred."
+      "after_len": 374,
+      "preview": "Bouncing someone’s head off a urinal, computer monitor, or brick wall is a handy way to increase the amount of hurt inflicted while not breaking the a"
     },
     {
       "key": "armoured-coffin",
@@ -1708,8 +1671,8 @@
       "category": "manoeuvre",
       "source": "CofD Rulebook + TM Errata",
       "before_len": 169,
-      "after_len": 102,
-      "preview": "Applies only when using Brawling disarm unless purchased with Transfer Manoeuvre. _Source:_ _HL pg 48_"
+      "after_len": 510,
+      "preview": "If your character’s caught short in a fight, his opponent’s weapon suits him just fine. When he attempts to Disarm his opponent, step the results up o"
     },
     {
       "key": "rapid-nock",
@@ -1870,8 +1833,8 @@
       "category": "manoeuvre",
       "source": "CofD Rulebook + TM Errata",
       "before_len": 150,
-      "after_len": 231,
-      "preview": "The benefit to Defence is independent of the user of covering fire. The final sentence now reads: \"Additionally, her training allows her to use Coveri"
+      "after_len": 777,
+      "preview": "Sometimes, the purpose of a shot is to distract, not necessarily to hit. Your character is trained to fire off a handful of rounds with the intent to "
     },
     {
       "key": "secondary-target",
@@ -1897,8 +1860,8 @@
       "category": "manoeuvre",
       "source": "Hurt Locker + TM Errata",
       "before_len": 192,
-      "after_len": 275,
-      "preview": "If used as the first or second manoeuvre in the same action as establishing the grapple, victim may attempt to maintain the grapple with a reflexive c"
+      "after_len": 525,
+      "preview": "Your character knows how to toss someone over his hip, trip, or sweep her while keeping his footing. He may inflict the Knocked Down Tilt as a grappli"
     },
     {
       "key": "small-joint-manipulation",
@@ -1906,8 +1869,8 @@
       "category": "manoeuvre",
       "source": "Hurt Locker + TM Errata",
       "before_len": 98,
-      "after_len": 921,
-      "preview": "Gains the Tactical (Street) Style Tag. _Source: HL pg 49_ **Joint Lock (•••)** now reads: You use joint locks and immobilising tactics to limit your o"
+      "after_len": 1528,
+      "preview": "By accepting a –2 penalty to the attack roll, your character may immediately dislocate or otherwise bend the opponent’s fingers in one hand (or toes i"
     },
     {
       "key": "takedown",
@@ -1915,8 +1878,8 @@
       "category": "manoeuvre",
       "source": "CofD Rulebook + TM Errata",
       "before_len": 171,
-      "after_len": 234,
-      "preview": "This is not a new grappling manoeuvre. It can only be used in place of establishing a grapple. If the roll is an exceptional success, the free second "
+      "after_len": 487,
+      "preview": "Your character can take an opponent to the ground rapidly. With a normal roll, you may choose to render an opponent prone instead of establishing a gr"
     },
     {
       "key": "ippon",
@@ -1942,8 +1905,8 @@
       "category": "manoeuvre",
       "source": "Hurt Locker + TM Errata",
       "before_len": 133,
-      "after_len": 89,
-      "preview": "Cannot get up from prone in any round in which this technique is used. _Source: HL pg 49_"
+      "after_len": 339,
+      "preview": "While prone, your character uses his body to shake and redirect his enemy. Reduce the opponent’s dice pool to grapple by your character’s Dexterity. U"
     },
     {
       "key": "lock-flow",
@@ -1969,8 +1932,8 @@
       "category": "manoeuvre",
       "source": "Hurt Locker + TM Errata",
       "before_len": 233,
-      "after_len": 325,
-      "preview": "A character who is immune to Beaten Down, on a successful contested Manipulation + Subterfuge – (opponent's Intimidation) vs. Wits + Empathy, may choo"
+      "after_len": 728,
+      "preview": "_Additional Prerequisite: Joint Lock_ _Maneuver_. If your character succeeds in a grapple in the turn after applying the Joint Lock maneuver, he may a"
     },
     {
       "key": "sure-strike",
@@ -1978,8 +1941,8 @@
       "category": "manoeuvre",
       "source": "CofD Rulebook + TM Errata",
       "before_len": 125,
-      "after_len": 296,
-      "preview": "Cannot be used in a turn the character is dodging. May remove up to nine dice from attack pool at a rate of three dice per one weapon rating increase."
+      "after_len": 700,
+      "preview": "Your character doesn’t always hit the hardest or the most frequently, but she guarantees a deadly strike when she does hit. You can reflexively remove"
     },
     {
       "key": "threat-range",
@@ -2050,8 +2013,8 @@
       "category": "manoeuvre",
       "source": "Hurt Locker + TM Errata",
       "before_len": 96,
-      "after_len": 284,
-      "preview": "Pool equals the dog's Wits + Survival + K-9 Merit dots, modified for Bonded Condition. If the selected substance is “Corpses” and the trainer is Kindr"
+      "after_len": 714,
+      "preview": "Your character’s dog has been trained to detect a certain class of substances by smell and indicate its location. Choose from one of the following: Dr"
     },
     {
       "key": "targeted-bite",
@@ -2077,8 +2040,8 @@
       "category": "manoeuvre",
       "source": "Hurt Locker + TM Errata",
       "before_len": 119,
-      "after_len": 111,
-      "preview": "Decision to Drop Prone or Hold may be made after rolling. Normal Brawling damage is applied. _Source: HL pg 49_"
+      "after_len": 995,
+      "preview": "At your character’s command, his dog may inflict a Drop Prone or Hold grappling maneuver on a target if it hits with a successful bite attack. The tar"
     },
     {
       "key": "hamstring",
@@ -2149,8 +2112,8 @@
       "category": "manoeuvre",
       "source": "Hurt Locker + TM Errata",
       "before_len": 111,
-      "after_len": 85,
-      "preview": "Blinded Tilt is as per exceptional success, blinding in both eyes. _Source: HL pg 50_"
+      "after_len": 509,
+      "preview": "While grappling, your character can drive her fingers into an enemy’s eyes with exceptional force and persistence. If you win a grappling roll and sco"
     },
     {
       "key": "continuous-bite",
@@ -2158,8 +2121,8 @@
       "category": "manoeuvre",
       "source": "Hurt Locker + TM Errata",
       "before_len": 140,
-      "after_len": 159,
-      "preview": "May upgrade an additional two successes of damage to lethal vs. Kindred. Other success damage is bashing, as per Terra Mortis house rules. _Source:_ _"
+      "after_len": 884,
+      "preview": "Your character knows how to apply pressure, rip flesh, and use the rest of her body’s musculature to enhance a bite. In a grapple, she may inflict let"
     },
     {
       "key": "rapidity",
@@ -2185,8 +2148,8 @@
       "category": "manoeuvre",
       "source": "CofD Rulebook + TM Errata",
       "before_len": 136,
-      "after_len": 203,
-      "preview": "Mechanic clarification – the round following a Feint, ignore Defence equal to the previous round's (successes + Weapon Rating) and increase weapon rat"
+      "after_len": 545,
+      "preview": "With a flourish in one direction, your character can distract an opponent for a cleaner, more effective follow-up strike. For example, if Feinting wit"
     },
     {
       "key": "flurry",
@@ -2329,8 +2292,8 @@
       "category": "manoeuvre",
       "source": "CofD Rulebook + TM Errata",
       "before_len": 54,
-      "after_len": 93,
-      "preview": "Gain +2 bonus to all overpower rolls once a Hold has been established. _Source: CoD 2e pg 64_"
+      "after_len": 188,
+      "preview": "Gain a +2 bonus to overpowering rolls to disarm or immobilize an opponent.  --- **TM Errata:** Gain +2 bonus to all overpower rolls once a Hold has be"
     },
     {
       "key": "weapon-retention",
@@ -2338,8 +2301,8 @@
       "category": "manoeuvre",
       "source": "CofD Rulebook + TM Errata",
       "before_len": 94,
-      "after_len": 353,
-      "preview": "Reduce successes to disarm or control your weapon by your Weaponry score, or Brawling score for Brawling weapons. _Source: CoD 2e pg 64_ **Speed Cuff "
+      "after_len": 508,
+      "preview": "Opponents attempting to disarm your character or turn his weapon against him must exceed your character’s Weaponry score in successes.  --- **TM Errat"
     },
     {
       "key": "speed-cuff",
@@ -2401,8 +2364,8 @@
       "category": "manoeuvre",
       "source": "Hurt Locker + TM Errata",
       "before_len": 104,
-      "after_len": 306,
-      "preview": "Merit now reads:  **Effect:** You gain a new grapple manoeuvre, Headbutt, which allows inflicting the Stunned Tilt without making a called shot to the"
+      "after_len": 1326,
+      "preview": "**Prerequisites:** Brawl •• **Style Tags:** Striking, Grappling **Effect:** Your character has found few arguments she can’t end by ramming her skull "
     },
     {
       "key": "phalanx-fighter",
@@ -2581,8 +2544,8 @@
       "category": "manoeuvre",
       "source": "CofD Rulebook + TM Errata",
       "before_len": 77,
-      "after_len": 63,
-      "preview": "Does not apply when making called shots. _Source: CoD 2e pg 65_"
+      "after_len": 703,
+      "preview": "Shots to the center mass can shake an opponent, and your character knows this well. When your character makes a successful unarmed attack, the opponen"
     },
     {
       "key": "one-two-punch",
@@ -2599,8 +2562,8 @@
       "category": "manoeuvre",
       "source": "CofD Rulebook + TM Errata",
       "before_len": 193,
-      "after_len": 144,
-      "preview": "The decision to sacrifice Defence and spend Willpower is made when an attack is declared, not after the dice have rolled. _Source: CoD 2e pg 65_"
+      "after_len": 1145,
+      "preview": "In a street fight, every second could mean the loss of your life. A proficient street fighter is a remarkable survivalist. She bites, headbutts, trips"
     },
     {
       "key": "strength-tricks",
@@ -2707,8 +2670,8 @@
       "category": "manoeuvre",
       "source": "CofD Rulebook + TM Errata",
       "before_len": 169,
-      "after_len": 214,
-      "preview": "Applies when Defence reduces an attack pool to zero or when successes on Dodge roll reduce attacker's successes to zero. If 10-again quality is lost, "
+      "after_len": 522,
+      "preview": "Your character focuses on reading one opponent, avoiding his attacks and frustrating him. Attacks from that opponent do not reduce your character’s De"
     },
     {
       "key": "redirect",
@@ -2941,8 +2904,8 @@
       "category": "rite",
       "source": "Secrets of the Covenants + TM Errata",
       "before_len": 383,
-      "after_len": 128,
-      "preview": "Prerequisites now read: Lancea et Sanctum Status •, Humanity 3 + Merit rating, or mortal. _Source: SotC pg 193_ **CRÚAC STYLES**"
+      "after_len": 2393,
+      "preview": "**Prerequisites:** Humanity (three or more dots higher than the Merit) or mortal Your character bleeds in an unnatural, holy way. Usually, this manife"
     }
   ],
   "ambiguous": [
@@ -4476,6 +4439,33 @@
       "key": "true-worm",
       "name": "True Worm",
       "category": "merit"
+    }
+  ],
+  "skipped_auspex": [
+    {
+      "key": "beasts-hackles",
+      "name": "Beast's Hackles",
+      "category": "discipline"
+    },
+    {
+      "key": "lay-open-the-mind",
+      "name": "Lay Open the Mind",
+      "category": "discipline"
+    },
+    {
+      "key": "spirits-touch",
+      "name": "Spirit's Touch",
+      "category": "discipline"
+    },
+    {
+      "key": "twilight-projection",
+      "name": "Twilight Projection",
+      "category": "discipline"
+    },
+    {
+      "key": "uncanny-perception",
+      "name": "Uncanny Perception",
+      "category": "discipline"
     }
   ]
 }

--- a/server/scripts/reports/992-uplift-report.json
+++ b/server/scripts/reports/992-uplift-report.json
@@ -1,0 +1,4481 @@
+{
+  "generated_at": "2026-07-14T13:16:01.621Z",
+  "book_status": [
+    {
+      "file": "Vampire the Requiem 2e Rulebook.md",
+      "found": true,
+      "blocks": 193
+    },
+    {
+      "file": "Chronicles of Darkness Rulebook.md",
+      "found": true,
+      "blocks": 137
+    },
+    {
+      "file": "Hurt Locker.md",
+      "found": true,
+      "blocks": 122
+    },
+    {
+      "file": "Secrets of the Covenants.md",
+      "found": true,
+      "blocks": 69
+    },
+    {
+      "file": "Blood Sorcery- New Rules.md",
+      "found": true,
+      "blocks": 0
+    },
+    {
+      "file": "Damnation City Model - New Rules.md",
+      "found": true,
+      "blocks": 3
+    },
+    {
+      "file": "Blood Sorcery Themes and Motifs.md",
+      "found": true,
+      "blocks": 25
+    },
+    {
+      "file": "Terra Mortis - Errata Master.md",
+      "found": true,
+      "blocks": 154
+    },
+    {
+      "file": "Auspex Errata.md",
+      "found": true,
+      "blocks": 0
+    }
+  ],
+  "totals": {
+    "matched": 317,
+    "ambiguous": 19,
+    "unmatched": 283,
+    "total": 619
+  },
+  "by_category": {
+    "attribute": {
+      "matched": 0,
+      "unmatched": 9,
+      "ambiguous": 0
+    },
+    "skill": {
+      "matched": 0,
+      "unmatched": 24,
+      "ambiguous": 0
+    },
+    "discipline": {
+      "matched": 29,
+      "unmatched": 16,
+      "ambiguous": 5
+    },
+    "merit": {
+      "matched": 126,
+      "unmatched": 42,
+      "ambiguous": 13
+    },
+    "devotion": {
+      "matched": 0,
+      "unmatched": 45,
+      "ambiguous": 0
+    },
+    "manoeuvre": {
+      "matched": 144,
+      "unmatched": 33,
+      "ambiguous": 1
+    },
+    "rite": {
+      "matched": 18,
+      "unmatched": 114,
+      "ambiguous": 0
+    }
+  },
+  "matches": [
+    {
+      "key": "feral-whispers",
+      "name": "Feral Whispers",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook",
+      "before_len": 31,
+      "after_len": 2041,
+      "preview": "To those she would command, a vampire must first make herself understood. So it is with beasts as well as men. A vampire using Feral Whispers overpowe"
+    },
+    {
+      "key": "raise-the-familiar",
+      "name": "Raise the Familiar",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 44,
+      "after_len": 149,
+      "preview": "Maintained familiars must be purchased as Retainers and impose a –1 Vitae from the character's starting Vitae pool each game. _Source: VTR 2e pg 121_"
+    },
+    {
+      "key": "beasts-hackles",
+      "name": "Beast's Hackles",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 45,
+      "after_len": 419,
+      "preview": "**Clarification:** All questions at this level must be related to weakness or danger. If the Storyteller cannot determine the answer to a player's que"
+    },
+    {
+      "key": "lay-open-the-mind",
+      "name": "Lay Open the Mind",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook",
+      "before_len": 46,
+      "after_len": 2012,
+      "preview": "The Mekhet focuses on bringing her thoughts in line with her victim. He begins to think like her, and soon hears her thoughts in his mind. By concentr"
+    },
+    {
+      "key": "spirits-touch",
+      "name": "Spirit's Touch",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 53,
+      "after_len": 920,
+      "preview": "**Cost** is now: Varies, as the Discipline is slightly tiring; the first use in a scene is free, but subsequent uses in the same scene cost 1 Vitae ea"
+    },
+    {
+      "key": "twilight-projection",
+      "name": "Twilight Projection",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 33,
+      "after_len": 515,
+      "preview": "A vampire in Twilight Projection can use Auspex 1–3 once per scene, but may not spend blood for additional uses. _Source: VTR 2e pg 125_  **CELERITY:*"
+    },
+    {
+      "key": "uncanny-perception",
+      "name": "Uncanny Perception",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 56,
+      "after_len": 284,
+      "preview": "This power must be used on a single creature that can currently be perceived. This power can be used to initiate a Clash of Wills against any objects "
+    },
+    {
+      "key": "iron-edict",
+      "name": "Iron Edict",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook",
+      "before_len": 57,
+      "after_len": 1326,
+      "preview": "Once she’s got a hotline into her victim’s mind, the vampire can take some time to play with his thoughts and memories. While it takes more of her pow"
+    },
+    {
+      "key": "possession",
+      "name": "Possession",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 22,
+      "after_len": 281,
+      "preview": "Resistance to Possession is now – victim's Resolve + Supernatural Tolerance. Possession only allows the possessor to walk in the sun without consequen"
+    },
+    {
+      "key": "awe",
+      "name": "Awe",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook",
+      "before_len": 49,
+      "after_len": 1469,
+      "preview": "Awe shines a spotlight on the vampire even in a crowded room. He’s the most important person around and people want to be around him. Awe creates an a"
+    },
+    {
+      "key": "confidant",
+      "name": "Confidant",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook",
+      "before_len": 25,
+      "after_len": 1071,
+      "preview": "The vampire doesn’t have to shout to be heard, and in a crowd that he’s already Awed, sometimes speaking quietly is the best way to get attention. Wit"
+    },
+    {
+      "key": "green-eyes",
+      "name": "Green Eyes",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 65,
+      "after_len": 665,
+      "preview": "**Clarification:** Green Eyes has two different uses. The first is to change emotional state and requires no action; the second is to make requests. O"
+    },
+    {
+      "key": "idol",
+      "name": "Idol",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 71,
+      "after_len": 163,
+      "preview": "**Clarification:** A successful reflexive roll to resist Idol only allows for one action before the check must be made again. _Source: VTR 2e pg 139_ "
+    },
+    {
+      "key": "loyalty",
+      "name": "Loyalty",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook",
+      "before_len": 28,
+      "after_len": 1257,
+      "preview": "Among his inner circle, the vampire praises some more than others, bringing them even closer to him. With a few words he can inflame their love for hi"
+    },
+    {
+      "key": "dread-presence",
+      "name": "Dread Presence",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook",
+      "before_len": 79,
+      "after_len": 1724,
+      "preview": "Everyone around the vampire feels the world go slightly wrong as she exudes a deeply unsettling aura. Even if they barely notice her, they feel a wave"
+    },
+    {
+      "key": "face-of-the-beast",
+      "name": "Face of the Beast",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook",
+      "before_len": 43,
+      "after_len": 1148,
+      "preview": "All it takes is a glance, and the vampire can magnify one of his victim’s fears to truly horrifying levels. If she knows what sort of things her victi"
+    },
+    {
+      "key": "grand-delusion",
+      "name": "Grand Delusion",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook",
+      "before_len": 28,
+      "after_len": 1614,
+      "preview": "Touching her victim’s mind, the vampire sparks a delusion that only she fully understands. What she makes him believe doesn’t match up with the world "
+    },
+    {
+      "key": "mortal-terror",
+      "name": "Mortal Terror",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 54,
+      "after_len": 324,
+      "preview": "Resistance to Mortal Terror is now – victim's Composure + Supernatural Tolerance. Full lethal damage is applied to vampires. Composure damage on vampi"
+    },
+    {
+      "key": "waking-nightmare",
+      "name": "Waking Nightmare",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook",
+      "before_len": 34,
+      "after_len": 2441,
+      "preview": "Having altered her victims’ beliefs and stoked their fears, the vampire can now spark disturbing hallucinations of a kind that all vampires suffer in "
+    },
+    {
+      "key": "cloak-of-night",
+      "name": "Cloak of Night",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 17,
+      "after_len": 174,
+      "preview": "When using Cloak of Night to leave active combat they have participated in, it will initiate an automatic Clash of Wills against anyone with Auspex 2."
+    },
+    {
+      "key": "face-in-the-crowd",
+      "name": "Face in the Crowd",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 71,
+      "after_len": 541,
+      "preview": "When using Face in the Crowd to leave active combat they have participated in, onlookers can make a reflexive Wits + Composure – Obfuscate to still no"
+    },
+    {
+      "key": "oubliette",
+      "name": "Oubliette",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 87,
+      "after_len": 186,
+      "preview": "This power has no cost and is always considered active on a character's Haven/Safe Place. Further uses of this power can occur for the standard cost. "
+    },
+    {
+      "key": "the-familiar-stranger",
+      "name": "The Familiar Stranger",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 43,
+      "after_len": 291,
+      "preview": "As per Touch of Shadow, can be used at no cost for an unlimited duration on inanimate objects carried or worn by the vampire to reskin. However, no eq"
+    },
+    {
+      "key": "touch-of-shadow",
+      "name": "Touch of Shadow",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 43,
+      "after_len": 224,
+      "preview": "The effects of Touch of Shadow can be used at no cost for an unlimited duration on inanimate objects carried or worn by the vampire, so long as the ch"
+    },
+    {
+      "key": "beasts-skin",
+      "name": "Beast's Skin",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook",
+      "before_len": 32,
+      "after_len": 1430,
+      "preview": "The Beast can warp a vampire’s flesh, taking the form of an animal that she has consumed. Her body warps and shifts, growing extra muscle or folding i"
+    },
+    {
+      "key": "predatory-aspect",
+      "name": "Predatory Aspect",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook",
+      "before_len": 22,
+      "after_len": 2815,
+      "preview": "All the vampire has to do is give in just a little bit, and her Beast can slip out through her flesh, warping her body into a monstrous form. While ev"
+    },
+    {
+      "key": "primeval-miasma",
+      "name": "Primeval Miasma",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 21,
+      "after_len": 1459,
+      "preview": "Feeding on a vampire's open wounds shares all the same drawbacks as drinking Vitae. Kindred cannot be fed from if they have no open wounds. _Source: V"
+    },
+    {
+      "key": "unmarked-grave",
+      "name": "Unmarked Grave",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook",
+      "before_len": 16,
+      "after_len": 1670,
+      "preview": "With a silent command, the earth itself yawns open to embrace the vampire. She merges with the ground, becoming immune to almost any harm. She can rem"
+    },
+    {
+      "key": "unnatural-aspect",
+      "name": "Unnatural Aspect",
+      "category": "discipline",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 25,
+      "after_len": 94,
+      "preview": "**Adaptations:** ● **Barbed Hands:** Damage is not lethal to vampires. _Source: VTR 2e pg 147_"
+    },
+    {
+      "key": "acute-senses",
+      "name": "Acute Senses",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 78,
+      "after_len": 857,
+      "preview": "**Effect:** The vampire can see, smell, and hear at twice the distance and with twice the accuracy of an average, healthy mortal. The vampire’s senses"
+    },
+    {
+      "key": "alley-cat",
+      "name": "Alley Cat",
+      "category": "merit",
+      "source": "Secrets of the Covenants + TM Errata",
+      "before_len": 69,
+      "after_len": 437,
+      "preview": "Merit now reads:  **Prerequisites:** Carthian Status •, Athletics ••, Stealth ••, Streetwise •• **Effect:** Carthians are the vampires most intimately"
+    },
+    {
+      "key": "allies",
+      "name": "Allies",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 102,
+      "after_len": 631,
+      "preview": "Each instance represents one area of influence: Bureaucracy, Church, Finance, Health, High Society, Industry, Legal, Military, Media, Occult, Police, "
+    },
+    {
+      "key": "altar",
+      "name": "Altar",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 104,
+      "after_len": 567,
+      "preview": "Merit now reads:  **Prerequisite:** Circle of the Crone Status • **Effect:** You've contributed to attuning a blood altar. In the presence of the alta"
+    },
+    {
+      "key": "ambidextrous",
+      "name": "Ambidextrous",
+      "category": "merit",
+      "source": "CofD Rulebook + TM Errata",
+      "before_len": 36,
+      "after_len": 58,
+      "preview": "Cost reduced from 3 dots to 2 dots. _Source: CoD 2e pg 49_"
+    },
+    {
+      "key": "anointed",
+      "name": "Anointed",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 90,
+      "after_len": 523,
+      "preview": "**Prerequisites:** Lancea et Sanctum Status • **Effect:** Not all Sanctified are members of the clergy. Most are lay members. Those anointed under the"
+    },
+    {
+      "key": "army-of-one",
+      "name": "Army of One",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 93,
+      "after_len": 1593,
+      "preview": "**Prerequisites:** Carthian Status at equal or higher level Carthians always have each other’s backs. A ranking member of the Movement is never alone."
+    },
+    {
+      "key": "atrocious",
+      "name": "Atrocious",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 73,
+      "after_len": 403,
+      "preview": "**Prerequisites:** Cannot have the Cutthroat or Enticing Merits **Effect:** Your character’s monstrous Beast dominates her personality. Her threats al"
+    },
+    {
+      "key": "barfly",
+      "name": "Barfly",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 52,
+      "after_len": 57,
+      "preview": "Cost reduced from 2 dots to 1 dot. _Source: CoD 2e pg 50_"
+    },
+    {
+      "key": "bloodhound",
+      "name": "Bloodhound",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 49,
+      "after_len": 58,
+      "preview": "Cost reduced from 2 dots to 1 dot. _Source: VTR 2e pg 110_"
+    },
+    {
+      "key": "breaking-the-chains",
+      "name": "Breaking The Chains",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 54,
+      "after_len": 1687,
+      "preview": "**Prerequisites:** Carthian Status • The Vinculum, the blood bond, is one of the oldest, most fearsome tools of Kindred tyrants. To the Movement, bloo"
+    },
+    {
+      "key": "cacophony-savvy",
+      "name": "Cacophony Savvy",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 61,
+      "after_len": 74,
+      "preview": "Only level 1 is available at character creation. _Source: VTR 2e_ _pg 110_"
+    },
+    {
+      "key": "carthian-pull",
+      "name": "Carthian Pull",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 51,
+      "after_len": 604,
+      "preview": "**Prerequisite:** Carthian Status • **Effect:** Carthians know people. Being the covenant arguably most in touch with humanity, they tend to have the "
+    },
+    {
+      "key": "casual-user",
+      "name": "Casual User",
+      "category": "merit",
+      "source": "Secrets of the Covenants + TM Errata",
+      "before_len": 68,
+      "after_len": 56,
+      "preview": "Cost reduced from 2 dots to 1 dot. _Source: SotC pg 178_"
+    },
+    {
+      "key": "cease-fire",
+      "name": "Cease Fire",
+      "category": "merit",
+      "source": "Secrets of the Covenants + TM Errata",
+      "before_len": 53,
+      "after_len": 82,
+      "preview": "Talk to Storytellers about how a Cease Fire can be declared. _Source: SotC pg 180_"
+    },
+    {
+      "key": "cheap-shot",
+      "name": "Cheap Shot",
+      "category": "merit",
+      "source": "CofD Rulebook",
+      "before_len": 29,
+      "after_len": 599,
+      "preview": "**Prerequisites:** Street Fighting •••, Subterfuge •• **Effect:** Your character is a master at the bait and switch. She can look off in an odd direct"
+    },
+    {
+      "key": "chorister",
+      "name": "Chorister",
+      "category": "merit",
+      "source": "Secrets of the Covenants + TM Errata",
+      "before_len": 65,
+      "after_len": 206,
+      "preview": "Changed mechanics. Cost reduced from 2 dots to 1 dot. Ability to purchase Crúac (first dot), rituals, and Circle Merits removed to maintain parity wit"
+    },
+    {
+      "key": "claws-of-the-unholy",
+      "name": "Claws Of The Unholy",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 119,
+      "after_len": 83,
+      "preview": "Now does +2 Aggravated Damage. Only ignores mundane armour. _Source: VTR 2e pg 110_"
+    },
+    {
+      "key": "clipping",
+      "name": "Clipping",
+      "category": "merit",
+      "source": "CofD Rulebook",
+      "before_len": 32,
+      "after_len": 380,
+      "preview": "Your character has experience hitting things with her vehicle in such a way as to not hurt herself much. When voluntarily hitting another character or"
+    },
+    {
+      "key": "close-family",
+      "name": "Close Family",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 40,
+      "after_len": 128,
+      "preview": "Removed drawback \"cannot spend Willpower for bonus dice in scenes where blood sympathy has been felt\". _Source: VTR_ _2e pg 111_"
+    },
+    {
+      "key": "closed-book",
+      "name": "Closed Book",
+      "category": "merit",
+      "source": "CofD Rulebook",
+      "before_len": 39,
+      "after_len": 677,
+      "preview": "**Prerequisites:** Manipulation •••, Resolve ••• **Effect:** Your character is particularly tough to crack. When a character uses Social Maneuvering *"
+    },
+    {
+      "key": "coda-against-sorcery",
+      "name": "Coda Against Sorcery",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 34,
+      "after_len": 1300,
+      "preview": "**Prerequisites:** Carthian Status • The largely secular Carthian Movement maintains this ancient practice as a defense against sorcery. Precedent for"
+    },
+    {
+      "key": "contacts",
+      "name": "Contacts",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 40,
+      "after_len": 519,
+      "preview": "**Effect:** Each dot represents an area of influence for gathering information: Bureaucracy, Church, Finance, Health, High Society, Industry, Legal, M"
+    },
+    {
+      "key": "court-jester",
+      "name": "Court Jester",
+      "category": "merit",
+      "source": "Secrets of the Covenants + TM Errata",
+      "before_len": 86,
+      "after_len": 193,
+      "preview": "There can only be one Jester per domain. To become the Jester if one is already present, you must convince them to give up the title, kill them, or pu"
+    },
+    {
+      "key": "crowdsourcing",
+      "name": "Crowdsourcing",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 96,
+      "after_len": 1179,
+      "preview": "**Prerequisites:** Contacts •, Resources ••• Your character is an expert at networking, and gathering together resources for the covenant’s consumptio"
+    },
+    {
+      "key": "cutthroat",
+      "name": "Cutthroat",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 73,
+      "after_len": 392,
+      "preview": "**Prerequisites:** Cannot have the Atrocious or Enticing Merits **Effect:** Your character’s competitive Beast flows in her every action. Her smug bea"
+    },
+    {
+      "key": "danger-sense",
+      "name": "Danger Sense",
+      "category": "merit",
+      "source": "CofD Rulebook",
+      "before_len": 40,
+      "after_len": 195,
+      "preview": "**Effect:** You gain a +2 modifier on reflexive Wits + Composure rolls for your character to detect an impending ambush. Your character’s reflexes are"
+    },
+    {
+      "key": "demolisher",
+      "name": "Demolisher",
+      "category": "merit",
+      "source": "CofD Rulebook",
+      "before_len": 44,
+      "after_len": 227,
+      "preview": "**Prerequisite:** Strength ••• or Intelligence ••• **Effect:** Your character has an innate feel for the weak points in objects. When damaging an obje"
+    },
+    {
+      "key": "devotion-experimenter",
+      "name": "Devotion Experimenter",
+      "category": "merit",
+      "source": "Secrets of the Covenants + TM Errata",
+      "before_len": 64,
+      "after_len": 109,
+      "preview": "Experience cost reduction and teaching Beat removed. Cost reduced from 2 dots to 1 dot. _Source: SotC pg 178_"
+    },
+    {
+      "key": "distinguished-palate",
+      "name": "Distinguished Palate",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 82,
+      "after_len": 58,
+      "preview": "Cost reduced from 2 dots to 1 dot. _Source: VTR 2e pg 111_"
+    },
+    {
+      "key": "double-jointed",
+      "name": "Double Jointed",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 56,
+      "after_len": 245,
+      "preview": "Benefit of Double Jointed applies when already grappled and defending an overpower, or when attacking if she declares her intention to Break Free on a"
+    },
+    {
+      "key": "dream-visions",
+      "name": "Dream Visions",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 63,
+      "after_len": 781,
+      "preview": "**Prerequisites:** Must be Mekhet **Effect:** Your character’s Mekhet blood touches on a level of universal interconnectedness that her mind cannot tr"
+    },
+    {
+      "key": "dynasty-membership",
+      "name": "Dynasty Membership",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 87,
+      "after_len": 161,
+      "preview": "This Merit is now free and given in game by Storyteller on request. New Kid now applies to any Kindred Status. Exemplar has been removed. _Source: VTR"
+    },
+    {
+      "key": "eidetic-memory",
+      "name": "Eidetic Memory",
+      "category": "merit",
+      "source": "CofD Rulebook + TM Errata",
+      "before_len": 38,
+      "after_len": 57,
+      "preview": "Cost reduced from 2 dots to 1 dot. _Source: CoD 2e pg 46_"
+    },
+    {
+      "key": "empower-judiciary",
+      "name": "Empower Judiciary",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 44,
+      "after_len": 2205,
+      "preview": "**Prerequisites:** Carthian Status ••• In many domains, a single Kindred is established as interpreter of the law. In Carthian domains, this is freque"
+    },
+    {
+      "key": "encyclopaedic-knowledge",
+      "name": "Encyclopaedic Knowledge",
+      "category": "merit",
+      "source": "TM Errata",
+      "before_len": 41,
+      "after_len": 57,
+      "preview": "Cost reduced from 2 dots to 1 dot. _Source: CoD 2e pg 46_"
+    },
+    {
+      "key": "enticing",
+      "name": "Enticing",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 73,
+      "after_len": 427,
+      "preview": "**Prerequisites:** Cannot have the Atrocious or Cutthroat Merits **Effect:** Your character’s seductive Beast oozes with ease and confidence. Her smok"
+    },
+    {
+      "key": "establish-precedent",
+      "name": "Establish Precedent",
+      "category": "merit",
+      "source": "Secrets of the Covenants + TM Errata",
+      "before_len": 49,
+      "after_len": 736,
+      "preview": "Merit now reads:  **Prerequisite:** Carthian Status •••• **Effect:** Must be publicly announced on the same night a law is established. Invest 1 Willp"
+    },
+    {
+      "key": "eye-for-the-strange",
+      "name": "Eye For The Strange",
+      "category": "merit",
+      "source": "CofD Rulebook",
+      "before_len": 42,
+      "after_len": 780,
+      "preview": "**Prerequisite:** Resolve ••, Occult • **Effect:** While your character does not necessarily possess a breadth of knowledge about the supernatural, sh"
+    },
+    {
+      "key": "feeding-grounds",
+      "name": "Feeding Grounds",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 158,
+      "after_len": 137,
+      "preview": "Allows the use of Disciplines up to Merit rating without risking Dramatic Failure on Start of Game Hunting Rolls. _Source: VTR 2e pg 112_"
+    },
+    {
+      "key": "fighting-finesse",
+      "name": "Fighting Finesse",
+      "category": "merit",
+      "source": "CofD Rulebook",
+      "before_len": 63,
+      "after_len": 961,
+      "preview": "**Prerequisites:** Dexterity •••, a Specialty in Weaponry or Brawl **Effect:** Choose a Specialty in Weaponry or Brawl when you purchase this Merit. Y"
+    },
+    {
+      "key": "fixer",
+      "name": "Fixer",
+      "category": "merit",
+      "source": "CofD Rulebook + TM Errata",
+      "before_len": 38,
+      "after_len": 96,
+      "preview": "Now reduces all availability costs by one on anything, not just Services. _Source: CoD 2e pg 51_"
+    },
+    {
+      "key": "flock",
+      "name": "Flock",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 73,
+      "after_len": 733,
+      "preview": "**Prerequisite:** Herd (equal or greater level) Your character not only maintains a Herd, he empowers, emboldens, and inspires them. Because of his pr"
+    },
+    {
+      "key": "friends-in-high-places",
+      "name": "Friends In High Places",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 114,
+      "after_len": 212,
+      "preview": "Once per Chapter, you may use dots equal to your Invictus Status as dots in Mortal Status for areas you do not already possess. Drawback: Other Invict"
+    },
+    {
+      "key": "fucking-thief",
+      "name": "Fucking Thief",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 68,
+      "after_len": 875,
+      "preview": "**Prerequisites:** Subterfuge ••• Fucking Thieves, or Magpies to the less resentful, are Carthians that specialize in stealing the secrets of other or"
+    },
+    {
+      "key": "giant",
+      "name": "Giant",
+      "category": "merit",
+      "source": "CofD Rulebook + TM Errata",
+      "before_len": 47,
+      "after_len": 81,
+      "preview": "Available only at character creation and must be costumed. _Source: CoD 2e pg 49_"
+    },
+    {
+      "key": "haven",
+      "name": "Haven",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 46,
+      "after_len": 872,
+      "preview": "**Prerequisite:** Safe Place • **Effect:** A good haven is not only safe from the sun, but also familiar and comforting. The dot rating reflects your "
+    },
+    {
+      "key": "herd",
+      "name": "Herd",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 60,
+      "after_len": 75,
+      "preview": "Herd provides one-for-one Vitae at start of game. _Source:_ _VTR 2e pg 112_"
+    },
+    {
+      "key": "honey-trap",
+      "name": "Honey Trap",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 61,
+      "after_len": 234,
+      "preview": "**Effect:** Your character’s blood not only bonds, but it invigorates. When a vampire tastes your character’s Vitae, she regains a point of Willpower."
+    },
+    {
+      "key": "i-know-a-guy",
+      "name": "I Know A Guy",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 39,
+      "after_len": 770,
+      "preview": "**Prerequisites:** Carthian Status • **Effect:** When Carthians make Allies (see p. 118), their covenant acts as a sort of support network that bolste"
+    },
+    {
+      "key": "information-network",
+      "name": "Information Network",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 39,
+      "after_len": 439,
+      "preview": "**Prerequisites:** Contacts •, Invictus Status •• As a member of the Invictus, your character has support to investigate, maintain, and motivate her c"
+    },
+    {
+      "key": "invested",
+      "name": "Invested",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 78,
+      "after_len": 2657,
+      "preview": "**Prerequisite:** Invictus Status • **Effect:** In the Invictus, you get out what you put in. Through doing favors and making herself noticed, your ch"
+    },
+    {
+      "key": "iron-stamina",
+      "name": "Iron Stamina",
+      "category": "merit",
+      "source": "CofD Rulebook",
+      "before_len": 41,
+      "after_len": 1340,
+      "preview": "**Prerequisites:** Stamina ••• or Resolve ••• **Effect:** Each dot eliminates a negative modifier (on a onefor-one basis) when resisting the effects o"
+    },
+    {
+      "key": "iron-will",
+      "name": "Iron Will",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 80,
+      "after_len": 133,
+      "preview": "Cost reduced from 2 dots to 1 dot. _Source: CoD 2e pg 51_ Iron Will does not apply to resisting or contesting supernatural influence."
+    },
+    {
+      "key": "jack-booted-thug",
+      "name": "Jack-booted Thug",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 95,
+      "after_len": 2844,
+      "preview": "**Prerequisites:** Carthian Status ••, City Status •, Intimidation ••• A Carthian with this Merit is widely recognized as a loose cannon, willing and "
+    },
+    {
+      "key": "kiss-of-the-succubus",
+      "name": "Kiss Of The Succubus",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 52,
+      "after_len": 419,
+      "preview": "**Prerequisite:** Must be Daeva **Effect:** All Kindred can evoke lustful, passionate reactions with a bite. The Daeva’s bite is downright addicting. "
+    },
+    {
+      "key": "laity",
+      "name": "Laity",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 66,
+      "after_len": 945,
+      "preview": "**Prerequisites:** _Not_ a member of the Lancea et Sanctum Your character attends Mass, but has not formally joined the church. Perhaps she’s an Invic"
+    },
+    {
+      "key": "lex-terrae",
+      "name": "Lex Terrae",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 34,
+      "after_len": 574,
+      "preview": "**Prerequisites:** Carthian Status ••, Feeding Ground • **Effect:** Territory is bond. Feeding ground is sacrosanct. Any blood poached from your chara"
+    },
+    {
+      "key": "library",
+      "name": "Library",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 49,
+      "after_len": 80,
+      "preview": "Use of Merit can be loaned for mundane extended actions. _Source: VTR 2e pg 120_"
+    },
+    {
+      "key": "lorekeeper",
+      "name": "Lorekeeper",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 74,
+      "after_len": 900,
+      "preview": "**Prerequisites:** Lancea et Sanctum Status • **Effect**: The Spear is tasked with the acquisition and maintenance of history and mystical secrets. Mo"
+    },
+    {
+      "key": "mandate-from-the-masses",
+      "name": "Mandate From The Masses",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 40,
+      "after_len": 108,
+      "preview": "Status requirement increased from 5 to 15 dots of Status per Blood Potency stripped. _Source: VTR 2e pg 116_"
+    },
+    {
+      "key": "mandragora-garden",
+      "name": "Mandragora Garden",
+      "category": "merit",
+      "source": "Secrets of the Covenants + TM Errata",
+      "before_len": 160,
+      "after_len": 1416,
+      "preview": "Merit now reads:  **Prerequisites:** Circle Status •, Safe Place (equal level), Crúac • **Effect:** Your character cultivates and maintains a ghouled "
+    },
+    {
+      "key": "mentor",
+      "name": "Mentor",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 93,
+      "after_len": 222,
+      "preview": "Rather than levels of favours, the use of a Mentor requires the sacrifice of downtime action, potentially more depending on Storyteller discretion. Ge"
+    },
+    {
+      "key": "moderator",
+      "name": "Moderator",
+      "category": "merit",
+      "source": "Secrets of the Covenants + TM Errata",
+      "before_len": 76,
+      "after_len": 89,
+      "preview": "Now once per chapter, not once per story, and all dots may be used. _Source: SotC pg 187_"
+    },
+    {
+      "key": "mortal-status",
+      "name": "Mortal Status",
+      "category": "merit",
+      "source": "TM Errata",
+      "before_len": 107,
+      "after_len": 750,
+      "preview": "**Effect:** Your character has standing within a mortal group or organisation: Bureaucracy, Church, Finance, Health, High Society, Industry, Legal, Mi"
+    },
+    {
+      "key": "multilingual",
+      "name": "Multilingual",
+      "category": "merit",
+      "source": "CofD Rulebook",
+      "before_len": 34,
+      "after_len": 543,
+      "preview": "**Effect:** Your character has a strong affinity for language acquisition. Each time you purchase this Merit, choose two languages. Your character can"
+    },
+    {
+      "key": "mystery-cult-initiation",
+      "name": "Mystery Cult Initiation",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 47,
+      "after_len": 189,
+      "preview": "Benefits can only be mundane. Can have Status in multiple Mystery Cults, but can only receive membership dot benefits from one instance of each level "
+    },
+    {
+      "key": "night-doctor-surgery",
+      "name": "Night Doctor Surgery",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 45,
+      "after_len": 1163,
+      "preview": "**Prerequisite:** Carthian Status •• **Effect:** Carthians have adapted a bit of real-world surgery and a little body horror into a series of morbid r"
+    },
+    {
+      "key": "noblesse-oblige",
+      "name": "Noblesse Oblige",
+      "category": "merit",
+      "source": "Secrets of the Covenants + TM Errata",
+      "before_len": 37,
+      "after_len": 56,
+      "preview": "Cost reduced from 3 dots to 1 dot. _Source: SotC pg 188_"
+    },
+    {
+      "key": "notary",
+      "name": "Notary",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 62,
+      "after_len": 59,
+      "preview": "Cost reduced from 3 dots to 2 dots. _Source: VTR 2e pg 116_"
+    },
+    {
+      "key": "oath-of-abstinence",
+      "name": "Oath Of Abstinence",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 38,
+      "after_len": 1143,
+      "preview": "This rare Oath is considered anathema to many Invictus, particularly those with strong ties to the Lancea et Sanctum. Functionally, it spits in the fa"
+    },
+    {
+      "key": "oath-of-action",
+      "name": "Oath Of Action",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 45,
+      "after_len": 72,
+      "preview": "The timeframe is now one Story, not one month. _Source:_ _VTR 2e pg 117_"
+    },
+    {
+      "key": "oath-of-fealty",
+      "name": "Oath Of Fealty",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 52,
+      "after_len": 486,
+      "preview": "**Prerequisites:** Invictus Status • **Effect:** This most basic Oath establishes a foundation of trust within the Invictus. The vassal may draw a num"
+    },
+    {
+      "key": "oath-of-matrimony",
+      "name": "Oath Of Matrimony",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 38,
+      "after_len": 3195,
+      "preview": "This Oath binds two Kindred together in a powerful union, where their collective capabilities are shared, but they must maintain loyalty to one anothe"
+    },
+    {
+      "key": "oath-of-office",
+      "name": "Oath Of Office",
+      "category": "merit",
+      "source": "Secrets of the Covenants + TM Errata",
+      "before_len": 54,
+      "after_len": 145,
+      "preview": "Cost reduced from 3 dots to 1 dot. Ending this Oath can only be done by losing this position or release by Liege or Notary. _Source: SotC pg 191_"
+    },
+    {
+      "key": "oath-of-penance",
+      "name": "Oath Of Penance",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 57,
+      "after_len": 610,
+      "preview": "**Effect:** This Oath is a form of apology from a vassal to an aggrieved liege. For the agreed-upon term, the liege receives every tenth Vitae the vas"
+    },
+    {
+      "key": "oath-of-serfdom",
+      "name": "Oath Of Serfdom",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 45,
+      "after_len": 1862,
+      "preview": "**Effect:** This Oath is a contract between a landlord and a tenant. In Invictus domains, Princes often use this Oath as the go-to for granting territ"
+    },
+    {
+      "key": "oath-of-the-handshake-deal",
+      "name": "Oath Of The Handshake Deal",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 39,
+      "after_len": 1559,
+      "preview": "This simple Oath features as a foundation for many Invictus interactions. As the name suggests, it solidifies a handshake deal. Both participants offe"
+    },
+    {
+      "key": "oath-of-the-hard-motherfucker",
+      "name": "Oath of the Hard Motherfucker",
+      "category": "merit",
+      "source": "Secrets of the Covenants + TM Errata",
+      "before_len": 413,
+      "after_len": 109,
+      "preview": "Oath now also provides Friends in High Places (•), as Invictus Status is not purchased. _Source: SotC pg 189_"
+    },
+    {
+      "key": "oath-of-the-model-prisoner",
+      "name": "Oath Of The Model Prisoner",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 27,
+      "after_len": 2732,
+      "preview": "Say what you will about the Invictus. However, they (usually) treat their prisoners with some degree of honor, and Invictus imprisoned by others (usua"
+    },
+    {
+      "key": "oath-of-the-refugee",
+      "name": "Oath Of The Refugee",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 38,
+      "after_len": 968,
+      "preview": "In some domains, the very act of identifying oneself as Invictus is criminal or otherwise shunned. Sometimes, Invictus ideology forces a vampire to ta"
+    },
+    {
+      "key": "oath-of-the-righteous-kill",
+      "name": "Oath Of The Righteous Kill",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 33,
+      "after_len": 1352,
+      "preview": "**Prerequisites:** Empathy •••, Invictus Status ••• In defense of the Masquerade, sometimes witnesses and offenders must die. Invictus ideology teache"
+    },
+    {
+      "key": "oath-of-the-safe-word",
+      "name": "Oath Of The Safe Word",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 519,
+      "after_len": 1370,
+      "preview": "With this Oath, two Kindred enter into a trust agreement. While mutually beneficial, either party can end the agreement in a remarkable, crippling fas"
+    },
+    {
+      "key": "oath-of-the-true-knight",
+      "name": "Oath Of The True Knight",
+      "category": "merit",
+      "source": "Secrets of the Covenants + TM Errata",
+      "before_len": 47,
+      "after_len": 352,
+      "preview": "Clarification:  **Drawback:** Cannot be woken from torpor by being fed blood whilst under this Oath, and Vitae from any source cannot be consumed. _So"
+    },
+    {
+      "key": "one-foot-in-the-door",
+      "name": "One Foot In The Door",
+      "category": "merit",
+      "source": "Secrets of the Covenants + TM Errata",
+      "before_len": 68,
+      "after_len": 56,
+      "preview": "Cost reduced from 2 dots to 1 dot. _Source: SotC pg 187_"
+    },
+    {
+      "key": "pack-alpha",
+      "name": "Pack Alpha",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 78,
+      "after_len": 740,
+      "preview": "**Prerequisite:** Must be Gangrel **Effect:** You’re pack-minded. Your blood draws to blood. You may designate a coterie of Kindred and ghouls as your"
+    },
+    {
+      "key": "plausible-deniability",
+      "name": "Plausible Deniability",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 34,
+      "after_len": 2006,
+      "preview": "**Prerequisites:** Carthian Status ••• **Effect:** Carthians don’t break laws; they defy laws. Influential Carthians can throw law to the wind, then l"
+    },
+    {
+      "key": "prestigious-sire",
+      "name": "Prestigious Sire",
+      "category": "merit",
+      "source": "Secrets of the Covenants + TM Errata",
+      "before_len": 71,
+      "after_len": 114,
+      "preview": "Prerequisites changed to: Invictus Status •, In-game sire with a Kindred Status 4 or higher. _Source: SotC pg 188_"
+    },
+    {
+      "key": "primal-creation",
+      "name": "Primal Creation",
+      "category": "merit",
+      "source": "TM Errata",
+      "before_len": 50,
+      "after_len": 274,
+      "preview": "Additionally, when purchasing a Retainer with a dot rating equal to or less than this style rating, receive a second identical Retainer for free. Thes"
+    },
+    {
+      "key": "professional-training",
+      "name": "Professional Training",
+      "category": "merit",
+      "source": "CofD Rulebook + TM Errata",
+      "before_len": 67,
+      "after_len": 132,
+      "preview": "••••• The Routine: The Rote mechanic has been changed. See Dice Rolls / Dice Variations. _Source: CoD 2e pg 48_  **PHYSICAL MERITS**"
+    },
+    {
+      "key": "pusher",
+      "name": "Pusher",
+      "category": "merit",
+      "source": "CofD Rulebook",
+      "before_len": 46,
+      "after_len": 282,
+      "preview": "**Prerequisite:** Persuasion •• **Effect:** Your character tempts and bribes as second nature. Any time a mark in a Social interaction accepts his sof"
+    },
+    {
+      "key": "quick-draw",
+      "name": "Quick Draw",
+      "category": "merit",
+      "source": "CofD Rulebook + TM Errata",
+      "before_len": 41,
+      "after_len": 104,
+      "preview": "Any bonuses to initiative only apply if the character attempts to use the weapon. _Source: CoD 2e pg 49_"
+    },
+    {
+      "key": "resources",
+      "name": "Resources",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 29,
+      "after_len": 88,
+      "preview": "Generates 1 Influence at Resources 3; 2 Influence at Resources 5. _Source: CoD 2e pg 53_"
+    },
+    {
+      "key": "retainer",
+      "name": "Retainer",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 28,
+      "after_len": 208,
+      "preview": "For Retainers that will come into direct contact with PCs (e.g. combat), the Storytellers will develop a relevant sheet. Generates 1 Influence at Reta"
+    },
+    {
+      "key": "right-of-return",
+      "name": "Right Of Return",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 31,
+      "after_len": 298,
+      "preview": "Replace the sentence: \"In any Social Maneuvering with members of a covenant she claims Status in, treat her impressions as one step better.\" With: \"In"
+    },
+    {
+      "key": "safe-place",
+      "name": "Safe Place",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 28,
+      "after_len": 138,
+      "preview": "Safe Place also adds rounds of preparation equal to Merit rating when Safe Place is under threat where appropriate. _Source: CoD 2e pg 53_"
+    },
+    {
+      "key": "sanctuary",
+      "name": "Sanctuary",
+      "category": "merit",
+      "source": "Secrets of the Covenants + TM Errata",
+      "before_len": 82,
+      "after_len": 120,
+      "preview": "Prerequisites now read: Lancea et Sanctum Status ••, City Status •••, Safe Place equal or greater. _Source: SotC pg 193_"
+    },
+    {
+      "key": "sell-out",
+      "name": "Sell Out",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 98,
+      "after_len": 1116,
+      "preview": "**Prerequisites:** Carthian Status ••••, City Status ••••, Politics ••• A Carthian that takes the role of Prince often finds herself assailed from all"
+    },
+    {
+      "key": "small-unit-tactics",
+      "name": "Small Unit Tactics",
+      "category": "merit",
+      "source": "CofD Rulebook",
+      "before_len": 40,
+      "after_len": 413,
+      "preview": "**Prerequisites:** Presence ••• **Effect:** Your character is a proficient leader in the field. She can organize efforts and bark orders to remarkable"
+    },
+    {
+      "key": "social-engineering",
+      "name": "Social Engineering",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 80,
+      "after_len": 1239,
+      "preview": "**Prerequisites:** Investigation ••, Manipulation •••, Subterfuge ••, Wits ••• Your character is a master of digging up little private bits and person"
+    },
+    {
+      "key": "sorcerous-eunuch",
+      "name": "Sorcerous Eunuch",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 93,
+      "after_len": 733,
+      "preview": "**Prerequisites:** Resolve ••• **Effect:** Your character has been subject to a series of terrifying rituals and experiments, which affords him a near"
+    },
+    {
+      "key": "speaker-for-the-silent",
+      "name": "Speaker For The Silent",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 61,
+      "after_len": 70,
+      "preview": "Discuss with Storytellers before purchasing. _Source: VTR 2e_ _pg 114_"
+    },
+    {
+      "key": "staff",
+      "name": "Staff",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 95,
+      "after_len": 80,
+      "preview": "Generates 1 Influence at Staff 3; 2 Influence at Staff 5. _Source: CoD 2e pg 54_"
+    },
+    {
+      "key": "stigmata",
+      "name": "Stigmata",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 109,
+      "after_len": 128,
+      "preview": "Prerequisites now read: Lancea et Sanctum Status •, Humanity 3 + Merit rating, or mortal. _Source: SotC pg 193_ **CRÚAC STYLES**"
+    },
+    {
+      "key": "strength-of-resolution",
+      "name": "Strength of Resolution",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 29,
+      "after_len": 285,
+      "preview": "**Prerequisites:** Carthian Status • **Effect:** A Carthian stands resolute in the face of that which would force her to violate the law. Add her Cart"
+    },
+    {
+      "key": "swarm-form",
+      "name": "Swarm Form",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 69,
+      "after_len": 1541,
+      "preview": "**Prerequisite:** Protean ••• **Effect:** When taking the Beast’s Skin, some Gangrel can instead become a swarm of small creatures: Size 0 or Size 1 a"
+    },
+    {
+      "key": "table-turner",
+      "name": "Table Turner",
+      "category": "merit",
+      "source": "CofD Rulebook",
+      "before_len": 50,
+      "after_len": 340,
+      "preview": "**Prerequisites:** Composure •••, Manipulation •••, Wits ••• **Effects:** Your character can turn any attempt to leverage her into an opportunity. Any"
+    },
+    {
+      "key": "tech-savvy",
+      "name": "Tech-savvy",
+      "category": "merit",
+      "source": "Secrets of the Covenants + TM Errata",
+      "before_len": 94,
+      "after_len": 132,
+      "preview": "Merit now usable once per Chapter and cannot grant 9- again to combat equipment. _Source: SotC pg 189_  **LANCEA ET SANCTUM MERITS**"
+    },
+    {
+      "key": "the-mother-daughter-bond",
+      "name": "The Mother-Daughter Bond",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 261,
+      "after_len": 371,
+      "preview": "Merit now reads:  **Prerequisite:** Circle of the Crone Status • **Effect:** Strong mentorship defines the Circle. When purchasing Mentor, take additi"
+    },
+    {
+      "key": "toss-that-shit-right-back",
+      "name": "Toss That Shit Right Back",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 71,
+      "after_len": 1124,
+      "preview": "**Prerequisites:** Athletics ••, Dexterity ••• When the revolution is backed against the wall and outgunned, the best option is to throw the enemy’s w"
+    },
+    {
+      "key": "travel-agent",
+      "name": "Travel Agent",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 104,
+      "after_len": 1580,
+      "preview": "**Prerequisite:** Contacts (Inter-City) •, Invictus Status •• One of the perks of Invictus membership pertains directly to the Invictus’ strength of o"
+    },
+    {
+      "key": "undead-menses",
+      "name": "Undead Menses",
+      "category": "merit",
+      "source": "VtR 2e Rulebook + TM Errata",
+      "before_len": 77,
+      "after_len": 139,
+      "preview": "This Merit can be purchased by any Crone, embodying the feminine power of creation. Bleeding from relevant orifice. _Source: VTR 2e pg 115_"
+    },
+    {
+      "key": "unsettling-gaze",
+      "name": "Unsettling Gaze",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 75,
+      "after_len": 554,
+      "preview": "**Prerequisites:** Must be Nosferatu **Effect:** All Haunts have an unsettling effect. Your character’s Beast oozes with terror. When she evokes the m"
+    },
+    {
+      "key": "viral-mythology",
+      "name": "Viral Mythology",
+      "category": "merit",
+      "source": "Secrets of the Covenants",
+      "before_len": 71,
+      "after_len": 1238,
+      "preview": "**Prerequisites:** Crúac •, Presence •••, Expression ••• Your character has established and grooms a reputation, a personal myth that’s greater than t"
+    },
+    {
+      "key": "what-youve-done-for-her-lately",
+      "name": "What You've Done For Her Lately",
+      "category": "merit",
+      "source": "Secrets of the Covenants + TM Errata",
+      "before_len": 71,
+      "after_len": 400,
+      "preview": "Merit now reads:  **Prerequisites:** Circle Status •, Crúac •• **Effect:** Performing Crúac rituals enhances your standing within the Circle. Once per"
+    },
+    {
+      "key": "where-the-bodies-are-buried",
+      "name": "Where The Bodies Are Buried",
+      "category": "merit",
+      "source": "VtR 2e Rulebook",
+      "before_len": 75,
+      "after_len": 1291,
+      "preview": "**Prerequisites:** Invictus Status •• **Effect:** The Conspiracy of Silence covers up a lot of secrets… and your character’s been quietly keeping trac"
+    },
+    {
+      "key": "air-of-menace",
+      "name": "Air of Menace",
+      "category": "merit",
+      "source": "Hurt Locker",
+      "before_len": 79,
+      "after_len": 826,
+      "preview": "**Prerequisites:** Intimidation •• **Effect:** Your character has survived dozens of fights, and each one has taken its toll. He carries scars, featur"
+    },
+    {
+      "key": "body-as-weapon",
+      "name": "Body As Weapon",
+      "category": "merit",
+      "source": "Hurt Locker",
+      "before_len": 30,
+      "after_len": 3460,
+      "preview": "**Prerequisites:** Stamina •••, Brawl •• **Effect:** Your character has honed her body to be a hardened weapon. She has trained long, punishing hours "
+    },
+    {
+      "key": "covert-operative",
+      "name": "Covert Operative",
+      "category": "merit",
+      "source": "Hurt Locker",
+      "before_len": 68,
+      "after_len": 750,
+      "preview": "**Prerequisites:** Wits •••, Dexterity •••, Stealth •• **Style Tags:** Tactical (Military) **Effect:** Your character is trained in getting the jump o"
+    },
+    {
+      "key": "empath",
+      "name": "Empath",
+      "category": "merit",
+      "source": "Hurt Locker",
+      "before_len": 109,
+      "after_len": 1129,
+      "preview": "Prerequisites: Empathy ••  **Effect:** Your character has seen pain, and can identify it instantly. With a single Wits + Empathy roll, you can identif"
+    },
+    {
+      "key": "finger-on-the-pulse",
+      "name": "Finger On The Pulse",
+      "category": "merit",
+      "source": "TM Errata",
+      "before_len": 85,
+      "after_len": 144,
+      "preview": "**Prerequisites:** Carthian Status 1 Carthians with this merit are immersed in the Cacophony, and do not suffer the drawback of Cacophony Savvy."
+    },
+    {
+      "key": "honey-with-vinegar",
+      "name": "Honey With Vinegar",
+      "category": "merit",
+      "source": "TM Errata",
+      "before_len": 147,
+      "after_len": 200,
+      "preview": "**Prerequisites:** Carthian Status 1 Carthians earn influence from Allies, Contacts, and wide Mortal Status one step lower than normal. They gain 1 po"
+    },
+    {
+      "key": "picket-line",
+      "name": "Picket Line",
+      "category": "merit",
+      "source": "TM Errata",
+      "before_len": 207,
+      "after_len": 275,
+      "preview": "**Prerequisites:** Carthian Status 1 Each chapter, you have a pool of dots equal to their Contacts (max 5), which can be applied to Allies separately "
+    },
+    {
+      "key": "punch-drunk",
+      "name": "Punch Drunk",
+      "category": "merit",
+      "source": "Hurt Locker",
+      "before_len": 89,
+      "after_len": 448,
+      "preview": "**Prerequisite:** Willpower ••••••+ **Effect:** Your character’s resolve is unwavering, even when suffering wounds, broken limbs, and lost blood. She "
+    },
+    {
+      "key": "survivalist",
+      "name": "Survivalist",
+      "category": "merit",
+      "source": "Hurt Locker",
+      "before_len": 43,
+      "after_len": 12724,
+      "preview": "**Prerequisites:** Survival •••, Iron Stamina ••• **Effect:** Your character has been trained to fight even through the most dangerous environmental e"
+    },
+    {
+      "key": "trigger-discipline",
+      "name": "Trigger Discipline",
+      "category": "merit",
+      "source": "Hurt Locker",
+      "before_len": 92,
+      "after_len": 6150,
+      "preview": "**Prerequisites:** Wits ••, Firearms •• **Effect:** Your character is a disciplined shooter, able to maximize her shots and conserve ammo appropriatel"
+    },
+    {
+      "key": "cover-the-angles",
+      "name": "Cover the Angles",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 70,
+      "after_len": 204,
+      "preview": "Whenever you take a Dodge action, reduce the Defense penalties for multiple attackers by 1. You can apply your full Defense against the first two atta"
+    },
+    {
+      "key": "weak-spot",
+      "name": "Weak Spot",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 64,
+      "after_len": 281,
+      "preview": "You swing against your opponent’s arm, rather than his own weapon. Use this ability when defending against an armed attacker. If your Defense reduces "
+    },
+    {
+      "key": "aggressive-defence",
+      "name": "Aggressive Defence",
+      "category": "manoeuvre",
+      "source": "TM Errata",
+      "before_len": 140,
+      "after_len": 40,
+      "preview": "Bashing to Kindred. _Source: HL pg_ _46_"
+    },
+    {
+      "key": "iron-guard",
+      "name": "Iron Guard",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 58,
+      "after_len": 263,
+      "preview": "You and your weapon are one. At the start of each turn, you can choose to reduce your weapon bonus (down to a minimum of 0) to increase your Defense b"
+    },
+    {
+      "key": "press-the-advantage",
+      "name": "Press the Advantage",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 109,
+      "after_len": 407,
+      "preview": "You create an opening with a block, and lash out with a fist or foot. When you’re taking a Dodge action, if your Defense roll reduces the attacker’s s"
+    },
+    {
+      "key": "insignificance",
+      "name": "Insignificance",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 81,
+      "after_len": 423,
+      "preview": "When a fight starts you ease out of sight and try to become a part of the scenery. Make a roll of Manipulation + Stealth – the highest Composure in th"
+    },
+    {
+      "key": "coattails",
+      "name": "Coattails",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 83,
+      "after_len": 295,
+      "preview": "Your character’s reaction to being attacked is to dive behind her bigger friend and let him take care of it. When taking a Dodge action she can design"
+    },
+    {
+      "key": "whack-a-mole",
+      "name": "Whack-a-Mole",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 117,
+      "after_len": 2069,
+      "preview": "Your character makes herself into a tempting target and unsuspecting opponents end up doing more damage to themselves than her. Once per turn you may "
+    },
+    {
+      "key": "play-dead",
+      "name": "Play Dead",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 98,
+      "after_len": 863,
+      "preview": "When your character wants to bow out of a combat she makes even the most superficial wounds look fatal. After any attack your character sustained leth"
+    },
+    {
+      "key": "arcing-fire",
+      "name": "Arcing Fire",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 13,
+      "after_len": 147,
+      "preview": "Your character knows how to tilt her aim to make a shot hit true even from afar. Double range increments, or increase her range band by one degree."
+    },
+    {
+      "key": "bullseye",
+      "name": "Bullseye",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 70,
+      "after_len": 230,
+      "preview": "Your character places her shots to hit deep into an opponent’s weak spots. When attacking a specified target you may lower your bow’s damage rating to"
+    },
+    {
+      "key": "out-of-nowhere",
+      "name": "Out of Nowhere",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 145,
+      "after_len": 333,
+      "preview": "Your character fires her arrows and then ducks out of sight, leaving her enemies bleeding and confused. Roll Dexterity + Stealth as a reflexive action"
+    },
+    {
+      "key": "death-from-above",
+      "name": "Death from Above",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 99,
+      "after_len": 1161,
+      "preview": "Loose vertical shots to reach opponents behind cover. Reduce their Concealment by 1 per 10 yards (9 meters) added to the shot’s range. Or ignore entir"
+    },
+    {
+      "key": "head-protection",
+      "name": "Head Protection",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 56,
+      "after_len": 308,
+      "preview": "The head is the primary target for most boxers, so your character has learned to protect it by bobbing, weaving, and angling away from blows. Your cha"
+    },
+    {
+      "key": "defensive-jab",
+      "name": "Defensive Jab",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 86,
+      "after_len": 390,
+      "preview": "Your character interrupts attacks with well-timed punches from the lead hand. Any time an opponent misses with a Brawl or Weaponry attack, your charac"
+    },
+    {
+      "key": "knockout-artist",
+      "name": "Knockout Artist",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 77,
+      "after_len": 358,
+      "preview": "Your character knows how to knock someone out. She now treats the target’s Size as 1 lower at all times for the purposes of inflicting the Stunned Til"
+    },
+    {
+      "key": "combination",
+      "name": "Combination",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 47,
+      "after_len": 255,
+      "preview": "Your character learns to fire off several blows in rapid succession, so that if one hits, the others often follow. If your character’s Brawl strike su"
+    },
+    {
+      "key": "out-for-the-count",
+      "name": "Out for the Count",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 105,
+      "after_len": 776,
+      "preview": "When your character knocks someone out they don’t get back up any time soon. When she inflicts the Stunned Tilt it not only lasts for a number of turn"
+    },
+    {
+      "key": "backpacker",
+      "name": "Backpacker",
+      "category": "manoeuvre",
+      "source": "VtR 2e Rulebook",
+      "before_len": 76,
+      "after_len": 344,
+      "preview": "Your character is privy to all the personal ads, magazine codes, tracts, and tagging locations to find the latest Kindred news. Any time new Kindred c"
+    },
+    {
+      "key": "wearing-a-hat",
+      "name": "Wearing a Hat",
+      "category": "manoeuvre",
+      "source": "VtR 2e Rulebook",
+      "before_len": 184,
+      "after_len": 684,
+      "preview": "Your character embodies honor among thieves. She’s a highly respected part of the Cacophony, and as a result, nothing happens without her knowledge. S"
+    },
+    {
+      "key": "firing-lines",
+      "name": "Firing Lines",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 80,
+      "after_len": 326,
+      "preview": "In some situations, your character’s best option is a tactical retreat — especially if he’s inadvertently brought a knife to a gunfight. He can run fo"
+    },
+    {
+      "key": "hard-surfaces",
+      "name": "Hard Surfaces",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook + TM Errata",
+      "before_len": 109,
+      "after_len": 19,
+      "preview": "Bashing to Kindred."
+    },
+    {
+      "key": "armoured-coffin",
+      "name": "Armoured Coffin",
+      "category": "manoeuvre",
+      "source": "TM Errata",
+      "before_len": 184,
+      "after_len": 85,
+      "preview": "Applies only to worn armour. Supernatural armour or armour from Iron Skin is ignored."
+    },
+    {
+      "key": "prep-work",
+      "name": "Prep Work",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 71,
+      "after_len": 300,
+      "preview": "If your character has a second to look around, he can catch someone by surprise almost anywhere. When launching a surprise attack, your Dexterity + St"
+    },
+    {
+      "key": "turnabout",
+      "name": "Turnabout",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook + TM Errata",
+      "before_len": 169,
+      "after_len": 102,
+      "preview": "Applies only when using Brawling disarm unless purchased with Transfer Manoeuvre. _Source:_ _HL pg 48_"
+    },
+    {
+      "key": "rapid-nock",
+      "name": "Rapid Nock",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 59,
+      "after_len": 297,
+      "preview": "Your character has trained herself to have another arrow set and her bow drawn within a heartbeat of her last shot. As long as there is a supply of ar"
+    },
+    {
+      "key": "reflex-aiming",
+      "name": "Reflex Aiming",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 46,
+      "after_len": 136,
+      "preview": "Your character knows how to time her shots to hit her opponents and not her allies. Ignore penalties for firing a bow into close combat."
+    },
+    {
+      "key": "parthian-shot",
+      "name": "Parthian Shot",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 111,
+      "after_len": 290,
+      "preview": "Your character feints retreat to lure an opponent in for a close-range shot. The first time in a turn an opponent attempts a close-range attack, you m"
+    },
+    {
+      "key": "rain-of-arrows",
+      "name": "Rain of Arrows",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 55,
+      "after_len": 311,
+      "preview": "Your character fires a group of shots at multiple opponents in the blink of an eye. She can attack with a bow as an autofire medium burst with three a"
+    },
+    {
+      "key": "trick-shot",
+      "name": "Trick Shot",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 83,
+      "after_len": 1515,
+      "preview": "Your character rolls, leaps, and runs along walls while firing arrows in any direction. Your character can fire her bow simultaneously while taking an"
+    },
+    {
+      "key": "in-high-cotton",
+      "name": "In High Cotton",
+      "category": "manoeuvre",
+      "source": "VtR 2e Rulebook",
+      "before_len": 83,
+      "after_len": 230,
+      "preview": "Your character cultivates standing and respect, and carries it like a knight wears armor. You may apply one relevant Status or Fame Merit to rolls to "
+    },
+    {
+      "key": "half-cocked",
+      "name": "Half-Cocked",
+      "category": "manoeuvre",
+      "source": "VtR 2e Rulebook",
+      "before_len": 131,
+      "after_len": 210,
+      "preview": "Your character is always prepared. On the other hand, others are not. In a new Social interaction, if the impression is good, excellent, or perfect, i"
+    },
+    {
+      "key": "grace-under-fire",
+      "name": "Grace Under Fire",
+      "category": "manoeuvre",
+      "source": "VtR 2e Rulebook",
+      "before_len": 136,
+      "after_len": 217,
+      "preview": "While your character may not always win, she never looks bad. If a character opens all her Doors, and you opt to offer an alternative, his player choo"
+    },
+    {
+      "key": "predators-vigil",
+      "name": "Predator's Vigil",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 97,
+      "after_len": 342,
+      "preview": "The presence of your bird instinctively wards off prey animals. Even a flock of pigeons or swarm of rats won’t come too close when a natural predator "
+    },
+    {
+      "key": "flyby",
+      "name": "Flyby",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 97,
+      "after_len": 266,
+      "preview": "Your character commands her bird to dive past an enemy at high speed, creating a distraction. Roll Presence \\+ Intimidation against an opponent’s Reso"
+    },
+    {
+      "key": "retrieve-item",
+      "name": "Retrieve Item",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 133,
+      "after_len": 482,
+      "preview": "Your bird knows how to grab small items and bring them back to you, even snatching them from someone’s hand. On your character’s turn she can designat"
+    },
+    {
+      "key": "rake-the-eyes",
+      "name": "Rake the Eyes",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 42,
+      "after_len": 701,
+      "preview": "Your character commands her bird to claw at an opponent’s eyes. Take a –1 penalty to attack. A successful attack applies the Blinded Tilt. Grappling ("
+    },
+    {
+      "key": "always-be-closing",
+      "name": "Always Be Closing",
+      "category": "manoeuvre",
+      "source": "VtR 2e Rulebook",
+      "before_len": 75,
+      "after_len": 272,
+      "preview": "With the right leading phrases, your character can direct a mark to say what she wants, when she wants. This trips the mark into vulnerable positions."
+    },
+    {
+      "key": "jargon",
+      "name": "Jargon",
+      "category": "manoeuvre",
+      "source": "VtR 2e Rulebook",
+      "before_len": 68,
+      "after_len": 179,
+      "preview": "Your character confuses her mark using complex terminology. You may apply one relevant Specialty to any Social roll you make, even if the Specialty is"
+    },
+    {
+      "key": "devils-advocacy",
+      "name": "Devil's Advocacy",
+      "category": "manoeuvre",
+      "source": "VtR 2e Rulebook",
+      "before_len": 44,
+      "after_len": 192,
+      "preview": "Your character often poses arguments she doesn’t agree with in order to challenge a mark’s position and keep him from advancing discussion. You can re"
+    },
+    {
+      "key": "salting",
+      "name": "Salting",
+      "category": "manoeuvre",
+      "source": "VtR 2e Rulebook",
+      "before_len": 83,
+      "after_len": 256,
+      "preview": "Your character can position herself so a mark pursues a non-issue or something unimportant to her. When your character opens a Door using conversation"
+    },
+    {
+      "key": "shoot-first",
+      "name": "Shoot First",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 51,
+      "after_len": 309,
+      "preview": "In a firefight, the person shot first is usually the loser. Your character has trained herself to fire first in an altercation. If her gun is drawn, a"
+    },
+    {
+      "key": "suppressive-fire",
+      "name": "Suppressive Fire",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook + TM Errata",
+      "before_len": 150,
+      "after_len": 231,
+      "preview": "The benefit to Defence is independent of the user of covering fire. The final sentence now reads: \"Additionally, her training allows her to use Coveri"
+    },
+    {
+      "key": "secondary-target",
+      "name": "Secondary Target",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 129,
+      "after_len": 627,
+      "preview": "Sometimes, shooting an opponent behind cover is all but impossible. However, a bullet can knock objects off balance, or cause ricochets. By using Seco"
+    },
+    {
+      "key": "sprawl",
+      "name": "Sprawl",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 66,
+      "after_len": 162,
+      "preview": "Your character can adjust his weight to defend himself in a grapple. While in a grapple, the character’s opponent cannot apply the Drop Prone or Take "
+    },
+    {
+      "key": "standing-throw",
+      "name": "Standing Throw",
+      "category": "manoeuvre",
+      "source": "Hurt Locker + TM Errata",
+      "before_len": 192,
+      "after_len": 275,
+      "preview": "If used as the first or second manoeuvre in the same action as establishing the grapple, victim may attempt to maintain the grapple with a reflexive c"
+    },
+    {
+      "key": "small-joint-manipulation",
+      "name": "Small Joint Manipulation",
+      "category": "manoeuvre",
+      "source": "Hurt Locker + TM Errata",
+      "before_len": 98,
+      "after_len": 921,
+      "preview": "Gains the Tactical (Street) Style Tag. _Source: HL pg 49_ **Joint Lock (•••)** now reads: You use joint locks and immobilising tactics to limit your o"
+    },
+    {
+      "key": "takedown",
+      "name": "Takedown",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook + TM Errata",
+      "before_len": 171,
+      "after_len": 234,
+      "preview": "This is not a new grappling manoeuvre. It can only be used in place of establishing a grapple. If the roll is an exceptional success, the free second "
+    },
+    {
+      "key": "ippon",
+      "name": "Ippon",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 164,
+      "after_len": 276,
+      "preview": "_Additional Prerequisite: Takedown Maneuver._ While using Drop Prone with the Takedown Maneuver, your character hurls his opponent to the ground with "
+    },
+    {
+      "key": "joint-lock",
+      "name": "Joint Lock",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 199,
+      "after_len": 747,
+      "preview": "ou use joint locks and immobilizing tactics to limit your opponent’s movement. You can use the Joint Lock move in a grapple. Next turn, your opponent "
+    },
+    {
+      "key": "dynamic-guard",
+      "name": "Dynamic Guard",
+      "category": "manoeuvre",
+      "source": "Hurt Locker + TM Errata",
+      "before_len": 133,
+      "after_len": 89,
+      "preview": "Cannot get up from prone in any round in which this technique is used. _Source: HL pg 49_"
+    },
+    {
+      "key": "lock-flow",
+      "name": "Lock Flow",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 50,
+      "after_len": 259,
+      "preview": "_Additional Prerequisite: Joint Lock_ _Maneuver_. When your character’s opponent slips out of one lock you know how to go with the motion and trap her"
+    },
+    {
+      "key": "positional-dominance",
+      "name": "Positional Dominance",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 71,
+      "after_len": 1215,
+      "preview": "Your character knows how to hurt and tire an opponent from any position, crushing the life out of him. No matter which maneuver you choose on a succes"
+    },
+    {
+      "key": "tap-or-snap",
+      "name": "Tap or Snap",
+      "category": "manoeuvre",
+      "source": "Hurt Locker + TM Errata",
+      "before_len": 233,
+      "after_len": 325,
+      "preview": "A character who is immune to Beaten Down, on a successful contested Manipulation + Subterfuge – (opponent's Intimidation) vs. Wits + Empathy, may choo"
+    },
+    {
+      "key": "sure-strike",
+      "name": "Sure Strike",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook + TM Errata",
+      "before_len": 125,
+      "after_len": 296,
+      "preview": "Cannot be used in a turn the character is dodging. May remove up to nine dice from attack pool at a rate of three dice per one weapon rating increase."
+    },
+    {
+      "key": "threat-range",
+      "name": "Threat Range",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 125,
+      "after_len": 364,
+      "preview": "Your character’s weapon is immense and keeps opponents at bay. If you opt not to move or Dodge during your turn, any character moving into your charac"
+    },
+    {
+      "key": "bring-the-pain",
+      "name": "Bring the Pain",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 100,
+      "after_len": 378,
+      "preview": "Your character’s strikes stun and incapacitate as well as causing massive trauma to the body. Sacrifice your character’s Defense to use Bring the Pain"
+    },
+    {
+      "key": "warding-stance",
+      "name": "Warding Stance",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 79,
+      "after_len": 236,
+      "preview": "Your character holds her weapon in such a way as to make attacks much harder. If her weapon’s drawn, spend a point of Willpower reflexively to add her"
+    },
+    {
+      "key": "rending",
+      "name": "Rending",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 86,
+      "after_len": 986,
+      "preview": "Your character’s cuts leave crippling, permanent wounds. By spending a Willpower point before making an attack roll, her successful attacks cause one "
+    },
+    {
+      "key": "always-armed",
+      "name": "Always Armed",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 116,
+      "after_len": 881,
+      "preview": "Your character can always get his hands on something dangerous, and he has an instinctive understanding of how to put it to good — and deadly — use. A"
+    },
+    {
+      "key": "in-harms-way",
+      "name": "In Harm's Way",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 112,
+      "after_len": 592,
+      "preview": "Your character’s got a knack for putting his weapon in the way of an oncoming attack, no matter how small or inappropriate for blocking it might be. W"
+    },
+    {
+      "key": "breaking-point",
+      "name": "Breaking Point",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 127,
+      "after_len": 1747,
+      "preview": "One sure way to win a fight is to hit the other guy so hard that he doesn’t get back up, even if that means losing a weapon in the process. When makin"
+    },
+    {
+      "key": "detection",
+      "name": "Detection",
+      "category": "manoeuvre",
+      "source": "Hurt Locker + TM Errata",
+      "before_len": 96,
+      "after_len": 284,
+      "preview": "Pool equals the dog's Wits + Survival + K-9 Merit dots, modified for Bonded Condition. If the selected substance is “Corpses” and the trainer is Kindr"
+    },
+    {
+      "key": "targeted-bite",
+      "name": "Targeted Bite",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 81,
+      "after_len": 116,
+      "preview": "Your character may command his dog to target specific body parts. Reduce penalties to attack specific targets by –2."
+    },
+    {
+      "key": "tactical-positioning",
+      "name": "Tactical Positioning",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 185,
+      "after_len": 760,
+      "preview": "The character’s dog knows how to position itself to make it difficult for opponents to ![](./assets/output_16_1.jpeg)![](./assets/output_16_2.png)![]("
+    },
+    {
+      "key": "takedown-bite",
+      "name": "Takedown Bite",
+      "category": "manoeuvre",
+      "source": "Hurt Locker + TM Errata",
+      "before_len": 119,
+      "after_len": 111,
+      "preview": "Decision to Drop Prone or Hold may be made after rolling. Normal Brawling damage is applied. _Source: HL pg 49_"
+    },
+    {
+      "key": "hamstring",
+      "name": "Hamstring",
+      "category": "manoeuvre",
+      "source": "VtR 2e Rulebook",
+      "before_len": 86,
+      "after_len": 337,
+      "preview": "With a well-placed tendon strike, you can briefly cripple a vampire’s ability to augment their physical prowess with Vitae. By targeting a limb (and t"
+    },
+    {
+      "key": "taunt",
+      "name": "Taunt",
+      "category": "manoeuvre",
+      "source": "VtR 2e Rulebook",
+      "before_len": 111,
+      "after_len": 308,
+      "preview": "You know the way the Beast works, and how to taunt it with short, shallow swipes. Before you roll, remove a number of dice from your pool no greater t"
+    },
+    {
+      "key": "carving",
+      "name": "Carving",
+      "category": "manoeuvre",
+      "source": "VtR 2e Rulebook",
+      "before_len": 39,
+      "after_len": 222,
+      "preview": "When you strike, you curve the blade hard and strike to pull the flesh apart, making it harder to heal in the heat of the moment. When Carving, your w"
+    },
+    {
+      "key": "pincushion",
+      "name": "Pincushion",
+      "category": "manoeuvre",
+      "source": "VtR 2e Rulebook",
+      "before_len": 212,
+      "after_len": 384,
+      "preview": "You hit deep, intending to lodge your weapon in its victim. If you choose to leave your weapon in the victim on a successful strike, the victim cannot"
+    },
+    {
+      "key": "spray",
+      "name": "Spray",
+      "category": "manoeuvre",
+      "source": "VtR 2e Rulebook",
+      "before_len": 114,
+      "after_len": 653,
+      "preview": "You cut to remove mass from the body, and by extension, blood. Sacrifice your Defense for the turn to use this maneuver. On a successful attack roll, "
+    },
+    {
+      "key": "trained-bite",
+      "name": "Trained Bite",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 90,
+      "after_len": 403,
+      "preview": "If your character prevails in a grapple she may bite harder than normal, targeting sensitive parts of an opponent’s anatomy. This acts as the Damage m"
+    },
+    {
+      "key": "ripping",
+      "name": "Ripping",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 94,
+      "after_len": 462,
+      "preview": "Your character overcomes squeamishness and distractions to grab and tear earlobes, eyelids, and other soft, loose parts. She doesn’t pause before ripp"
+    },
+    {
+      "key": "trained-gouge",
+      "name": "Trained Gouge",
+      "category": "manoeuvre",
+      "source": "Hurt Locker + TM Errata",
+      "before_len": 111,
+      "after_len": 85,
+      "preview": "Blinded Tilt is as per exceptional success, blinding in both eyes. _Source: HL pg 50_"
+    },
+    {
+      "key": "continuous-bite",
+      "name": "Continuous Bite",
+      "category": "manoeuvre",
+      "source": "Hurt Locker + TM Errata",
+      "before_len": 140,
+      "after_len": 159,
+      "preview": "May upgrade an additional two successes of damage to lethal vs. Kindred. Other success damage is bashing, as per Terra Mortis house rules. _Source:_ _"
+    },
+    {
+      "key": "rapidity",
+      "name": "Rapidity",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 68,
+      "after_len": 242,
+      "preview": "Your character moves with swiftness to find just the right spot to strike. You can sacrifice your character’s weapon damage rating to add his Weaponry"
+    },
+    {
+      "key": "thrust",
+      "name": "Thrust",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 50,
+      "after_len": 378,
+      "preview": "Your character knows when to defend himself, and when to move in for the kill. At any time, you can sacrifice points of Defense one-for-one to add to "
+    },
+    {
+      "key": "feint",
+      "name": "Feint",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook + TM Errata",
+      "before_len": 136,
+      "after_len": 203,
+      "preview": "Mechanic clarification – the round following a Feint, ignore Defence equal to the previous round's (successes + Weapon Rating) and increase weapon rat"
+    },
+    {
+      "key": "flurry",
+      "name": "Flurry",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 95,
+      "after_len": 548,
+      "preview": "Your character moves quickly enough to stab opponents with numerous pricks and swipes in the blink of an eye. As long as your character has his Defens"
+    },
+    {
+      "key": "vital-shot",
+      "name": "Vital Shot",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 93,
+      "after_len": 835,
+      "preview": "Your character can use his smaller weapon to get into an opponent’s defenses and hit where it hurts most. Sacrifice your character’s Defense for the t"
+    },
+    {
+      "key": "through-the-crosshairs",
+      "name": "Through the Crosshairs",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 53,
+      "after_len": 204,
+      "preview": "Your character is a competent sniper, able to sit in position and steel her wits. Usually, the maximum bonus from aiming is three dice. With Through t"
+    },
+    {
+      "key": "precision-shot",
+      "name": "Precision Shot",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 83,
+      "after_len": 482,
+      "preview": "With this level of training, your character knows how to effectively disable a victim instead of focusing on the kill. When attacking a specified targ"
+    },
+    {
+      "key": "a-shot-rings-out",
+      "name": "A Shot Rings Out",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 90,
+      "after_len": 230,
+      "preview": "A master sniper, your character has no worries or lack of confidence. She can fire into a crowd and strike a specific target without penalty. If she m"
+    },
+    {
+      "key": "ghost",
+      "name": "Ghost",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 95,
+      "after_len": 765,
+      "preview": "Your character has trained to shoot unseen, and vanish without a trace. Her Firearms score acts as a penalty on any roll to notice her vantage point, "
+    },
+    {
+      "key": "focused-attack",
+      "name": "Focused Attack",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 72,
+      "after_len": 558,
+      "preview": "Your character has trained extensively in striking specific parts of an opponent’s body. Reduce penalties for hitting specific targets by one. Additio"
+    },
+    {
+      "key": "leg-kick",
+      "name": "Leg Kick",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 73,
+      "after_len": 596,
+      "preview": "Your character knows how to kick an opponent’s legs out from under him. She might use a Thai-style round kick or drive her heel into his kneecap. If s"
+    },
+    {
+      "key": "cutting-elbow",
+      "name": "Cutting Elbow",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 63,
+      "after_len": 455,
+      "preview": "When striking with an elbow, your character targets thin skin in the opponent’s scalp with the aim of ripping it open. She only suffers a –2 penalty t"
+    },
+    {
+      "key": "trapping",
+      "name": "Trapping",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 99,
+      "after_len": 622,
+      "preview": "This maneuver has a lot of names, including “sticking hands” or “scissors.” Using it, your character knows how to control her opponent’s limbs so they"
+    },
+    {
+      "key": "whirlwind-strike",
+      "name": "Whirlwind Strike",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 129,
+      "after_len": 443,
+      "preview": "When engaged, your character becomes a storm of threatening kicks and punches; nothing close is safe. As long as your character has her Defense availa"
+    },
+    {
+      "key": "inch-force",
+      "name": "Inch Force",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 150,
+      "after_len": 583,
+      "preview": "Your character knows how to swiftly strike across extremely short distances. She can hit hard with an inch of movement, or smash with a shoulder, hip,"
+    },
+    {
+      "key": "the-hand-as-weapon",
+      "name": "The Hand As Weapon",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 30,
+      "after_len": 131,
+      "preview": "With this degree of training, your character’s limbs are hardened to cause massive trauma. Her unarmed strikes cause lethal damage."
+    },
+    {
+      "key": "high-momentum-strike",
+      "name": "High Momentum Strike",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 214,
+      "after_len": 1239,
+      "preview": "Tornado kicks, spinning backfists, and flying knees are hard to pull off, but in the right circumstances can be devastating. If your character has a h"
+    },
+    {
+      "key": "the-touch-of-death",
+      "name": "The Touch of Death",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 40,
+      "after_len": 430,
+      "preview": "Your character’s mastery has brought with it the daunting power of causing lethal injury with a touch. If she chooses, her unarmed strikes count as we"
+    },
+    {
+      "key": "compliance-hold",
+      "name": "Compliance Hold",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook + TM Errata",
+      "before_len": 54,
+      "after_len": 93,
+      "preview": "Gain +2 bonus to all overpower rolls once a Hold has been established. _Source: CoD 2e pg 64_"
+    },
+    {
+      "key": "weapon-retention",
+      "name": "Weapon Retention",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook + TM Errata",
+      "before_len": 94,
+      "after_len": 353,
+      "preview": "Reduce successes to disarm or control your weapon by your Weaponry score, or Brawling score for Brawling weapons. _Source: CoD 2e pg 64_ **Speed Cuff "
+    },
+    {
+      "key": "speed-cuff",
+      "name": "Speed Cuff",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 79,
+      "after_len": 1109,
+      "preview": "Against an immobilized opponent, your character may apply handcuffs, cable ties, or similar restraints as a reflexive action. Shiv (• or ••)  **Prereq"
+    },
+    {
+      "key": "quick-reload",
+      "name": "Quick Reload",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 64,
+      "after_len": 196,
+      "preview": "Your character has trained herself on the steps to reload her weapon to the point it’s ingrained in her muscle memory. She reloads one turn faster tha"
+    },
+    {
+      "key": "intercept-shot",
+      "name": "Intercept Shot",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 92,
+      "after_len": 455,
+      "preview": "Your character can shoot a projectile out of the air with her own. This maneuver is not capable of stopping bullets, though it could be used to deflec"
+    },
+    {
+      "key": "penetration",
+      "name": "Penetration",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 60,
+      "after_len": 273,
+      "preview": "Your character knows how to best exploit the weaknesses in a target’s armor. She can add +2 to her weapon’s armor piercing rating for her next attack."
+    },
+    {
+      "key": "skewer",
+      "name": "Skewer",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 175,
+      "after_len": 676,
+      "preview": "Your character uses her projectiles to impale parts of an opponent’s anatomy. When attacking a specified target, reduce the penalty by –2, and any inf"
+    },
+    {
+      "key": "clinch-strike",
+      "name": "Clinch Strike",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 44,
+      "after_len": 413,
+      "preview": "**Prerequisites:** Brawl •• **Style Tags:** Striking, Grappling, Tactical (Street) **Effect:** Most people will instinctively grab anyone they want to"
+    },
+    {
+      "key": "headbutt",
+      "name": "Headbutt",
+      "category": "manoeuvre",
+      "source": "Hurt Locker + TM Errata",
+      "before_len": 104,
+      "after_len": 306,
+      "preview": "Merit now reads:  **Effect:** You gain a new grapple manoeuvre, Headbutt, which allows inflicting the Stunned Tilt without making a called shot to the"
+    },
+    {
+      "key": "phalanx-fighter",
+      "name": "Phalanx Fighter",
+      "category": "manoeuvre",
+      "source": "TM Errata",
+      "before_len": 70,
+      "after_len": 53,
+      "preview": "Cost reduced from 2 dots to 1 dot. _Source: HL pg 50_"
+    },
+    {
+      "key": "boot-party",
+      "name": "Boot Party",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 49,
+      "after_len": 345,
+      "preview": "**Prerequisites:** Brawl •• **Style Tags:** Striking **Effect:** Your character understands the effectiveness of grinding her heel into a delicate par"
+    },
+    {
+      "key": "ground-and-pound",
+      "name": "Ground and Pound",
+      "category": "manoeuvre",
+      "source": "TM Errata",
+      "before_len": 62,
+      "after_len": 54,
+      "preview": "Cost reduced from 3 dots to 2 dots. _Source: HL pg 49_"
+    },
+    {
+      "key": "ground-fighter",
+      "name": "Ground Fighter",
+      "category": "manoeuvre",
+      "source": "TM Errata",
+      "before_len": 70,
+      "after_len": 58,
+      "preview": "Cost reduced from 3 dots to 2 dots. _Source: CoD 2e pg 56_"
+    },
+    {
+      "key": "retain-weapon",
+      "name": "Retain Weapon",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 48,
+      "after_len": 776,
+      "preview": "**Prerequisites:** Wits ••, Brawl •• **Style Tags:** Light Weapon, Pistol, Tactical (Police, Military) **Effect:** Your character has trained to resis"
+    },
+    {
+      "key": "trunk-squeeze",
+      "name": "Trunk Squeeze",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 105,
+      "after_len": 795,
+      "preview": "**Prerequisites:** Brawl •• **Style Tags:** Creature (Constrictor), Grappling **Effect:** By wrapping arms or legs around an opponent’s torso, your ch"
+    },
+    {
+      "key": "ravage",
+      "name": "Ravage",
+      "category": "manoeuvre",
+      "source": "VtR 2e Rulebook",
+      "before_len": 37,
+      "after_len": 247,
+      "preview": "Due to your character’s connection to her Beast, her fangs become horrendous weapons. They look no different, but her Beast knows how to use them with"
+    },
+    {
+      "key": "primal-strength",
+      "name": "Primal Strength",
+      "category": "manoeuvre",
+      "source": "VtR 2e Rulebook",
+      "before_len": 84,
+      "after_len": 220,
+      "preview": "Your character’s Beast blasts outward in short bursts, in order to accomplish quick feats of strength. When lifting, jumping, or destroying objects as"
+    },
+    {
+      "key": "in-the-zone",
+      "name": "In the Zone",
+      "category": "manoeuvre",
+      "source": "VtR 2e Rulebook",
+      "before_len": 85,
+      "after_len": 269,
+      "preview": "When attempting to leash the Beast and ride the wave, your character still operates at peak efficiency. She still has to spend Willpower points in ord"
+    },
+    {
+      "key": "unyielding",
+      "name": "Unyielding",
+      "category": "manoeuvre",
+      "source": "VtR 2e Rulebook",
+      "before_len": 76,
+      "after_len": 196,
+      "preview": "Your character rides the wave frequently; it ceases to be taxing on her mental reserves. After a scene where she successfully rides the wave, she reco"
+    },
+    {
+      "key": "animal-grace",
+      "name": "Animal Grace",
+      "category": "manoeuvre",
+      "source": "VtR 2e Rulebook",
+      "before_len": 112,
+      "after_len": 557,
+      "preview": "Your character dodges and strikes as fluidly as an animal, with confidence and awareness. When spending Willpower to attack or defend, gain both benef"
+    },
+    {
+      "key": "firm-footing",
+      "name": "Firm Footing",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 133,
+      "after_len": 329,
+      "preview": "Your character braces herself with her weapon to skewer a charging opponent. Any opponent attempting an all-out or charge attack against your characte"
+    },
+    {
+      "key": "keep-at-bay",
+      "name": "Keep at Bay",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 123,
+      "after_len": 318,
+      "preview": "Your character can threaten an opponent with her weapon to prevent maneuvering. Choose an opponent with a shorter weapon; if that opponent takes any a"
+    },
+    {
+      "key": "strike-and-develop",
+      "name": "Strike and Develop",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 113,
+      "after_len": 872,
+      "preview": "Your character stabs an opponent with her weapon then turns the blade before removing it, leaving a more grisly wound. Attacks made with her weapon th"
+    },
+    {
+      "key": "short-grip",
+      "name": "Short Grip",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 67,
+      "after_len": 250,
+      "preview": "Your character moves her grip to the end of the staff, maximizing reach but losing speed. She gains a +1 to attack at the cost of her staff’s +1 bonus"
+    },
+    {
+      "key": "thwack-weapon",
+      "name": "Thwack Weapon",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 74,
+      "after_len": 601,
+      "preview": "Your character slaps away an opponent’s weapon with the tip of her staff. She can Disarm with a roll of Strength + Weaponry contested by an opponent’s"
+    },
+    {
+      "key": "vaulting-defense",
+      "name": "Vaulting Defense",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 92,
+      "after_len": 196,
+      "preview": "Your character knows how to use her staff to rapidly reposition herself in a fight. Spend a point of Willpower; your character can add her dots in Mel"
+    },
+    {
+      "key": "tornado-strike",
+      "name": "Tornado Strike",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 86,
+      "after_len": 1426,
+      "preview": "Your character spins her staff rapidly in a circle, hitting opponents all around her. She treats her staff attack as an autofire medium burst against "
+    },
+    {
+      "key": "duck-and-weave",
+      "name": "Duck and Weave",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 104,
+      "after_len": 328,
+      "preview": "Your character has been beaten all to hell more than a few times. Now she dodges on instinct, not on skill. You can reflexively take a one-die penalty"
+    },
+    {
+      "key": "knocking-the-wind-out",
+      "name": "Knocking the Wind Out",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook + TM Errata",
+      "before_len": 77,
+      "after_len": 63,
+      "preview": "Does not apply when making called shots. _Source: CoD 2e pg 65_"
+    },
+    {
+      "key": "one-two-punch",
+      "name": "One-Two Punch",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 65,
+      "after_len": 185,
+      "preview": "Your character hits fast, and she follows through with every hit. Whenever she makes a successful attack, you can spend a point of Willpower to cause "
+    },
+    {
+      "key": "last-ditch-effort",
+      "name": "Last-Ditch Effort",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook + TM Errata",
+      "before_len": 193,
+      "after_len": 144,
+      "preview": "The decision to sacrifice Defence and spend Willpower is made when an attack is declared, not after the dice have rolled. _Source: CoD 2e pg 65_"
+    },
+    {
+      "key": "strength-tricks",
+      "name": "Strength Tricks",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 82,
+      "after_len": 387,
+      "preview": "Your character combines trained strength with a practical knowledge of physics to perform impressive, if minor, feats of strength. He can rip phone bo"
+    },
+    {
+      "key": "lifting",
+      "name": "Lifting",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 95,
+      "after_len": 891,
+      "preview": "Your character can perform incredible feats of raw strength. When attempting a feat of strength that requires a Strength + Stamina roll, you gain the "
+    },
+    {
+      "key": "stronger-than-you",
+      "name": "Stronger Than You",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 57,
+      "after_len": 859,
+      "preview": "If your character succeeds at Strength-based tasks, he does so with an increased level of performance. You don’t gain bonus dice for Strength-related "
+    },
+    {
+      "key": "eriss-glory",
+      "name": "Eris's Glory",
+      "category": "manoeuvre",
+      "source": "Secrets of the Covenants",
+      "before_len": 169,
+      "after_len": 440,
+      "preview": "Your character’s relentless defense of her sisters inspires them to greatness. Any turn where your character takes lethal or aggravated damage from a "
+    },
+    {
+      "key": "practiced-toss",
+      "name": "Practiced Toss",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 73,
+      "after_len": 141,
+      "preview": "Your character knows how to throw her weapon with a quick and fluid motion. Add her Athletics score to Initiative when using a thrown weapon."
+    },
+    {
+      "key": "impalement-arts",
+      "name": "Impalement Arts",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 231,
+      "after_len": 1297,
+      "preview": "A well-placed throw staples an opponent’s limbs to the environment. If your character succeeds in damaging a specified target arm, leg, or hand with a"
+    },
+    {
+      "key": "balanced-grip",
+      "name": "Balanced Grip",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 114,
+      "after_len": 216,
+      "preview": "Your character knows how to use her weapons so they’re not awkward to hold. Your character does not count her weapons’ Initiative penalties as long as"
+    },
+    {
+      "key": "protective-striking",
+      "name": "Protective Striking",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 96,
+      "after_len": 217,
+      "preview": "Your character uses her off-hand weapon to deflect attacks. She adds her off-hand weapon’s bonus to her Defense for the first attack made against her "
+    },
+    {
+      "key": "dual-swipe",
+      "name": "Dual Swipe",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 140,
+      "after_len": 264,
+      "preview": "Your character attacks with both of her weapons simultaneously against one target. As part of an all-out melee attack, add her off-hand weapon’s bonus"
+    },
+    {
+      "key": "double-strike",
+      "name": "Double Strike",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 128,
+      "after_len": 999,
+      "preview": "Your character attacks two different targets simultaneously. Spend a point of Willpower and designate two targets in close range of your character. Ta"
+    },
+    {
+      "key": "like-a-book",
+      "name": "Like a Book",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 56,
+      "after_len": 196,
+      "preview": "Your character can read his opponents, knowing where they’re likely to strike. When facing an unarmed opponent and not Dodging, increase your characte"
+    },
+    {
+      "key": "studied-style",
+      "name": "Studied Style",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook + TM Errata",
+      "before_len": 169,
+      "after_len": 214,
+      "preview": "Applies when Defence reduces an attack pool to zero or when successes on Dodge roll reduce attacker's successes to zero. If 10-again quality is lost, "
+    },
+    {
+      "key": "redirect",
+      "name": "Redirect",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 133,
+      "after_len": 384,
+      "preview": "When your character is being attacked by multiple opponents, he can direct their blows against one another. When he Dodges, if his Defense roll reduce"
+    },
+    {
+      "key": "joint-strike",
+      "name": "Joint Strike",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 148,
+      "after_len": 422,
+      "preview": "Your character waits until the last possible second, then lashes out at his opponent’s elbow or wrist as he attacks, hoping to cripple his limbs. Roll"
+    },
+    {
+      "key": "like-the-breeze",
+      "name": "Like the Breeze",
+      "category": "manoeuvre",
+      "source": "CofD Rulebook",
+      "before_len": 123,
+      "after_len": 209900,
+      "preview": "Your characters steps to one side as his opponent attacks, and gives her enough of a push to send her flying past him. When dodging, if your Defense r"
+    },
+    {
+      "key": "shield-bash",
+      "name": "Shield Bash",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 119,
+      "after_len": 234,
+      "preview": "Your character slams her shield into an oncoming opponent, disrupting his attack. When Dodging add her shield’s Size to her pool. If she reduces an op"
+    },
+    {
+      "key": "boars-snout",
+      "name": "Boar's Snout",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 143,
+      "after_len": 331,
+      "preview": "Your character throws everything into a forward charge, trusting in her shield to protect her. Using a weapon and shield, your character can all-out a"
+    },
+    {
+      "key": "pin-weapon",
+      "name": "Pin Weapon",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 42,
+      "after_len": 150,
+      "preview": "Your character uses her shield to trap an opponent’s weapon. If an opponent misses a melee attack against your character he is automatically disarmed."
+    },
+    {
+      "key": "tortoise-shell",
+      "name": "Tortoise Shell",
+      "category": "manoeuvre",
+      "source": "Hurt Locker",
+      "before_len": 108,
+      "after_len": 429,
+      "preview": "Your character knows how to position herself so that she’s completely protected by her shield. When using a shield she is considered behind cover with"
+    },
+    {
+      "key": "patrons-privilege",
+      "name": "Patron's Privilege",
+      "category": "manoeuvre",
+      "source": "VtR 2e Rulebook",
+      "before_len": 103,
+      "after_len": 388,
+      "preview": "Your character can take advantage of her mark’s greed or zeal. When the mark does particularly well, it’s because your character was there to set him "
+    },
+    {
+      "key": "rite-pangs-of-proserpina",
+      "name": "Pangs of Proserpina",
+      "category": "rite",
+      "source": "VtR 2e Rulebook",
+      "before_len": 66,
+      "after_len": 331,
+      "preview": "**Target number of successes:** 6 **Contested:** by Composure + Blood Potency The victim suffers feelings of intense hunger, provoking frenzy in Kindr"
+    },
+    {
+      "key": "rite-rigor-mortis",
+      "name": "Rigor Mortis",
+      "category": "rite",
+      "source": "VtR 2e Rulebook",
+      "before_len": 80,
+      "after_len": 234,
+      "preview": "**Target number of successes:** 5 **Resisted:** by Composure The victim, who must be a vampire within a mile of the ritual, suffers the loss of the re"
+    },
+    {
+      "key": "rite-cheval",
+      "name": "Cheval",
+      "category": "rite",
+      "source": "VtR 2e Rulebook",
+      "before_len": 32,
+      "after_len": 275,
+      "preview": "**Target number of successes**: 5  **Resisted:** by Composure The subject of this ritual must be present at the casting, being physically touched by t"
+    },
+    {
+      "key": "rite-the-hydras-vitae",
+      "name": "The Hydra's Vitae",
+      "category": "rite",
+      "source": "VtR 2e Rulebook",
+      "before_len": 101,
+      "after_len": 471,
+      "preview": "**Target number of successes:** 5 The ritualist lays a curse on his own blood, transforming it into poison. Vampires and Strix drinking from the ritua"
+    },
+    {
+      "key": "rite-deflection-of-wooden-doom",
+      "name": "Deflection of Wooden Doom",
+      "category": "rite",
+      "source": "VtR 2e Rulebook",
+      "before_len": 64,
+      "after_len": 157,
+      "preview": "**Target number of successes:** 6 The ritualist wards himself from having his heart impaled. All attempts to stake the ritualist fail until the next s"
+    },
+    {
+      "key": "rite-touch-of-the-morrigan",
+      "name": "Touch of the Morrigan",
+      "category": "rite",
+      "source": "VtR 2e Rulebook",
+      "before_len": 88,
+      "after_len": 401,
+      "preview": "**Target number of successes:** 6 The ritualist pours the consuming, tearing force of his Beast into his hands. He may attempt to strike an opponent w"
+    },
+    {
+      "key": "rite-blood-blight",
+      "name": "Blood Blight",
+      "category": "rite",
+      "source": "VtR 2e Rulebook",
+      "before_len": 134,
+      "after_len": 313,
+      "preview": "**Target number of successes:** 8 **Contested by:** Stamina + Blood Potency The ritualist mystically destroys his victim’s blood. Mortal victims suffe"
+    },
+    {
+      "key": "rite-blood-price",
+      "name": "Blood Price",
+      "category": "rite",
+      "source": "VtR 2e Rulebook",
+      "before_len": 92,
+      "after_len": 464,
+      "preview": "**Target number of successes:** 8 **Contested by:** Composure + Blood Potency The ritualist claims blood consumed by his ritual’s subject. The subject"
+    },
+    {
+      "key": "rite-feeding-the-crone",
+      "name": "Feeding the Crone",
+      "category": "rite",
+      "source": "VtR 2e Rulebook",
+      "before_len": 150,
+      "after_len": 466,
+      "preview": "**Target number of successes:** 10 The ritualist transforms her fangs into a maw of wicked, flesh-tearing teeth. She gains no Vitae from feeding as lo"
+    },
+    {
+      "key": "rite-willful-vitae",
+      "name": "Willful Vitae",
+      "category": "rite",
+      "source": "VtR 2e Rulebook",
+      "before_len": 71,
+      "after_len": 221,
+      "preview": "**Target number of successes:** 7 The ritualist makes herself immune to Vinculum and blood addiction for the remainder of the night. The ritual does n"
+    },
+    {
+      "key": "rite-blandishment-of-sin",
+      "name": "Blandishment of Sin",
+      "category": "rite",
+      "source": "VtR 2e Rulebook",
+      "before_len": 377,
+      "after_len": 522,
+      "preview": "**Target number of successes:** 5 **Contested by:** Resolve + Blood Potency **Sacrament:** a scrap of paper with the victim’s name written on it The r"
+    },
+    {
+      "key": "rite-blood-scourge",
+      "name": "Blood Scourge",
+      "category": "rite",
+      "source": "VtR 2e Rulebook",
+      "before_len": 266,
+      "after_len": 362,
+      "preview": "**Target number of successes:** 6 **Sacrament:** The ritualist’s own blood — at least one Vitae The ritualist transforms a portion of his blood into a"
+    },
+    {
+      "key": "rite-vitae-reliquary",
+      "name": "Vitae Reliquary",
+      "category": "rite",
+      "source": "VtR 2e Rulebook",
+      "before_len": 237,
+      "after_len": 442,
+      "preview": "**Target number of successes:** 5 **Sacrament:** any object up to size ••• The ritualist infuses an object with up to the ritual’s Potency in Vitae. T"
+    },
+    {
+      "key": "rite-curse-of-babel",
+      "name": "Curse of Babel",
+      "category": "rite",
+      "source": "VtR 2e Rulebook",
+      "before_len": 64,
+      "after_len": 230,
+      "preview": "**Target number of successes:** 6 **Resisted by:** Resolve **Sacrament:** an animal or human tongue The victim of this ritual, who must be within one "
+    },
+    {
+      "key": "rite-liars-plague",
+      "name": "Liar's Plague",
+      "category": "rite",
+      "source": "VtR 2e Rulebook",
+      "before_len": 180,
+      "after_len": 323,
+      "preview": "**Target number of successes:** 5 **Contested by:** Resolve + Blood Potency **Sacrament:** an insect carapace The ritualist curses his victim, who mus"
+    },
+    {
+      "key": "rite-malediction-of-despair",
+      "name": "Malediction of Despair",
+      "category": "rite",
+      "source": "VtR 2e Rulebook",
+      "before_len": 230,
+      "after_len": 394,
+      "preview": "**Target number of successes:** 13 **Contested by:** Resolve + Blood Potency **Sacrament:** a lock of the victim’s hair The ritualist curses her victi"
+    },
+    {
+      "key": "rite-gift-of-lazarus",
+      "name": "Gift of Lazarus",
+      "category": "rite",
+      "source": "VtR 2e Rulebook",
+      "before_len": 461,
+      "after_len": 558,
+      "preview": "**Target number of successes:** 8 **Sacrament:** a communion wafer placed under a corpse’s tongue The ritualist raises a servant by animating a human "
+    },
+    {
+      "key": "rite-stigmata",
+      "name": "Stigmata",
+      "category": "rite",
+      "source": "Secrets of the Covenants + TM Errata",
+      "before_len": 383,
+      "after_len": 128,
+      "preview": "Prerequisites now read: Lancea et Sanctum Status •, Humanity 3 + Merit rating, or mortal. _Source: SotC pg 193_ **CRÚAC STYLES**"
+    }
+  ],
+  "ambiguous": [
+    {
+      "key": "feral-infection",
+      "name": "Feral Infection",
+      "category": "discipline",
+      "reason": "rank_mismatch"
+    },
+    {
+      "key": "lord-of-the-land",
+      "name": "Lord of the Land",
+      "category": "discipline",
+      "reason": "rank_mismatch"
+    },
+    {
+      "key": "summon-the-hunt",
+      "name": "Summon the Hunt",
+      "category": "discipline",
+      "reason": "rank_mismatch"
+    },
+    {
+      "key": "entombed-command",
+      "name": "Entombed Command",
+      "category": "discipline",
+      "reason": "rank_mismatch"
+    },
+    {
+      "key": "the-lying-mind",
+      "name": "The Lying Mind",
+      "category": "discipline",
+      "reason": "rank_mismatch"
+    },
+    {
+      "key": "anonymity",
+      "name": "Anonymity",
+      "category": "merit",
+      "reason": "multiple_book_sources"
+    },
+    {
+      "key": "area-of-expertise",
+      "name": "Area of Expertise",
+      "category": "merit",
+      "reason": "multiple_book_sources"
+    },
+    {
+      "key": "fame",
+      "name": "Fame",
+      "category": "merit",
+      "reason": "multiple_book_sources"
+    },
+    {
+      "key": "fleet-of-foot",
+      "name": "Fleet Of Foot",
+      "category": "merit",
+      "reason": "multiple_book_sources"
+    },
+    {
+      "key": "indomitable",
+      "name": "Indomitable",
+      "category": "merit",
+      "reason": "multiple_book_sources"
+    },
+    {
+      "key": "inspiring",
+      "name": "Inspiring",
+      "category": "merit",
+      "reason": "multiple_book_sources"
+    },
+    {
+      "key": "interdisciplinary-specialty",
+      "name": "Interdisciplinary Specialty",
+      "category": "merit",
+      "reason": "multiple_book_sources"
+    },
+    {
+      "key": "kindred-status",
+      "name": "Kindred Status",
+      "category": "merit",
+      "reason": "rank_mismatch"
+    },
+    {
+      "key": "language",
+      "name": "Language",
+      "category": "merit",
+      "reason": "multiple_book_sources"
+    },
+    {
+      "key": "sympathetic",
+      "name": "Sympathetic",
+      "category": "merit",
+      "reason": "multiple_book_sources"
+    },
+    {
+      "key": "object-fetishism",
+      "name": "Object Fetishism",
+      "category": "merit",
+      "reason": "rank_mismatch"
+    },
+    {
+      "key": "support-network",
+      "name": "Support Network",
+      "category": "merit",
+      "reason": "rank_mismatch"
+    },
+    {
+      "key": "kick-em-while-theyre-down",
+      "name": "Kick 'Em While They're Down",
+      "category": "manoeuvre",
+      "reason": "rank_mismatch"
+    },
+    {
+      "key": "status",
+      "name": "Status",
+      "category": "merit",
+      "reason": "multiple_book_sources"
+    }
+  ],
+  "unmatched": [
+    {
+      "key": "intelligence",
+      "name": "Intelligence",
+      "category": "attribute"
+    },
+    {
+      "key": "wits",
+      "name": "Wits",
+      "category": "attribute"
+    },
+    {
+      "key": "resolve",
+      "name": "Resolve",
+      "category": "attribute"
+    },
+    {
+      "key": "strength",
+      "name": "Strength",
+      "category": "attribute"
+    },
+    {
+      "key": "dexterity",
+      "name": "Dexterity",
+      "category": "attribute"
+    },
+    {
+      "key": "stamina",
+      "name": "Stamina",
+      "category": "attribute"
+    },
+    {
+      "key": "presence",
+      "name": "Presence",
+      "category": "attribute"
+    },
+    {
+      "key": "manipulation",
+      "name": "Manipulation",
+      "category": "attribute"
+    },
+    {
+      "key": "composure",
+      "name": "Composure",
+      "category": "attribute"
+    },
+    {
+      "key": "academics",
+      "name": "Academics",
+      "category": "skill"
+    },
+    {
+      "key": "computer",
+      "name": "Computer",
+      "category": "skill"
+    },
+    {
+      "key": "crafts",
+      "name": "Crafts",
+      "category": "skill"
+    },
+    {
+      "key": "investigation",
+      "name": "Investigation",
+      "category": "skill"
+    },
+    {
+      "key": "medicine",
+      "name": "Medicine",
+      "category": "skill"
+    },
+    {
+      "key": "occult",
+      "name": "Occult",
+      "category": "skill"
+    },
+    {
+      "key": "politics",
+      "name": "Politics",
+      "category": "skill"
+    },
+    {
+      "key": "science",
+      "name": "Science",
+      "category": "skill"
+    },
+    {
+      "key": "athletics",
+      "name": "Athletics",
+      "category": "skill"
+    },
+    {
+      "key": "brawl",
+      "name": "Brawl",
+      "category": "skill"
+    },
+    {
+      "key": "drive",
+      "name": "Drive",
+      "category": "skill"
+    },
+    {
+      "key": "firearms",
+      "name": "Firearms",
+      "category": "skill"
+    },
+    {
+      "key": "larceny",
+      "name": "Larceny",
+      "category": "skill"
+    },
+    {
+      "key": "stealth",
+      "name": "Stealth",
+      "category": "skill"
+    },
+    {
+      "key": "survival",
+      "name": "Survival",
+      "category": "skill"
+    },
+    {
+      "key": "weaponry",
+      "name": "Weaponry",
+      "category": "skill"
+    },
+    {
+      "key": "animal-ken",
+      "name": "Animal Ken",
+      "category": "skill"
+    },
+    {
+      "key": "empathy",
+      "name": "Empathy",
+      "category": "skill"
+    },
+    {
+      "key": "expression",
+      "name": "Expression",
+      "category": "skill"
+    },
+    {
+      "key": "intimidation",
+      "name": "Intimidation",
+      "category": "skill"
+    },
+    {
+      "key": "persuasion",
+      "name": "Persuasion",
+      "category": "skill"
+    },
+    {
+      "key": "socialise",
+      "name": "Socialise",
+      "category": "skill"
+    },
+    {
+      "key": "streetwise",
+      "name": "Streetwise",
+      "category": "skill"
+    },
+    {
+      "key": "subterfuge",
+      "name": "Subterfuge",
+      "category": "skill"
+    },
+    {
+      "key": "celerity-1",
+      "name": "Celerity 1",
+      "category": "discipline"
+    },
+    {
+      "key": "celerity-2",
+      "name": "Celerity 2",
+      "category": "discipline"
+    },
+    {
+      "key": "celerity-3",
+      "name": "Celerity 3",
+      "category": "discipline"
+    },
+    {
+      "key": "celerity-4",
+      "name": "Celerity 4",
+      "category": "discipline"
+    },
+    {
+      "key": "celerity-5",
+      "name": "Celerity 5",
+      "category": "discipline"
+    },
+    {
+      "key": "mesmerise",
+      "name": "Mesmerise",
+      "category": "discipline"
+    },
+    {
+      "key": "resilience-1",
+      "name": "Resilience 1",
+      "category": "discipline"
+    },
+    {
+      "key": "resilience-2",
+      "name": "Resilience 2",
+      "category": "discipline"
+    },
+    {
+      "key": "resilience-3",
+      "name": "Resilience 3",
+      "category": "discipline"
+    },
+    {
+      "key": "resilience-4",
+      "name": "Resilience 4",
+      "category": "discipline"
+    },
+    {
+      "key": "resilience-5",
+      "name": "Resilience 5",
+      "category": "discipline"
+    },
+    {
+      "key": "vigour-1",
+      "name": "Vigour 1",
+      "category": "discipline"
+    },
+    {
+      "key": "vigour-2",
+      "name": "Vigour 2",
+      "category": "discipline"
+    },
+    {
+      "key": "vigour-3",
+      "name": "Vigour 3",
+      "category": "discipline"
+    },
+    {
+      "key": "vigour-4",
+      "name": "Vigour 4",
+      "category": "discipline"
+    },
+    {
+      "key": "vigour-5",
+      "name": "Vigour 5",
+      "category": "discipline"
+    },
+    {
+      "key": "alternate-identity",
+      "name": "Alternate Identity",
+      "category": "merit"
+    },
+    {
+      "key": "attach",
+      "name": "Attaché (depreicated)",
+      "category": "merit"
+    },
+    {
+      "key": "call-the-beast",
+      "name": "Call the Beast",
+      "category": "merit"
+    },
+    {
+      "key": "defensive-combat",
+      "name": "Defensive Combat (depreicated)",
+      "category": "merit"
+    },
+    {
+      "key": "defensive-driving",
+      "name": "Defensive Driving (depreicated)",
+      "category": "merit"
+    },
+    {
+      "key": "drift",
+      "name": "Drift (depreicated)",
+      "category": "merit"
+    },
+    {
+      "key": "faith-militant",
+      "name": "Faith Militant",
+      "category": "merit"
+    },
+    {
+      "key": "hobbyist-clique",
+      "name": "Hobbyist Clique (depreicated)",
+      "category": "merit"
+    },
+    {
+      "key": "iron-skin",
+      "name": "Iron Skin",
+      "category": "merit"
+    },
+    {
+      "key": "lingering-dreams",
+      "name": "Lingering Dreams",
+      "category": "merit"
+    },
+    {
+      "key": "major-domo",
+      "name": "Major Domo",
+      "category": "merit"
+    },
+    {
+      "key": "meditative-mind",
+      "name": "Meditative Mind",
+      "category": "merit"
+    },
+    {
+      "key": "oath-of-the-scapegoat",
+      "name": "Oath Of The Scapegoat",
+      "category": "merit"
+    },
+    {
+      "key": "opening-the-void",
+      "name": "Opening The Void",
+      "category": "merit"
+    },
+    {
+      "key": "speed-demon",
+      "name": "Speed Demon (depreicated)",
+      "category": "merit"
+    },
+    {
+      "key": "striking-looks",
+      "name": "Striking Looks",
+      "category": "merit"
+    },
+    {
+      "key": "three-heads-of-kerberos",
+      "name": "Three Heads of Kerberos",
+      "category": "merit"
+    },
+    {
+      "key": "trained-observer",
+      "name": "Trained Observer",
+      "category": "merit"
+    },
+    {
+      "key": "unassuming-guise",
+      "name": "Unassuming Guise",
+      "category": "merit"
+    },
+    {
+      "key": "unbridled-chaos",
+      "name": "Unbridled Chaos",
+      "category": "merit"
+    },
+    {
+      "key": "weaponise-dissent",
+      "name": "Weaponise Dissent",
+      "category": "merit"
+    },
+    {
+      "key": "wicked-jaws",
+      "name": "Wicked Jaws",
+      "category": "merit"
+    },
+    {
+      "key": "cohesive-unit",
+      "name": "Cohesive Unit",
+      "category": "merit"
+    },
+    {
+      "key": "defender",
+      "name": "Defender",
+      "category": "merit"
+    },
+    {
+      "key": "esoteric-armoury",
+      "name": "Esoteric Armoury",
+      "category": "merit"
+    },
+    {
+      "key": "loaded-for-bear",
+      "name": "Loaded For Bear",
+      "category": "merit"
+    },
+    {
+      "key": "peacemaker",
+      "name": "Peacemaker",
+      "category": "merit"
+    },
+    {
+      "key": "whipping-boy",
+      "name": "Whipping Boy",
+      "category": "merit"
+    },
+    {
+      "key": "devotion-body-of-will",
+      "name": "Body of Will",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-chain-of-command",
+      "name": "Chain of Command",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-city-attunement",
+      "name": "City Attunement",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-cloak-the-gathering",
+      "name": "Cloak the Gathering",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-conditioning",
+      "name": "Conditioning",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-cross-contamination",
+      "name": "Cross-Contamination",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-cult-of-personality",
+      "name": "Cult of Personality",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-enchantment",
+      "name": "Enchantment",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-enfeebling-aura",
+      "name": "Enfeebling Aura",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-force-of-nature",
+      "name": "Force of Nature",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-foul-grave",
+      "name": "Foul Grave",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-gargoyles-vigilance",
+      "name": "Gargoyle's Vigilance",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-govi-trap",
+      "name": "Govi Trap",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-hint-of-fear",
+      "name": "Hint of Fear",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-hold-my-beer",
+      "name": "Hold my Beer",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-incriminating-evidence",
+      "name": "Incriminating Evidence",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-juggernauts-gait",
+      "name": "Juggernaut's Gait",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-our-mothers-mind",
+      "name": "Our Mother's Mind",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-quicken-sight",
+      "name": "Quicken Sight",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-reasons-salon",
+      "name": "Reason's Salon",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-repulsive-mien",
+      "name": "Repulsive Mien",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-rime-of-salt",
+      "name": "Rime of Salt",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-riot",
+      "name": "Riot",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-shared-sight",
+      "name": "Shared Sight",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-shatter-the-shroud",
+      "name": "Shatter the Shroud",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-skeleton-key",
+      "name": "Skeleton Key",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-skim-the-void",
+      "name": "Skim the Void",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-stalwart-servant",
+      "name": "Stalwart Servant",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-subsume-the-lesser-beast",
+      "name": "Subsume the Lesser Beast",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-summoning",
+      "name": "Summoning",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-suns-brutal-dreamscape",
+      "name": "Sun's Brutal Dreamscape",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-the-exchange-of-things-past",
+      "name": "The Exchange of Things Past",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-the-taste-of-things-lived",
+      "name": "The Taste of Things Lived",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-the-wish",
+      "name": "The Wish",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-touch-of-deprivation",
+      "name": "Touch of Deprivation",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-turn-of-phrase",
+      "name": "Turn of Phrase",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-undying-familiar",
+      "name": "Undying Familiar",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-vermin-flood",
+      "name": "Vermin Flood",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-veve-passageway",
+      "name": "Veve Passageway",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-vitae-spines",
+      "name": "Vitae Spines",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-wet-dream",
+      "name": "Wet Dream",
+      "category": "devotion"
+    },
+    {
+      "key": "devotion-wraiths-presence",
+      "name": "Wraith's Presence",
+      "category": "devotion"
+    },
+    {
+      "key": "gettin-up",
+      "name": "Gettin' Up",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "establish-the-duel",
+      "name": "Establish the Duel",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "value-of-the-spoken-word",
+      "name": "Value of the Spoken Word",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "demanding-attention",
+      "name": "Demanding Attention",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "shield-against-sorcery",
+      "name": "Shield Against Sorcery",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "silence",
+      "name": "Silence",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "a-hammer-against-witches",
+      "name": "A Hammer Against Witches",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "bless-his-heart",
+      "name": "Bless His Heart",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "losing-your-religion",
+      "name": "Losing Your Religion",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "defensive-strike",
+      "name": "Defensive Strike",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "strike-to-preempt",
+      "name": "Strike to Preempt",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "unbreakable",
+      "name": "Unbreakable",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "dying-on-your-feet",
+      "name": "Dying on Your Feet",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "subduing-strikes",
+      "name": "Subduing Strikes",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "transfer-manoeuvre",
+      "name": "Transfer Manoeuvre",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "push-pull",
+      "name": "Push/Pull",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "athenas-armour",
+      "name": "Athena's Armour",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "enyos-defence",
+      "name": "Enyo's Defence",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "honing-competitive",
+      "name": "Honing - Competitive",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "honing-monstrous",
+      "name": "Honing - Monstrous",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "honing-seductive",
+      "name": "Honing - Seductive",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "internalising-competitive",
+      "name": "Internalising - Competitive",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "internalising-monstrous",
+      "name": "Internalising - Monstrous",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "internalising-seductive",
+      "name": "Internalising - Seductive",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "cowing-competitive",
+      "name": "Cowing - Competitive",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "cowing-monstrous",
+      "name": "Cowing - Monstrous",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "cowing-seductive",
+      "name": "Cowing - Seductive",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "striking-competitive",
+      "name": "Striking - Competitive",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "striking-monstrous",
+      "name": "Striking - Monstrous",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "striking-seductive",
+      "name": "Striking - Seductive",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "the-fires-of-hell-competitive",
+      "name": "The Fires of Hell - Competitive",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "the-fires-of-hell-monstrous",
+      "name": "The Fires of Hell - Monstrous",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "the-fires-of-hell-seductive",
+      "name": "The Fires of Hell - Seductive",
+      "category": "manoeuvre"
+    },
+    {
+      "key": "summoningdominate",
+      "name": "Summoning",
+      "category": "devotion"
+    },
+    {
+      "key": "eye-behind-glass",
+      "name": "Eye Behind Glass",
+      "category": "devotion"
+    },
+    {
+      "key": "arms-of-the-abyss",
+      "name": "Arms of the Abyss",
+      "category": "devotion"
+    },
+    {
+      "key": "rite-lightning-rod",
+      "name": "Lightning Rod",
+      "category": "rite"
+    },
+    {
+      "key": "rite-sanguine-clarity",
+      "name": "Sanguine Clarity",
+      "category": "rite"
+    },
+    {
+      "key": "rite-whispers-through-time",
+      "name": "Whispers Through Time",
+      "category": "rite"
+    },
+    {
+      "key": "rite-the-invisible",
+      "name": "The Invisible",
+      "category": "rite"
+    },
+    {
+      "key": "rite-pax-of-wind",
+      "name": "Pax of Wind",
+      "category": "rite"
+    },
+    {
+      "key": "rite-gora-mukhi",
+      "name": "Gora Mukhi",
+      "category": "rite"
+    },
+    {
+      "key": "rite-confidence-in-adversity",
+      "name": "Confidence in Adversity",
+      "category": "rite"
+    },
+    {
+      "key": "rite-drops-of-destiny",
+      "name": "Drops of Destiny",
+      "category": "rite"
+    },
+    {
+      "key": "rite-fires-of-inspiration",
+      "name": "Fires of Inspiration",
+      "category": "rite"
+    },
+    {
+      "key": "rite-love-lies-bleeding",
+      "name": "Love-Lies-Bleeding",
+      "category": "rite"
+    },
+    {
+      "key": "rite-taste-of-knowledge",
+      "name": "Taste of Knowledge",
+      "category": "rite"
+    },
+    {
+      "key": "rite-visage-of-the-crone",
+      "name": "Visage of the Maiden Crone",
+      "category": "rite"
+    },
+    {
+      "key": "rite-harai",
+      "name": "Harai",
+      "category": "rite"
+    },
+    {
+      "key": "rite-imperious-call",
+      "name": "Imperious Call",
+      "category": "rite"
+    },
+    {
+      "key": "rite-maiden-skin",
+      "name": "Maiden Skin",
+      "category": "rite"
+    },
+    {
+      "key": "rite-painted-fears",
+      "name": "Painted Fears",
+      "category": "rite"
+    },
+    {
+      "key": "rite-path-of-thorns",
+      "name": "Path of Thorns",
+      "category": "rite"
+    },
+    {
+      "key": "rite-souls-work",
+      "name": "Soul's Work",
+      "category": "rite"
+    },
+    {
+      "key": "rite-succulent-buboes",
+      "name": "Succulent Buboes",
+      "category": "rite"
+    },
+    {
+      "key": "rite-wisdom-of-the-soul",
+      "name": "Wisdom of the Soul",
+      "category": "rite"
+    },
+    {
+      "key": "rite-beloved-deodand",
+      "name": "Beloved Deodand",
+      "category": "rite"
+    },
+    {
+      "key": "rite-final-service-of-the-slave",
+      "name": "Final Service of the Slave",
+      "category": "rite"
+    },
+    {
+      "key": "rite-rain",
+      "name": "Rain",
+      "category": "rite"
+    },
+    {
+      "key": "rite-servant-from-the-hidden-realms",
+      "name": "Servant from the Hidden Realms",
+      "category": "rite"
+    },
+    {
+      "key": "rite-taste-of-destiny",
+      "name": "Taste of Destiny",
+      "category": "rite"
+    },
+    {
+      "key": "rite-the-metamorphosis-of-spilt-blood",
+      "name": "The Metamorphosis of Spilt Blood",
+      "category": "rite"
+    },
+    {
+      "key": "rite-tiamat-offspring",
+      "name": "Tiamat Offspring",
+      "category": "rite"
+    },
+    {
+      "key": "rite-veiled-curse",
+      "name": "Veiled Curse",
+      "category": "rite"
+    },
+    {
+      "key": "rite-eternal-guardian-of-the-dark-moon",
+      "name": "Eternal Guardian of the Dark Moon",
+      "category": "rite"
+    },
+    {
+      "key": "rite-eye-of-the-norn",
+      "name": "Eye of the Norn",
+      "category": "rite"
+    },
+    {
+      "key": "rite-fount-of-wisdom",
+      "name": "Fount of Wisdom",
+      "category": "rite"
+    },
+    {
+      "key": "rite-mask-of-blood",
+      "name": "Mask of Blood",
+      "category": "rite"
+    },
+    {
+      "key": "rite-sacrifice-of-odin",
+      "name": "Sacrifice of Odin",
+      "category": "rite"
+    },
+    {
+      "key": "rite-a-child-from-the-stones",
+      "name": "A Child from the Stones",
+      "category": "rite"
+    },
+    {
+      "key": "rite-as-one",
+      "name": "As One",
+      "category": "rite"
+    },
+    {
+      "key": "rite-crones-renewal",
+      "name": "Crone's Renewal",
+      "category": "rite"
+    },
+    {
+      "key": "rite-roving-hut",
+      "name": "Roving Hut",
+      "category": "rite"
+    },
+    {
+      "key": "rite-paladins-absolution",
+      "name": "Paladin's Absolution",
+      "category": "rite"
+    },
+    {
+      "key": "rite-blood-witness",
+      "name": "Blood Witness",
+      "category": "rite"
+    },
+    {
+      "key": "rite-barrier-of-blood",
+      "name": "Barrier of Blood",
+      "category": "rite"
+    },
+    {
+      "key": "rite-flower-of-demeter",
+      "name": "Flower of Demeter",
+      "category": "rite"
+    },
+    {
+      "key": "rite-preys-blood",
+      "name": "Prey's Blood",
+      "category": "rite"
+    },
+    {
+      "key": "rite-celibacy",
+      "name": "Celibacy",
+      "category": "rite"
+    },
+    {
+      "key": "rite-crown-of-thorns",
+      "name": "Crown of Thorns",
+      "category": "rite"
+    },
+    {
+      "key": "rite-sinner-song",
+      "name": "Sinner Song",
+      "category": "rite"
+    },
+    {
+      "key": "rite-theban-inscription",
+      "name": "Theban Inscription",
+      "category": "rite"
+    },
+    {
+      "key": "rite-bird-of-sin",
+      "name": "Bird of Sin",
+      "category": "rite"
+    },
+    {
+      "key": "rite-damned-radiance",
+      "name": "Damned Radiance",
+      "category": "rite"
+    },
+    {
+      "key": "rite-prison-of-denial",
+      "name": "Prison of Denial",
+      "category": "rite"
+    },
+    {
+      "key": "rite-resistance-of-discipline",
+      "name": "Resistance of Discipline",
+      "category": "rite"
+    },
+    {
+      "key": "rite-sanctity",
+      "name": "Sanctity",
+      "category": "rite"
+    },
+    {
+      "key": "rite-blood-fire",
+      "name": "Blood Fire",
+      "category": "rite"
+    },
+    {
+      "key": "rite-hauberk-of-blood",
+      "name": "Hauberk of Blood",
+      "category": "rite"
+    },
+    {
+      "key": "rite-lash-beyond-death",
+      "name": "Lash Beyond Death",
+      "category": "rite"
+    },
+    {
+      "key": "rite-legionnaires-blessing",
+      "name": "Legionnaire's Blessing",
+      "category": "rite"
+    },
+    {
+      "key": "rite-pharaohs-paces",
+      "name": "Pharaoh's Paces",
+      "category": "rite"
+    },
+    {
+      "key": "rite-vision-of-the-will",
+      "name": "Vision of the Will",
+      "category": "rite"
+    },
+    {
+      "key": "rite-song-of-the-prey",
+      "name": "Song of the Prey",
+      "category": "rite"
+    },
+    {
+      "key": "rite-call-of-amoniel",
+      "name": "Call of Amoniel",
+      "category": "rite"
+    },
+    {
+      "key": "rite-display-of-the-beast",
+      "name": "Display of the Beast",
+      "category": "rite"
+    },
+    {
+      "key": "rite-mark-of-the-damned",
+      "name": "Mark of the Damned",
+      "category": "rite"
+    },
+    {
+      "key": "rite-spear-of-faith",
+      "name": "Spear of Faith",
+      "category": "rite"
+    },
+    {
+      "key": "rite-damneds-day",
+      "name": "Damned's Day",
+      "category": "rite"
+    },
+    {
+      "key": "rite-imprecation-of-sin",
+      "name": "Imprecation of Sin",
+      "category": "rite"
+    },
+    {
+      "key": "rite-fires-of-vengeance",
+      "name": "Fires of Vengeance",
+      "category": "rite"
+    },
+    {
+      "key": "rite-night-of-hell",
+      "name": "Night of Hell",
+      "category": "rite"
+    },
+    {
+      "key": "rite-rain-of-blood",
+      "name": "Rain of Blood",
+      "category": "rite"
+    },
+    {
+      "key": "rite-anoint-the-spear",
+      "name": "Anoint the Spear",
+      "category": "rite"
+    },
+    {
+      "key": "rite-the-fruitful-womb",
+      "name": "The Fruitful Womb",
+      "category": "rite"
+    },
+    {
+      "key": "rite-messengers-mark",
+      "name": "Messenger's Mark",
+      "category": "rite"
+    },
+    {
+      "key": "rite-wings-of-the-seraph",
+      "name": "Wings of the Seraph",
+      "category": "rite"
+    },
+    {
+      "key": "rite-scriveners-eye",
+      "name": "Scrivener’s Eye",
+      "category": "rite"
+    },
+    {
+      "key": "rite-sacred-haven",
+      "name": "Sacred Haven",
+      "category": "rite"
+    },
+    {
+      "key": "rite-balancing-the-four-humors",
+      "name": "Balancing the Four Humors",
+      "category": "rite"
+    },
+    {
+      "key": "rite-the-heliolaters-warning",
+      "name": "The Heliolater's Warning",
+      "category": "rite"
+    },
+    {
+      "key": "rite-song-of-the-blood",
+      "name": "Song of the Blood",
+      "category": "rite"
+    },
+    {
+      "key": "rite-bleeding-the-tarantula",
+      "name": "Bleeding the Tarantula",
+      "category": "rite"
+    },
+    {
+      "key": "rite-curse-of-ahasverus",
+      "name": "Curse of Ahasverus",
+      "category": "rite"
+    },
+    {
+      "key": "rite-apple-of-eden",
+      "name": "Apple of Eden",
+      "category": "rite"
+    },
+    {
+      "key": "rite-marian-apparition",
+      "name": "Marian Apparition",
+      "category": "rite"
+    },
+    {
+      "key": "rite-revelatory-shroud",
+      "name": "Revelatory Shroud",
+      "category": "rite"
+    },
+    {
+      "key": "rite-apparition-of-the-host",
+      "name": "Apparition of the Host",
+      "category": "rite"
+    },
+    {
+      "key": "rite-bloody-icon",
+      "name": "Bloody Icon",
+      "category": "rite"
+    },
+    {
+      "key": "rite-the-walls-of-jericho",
+      "name": "The Walls of Jericho",
+      "category": "rite"
+    },
+    {
+      "key": "rite-aarons-rod",
+      "name": "Aaron's Rod",
+      "category": "rite"
+    },
+    {
+      "key": "rite-blessing-the-legion",
+      "name": "Blessing the Legion",
+      "category": "rite"
+    },
+    {
+      "key": "rite-miracle-of-the-dead-sun",
+      "name": "Miracle of the Dead Sun",
+      "category": "rite"
+    },
+    {
+      "key": "rite-pledge-to-the-worthless-one",
+      "name": "Pledge to the Worthless One",
+      "category": "rite"
+    },
+    {
+      "key": "rite-the-guiding-star",
+      "name": "The Guiding Star",
+      "category": "rite"
+    },
+    {
+      "key": "rite-great-prophecy",
+      "name": "Great Prophecy",
+      "category": "rite"
+    },
+    {
+      "key": "rite-apocalypse",
+      "name": "Apocalypse",
+      "category": "rite"
+    },
+    {
+      "key": "rite-the-judgment-fast",
+      "name": "The Judgment Fast",
+      "category": "rite"
+    },
+    {
+      "key": "rite-hag-mask",
+      "name": "Hag Mask",
+      "category": "rite"
+    },
+    {
+      "key": "rite-the-mantle-of-amorous-fire",
+      "name": "The Mantle of Amorous Fire",
+      "category": "rite"
+    },
+    {
+      "key": "rite-the-pool-of-forbidden-truths",
+      "name": "The Pool of Forbidden Truths",
+      "category": "rite"
+    },
+    {
+      "key": "rite-mantle-of-the-beasts-breath",
+      "name": "Mantle of the Beast's Breath",
+      "category": "rite"
+    },
+    {
+      "key": "rite-shed-the-virulent-bowels",
+      "name": "Shed the Virulent Bowels",
+      "category": "rite"
+    },
+    {
+      "key": "rite-curse-of-aphrodites-favor",
+      "name": "Curse of Aphrodite's Favor",
+      "category": "rite"
+    },
+    {
+      "key": "rite-curse-of-the-beloved-toy",
+      "name": "Curse of the Beloved Toy",
+      "category": "rite"
+    },
+    {
+      "key": "rite-donning-the-beasts-flesh",
+      "name": "Donning the Beast's Flesh",
+      "category": "rite"
+    },
+    {
+      "key": "rite-mantle-of-the-glorious-dervish",
+      "name": "Mantle of the Glorious Dervish",
+      "category": "rite"
+    },
+    {
+      "key": "rite-bounty-of-the-storm",
+      "name": "Bounty of the Storm",
+      "category": "rite"
+    },
+    {
+      "key": "rite-gorgons-gaze",
+      "name": "Gorgon's Gaze",
+      "category": "rite"
+    },
+    {
+      "key": "rite-mantle-of-the-predator-goddess",
+      "name": "Mantle of the Predator Goddess",
+      "category": "rite"
+    },
+    {
+      "key": "rite-birthing-the-god",
+      "name": "Birthing the God",
+      "category": "rite"
+    },
+    {
+      "key": "rite-denying-hades",
+      "name": "Denying Hades",
+      "category": "rite"
+    },
+    {
+      "key": "rite-mantle-of-the-crone",
+      "name": "Mantle of the Crone",
+      "category": "rite"
+    },
+    {
+      "key": "rite-serpentine-union",
+      "name": "Serpentine Union",
+      "category": "rite"
+    },
+    {
+      "key": "rite-scapegoat",
+      "name": "Scapegoat",
+      "category": "rite"
+    },
+    {
+      "key": "rite-wrathful-judgement",
+      "name": "Wrathful Judgement",
+      "category": "rite"
+    },
+    {
+      "key": "rite-transubstantiation",
+      "name": "Transubstantiation",
+      "category": "rite"
+    },
+    {
+      "key": "rite-tempers-eye",
+      "name": "Temper's Eye",
+      "category": "rite"
+    },
+    {
+      "key": "rite-baptism-of-damnation",
+      "name": "Baptism of Damnation",
+      "category": "rite"
+    },
+    {
+      "key": "rite-blood-portrait",
+      "name": "Blood Portrait",
+      "category": "rite"
+    },
+    {
+      "key": "friends-with-benefits",
+      "name": "Friends with Benefits",
+      "category": "merit"
+    },
+    {
+      "key": "attache-safe-place",
+      "name": "Attaché (Safe Place)",
+      "category": "merit"
+    },
+    {
+      "key": "attache-contacts",
+      "name": "Attaché (Contacts)",
+      "category": "merit"
+    },
+    {
+      "key": "attache-resources",
+      "name": "Attaché (Resources)",
+      "category": "merit"
+    },
+    {
+      "key": "haven-roving-hut",
+      "name": "Animated Haven",
+      "category": "merit"
+    },
+    {
+      "key": "necropolis-sepulcher",
+      "name": "Necropolis Sepulcher",
+      "category": "merit"
+    },
+    {
+      "key": "catacombs",
+      "name": "Catacombs",
+      "category": "merit"
+    },
+    {
+      "key": "caldarium",
+      "name": "Caldarium",
+      "category": "merit"
+    },
+    {
+      "key": "garbage-pit",
+      "name": "Garbage Pit",
+      "category": "merit"
+    },
+    {
+      "key": "labyrinth-guardians",
+      "name": "Labyrinth Guardians",
+      "category": "merit"
+    },
+    {
+      "key": "dark-temple",
+      "name": "Dark Temple",
+      "category": "merit"
+    },
+    {
+      "key": "white-ants",
+      "name": "White Ants",
+      "category": "merit"
+    },
+    {
+      "key": "trap-door",
+      "name": "Trap Door",
+      "category": "merit"
+    },
+    {
+      "key": "true-worm",
+      "name": "True Worm",
+      "category": "merit"
+    }
+  ]
+}

--- a/server/scripts/reports/992-uplift-report.md
+++ b/server/scripts/reports/992-uplift-report.md
@@ -1,6 +1,6 @@
 # Story 992 — power rules-text uplift dry-run report
 
-Generated: 2026-07-14T13:16:01.621Z
+Generated: 2026-07-15T03:43:21.626Z
 
 ## Book segmentation
 
@@ -18,46 +18,36 @@ Generated: 2026-07-14T13:16:01.621Z
 
 ## Per-category match statistics
 
-| Category | Matched | Unmatched | Ambiguous |
-|---|---|---|---|
-| attribute | 0 | 9 | 0 |
-| skill | 0 | 24 | 0 |
-| discipline | 29 | 16 | 5 |
-| merit | 126 | 42 | 13 |
-| devotion | 0 | 45 | 0 |
-| manoeuvre | 144 | 33 | 1 |
-| rite | 18 | 114 | 0 |
+| Category | Matched | Unmatched | Ambiguous | Skipped (Auspex) |
+|---|---|---|---|---|
+| attribute | 0 | 9 | 0 | 0 |
+| skill | 0 | 24 | 0 | 0 |
+| discipline | 24 | 16 | 5 | 5 |
+| merit | 126 | 42 | 13 | 0 |
+| devotion | 0 | 45 | 0 | 0 |
+| manoeuvre | 144 | 33 | 1 | 0 |
+| rite | 18 | 114 | 0 | 0 |
 
-**Totals** — matched: 317, unmatched: 283, ambiguous: 19, total DB docs: 619
+**Totals** — matched: 312, unmatched: 283, ambiguous: 19, skipped_auspex: 5, total DB docs: 619
 
 ## Sample matches
 
 - **Feral Whispers** (discipline, `feral-whispers`) — source: VtR 2e Rulebook, 31 → 2041 chars
   > To those she would command, a vampire must first make herself understood. So it is with beasts as well as men. A vampire using Feral Whispers overpowe
-- **Raise the Familiar** (discipline, `raise-the-familiar`) — source: VtR 2e Rulebook + TM Errata, 44 → 149 chars
-  > Maintained familiars must be purchased as Retainers and impose a –1 Vitae from the character's starting Vitae pool each game. _Source: VTR 2e pg 121_
-- **Beast's Hackles** (discipline, `beasts-hackles`) — source: VtR 2e Rulebook + TM Errata, 45 → 419 chars
-  > **Clarification:** All questions at this level must be related to weakness or danger. If the Storyteller cannot determine the answer to a player's que
-- **Lay Open the Mind** (discipline, `lay-open-the-mind`) — source: VtR 2e Rulebook, 46 → 2012 chars
-  > The Mekhet focuses on bringing her thoughts in line with her victim. He begins to think like her, and soon hears her thoughts in his mind. By concentr
-- **Spirit's Touch** (discipline, `spirits-touch`) — source: VtR 2e Rulebook + TM Errata, 53 → 920 chars
-  > **Cost** is now: Varies, as the Discipline is slightly tiring; the first use in a scene is free, but subsequent uses in the same scene cost 1 Vitae ea
-- **Twilight Projection** (discipline, `twilight-projection`) — source: VtR 2e Rulebook + TM Errata, 33 → 515 chars
-  > A vampire in Twilight Projection can use Auspex 1–3 once per scene, but may not spend blood for additional uses. _Source: VTR 2e pg 125_  **CELERITY:*
-- **Uncanny Perception** (discipline, `uncanny-perception`) — source: VtR 2e Rulebook + TM Errata, 56 → 284 chars
-  > This power must be used on a single creature that can currently be perceived. This power can be used to initiate a Clash of Wills against any objects 
+- **Raise the Familiar** (discipline, `raise-the-familiar`) — source: VtR 2e Rulebook + TM Errata, 44 → 2527 chars
+  > True beasts cannot be Embraced. They have never had the necessary Humanity. With this power, though, the vampire can complete the process halfway. By 
 - **Iron Edict** (discipline, `iron-edict`) — source: VtR 2e Rulebook, 57 → 1326 chars
   > Once she’s got a hotline into her victim’s mind, the vampire can take some time to play with his thoughts and memories. While it takes more of her pow
-- **Possession** (discipline, `possession`) — source: VtR 2e Rulebook + TM Errata, 22 → 281 chars
-  > Resistance to Possession is now – victim's Resolve + Supernatural Tolerance. Possession only allows the possessor to walk in the sun without consequen
+- **Possession** (discipline, `possession`) — source: VtR 2e Rulebook + TM Errata, 22 → 3050 chars
+  > Controlling a victim’s memories and actions is one thing, but for some vampires the truest expression of control comes from suppressing the victim’s w
 - **Awe** (discipline, `awe`) — source: VtR 2e Rulebook, 49 → 1469 chars
   > Awe shines a spotlight on the vampire even in a crowded room. He’s the most important person around and people want to be around him. Awe creates an a
 - **Confidant** (discipline, `confidant`) — source: VtR 2e Rulebook, 25 → 1071 chars
   > The vampire doesn’t have to shout to be heard, and in a crowd that he’s already Awed, sometimes speaking quietly is the best way to get attention. Wit
-- **Green Eyes** (discipline, `green-eyes`) — source: VtR 2e Rulebook + TM Errata, 65 → 665 chars
-  > **Clarification:** Green Eyes has two different uses. The first is to change emotional state and requires no action; the second is to make requests. O
-- **Idol** (discipline, `idol`) — source: VtR 2e Rulebook + TM Errata, 71 → 163 chars
-  > **Clarification:** A successful reflexive roll to resist Idol only allows for one action before the check must be made again. _Source: VTR 2e pg 139_ 
+- **Green Eyes** (discipline, `green-eyes`) — source: VtR 2e Rulebook + TM Errata, 65 → 2408 chars
+  > To a victim of this level of Majesty, the vampire’s attention feels so good that it’s addictive. His inner circle craves his attention like a crackhea
+- **Idol** (discipline, `idol`) — source: VtR 2e Rulebook + TM Errata, 71 → 2323 chars
+  > More than just a celebrity, a vampire who can play with people’s desires becomes a king or a star, the kind of person who wouldn’t ever be so crass as
 - **Loyalty** (discipline, `loyalty`) — source: VtR 2e Rulebook, 28 → 1257 chars
   > Among his inner circle, the vampire praises some more than others, bringing them even closer to him. With a few words he can inflame their love for hi
 - **Dread Presence** (discipline, `dread-presence`) — source: VtR 2e Rulebook, 79 → 1724 chars
@@ -66,12 +56,22 @@ Generated: 2026-07-14T13:16:01.621Z
   > All it takes is a glance, and the vampire can magnify one of his victim’s fears to truly horrifying levels. If she knows what sort of things her victi
 - **Grand Delusion** (discipline, `grand-delusion`) — source: VtR 2e Rulebook, 28 → 1614 chars
   > Touching her victim’s mind, the vampire sparks a delusion that only she fully understands. What she makes him believe doesn’t match up with the world 
-- **Mortal Terror** (discipline, `mortal-terror`) — source: VtR 2e Rulebook + TM Errata, 54 → 324 chars
-  > Resistance to Mortal Terror is now – victim's Composure + Supernatural Tolerance. Full lethal damage is applied to vampires. Composure damage on vampi
+- **Mortal Terror** (discipline, `mortal-terror`) — source: VtR 2e Rulebook + TM Errata, 54 → 2768 chars
+  > The Nosferatu can summon horrific visions from the depths of a victim’s soul. She twists everything around her victim to **Chapter Three: Laws of the 
 - **Waking Nightmare** (discipline, `waking-nightmare`) — source: VtR 2e Rulebook, 34 → 2441 chars
   > Having altered her victims’ beliefs and stoked their fears, the vampire can now spark disturbing hallucinations of a kind that all vampires suffer in 
-- **Cloak of Night** (discipline, `cloak-of-night`) — source: VtR 2e Rulebook + TM Errata, 17 → 174 chars
-  > When using Cloak of Night to leave active combat they have participated in, it will initiate an automatic Clash of Wills against anyone with Auspex 2.
+- **Cloak of Night** (discipline, `cloak-of-night`) — source: VtR 2e Rulebook + TM Errata, 17 → 1862 chars
+  > With but a thought, the vampire slips from both sight and mind. He doesn’t just fade into the background, he vanishes entirely. He leaves no scent and
+- **Face in the Crowd** (discipline, `face-in-the-crowd`) — source: VtR 2e Rulebook + TM Errata, 71 → 2216 chars
+  > The vampire can turn his predatory aura inwards, walking through crowds of people who pay him no heed. As long as he doesn’t do anything to obviously 
+- **Oubliette** (discipline, `oubliette`) — source: VtR 2e Rulebook + TM Errata, 87 → 3155 chars
+  > The vampire creates a realm of his own, hiding a place from mundane senses and scrambling the perceptions of everyone within. He can turn an alleyway 
+- **The Familiar Stranger** (discipline, `the-familiar-stranger`) — source: VtR 2e Rulebook + TM Errata, 43 → 1913 chars
+  > Rather than removing himself from the perceptions of other people, the vampire can instead adjust how they see him. He can either appear as a subjecti
+- **Touch of Shadow** (discipline, `touch-of-shadow`) — source: VtR 2e Rulebook + TM Errata, 43 → 2602 chars
+  > With just a touch, the vampire can extend the muted attentions of Face in the Crowd to an object or animal, rather than himself. His subject fades out
+- **Beast's Skin** (discipline, `beasts-skin`) — source: VtR 2e Rulebook, 32 → 1430 chars
+  > The Beast can warp a vampire’s flesh, taking the form of an animal that she has consumed. Her body warps and shifts, growing extra muscle or folding i
 
 ## Ambiguous (needs review)
 
@@ -94,3 +94,13 @@ Generated: 2026-07-14T13:16:01.621Z
 - **Support Network** (merit, `support-network`) — rank_mismatch
 - **Kick 'Em While They're Down** (manoeuvre, `kick-em-while-theyre-down`) — rank_mismatch
 - **Status** (merit, `status`) — multiple_book_sources
+
+## Skipped — Auspex (5)
+
+Peter is fixing the Auspex errata PDF; these powers are deliberately excluded from matching and writes until that lands.
+
+- **Beast's Hackles** (discipline, `beasts-hackles`)
+- **Lay Open the Mind** (discipline, `lay-open-the-mind`)
+- **Spirit's Touch** (discipline, `spirits-touch`)
+- **Twilight Projection** (discipline, `twilight-projection`)
+- **Uncanny Perception** (discipline, `uncanny-perception`)

--- a/server/scripts/reports/992-uplift-report.md
+++ b/server/scripts/reports/992-uplift-report.md
@@ -1,0 +1,96 @@
+# Story 992 — power rules-text uplift dry-run report
+
+Generated: 2026-07-14T13:16:01.621Z
+
+## Book segmentation
+
+| File | Found | Blocks parsed |
+|---|---|---|
+| Vampire the Requiem 2e Rulebook.md | yes | 193 |
+| Chronicles of Darkness Rulebook.md | yes | 137 |
+| Hurt Locker.md | yes | 122 |
+| Secrets of the Covenants.md | yes | 69 |
+| Blood Sorcery- New Rules.md | yes | 0 |
+| Damnation City Model - New Rules.md | yes | 3 |
+| Blood Sorcery Themes and Motifs.md | yes | 25 |
+| Terra Mortis - Errata Master.md | yes | 154 |
+| Auspex Errata.md | yes | 0 |
+
+## Per-category match statistics
+
+| Category | Matched | Unmatched | Ambiguous |
+|---|---|---|---|
+| attribute | 0 | 9 | 0 |
+| skill | 0 | 24 | 0 |
+| discipline | 29 | 16 | 5 |
+| merit | 126 | 42 | 13 |
+| devotion | 0 | 45 | 0 |
+| manoeuvre | 144 | 33 | 1 |
+| rite | 18 | 114 | 0 |
+
+**Totals** — matched: 317, unmatched: 283, ambiguous: 19, total DB docs: 619
+
+## Sample matches
+
+- **Feral Whispers** (discipline, `feral-whispers`) — source: VtR 2e Rulebook, 31 → 2041 chars
+  > To those she would command, a vampire must first make herself understood. So it is with beasts as well as men. A vampire using Feral Whispers overpowe
+- **Raise the Familiar** (discipline, `raise-the-familiar`) — source: VtR 2e Rulebook + TM Errata, 44 → 149 chars
+  > Maintained familiars must be purchased as Retainers and impose a –1 Vitae from the character's starting Vitae pool each game. _Source: VTR 2e pg 121_
+- **Beast's Hackles** (discipline, `beasts-hackles`) — source: VtR 2e Rulebook + TM Errata, 45 → 419 chars
+  > **Clarification:** All questions at this level must be related to weakness or danger. If the Storyteller cannot determine the answer to a player's que
+- **Lay Open the Mind** (discipline, `lay-open-the-mind`) — source: VtR 2e Rulebook, 46 → 2012 chars
+  > The Mekhet focuses on bringing her thoughts in line with her victim. He begins to think like her, and soon hears her thoughts in his mind. By concentr
+- **Spirit's Touch** (discipline, `spirits-touch`) — source: VtR 2e Rulebook + TM Errata, 53 → 920 chars
+  > **Cost** is now: Varies, as the Discipline is slightly tiring; the first use in a scene is free, but subsequent uses in the same scene cost 1 Vitae ea
+- **Twilight Projection** (discipline, `twilight-projection`) — source: VtR 2e Rulebook + TM Errata, 33 → 515 chars
+  > A vampire in Twilight Projection can use Auspex 1–3 once per scene, but may not spend blood for additional uses. _Source: VTR 2e pg 125_  **CELERITY:*
+- **Uncanny Perception** (discipline, `uncanny-perception`) — source: VtR 2e Rulebook + TM Errata, 56 → 284 chars
+  > This power must be used on a single creature that can currently be perceived. This power can be used to initiate a Clash of Wills against any objects 
+- **Iron Edict** (discipline, `iron-edict`) — source: VtR 2e Rulebook, 57 → 1326 chars
+  > Once she’s got a hotline into her victim’s mind, the vampire can take some time to play with his thoughts and memories. While it takes more of her pow
+- **Possession** (discipline, `possession`) — source: VtR 2e Rulebook + TM Errata, 22 → 281 chars
+  > Resistance to Possession is now – victim's Resolve + Supernatural Tolerance. Possession only allows the possessor to walk in the sun without consequen
+- **Awe** (discipline, `awe`) — source: VtR 2e Rulebook, 49 → 1469 chars
+  > Awe shines a spotlight on the vampire even in a crowded room. He’s the most important person around and people want to be around him. Awe creates an a
+- **Confidant** (discipline, `confidant`) — source: VtR 2e Rulebook, 25 → 1071 chars
+  > The vampire doesn’t have to shout to be heard, and in a crowd that he’s already Awed, sometimes speaking quietly is the best way to get attention. Wit
+- **Green Eyes** (discipline, `green-eyes`) — source: VtR 2e Rulebook + TM Errata, 65 → 665 chars
+  > **Clarification:** Green Eyes has two different uses. The first is to change emotional state and requires no action; the second is to make requests. O
+- **Idol** (discipline, `idol`) — source: VtR 2e Rulebook + TM Errata, 71 → 163 chars
+  > **Clarification:** A successful reflexive roll to resist Idol only allows for one action before the check must be made again. _Source: VTR 2e pg 139_ 
+- **Loyalty** (discipline, `loyalty`) — source: VtR 2e Rulebook, 28 → 1257 chars
+  > Among his inner circle, the vampire praises some more than others, bringing them even closer to him. With a few words he can inflame their love for hi
+- **Dread Presence** (discipline, `dread-presence`) — source: VtR 2e Rulebook, 79 → 1724 chars
+  > Everyone around the vampire feels the world go slightly wrong as she exudes a deeply unsettling aura. Even if they barely notice her, they feel a wave
+- **Face of the Beast** (discipline, `face-of-the-beast`) — source: VtR 2e Rulebook, 43 → 1148 chars
+  > All it takes is a glance, and the vampire can magnify one of his victim’s fears to truly horrifying levels. If she knows what sort of things her victi
+- **Grand Delusion** (discipline, `grand-delusion`) — source: VtR 2e Rulebook, 28 → 1614 chars
+  > Touching her victim’s mind, the vampire sparks a delusion that only she fully understands. What she makes him believe doesn’t match up with the world 
+- **Mortal Terror** (discipline, `mortal-terror`) — source: VtR 2e Rulebook + TM Errata, 54 → 324 chars
+  > Resistance to Mortal Terror is now – victim's Composure + Supernatural Tolerance. Full lethal damage is applied to vampires. Composure damage on vampi
+- **Waking Nightmare** (discipline, `waking-nightmare`) — source: VtR 2e Rulebook, 34 → 2441 chars
+  > Having altered her victims’ beliefs and stoked their fears, the vampire can now spark disturbing hallucinations of a kind that all vampires suffer in 
+- **Cloak of Night** (discipline, `cloak-of-night`) — source: VtR 2e Rulebook + TM Errata, 17 → 174 chars
+  > When using Cloak of Night to leave active combat they have participated in, it will initiate an automatic Clash of Wills against anyone with Auspex 2.
+
+## Ambiguous (needs review)
+
+- **Feral Infection** (discipline, `feral-infection`) — rank_mismatch
+- **Lord of the Land** (discipline, `lord-of-the-land`) — rank_mismatch
+- **Summon the Hunt** (discipline, `summon-the-hunt`) — rank_mismatch
+- **Entombed Command** (discipline, `entombed-command`) — rank_mismatch
+- **The Lying Mind** (discipline, `the-lying-mind`) — rank_mismatch
+- **Anonymity** (merit, `anonymity`) — multiple_book_sources
+- **Area of Expertise** (merit, `area-of-expertise`) — multiple_book_sources
+- **Fame** (merit, `fame`) — multiple_book_sources
+- **Fleet Of Foot** (merit, `fleet-of-foot`) — multiple_book_sources
+- **Indomitable** (merit, `indomitable`) — multiple_book_sources
+- **Inspiring** (merit, `inspiring`) — multiple_book_sources
+- **Interdisciplinary Specialty** (merit, `interdisciplinary-specialty`) — multiple_book_sources
+- **Kindred Status** (merit, `kindred-status`) — rank_mismatch
+- **Language** (merit, `language`) — multiple_book_sources
+- **Sympathetic** (merit, `sympathetic`) — multiple_book_sources
+- **Object Fetishism** (merit, `object-fetishism`) — rank_mismatch
+- **Support Network** (merit, `support-network`) — rank_mismatch
+- **Kick 'Em While They're Down** (manoeuvre, `kick-em-while-theyre-down`) — rank_mismatch
+- **Status** (merit, `status`) — multiple_book_sources

--- a/server/scripts/uplift-power-rules-text.js
+++ b/server/scripts/uplift-power-rules-text.js
@@ -1,0 +1,590 @@
+/**
+ * Issue #992 — uplift full rulebook text from `markdown/` sourcebooks into
+ * `purchasable_powers.rules_text` (+ `rules_source` provenance).
+ *
+ * `description` (the existing one-line summary) is NEVER read for matching
+ * beyond identity, and is NEVER written by this script. Option B (locked
+ * 2026-07-14, Peter): `description` untouched, new `rules_text` / `rules_source`
+ * fields added alongside it.
+ *
+ * ── Pipeline ────────────────────────────────────────────────────────────────
+ * 1. Read each book in `markdown/` (declarative BOOKS table below).
+ * 2. Normalise the PDF-extracted double-spaced wrap: the source has every
+ *    wrapped line followed by a blank line, whether that line is mid-paragraph
+ *    or a genuine paragraph break — the extraction does not distinguish them.
+ *    We therefore treat the file as a stream of non-blank "fragments" and
+ *    re-flow them: fragments before the first structured (`**Label:**`) line
+ *    in a block become one running flavour paragraph; fragments from the
+ *    first structured line onward are appended to whichever label is active.
+ * 3. Segment fragments into power blocks using a declarative heading-pattern
+ *    table (name + trailing dot glyphs, name + parenthesised dots, bold name
+ *    + parenthesised dots followed by a colon and inline body, etc). Heading
+ *    detection requires the ENTIRE trimmed fragment to match — normal prose
+ *    fragments never coincidentally satisfy this because the dot glyphs
+ *    (•/●) are used in this corpus only for power ranks.
+ * 4. Match blocks to DB `purchasable_powers` docs by normalised name (case /
+ *    punctuation / diacritic-insensitive, leading "the " stripped), sanity
+ *    checked against `rank` (or `rating_range` for ranged merits) where the
+ *    heading carries dots. A rank mismatch on the only candidate(s) is
+ *    reported as ambiguous, not guessed into a match.
+ * 5. Errata precedence: when a power appears in both an errata file and a
+ *    book, the errata block's text is used, `rules_source` records both
+ *    (e.g. "VtR 2e Rulebook + TM Errata").
+ * 6. No fuzzy matching beyond normalisation — unmatched is a reportable
+ *    outcome, not a failure (Design notes, story 992).
+ *
+ * ── Safety (2026-06-16 PR #813 lesson) ──────────────────────────────────────
+ * Apply mode writes ONLY `updateOne({ _id }, { $set: { rules_text, rules_source } })`
+ * — never find+projection+replaceOne. Apply mode also exports a full-collection
+ * backup JSON before any write. `--apply` is required for writes; default is
+ * dry-run (report-only, zero DB writes).
+ *
+ * Usage:
+ *   cd server && node scripts/uplift-power-rules-text.js              (dry-run)
+ *   cd server && node scripts/uplift-power-rules-text.js --apply       (write)
+ *
+ * NEVER run --apply against the live DB for this story (#992) — apply is a
+ * separate, explicitly-authorised step per the Decisions section of the story.
+ */
+
+import 'dotenv/config';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { connectDb, getCollection } from '../db.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MARKDOWN_DIR = path.resolve(__dirname, '..', '..', 'markdown');
+const REPORTS_DIR = path.resolve(__dirname, 'reports');
+const BACKUPS_DIR = path.resolve(__dirname, 'backups');
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Declarative per-book table — new books are additive, nothing else changes.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const BOOKS = [
+  { file: 'Vampire the Requiem 2e Rulebook.md', label: 'VtR 2e Rulebook', isErrata: false },
+  { file: 'Chronicles of Darkness Rulebook.md', label: 'CofD Rulebook', isErrata: false },
+  { file: 'Hurt Locker.md', label: 'Hurt Locker', isErrata: false },
+  { file: 'Secrets of the Covenants.md', label: 'Secrets of the Covenants', isErrata: false },
+  { file: 'Blood Sorcery- New Rules.md', label: 'Blood Sorcery - New Rules', isErrata: false },
+  { file: 'Damnation City Model - New Rules.md', label: 'Damnation City Model - New Rules', isErrata: false },
+  { file: 'Blood Sorcery Themes and Motifs.md', label: 'Blood Sorcery Themes and Motifs', isErrata: false },
+  { file: 'Terra Mortis - Errata Master.md', label: 'TM Errata', isErrata: true },
+  { file: 'Auspex Errata.md', label: 'Auspex Errata', isErrata: true },
+  // 'Terra Mortis Treatment.md' is campaign fiction — deliberately excluded.
+];
+
+const DOTS = '[•●]';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Name normalisation — the DB join key.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function normalizeName(s) {
+  if (!s) return '';
+  return s
+    .normalize('NFD').replace(/[̀-ͯ]/g, '') // strip diacritics (René -> Rene)
+    .toLowerCase()
+    .replace(/[’‘]/g, "'")
+    .replace(/^\s*the\s+/, '')
+    .replace(/[^a-z0-9' ]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function countDots(s) {
+  return (s.match(new RegExp(DOTS, 'g')) || []).length;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Heading patterns — declarative, applied to every book. A fragment is a
+// heading candidate only when the WHOLE trimmed fragment matches (no partial
+// matches inside a longer sentence) and is under HEADING_MAX_LEN chars.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const HEADING_MAX_LEN = 100;
+const NAME_CHARS = "[\\w'’.,\\-&À-ÿ ]"; // letters/digits/apostrophe/&/accents/space
+
+const HEADING_PATTERNS = [
+  // Bold name + parenthesised dot RANGE + colon, inline body follows.
+  // e.g. "**Army of One (• to •••••):** text..."
+  {
+    kind: 'boldColonRange',
+    re: new RegExp(`^\\*\\*(${NAME_CHARS}+?)\\s*\\(\\s*(${DOTS}{1,5})\\s+to\\s+(${DOTS}{1,5})\\s*\\)\\s*:\\*\\*\\s*(.*)$`),
+  },
+  // Bold name + parenthesised single rank + colon, inline body follows.
+  // e.g. "**Hamstring (•):** text..." (also covers the CofD split-bold
+  // artifact after normalizeSplitBoldDots() below has repaired it).
+  {
+    kind: 'boldColon',
+    re: new RegExp(`^\\*\\*(${NAME_CHARS}+?)\\s*\\(\\s*(${DOTS}{1,5})\\s*\\)\\s*:\\*\\*\\s*(.*)$`),
+  },
+  // Plain name + parenthesised dot RANGE, own line, no colon.
+  // e.g. "Alley Cat (• to •••)" (Secrets of the Covenants merits)
+  {
+    kind: 'parensRange',
+    re: new RegExp(`^\\*{0,2}(${NAME_CHARS}+?)\\s*\\(\\s*(${DOTS}{1,5})\\s+to\\s+(${DOTS}{1,5})\\s*\\)\\*{0,2}$`),
+  },
+  // Plain name + parenthesised single rank, own line, no colon.
+  // e.g. "Blandishment of Sin (•)", "Oath of Serfdom (••)"
+  {
+    kind: 'parens',
+    re: new RegExp(`^\\*{0,2}(${NAME_CHARS}+?)\\s*\\(\\s*(${DOTS}{1,5})\\s*\\)\\*{0,2}$`),
+  },
+  // Bold name + trailing dots, own line, no parens/colon.
+  // e.g. "**Creation •**" (Blood Sorcery Themes and Motifs)
+  {
+    kind: 'boldBareDots',
+    re: new RegExp(`^\\*\\*(${NAME_CHARS}+?)\\s+(${DOTS}{1,5})\\*\\*$`),
+  },
+  // Plain name + trailing dots, own line, no bold/parens.
+  // e.g. "Feral Whispers •", "Raise the Familiar ••"
+  {
+    kind: 'bareDots',
+    re: new RegExp(`^(${NAME_CHARS}+?)\\s+(${DOTS}{1,5})$`),
+  },
+];
+
+// The CofD Rulebook's PDF extraction splits the bold span around the dot
+// glyph itself, e.g.:
+//   **Cover the Angles (**• **):** Whenever you take a Dodge action,
+// Repair this into the canonical **Name (dots):** shape before heading
+// detection runs, so the boldColon pattern above matches normally.
+function normalizeSplitBoldDots(line) {
+  return line.replace(
+    new RegExp(`\\*\\*([^*()\\n]+?)\\(\\*\\*(${DOTS}{1,5})\\s*\\*\\*\\):\\*\\*`, 'g'),
+    (_m, name, dots) => `**${name.trim()} (${dots}):**`
+  );
+}
+
+// Patterns whose syntax is unambiguously a heading (bold name + parens +
+// colon, with an inline body) — these are accepted regardless of what
+// precedes them. The remaining "weak" patterns (bare/parenthesised dots with
+// no colon) are indistinguishable, in isolation, from a wrapped prerequisite
+// list item like "Martial Arts •• or Street Fighting ••,\nStamina •••" — the
+// second physical line reads exactly like a "Stamina •••" heading. Weak
+// patterns are only accepted when the preceding fragment reads like the END
+// of a sentence/section (see isPlausibleHeadingContext below).
+const STRONG_KINDS = new Set(['boldColon', 'boldColonRange']);
+
+function matchHeading(rawFragment) {
+  const fragment = normalizeSplitBoldDots(rawFragment.trim());
+  if (!fragment || fragment.length > HEADING_MAX_LEN) return null;
+  // Must start with a letter (excludes bare bullet-list markers like "●").
+  if (!/^[A-Za-zÀ-ÿ*]/.test(fragment)) return null;
+
+  for (const { kind, re } of HEADING_PATTERNS) {
+    const m = fragment.match(re);
+    if (!m) continue;
+    const name = m[1].trim().replace(/[*_]+$/, '');
+    if (!name || !/[A-Za-z]/.test(name)) continue;
+    const strong = STRONG_KINDS.has(kind);
+    if (kind === 'boldColonRange' || kind === 'parensRange') {
+      return { name, dots: null, dotsRange: [countDots(m[2]), countDots(m[3])], inlineBody: m[4] || '', strong };
+    }
+    if (kind === 'boldColon') {
+      return { name, dots: countDots(m[2]), dotsRange: null, inlineBody: m[3] || '', strong };
+    }
+    // parens / boldBareDots / bareDots
+    return { name, dots: countDots(m[2]), dotsRange: null, inlineBody: '', strong };
+  }
+  return null;
+}
+
+// A "weak" heading candidate (no colon) is implausible only when the
+// fragment immediately preceding it dangles mid-list — a trailing comma,
+// conjunction, or hyphenated word-wrap. That specific shape is what a
+// wrapped prerequisite list item looks like ("...Street Fighting ••,\n
+// Stamina •••" or "...Athletics ••, Stealth ••,\nStreetwise ••") and is
+// otherwise indistinguishable, fragment-by-fragment, from a genuine
+// "Name dots" heading. Everything else (including short label values like
+// "**Action:** Instant" with no terminal punctuation) is accepted — the
+// dangling-list shape is a much more reliable negative signal than
+// requiring an explicit positive one.
+function isPlausibleHeadingContext(lastFragment) {
+  const t = (lastFragment || '').trim();
+  if (!t) return true; // start of file / right after a heading with no body yet
+  if (/,$/.test(t)) return false; // dangling list item: "...Stealth ••,"
+  if (/\b(or|and|&)$/i.test(t)) return false; // dangling conjunction
+  if (/[a-z]-$/.test(t)) return false; // hyphenated word-wrap continuation
+  return true;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Structured (bold-label) line detection inside a block.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const LABEL_COLON_RE = /^\*\*([A-Za-z][A-Za-z0-9 /&'\-]*?)\s*:\*\*\s*(.*)$/;
+const LABEL_BARE_RE = /^\*\*([A-Za-z][A-Za-z0-9 /&'\-]*?)\*\*\s*$/;
+
+// PDF hyphenation-aware fragment joiner: "modi-" + "fier" -> "modifier";
+// otherwise space-join.
+export function joinFragment(acc, frag) {
+  const f = frag.trim();
+  if (!f) return acc;
+  if (!acc) return f;
+  if (/[a-z]-$/.test(acc)) return acc.slice(0, -1) + f;
+  return acc + ' ' + f;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Parse a single book's raw text into an array of power blocks.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function parseBook(rawText, book) {
+  const fragments = rawText.split('\n').map(l => l.trim()).filter(l => l.length > 0);
+  const blocks = [];
+  let current = null;
+  let lastFragment = '';
+
+  function closeCurrent() {
+    if (current) blocks.push(current);
+    current = null;
+  }
+
+  for (const fragment of fragments) {
+    const candidate = matchHeading(fragment);
+    const heading = candidate && (candidate.strong || isPlausibleHeadingContext(lastFragment)) ? candidate : null;
+    lastFragment = fragment;
+    if (heading) {
+      closeCurrent();
+      current = {
+        name: heading.name,
+        normName: normalizeName(heading.name),
+        dots: heading.dots,
+        dotsRange: heading.dotsRange,
+        flavourParts: [],
+        sections: [], // ordered [{ label, text }]
+        book: book.label,
+        file: book.file,
+        isErrata: book.isErrata,
+      };
+      if (heading.inlineBody) current.flavourParts.push(heading.inlineBody);
+      continue;
+    }
+    if (!current) continue; // preamble text before the first heading — discard
+
+    const colonMatch = fragment.match(LABEL_COLON_RE);
+    const bareMatch = !colonMatch && fragment.match(LABEL_BARE_RE);
+    if (colonMatch) {
+      current.sections.push({ label: colonMatch[1].trim(), text: colonMatch[2] || '' });
+      continue;
+    }
+    if (bareMatch) {
+      current.sections.push({ label: bareMatch[1].trim(), text: '' });
+      continue;
+    }
+    // Continuation: if we've started structured sections, this fragment
+    // continues the most recent one. Otherwise it's still flavour text.
+    if (current.sections.length > 0) {
+      const last = current.sections[current.sections.length - 1];
+      last.text = joinFragment(last.text, fragment);
+    } else {
+      current.flavourParts.push(fragment);
+    }
+  }
+  closeCurrent();
+
+  for (const b of blocks) {
+    b.flavour = b.flavourParts.reduce((acc, f) => joinFragment(acc, f), '');
+    delete b.flavourParts;
+    b.rulesText = buildRulesText(b);
+  }
+  return blocks;
+}
+
+export function buildRulesText(block) {
+  const parts = [];
+  if (block.flavour && block.flavour.trim()) parts.push(block.flavour.trim());
+  if (block.sections.length) {
+    const lines = block.sections.map(s =>
+      s.text && s.text.trim() ? `**${s.label}:** ${s.text.trim()}` : `**${s.label}**`
+    );
+    parts.push(lines.join('\n'));
+  }
+  return parts.join('\n\n');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Load + index every book.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function loadAllBlocks(markdownDir = MARKDOWN_DIR, books = BOOKS) {
+  const allBlocks = [];
+  const bookStatus = [];
+  for (const book of books) {
+    const filePath = path.join(markdownDir, book.file);
+    if (!fs.existsSync(filePath)) {
+      bookStatus.push({ file: book.file, found: false, blocks: 0 });
+      continue;
+    }
+    const raw = fs.readFileSync(filePath, 'utf8');
+    const blocks = parseBook(raw, book);
+    allBlocks.push(...blocks);
+    bookStatus.push({ file: book.file, found: true, blocks: blocks.length });
+  }
+
+  const byNormName = new Map();
+  for (const b of allBlocks) {
+    if (!byNormName.has(b.normName)) byNormName.set(b.normName, []);
+    byNormName.get(b.normName).push(b);
+  }
+  return { allBlocks, byNormName, bookStatus };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Match DB powers against parsed blocks.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function matchPower(power, byNormName) {
+  const norm = normalizeName(power.name);
+  const candidates = byNormName.get(norm) || [];
+  if (!candidates.length) return { status: 'unmatched' };
+
+  let rankFiltered = candidates;
+  if (power.rank != null) {
+    rankFiltered = candidates.filter(c => c.dots == null || c.dots === power.rank);
+  } else if (Array.isArray(power.rating_range)) {
+    rankFiltered = candidates.filter(c =>
+      !c.dotsRange || (c.dotsRange[0] === power.rating_range[0] && c.dotsRange[1] === power.rating_range[1])
+    );
+  }
+  if (!rankFiltered.length) {
+    return { status: 'ambiguous', reason: 'rank_mismatch', candidates };
+  }
+
+  const errataCands = rankFiltered.filter(c => c.isErrata);
+  const bookCands = rankFiltered.filter(c => !c.isErrata);
+
+  if (errataCands.length > 1) {
+    return { status: 'ambiguous', reason: 'multiple_errata_sources', candidates: rankFiltered };
+  }
+  if (errataCands.length === 1) {
+    const errBlock = errataCands[0];
+    const bookBlock = bookCands[0];
+    const source = bookBlock ? `${bookBlock.book} + ${errBlock.book}` : errBlock.book;
+    return { status: 'matched', block: errBlock, source };
+  }
+  if (bookCands.length === 1) {
+    return { status: 'matched', block: bookCands[0], source: bookCands[0].book };
+  }
+  return { status: 'ambiguous', reason: 'multiple_book_sources', candidates: rankFiltered };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Cost-extraction side artifact (GDX-6 / #987 reuse). No cost fields are
+// written to the DB by this script — this is a read-only JSON export.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function extractCost(block) {
+  const s = block.sections.find(sec => sec.label.toLowerCase() === 'cost');
+  return s ? s.text.trim() : null;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Report generation.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function buildReport(results, bookStatus) {
+  const byCategory = {};
+  for (const r of results) {
+    const cat = r.category;
+    if (!byCategory[cat]) byCategory[cat] = { matched: 0, unmatched: 0, ambiguous: 0 };
+    byCategory[cat][r.status === 'matched' ? 'matched' : r.status === 'ambiguous' ? 'ambiguous' : 'unmatched']++;
+  }
+
+  const matches = results
+    .filter(r => r.status === 'matched')
+    .map(r => ({
+      key: r.key,
+      name: r.name,
+      category: r.category,
+      source: r.source,
+      before_len: r.before_len,
+      after_len: r.after_len,
+      preview: r.preview,
+    }));
+
+  const ambiguous = results
+    .filter(r => r.status === 'ambiguous')
+    .map(r => ({ key: r.key, name: r.name, category: r.category, reason: r.reason }));
+
+  const unmatched = results
+    .filter(r => r.status === 'unmatched')
+    .map(r => ({ key: r.key, name: r.name, category: r.category }));
+
+  return {
+    generated_at: new Date().toISOString(),
+    book_status: bookStatus,
+    totals: {
+      matched: matches.length,
+      ambiguous: ambiguous.length,
+      unmatched: unmatched.length,
+      total: results.length,
+    },
+    by_category: byCategory,
+    matches,
+    ambiguous,
+    unmatched,
+  };
+}
+
+function buildMarkdownSummary(report) {
+  const lines = [];
+  lines.push('# Story 992 — power rules-text uplift dry-run report');
+  lines.push('');
+  lines.push(`Generated: ${report.generated_at}`);
+  lines.push('');
+  lines.push('## Book segmentation');
+  lines.push('');
+  lines.push('| File | Found | Blocks parsed |');
+  lines.push('|---|---|---|');
+  for (const b of report.book_status) {
+    lines.push(`| ${b.file} | ${b.found ? 'yes' : 'NO'} | ${b.blocks} |`);
+  }
+  lines.push('');
+  lines.push('## Per-category match statistics');
+  lines.push('');
+  lines.push('| Category | Matched | Unmatched | Ambiguous |');
+  lines.push('|---|---|---|---|');
+  for (const [cat, counts] of Object.entries(report.by_category)) {
+    lines.push(`| ${cat} | ${counts.matched} | ${counts.unmatched} | ${counts.ambiguous} |`);
+  }
+  lines.push('');
+  lines.push(`**Totals** — matched: ${report.totals.matched}, unmatched: ${report.totals.unmatched}, ambiguous: ${report.totals.ambiguous}, total DB docs: ${report.totals.total}`);
+  lines.push('');
+  lines.push('## Sample matches');
+  lines.push('');
+  for (const m of report.matches.slice(0, 20)) {
+    lines.push(`- **${m.name}** (${m.category}, \`${m.key}\`) — source: ${m.source}, ${m.before_len} → ${m.after_len} chars`);
+    lines.push(`  > ${m.preview}`);
+  }
+  lines.push('');
+  lines.push('## Ambiguous (needs review)');
+  lines.push('');
+  for (const a of report.ambiguous) {
+    lines.push(`- **${a.name}** (${a.category}, \`${a.key}\`) — ${a.reason}`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Backup export (apply mode only) — full collection dump before any write.
+// ─────────────────────────────────────────────────────────────────────────────
+
+function exportBackup(docs, backupsDir) {
+  if (!fs.existsSync(backupsDir)) fs.mkdirSync(backupsDir, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const backupPath = path.join(backupsDir, `992-purchasable-powers-backup-${stamp}.json`);
+  fs.writeFileSync(backupPath, JSON.stringify(docs, null, 2));
+  return backupPath;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// main()
+//
+// Accepts an optional overrides object so the integration test can point at
+// a fixture markdown dir + throwaway reports/backups dirs instead of the real
+// `markdown/` corpus and `server/scripts/{reports,backups}/`. CLI usage
+// (`node scripts/uplift-power-rules-text.js [--apply]`) needs none of this —
+// every override defaults to the real story-992 paths.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export async function main(overrides = {}) {
+  const APPLY = overrides.apply != null ? overrides.apply : process.argv.includes('--apply');
+  const DRY_RUN = !APPLY;
+  const markdownDir = overrides.markdownDir || MARKDOWN_DIR;
+  const books = overrides.books || BOOKS;
+  const reportsDir = overrides.reportsDir || REPORTS_DIR;
+  const backupsDir = overrides.backupsDir || BACKUPS_DIR;
+
+  await connectDb();
+  const col = getCollection('purchasable_powers');
+  const query = overrides.query || {};
+  const powers = await col.find(query).toArray();
+
+  const { byNormName, bookStatus } = loadAllBlocks(markdownDir, books);
+
+  const results = [];
+  const costArtifact = [];
+  let written = 0;
+  let skippedEmpty = 0;
+
+  let backupPath = null;
+  if (!DRY_RUN) {
+    backupPath = exportBackup(powers, backupsDir);
+  }
+
+  for (const p of powers) {
+    const m = matchPower(p, byNormName);
+    if (m.status === 'unmatched') {
+      results.push({ status: 'unmatched', key: p.key, name: p.name, category: p.category });
+      continue;
+    }
+    if (m.status === 'ambiguous') {
+      results.push({ status: 'ambiguous', key: p.key, name: p.name, category: p.category, reason: m.reason });
+      continue;
+    }
+
+    const rulesText = m.block.rulesText;
+    const before_len = (p.description || '').length;
+    const after_len = rulesText.length;
+    const preview = rulesText.slice(0, 150).replace(/\n/g, ' ');
+
+    results.push({
+      status: 'matched',
+      key: p.key,
+      name: p.name,
+      category: p.category,
+      source: m.source,
+      before_len,
+      after_len,
+      preview,
+    });
+
+    const cost_raw = extractCost(m.block);
+    if (cost_raw) costArtifact.push({ key: p.key, name: p.name, cost_raw });
+
+    if (!DRY_RUN) {
+      if (!rulesText || !rulesText.trim()) {
+        skippedEmpty++;
+        continue;
+      }
+      await col.updateOne(
+        { _id: p._id },
+        { $set: { rules_text: rulesText, rules_source: m.source } }
+      );
+      written++;
+    }
+  }
+
+  const report = buildReport(results, bookStatus);
+  const markdown = buildMarkdownSummary(report);
+
+  if (!fs.existsSync(reportsDir)) fs.mkdirSync(reportsDir, { recursive: true });
+  const reportJsonPath = path.join(reportsDir, '992-uplift-report.json');
+  const reportMdPath = path.join(reportsDir, '992-uplift-report.md');
+  const costsPath = path.join(reportsDir, '992-costs-extract.json');
+  fs.writeFileSync(reportJsonPath, JSON.stringify(report, null, 2));
+  fs.writeFileSync(reportMdPath, markdown);
+  fs.writeFileSync(costsPath, JSON.stringify(costArtifact, null, 2));
+
+  console.log(`\n${DRY_RUN ? '[DRY RUN]' : '[APPLY]'} uplift-power-rules-text.js`);
+  console.log(`Docs scanned: ${powers.length}`);
+  console.log(`Matched: ${report.totals.matched}, Unmatched: ${report.totals.unmatched}, Ambiguous: ${report.totals.ambiguous}`);
+  if (!DRY_RUN) {
+    console.log(`Backup written: ${backupPath}`);
+    console.log(`Written: ${written}, Skipped (empty parsed text): ${skippedEmpty}`);
+  } else {
+    console.log(`Reports written to ${reportsDir}. Re-run with --apply to write (never against the live DB for this story).`);
+  }
+
+  return { report, written, skippedEmpty, backupPath, reportJsonPath, reportMdPath, costsPath, costArtifact };
+}
+
+const _invokedDirectly = import.meta.url === `file://${process.argv[1]}`;
+if (_invokedDirectly) {
+  main().catch(err => { console.error(err); process.exit(1); });
+}

--- a/server/scripts/uplift-power-rules-text.js
+++ b/server/scripts/uplift-power-rules-text.js
@@ -27,11 +27,21 @@
  *    checked against `rank` (or `rating_range` for ranged merits) where the
  *    heading carries dots. A rank mismatch on the only candidate(s) is
  *    reported as ambiguous, not guessed into a match.
- * 5. Errata precedence: when a power appears in both an errata file and a
- *    book, the errata block's text is used, `rules_source` records both
- *    (e.g. "VtR 2e Rulebook + TM Errata").
+ * 5. Errata composition (revised 2026-07-15, Peter): when a power appears in
+ *    both an errata file and a book, `rules_text` is the FULL book text with
+ *    a clearly delimited errata section appended (blank line, `---`, then
+ *    `**<Errata Book>:**` and the errata text) — errata no longer replaces
+ *    the book text. `rules_source` still records both, e.g. "VtR 2e Rulebook
+ *    + TM Errata". Errata-only matches (no book block) keep the errata text
+ *    as the whole `rules_text`, unchanged.
  * 6. No fuzzy matching beyond normalisation — unmatched is a reportable
  *    outcome, not a failure (Design notes, story 992).
+ * 7. Auspex exclusion (2026-07-15, Peter): every power whose DB `parent`
+ *    (case-insensitive) is "Auspex" is skipped entirely — not matched, not
+ *    written — regardless of which source it would otherwise resolve from.
+ *    Peter is fixing the Auspex errata PDF; these wait. Reported in a
+ *    dedicated `skipped_auspex` list, separate from matched/unmatched/
+ *    ambiguous.
  *
  * ── Safety (2026-06-16 PR #813 lesson) ──────────────────────────────────────
  * Apply mode writes ONLY `updateOne({ _id }, { $set: { rules_text, rules_source } })`
@@ -334,6 +344,25 @@ export function loadAllBlocks(markdownDir = MARKDOWN_DIR, books = BOOKS) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Errata composition — Peter's 2026-07-15 revision (story 992 review).
+//
+// Errata no longer REPLACES the book text: when a power matches both a book
+// block and an errata block, rules_text is the full book text with a clearly
+// delimited errata section appended. Errata-only matches (no book block —
+// e.g. Encyclopaedic Knowledge, 11 cases in the live corpus) keep the errata
+// text as the whole rules_text, unchanged from before.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ERRATA_DELIMITER = '\n\n---\n';
+
+export function composeRulesText(bookBlock, errataBlock) {
+  if (bookBlock && errataBlock) {
+    return `${bookBlock.rulesText}${ERRATA_DELIMITER}**${errataBlock.book}:**\n${errataBlock.rulesText}`;
+  }
+  return (errataBlock || bookBlock).rulesText;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Match DB powers against parsed blocks.
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -364,10 +393,25 @@ export function matchPower(power, byNormName) {
     const errBlock = errataCands[0];
     const bookBlock = bookCands[0];
     const source = bookBlock ? `${bookBlock.book} + ${errBlock.book}` : errBlock.book;
-    return { status: 'matched', block: errBlock, source };
+    return {
+      status: 'matched',
+      block: errBlock,
+      bookBlock: bookBlock || null,
+      errataBlock: errBlock,
+      source,
+      rulesText: composeRulesText(bookBlock, errBlock),
+    };
   }
   if (bookCands.length === 1) {
-    return { status: 'matched', block: bookCands[0], source: bookCands[0].book };
+    const bookBlock = bookCands[0];
+    return {
+      status: 'matched',
+      block: bookBlock,
+      bookBlock,
+      errataBlock: null,
+      source: bookBlock.book,
+      rulesText: bookBlock.rulesText,
+    };
   }
   return { status: 'ambiguous', reason: 'multiple_book_sources', candidates: rankFiltered };
 }
@@ -390,8 +434,8 @@ function buildReport(results, bookStatus) {
   const byCategory = {};
   for (const r of results) {
     const cat = r.category;
-    if (!byCategory[cat]) byCategory[cat] = { matched: 0, unmatched: 0, ambiguous: 0 };
-    byCategory[cat][r.status === 'matched' ? 'matched' : r.status === 'ambiguous' ? 'ambiguous' : 'unmatched']++;
+    if (!byCategory[cat]) byCategory[cat] = { matched: 0, unmatched: 0, ambiguous: 0, skipped_auspex: 0 };
+    byCategory[cat][r.status]++;
   }
 
   const matches = results
@@ -414,6 +458,10 @@ function buildReport(results, bookStatus) {
     .filter(r => r.status === 'unmatched')
     .map(r => ({ key: r.key, name: r.name, category: r.category }));
 
+  const skippedAuspex = results
+    .filter(r => r.status === 'skipped_auspex')
+    .map(r => ({ key: r.key, name: r.name, category: r.category }));
+
   return {
     generated_at: new Date().toISOString(),
     book_status: bookStatus,
@@ -421,12 +469,14 @@ function buildReport(results, bookStatus) {
       matched: matches.length,
       ambiguous: ambiguous.length,
       unmatched: unmatched.length,
+      skipped_auspex: skippedAuspex.length,
       total: results.length,
     },
     by_category: byCategory,
     matches,
     ambiguous,
     unmatched,
+    skipped_auspex: skippedAuspex,
   };
 }
 
@@ -446,13 +496,13 @@ function buildMarkdownSummary(report) {
   lines.push('');
   lines.push('## Per-category match statistics');
   lines.push('');
-  lines.push('| Category | Matched | Unmatched | Ambiguous |');
-  lines.push('|---|---|---|---|');
+  lines.push('| Category | Matched | Unmatched | Ambiguous | Skipped (Auspex) |');
+  lines.push('|---|---|---|---|---|');
   for (const [cat, counts] of Object.entries(report.by_category)) {
-    lines.push(`| ${cat} | ${counts.matched} | ${counts.unmatched} | ${counts.ambiguous} |`);
+    lines.push(`| ${cat} | ${counts.matched} | ${counts.unmatched} | ${counts.ambiguous} | ${counts.skipped_auspex} |`);
   }
   lines.push('');
-  lines.push(`**Totals** — matched: ${report.totals.matched}, unmatched: ${report.totals.unmatched}, ambiguous: ${report.totals.ambiguous}, total DB docs: ${report.totals.total}`);
+  lines.push(`**Totals** — matched: ${report.totals.matched}, unmatched: ${report.totals.unmatched}, ambiguous: ${report.totals.ambiguous}, skipped_auspex: ${report.totals.skipped_auspex}, total DB docs: ${report.totals.total}`);
   lines.push('');
   lines.push('## Sample matches');
   lines.push('');
@@ -465,6 +515,14 @@ function buildMarkdownSummary(report) {
   lines.push('');
   for (const a of report.ambiguous) {
     lines.push(`- **${a.name}** (${a.category}, \`${a.key}\`) — ${a.reason}`);
+  }
+  lines.push('');
+  lines.push(`## Skipped — Auspex (${report.skipped_auspex.length})`);
+  lines.push('');
+  lines.push('Peter is fixing the Auspex errata PDF; these powers are deliberately excluded from matching and writes until that lands.');
+  lines.push('');
+  for (const a of report.skipped_auspex) {
+    lines.push(`- **${a.name}** (${a.category}, \`${a.key}\`)`);
   }
   lines.push('');
   return lines.join('\n');
@@ -518,6 +576,17 @@ export async function main(overrides = {}) {
   }
 
   for (const p of powers) {
+    // Peter's 2026-07-15 revision: skip every power whose DB `parent` is
+    // Auspex (case-insensitive) — Peter is fixing the Auspex errata PDF, so
+    // these wait. This is a DB-parent check, not a source check: it also
+    // catches Auspex powers that would otherwise match via TM Errata Master
+    // (Beast's Hackles, Uncanny Perception, Spirit's Touch, Twilight
+    // Projection) even though Auspex Errata.md itself fails to segment.
+    if (typeof p.parent === 'string' && p.parent.toLowerCase() === 'auspex') {
+      results.push({ status: 'skipped_auspex', key: p.key, name: p.name, category: p.category });
+      continue;
+    }
+
     const m = matchPower(p, byNormName);
     if (m.status === 'unmatched') {
       results.push({ status: 'unmatched', key: p.key, name: p.name, category: p.category });
@@ -528,7 +597,7 @@ export async function main(overrides = {}) {
       continue;
     }
 
-    const rulesText = m.block.rulesText;
+    const rulesText = m.rulesText;
     const before_len = (p.description || '').length;
     const after_len = rulesText.length;
     const preview = rulesText.slice(0, 150).replace(/\n/g, ' ');
@@ -573,7 +642,7 @@ export async function main(overrides = {}) {
 
   console.log(`\n${DRY_RUN ? '[DRY RUN]' : '[APPLY]'} uplift-power-rules-text.js`);
   console.log(`Docs scanned: ${powers.length}`);
-  console.log(`Matched: ${report.totals.matched}, Unmatched: ${report.totals.unmatched}, Ambiguous: ${report.totals.ambiguous}`);
+  console.log(`Matched: ${report.totals.matched}, Unmatched: ${report.totals.unmatched}, Ambiguous: ${report.totals.ambiguous}, Skipped (Auspex): ${report.totals.skipped_auspex}`);
   if (!DRY_RUN) {
     console.log(`Backup written: ${backupPath}`);
     console.log(`Written: ${written}, Skipped (empty parsed text): ${skippedEmpty}`);

--- a/server/tests/issue-992-uplift-rules-text.test.js
+++ b/server/tests/issue-992-uplift-rules-text.test.js
@@ -20,7 +20,7 @@ import os from 'os';
 import path from 'path';
 import { setupDb, teardownDb } from './helpers/db-setup.js';
 import { getCollection } from '../db.js';
-import { main, parseBook, normalizeName, matchPower, joinFragment } from '../scripts/uplift-power-rules-text.js';
+import { main, parseBook, normalizeName, matchPower, joinFragment, composeRulesText } from '../scripts/uplift-power-rules-text.js';
 
 const TEST_FLAG = { _test_992: true };
 
@@ -59,9 +59,17 @@ this must resolve to ambiguous (rank mismatch), never a guess.
 
 Fixture Errata Gamma •••
 
-Base-book flavour for Gamma, which the errata fixture below overrides.
+Base-book flavour for Gamma, which the errata fixture below appends to (not replaces).
 
 **Cost:** 2 Vitae
+
+Fixture Auspex Zeta •
+
+Book flavour for Zeta, an Auspex-parented power that must be skipped entirely —
+
+no match, no write — regardless of how cleanly it would otherwise resolve.
+
+**Cost:** 1 Vitae
 `;
 
 const FIXTURE_ERRATA_MD = `
@@ -69,9 +77,15 @@ Errata Preamble
 
 Fixture Errata Gamma (•••)
 
-**Clarification:** Errata-corrected text for Gamma supersedes the book version.
+**Clarification:** Errata-corrected addendum for Gamma.
 
 **Cost:** 1 Vitae (errata correction)
+
+Fixture Auspex Zeta (•)
+
+**Clarification:** Errata text for Zeta — must still be skipped since DB parent is Auspex,
+
+even though this errata block would otherwise resolve cleanly (2026-07-15 revision).
 `;
 
 function seedPowers() {
@@ -120,6 +134,24 @@ function seedPowers() {
       rank: 3,
       parent: 'TestDiscipline',
       description: 'Gamma one-line summary.',
+    },
+    {
+      ...TEST_FLAG,
+      key: 'test-fixture-auspex-zeta',
+      name: 'Fixture Auspex Zeta',
+      category: 'discipline',
+      rank: 1,
+      parent: 'Auspex', // exact DB casing
+      description: 'Zeta one-line summary (Auspex — excluded).',
+    },
+    {
+      ...TEST_FLAG,
+      key: 'test-fixture-auspex-eta',
+      name: 'Fixture Auspex Eta',
+      category: 'discipline',
+      rank: 1,
+      parent: 'AUSPEX', // different casing — exclusion is case-insensitive
+      description: 'Eta one-line summary (Auspex, uppercase parent — excluded).',
     },
   ];
 }
@@ -233,10 +265,61 @@ describe('#992 — main() dry-run', () => {
     const unmatchedKeys = report.unmatched.map(u => u.key);
     expect(unmatchedKeys).toContain('test-fixture-unmatched-delta');
 
+    // Auspex exclusion: Zeta is skipped entirely, not matched/ambiguous/unmatched.
+    expect(byKey['test-fixture-auspex-zeta']).toBeUndefined();
+    expect(ambiguousKeys).not.toContain('test-fixture-auspex-zeta');
+    expect(unmatchedKeys).not.toContain('test-fixture-auspex-zeta');
+    const skippedAuspexKeys = report.skipped_auspex.map(s => s.key);
+    expect(skippedAuspexKeys).toContain('test-fixture-auspex-zeta');
+    // Case-insensitive: parent 'AUSPEX' (uppercase) is excluded exactly the
+    // same as parent 'Auspex' — no markdown match required either, since
+    // exclusion happens before matchPower runs.
+    expect(skippedAuspexKeys).toContain('test-fixture-auspex-eta');
+    expect(report.totals.skipped_auspex).toBe(2);
+    expect(report.by_category.discipline.skipped_auspex).toBe(2);
+
+    // Errata append (not replace): rules_text carries BOTH book and errata text.
+    expect(byKey['test-fixture-errata-gamma'].preview).toMatch(/Base-book flavour for Gamma/);
+
     // Cost side-artifact: every matched power with a Cost line is present.
+    // No cost fields are ever written to the DB — report-only (GDX-6 reuse).
     const costsByKey = Object.fromEntries(result.costArtifact.map(c => [c.key, c.cost_raw]));
     expect(costsByKey['test-fixture-power-alpha']).toBe('1 Vitae');
-    expect(costsByKey['test-fixture-errata-gamma']).toBe('1 Vitae (errata correction)'); // errata wins, not book's "2 Vitae"
+    expect(costsByKey['test-fixture-errata-gamma']).toBe('1 Vitae (errata correction)'); // errata's Cost line still wins for the cost artifact
+    expect(costsByKey['test-fixture-auspex-zeta']).toBeUndefined(); // skipped before cost extraction runs
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Errata composition — append, not replace (2026-07-15 revision)
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#992 — composeRulesText (errata append)', () => {
+  it('appends the errata section after the full book text, delimited, when both exist', () => {
+    const bookBlock = { book: 'Fixture Book', rulesText: 'Book flavour text.\n\n**Cost:** 2 Vitae' };
+    const errataBlock = { book: 'Fixture Errata', rulesText: '**Clarification:** Errata addendum.\n\n**Cost:** 1 Vitae (errata correction)' };
+    const combined = composeRulesText(bookBlock, errataBlock);
+
+    // Book text is preserved in full, unmodified, first.
+    expect(combined.startsWith('Book flavour text.\n\n**Cost:** 2 Vitae')).toBe(true);
+    // Followed by a clear delimiter and a labelled errata section.
+    expect(combined).toMatch(/\n\n---\n\*\*Fixture Errata:\*\*\n/);
+    expect(combined).toMatch(/Errata addendum\./);
+    // The book's own (now-superseded) Cost line is still present — this is an
+    // append, not a replace; readers see both and the errata section is the
+    // clearly-marked authoritative correction.
+    expect(combined).toMatch(/\*\*Cost:\*\* 2 Vitae/);
+    expect(combined).toMatch(/\*\*Cost:\*\* 1 Vitae \(errata correction\)/);
+  });
+
+  it('errata-only match (no book block) keeps the errata text as the whole rules_text, unchanged', () => {
+    const errataBlock = { book: 'Fixture Errata', rulesText: 'Errata-only power text.' };
+    expect(composeRulesText(null, errataBlock)).toBe('Errata-only power text.');
+  });
+
+  it('book-only match (no errata) is untouched — just the book text', () => {
+    const bookBlock = { book: 'Fixture Book', rulesText: 'Book-only power text.' };
+    expect(composeRulesText(bookBlock, null)).toBe('Book-only power text.');
   });
 });
 
@@ -272,11 +355,16 @@ describe('#992 — main() apply', () => {
     expect(beta.description).toBe(beforeByKey['test-fixture-manoeuvre-beta'].description);
     expect(beta.rules_text).toMatch(/Body text for the manoeuvre style/);
 
-    // Errata precedence: rules_text is the ERRATA content, not the book's.
+    // Errata APPEND (2026-07-15 revision): rules_text carries the FULL book
+    // text followed by a clearly delimited errata section — not a replace.
     const gamma = afterByKey['test-fixture-errata-gamma'];
     expect(gamma.description).toBe(beforeByKey['test-fixture-errata-gamma'].description);
-    expect(gamma.rules_text).toMatch(/Errata-corrected text for Gamma/);
-    expect(gamma.rules_text).not.toMatch(/Base-book flavour for Gamma/);
+    expect(gamma.rules_text).toMatch(/Base-book flavour for Gamma/); // book text preserved
+    expect(gamma.rules_text).toMatch(/Errata-corrected addendum for Gamma/); // errata appended
+    expect(gamma.rules_text).toMatch(/\n\n---\n\*\*Fixture Errata:\*\*\n/); // delimiter + label
+    // Book text comes first, errata section after — order matters for readers.
+    expect(gamma.rules_text.indexOf('Base-book flavour for Gamma'))
+      .toBeLessThan(gamma.rules_text.indexOf('Errata-corrected addendum for Gamma'));
     expect(gamma.rules_source).toBe('Fixture Book + Fixture Errata');
 
     // ── Unmatched / ambiguous docs: completely untouched ──
@@ -287,6 +375,14 @@ describe('#992 — main() apply', () => {
     const epsilon = afterByKey['test-fixture-mismatch-epsilon'];
     expect(epsilon).toEqual(beforeByKey['test-fixture-mismatch-epsilon']);
     expect(epsilon.rules_text).toBeUndefined();
+
+    // ── Auspex exclusion: Zeta is completely untouched despite having both a
+    // clean book match AND a clean errata match — parent === 'Auspex' skips
+    // it before matchPower ever runs.
+    const zeta = afterByKey['test-fixture-auspex-zeta'];
+    expect(zeta).toEqual(beforeByKey['test-fixture-auspex-zeta']);
+    expect(zeta.rules_text).toBeUndefined();
+    expect(zeta.rules_source).toBeUndefined();
 
     // ── Only rules_text/rules_source changed — nothing else on matched docs ──
     for (const key of ['test-fixture-power-alpha', 'test-fixture-manoeuvre-beta', 'test-fixture-errata-gamma']) {

--- a/server/tests/issue-992-uplift-rules-text.test.js
+++ b/server/tests/issue-992-uplift-rules-text.test.js
@@ -1,0 +1,312 @@
+/**
+ * Issue #992 — integration test for uplift-power-rules-text.js `main()`
+ * end-to-end, dry-run AND apply, against a seeded test collection.
+ *
+ * Per `feedback_script_integration_test`: a data-mutating script needs at
+ * least one test calling main() end-to-end (not just unit tests on the pure
+ * parser helpers) — the #813 incident (find+projection+replaceOne wiping 13
+ * character docs) was caused by a write-path bug that helper-level unit
+ * tests never exercised.
+ *
+ * Uses a fixture markdown "book" (string written to a temp dir) rather than
+ * the real `markdown/` corpus, and throwaway reports/backups dirs — never
+ * the real `server/scripts/reports/` (which holds the committed AC9 live
+ * dry-run report) or `server/scripts/backups/`.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { setupDb, teardownDb } from './helpers/db-setup.js';
+import { getCollection } from '../db.js';
+import { main, parseBook, normalizeName, matchPower, joinFragment } from '../scripts/uplift-power-rules-text.js';
+
+const TEST_FLAG = { _test_992: true };
+
+// A fixture "book" covering: plain trailing-dot heading (discipline-style),
+// bold parens-colon heading (manoeuvre-style), a rank-mismatch heading, and
+// a base version of a power that's overridden by the errata fixture below.
+const FIXTURE_BOOK_MD = `
+Some Book Chapter Intro
+
+This paragraph is book intro prose before any heading and must be discarded,
+not attached to any block.
+
+Fixture Power Alpha •
+
+This is the flavour text for Alpha, explaining what it does in the
+
+fiction before the mechanics.
+
+**Cost:** 1 Vitae
+
+**Dice Pool:** Wits + Composure
+
+**Action:** Instant
+
+Fixture Manoeuvre Beta (••)
+
+Body text for the manoeuvre style, wrapped across two
+
+physical lines describing what Beta accomplishes in a fight.
+
+Fixture Mismatch Epsilon •
+
+Heading dots say rank 1, but the DB doc below will claim rank 5 —
+
+this must resolve to ambiguous (rank mismatch), never a guess.
+
+Fixture Errata Gamma •••
+
+Base-book flavour for Gamma, which the errata fixture below overrides.
+
+**Cost:** 2 Vitae
+`;
+
+const FIXTURE_ERRATA_MD = `
+Errata Preamble
+
+Fixture Errata Gamma (•••)
+
+**Clarification:** Errata-corrected text for Gamma supersedes the book version.
+
+**Cost:** 1 Vitae (errata correction)
+`;
+
+function seedPowers() {
+  return [
+    {
+      ...TEST_FLAG,
+      key: 'test-fixture-power-alpha',
+      name: 'Fixture Power Alpha',
+      category: 'discipline',
+      rank: 1,
+      parent: 'TestDiscipline',
+      description: 'Alpha one-line summary.',
+    },
+    {
+      ...TEST_FLAG,
+      key: 'test-fixture-manoeuvre-beta',
+      name: 'Fixture Manoeuvre Beta',
+      category: 'manoeuvre',
+      rank: 2,
+      parent: 'Test Style',
+      description: 'Beta one-line summary.',
+    },
+    {
+      ...TEST_FLAG,
+      key: 'test-fixture-unmatched-delta',
+      name: 'Fixture Unmatched Delta',
+      category: 'merit',
+      rank: null,
+      parent: 'Kindred',
+      description: 'Delta has no markdown counterpart.',
+    },
+    {
+      ...TEST_FLAG,
+      key: 'test-fixture-mismatch-epsilon',
+      name: 'Fixture Mismatch Epsilon',
+      category: 'discipline',
+      rank: 5,
+      parent: 'TestDiscipline',
+      description: 'Epsilon rank mismatch summary.',
+    },
+    {
+      ...TEST_FLAG,
+      key: 'test-fixture-errata-gamma',
+      name: 'Fixture Errata Gamma',
+      category: 'discipline',
+      rank: 3,
+      parent: 'TestDiscipline',
+      description: 'Gamma one-line summary.',
+    },
+  ];
+}
+
+let tmpDir;
+let tmpReportsDir;
+let tmpBackupsDir;
+let overrides;
+
+beforeAll(async () => {
+  await setupDb();
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-992-fixture-'));
+  fs.writeFileSync(path.join(tmpDir, 'fixture-book.md'), FIXTURE_BOOK_MD);
+  fs.writeFileSync(path.join(tmpDir, 'fixture-errata.md'), FIXTURE_ERRATA_MD);
+  tmpReportsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-992-reports-'));
+  tmpBackupsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tm-992-backups-'));
+
+  overrides = {
+    markdownDir: tmpDir,
+    books: [
+      { file: 'fixture-book.md', label: 'Fixture Book', isErrata: false },
+      { file: 'fixture-errata.md', label: 'Fixture Errata', isErrata: true },
+    ],
+    reportsDir: tmpReportsDir,
+    backupsDir: tmpBackupsDir,
+    query: TEST_FLAG,
+  };
+
+  await getCollection('purchasable_powers').deleteMany(TEST_FLAG);
+});
+
+afterAll(async () => {
+  await getCollection('purchasable_powers').deleteMany(TEST_FLAG);
+  await teardownDb();
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  fs.rmSync(tmpReportsDir, { recursive: true, force: true });
+  fs.rmSync(tmpBackupsDir, { recursive: true, force: true });
+});
+
+beforeEach(async () => {
+  await getCollection('purchasable_powers').deleteMany(TEST_FLAG);
+  await getCollection('purchasable_powers').insertMany(seedPowers());
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Pure helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#992 — pure parser helpers', () => {
+  it('normalizeName strips case/punctuation/diacritics and leading "the "', () => {
+    expect(normalizeName('The Spirit’s Touch')).toBe("spirit's touch");
+    expect(normalizeName('René')).toBe('rene');
+    expect(normalizeName('  Cover   the Angles ')).toBe('cover the angles');
+  });
+
+  it('joinFragment repairs PDF hyphenation and otherwise space-joins', () => {
+    expect(joinFragment('modi-', 'fier')).toBe('modifier');
+    expect(joinFragment('Intelligence +', 'Academics')).toBe('Intelligence + Academics');
+    expect(joinFragment('', 'first')).toBe('first');
+  });
+
+  it('parseBook segments both heading styles and captures structured sections', () => {
+    const blocks = parseBook(FIXTURE_BOOK_MD, { file: 'fixture-book.md', label: 'Fixture Book', isErrata: false });
+    const alpha = blocks.find(b => b.normName === 'fixture power alpha');
+    expect(alpha).toBeTruthy();
+    expect(alpha.dots).toBe(1);
+    expect(alpha.flavour).toMatch(/flavour text for Alpha/);
+    expect(alpha.sections.find(s => s.label === 'Cost').text).toBe('1 Vitae');
+    expect(alpha.sections.find(s => s.label === 'Dice Pool').text).toBe('Wits + Composure');
+
+    const beta = blocks.find(b => b.normName === 'fixture manoeuvre beta');
+    expect(beta).toBeTruthy();
+    expect(beta.dots).toBe(2);
+    expect(beta.flavour).toMatch(/Body text for the manoeuvre style/);
+
+    // Book intro prose before the first heading is discarded, not attached.
+    expect(blocks.every(b => !b.flavour.includes('must be discarded'))).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// main() — DRY RUN
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#992 — main() dry-run', () => {
+  it('writes nothing to the DB and produces report + cost artifact files', async () => {
+    const col = getCollection('purchasable_powers');
+    const before = await col.find(TEST_FLAG).toArray();
+
+    const result = await main({ ...overrides, apply: false });
+
+    const after = await col.find(TEST_FLAG).toArray();
+    expect(after).toEqual(before); // zero writes in dry-run
+
+    expect(fs.existsSync(result.reportJsonPath)).toBe(true);
+    expect(fs.existsSync(result.reportMdPath)).toBe(true);
+    expect(fs.existsSync(result.costsPath)).toBe(true);
+    expect(fs.existsSync(tmpBackupsDir)).toBe(true);
+    expect(fs.readdirSync(tmpBackupsDir)).toHaveLength(0); // no backup in dry-run
+
+    const report = JSON.parse(fs.readFileSync(result.reportJsonPath, 'utf8'));
+    const byKey = Object.fromEntries(report.matches.map(m => [m.key, m]));
+    expect(byKey['test-fixture-power-alpha']).toBeTruthy();
+    expect(byKey['test-fixture-power-alpha'].source).toBe('Fixture Book');
+    expect(byKey['test-fixture-manoeuvre-beta']).toBeTruthy();
+    expect(byKey['test-fixture-errata-gamma'].source).toBe('Fixture Book + Fixture Errata');
+
+    const ambiguousKeys = report.ambiguous.map(a => a.key);
+    expect(ambiguousKeys).toContain('test-fixture-mismatch-epsilon');
+
+    const unmatchedKeys = report.unmatched.map(u => u.key);
+    expect(unmatchedKeys).toContain('test-fixture-unmatched-delta');
+
+    // Cost side-artifact: every matched power with a Cost line is present.
+    const costsByKey = Object.fromEntries(result.costArtifact.map(c => [c.key, c.cost_raw]));
+    expect(costsByKey['test-fixture-power-alpha']).toBe('1 Vitae');
+    expect(costsByKey['test-fixture-errata-gamma']).toBe('1 Vitae (errata correction)'); // errata wins, not book's "2 Vitae"
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// main() — APPLY
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('#992 — main() apply', () => {
+  it('writes rules_text/rules_source via updateOne($set) only, leaves description and unmatched docs untouched, and backs up first', async () => {
+    const col = getCollection('purchasable_powers');
+    const beforeDocs = await col.find(TEST_FLAG).toArray();
+    const beforeByKey = Object.fromEntries(beforeDocs.map(d => [d.key, d]));
+
+    const result = await main({ ...overrides, apply: true });
+
+    // Backup exported before any write.
+    expect(result.backupPath).toBeTruthy();
+    expect(fs.existsSync(result.backupPath)).toBe(true);
+    const backupDocs = JSON.parse(fs.readFileSync(result.backupPath, 'utf8'));
+    expect(backupDocs.some(d => d.key === 'test-fixture-power-alpha')).toBe(true);
+
+    const afterDocs = await col.find(TEST_FLAG).toArray();
+    const afterByKey = Object.fromEntries(afterDocs.map(d => [d.key, d]));
+
+    // ── Matched docs: rules_text/rules_source set, description untouched ──
+    const alpha = afterByKey['test-fixture-power-alpha'];
+    expect(alpha.description).toBe(beforeByKey['test-fixture-power-alpha'].description);
+    expect(alpha.rules_text).toMatch(/flavour text for Alpha/);
+    expect(alpha.rules_text).toMatch(/\*\*Cost:\*\* 1 Vitae/);
+    expect(alpha.rules_source).toBe('Fixture Book');
+
+    const beta = afterByKey['test-fixture-manoeuvre-beta'];
+    expect(beta.description).toBe(beforeByKey['test-fixture-manoeuvre-beta'].description);
+    expect(beta.rules_text).toMatch(/Body text for the manoeuvre style/);
+
+    // Errata precedence: rules_text is the ERRATA content, not the book's.
+    const gamma = afterByKey['test-fixture-errata-gamma'];
+    expect(gamma.description).toBe(beforeByKey['test-fixture-errata-gamma'].description);
+    expect(gamma.rules_text).toMatch(/Errata-corrected text for Gamma/);
+    expect(gamma.rules_text).not.toMatch(/Base-book flavour for Gamma/);
+    expect(gamma.rules_source).toBe('Fixture Book + Fixture Errata');
+
+    // ── Unmatched / ambiguous docs: completely untouched ──
+    const delta = afterByKey['test-fixture-unmatched-delta'];
+    expect(delta).toEqual(beforeByKey['test-fixture-unmatched-delta']);
+    expect(delta.rules_text).toBeUndefined();
+
+    const epsilon = afterByKey['test-fixture-mismatch-epsilon'];
+    expect(epsilon).toEqual(beforeByKey['test-fixture-mismatch-epsilon']);
+    expect(epsilon.rules_text).toBeUndefined();
+
+    // ── Only rules_text/rules_source changed — nothing else on matched docs ──
+    for (const key of ['test-fixture-power-alpha', 'test-fixture-manoeuvre-beta', 'test-fixture-errata-gamma']) {
+      const b = beforeByKey[key];
+      const a = afterByKey[key];
+      const { rules_text: _rt, rules_source: _rs, ...aRest } = a;
+      expect(aRest).toEqual(b);
+    }
+  });
+
+  it('idempotent-ish: matchPower resolves rank mismatch as ambiguous, never guesses', () => {
+    const blocks = parseBook(FIXTURE_BOOK_MD, { file: 'fixture-book.md', label: 'Fixture Book', isErrata: false });
+    const byNormName = new Map();
+    for (const b of blocks) {
+      if (!byNormName.has(b.normName)) byNormName.set(b.normName, []);
+      byNormName.get(b.normName).push(b);
+    }
+    const power = { name: 'Fixture Mismatch Epsilon', rank: 5, rating_range: null };
+    const m = matchPower(power, byNormName);
+    expect(m.status).toBe('ambiguous');
+    expect(m.reason).toBe('rank_mismatch');
+  });
+});

--- a/specs/stories/992-power-rules-text-uplift.story.md
+++ b/specs/stories/992-power-rules-text-uplift.story.md
@@ -1,0 +1,82 @@
+---
+issue: 992
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/992
+branch: piatra/issue-992-power-rules-text-uplift
+---
+
+# Story 992: Uplift power rules text from markdown rulebooks into `purchasable_powers.rules_text`
+
+**Story ID:** feat.992
+**Status:** Draft
+**Date:** 2026-07-14
+**Issue:** [#992](https://github.com/angelusvmorningstar/TerraMortis/issues/992)
+**Branch:** `piatra/issue-992-power-rules-text-uplift`
+
+---
+
+## User Story
+
+As the ST maintaining the rules engine,
+I want the full rulebook text for every power stored alongside its one-line summary,
+so that players and STs can read complete, errata-corrected rules in-app instead of opening PDFs.
+
+---
+
+## Background
+
+- Source books live in `markdown/` (repo root): `Vampire the Requiem 2e Rulebook.md` (651KB), `Chronicles of Darkness Rulebook.md` (554KB), `Hurt Locker.md` (295KB, manoeuvres), `Secrets of the Covenants.md` (135KB), `Blood Sorcery- New Rules.md`, `Damnation City Model - New Rules.md`, `Blood Sorcery Themes and Motifs.md`, plus errata: `Terra Mortis - Errata Master.md` (61KB) and `Auspex Errata.md` (8KB). `Terra Mortis Treatment.md` is campaign fiction — exclude.
+- The markdown is PDF-extracted: **every wrapped line is followed by a blank line**. Normalise by joining consecutive non-blank-separated fragments into paragraphs before parsing (a "paragraph" ends where a structural marker begins, not at the double newline).
+- Power heading formats observed:
+  - `Feral Whispers •` — plain name + dot glyphs on its own line (VtR disciplines; rulebook line 12302)
+  - `**Hamstring (•):** text...` — bolded name with parenthesised dots, body runs on (Hurt Locker manoeuvres, merit styles; e.g. line 10781)
+  - Expect variants per book; the parser must be tolerant and REPORT what it could not classify rather than guessing.
+- A power block runs from its heading to the next heading of equal kind, typically containing flavour paragraphs then structured lines: `**Cost:**`, `**Dice Pool:**`, `**Action:**`, `**Duration:**`, `**Roll Results**` with `**Dramatic Failure:**/**Failure:**/**Success:**/**Exceptional Success:**` subsections, sometimes `**Suggested Modifiers**`.
+- Target collection: `purchasable_powers`, 619 docs. Categories and counts: discipline 50, devotion 45, rite 132, manoeuvre 178, merit 181, skill 24, attribute 9. ALL categories in scope (skills/attributes will mostly match CofD rulebook chapters; low match rates there are acceptable and simply reported).
+- Doc shape: `{ key, name, category, parent, rank, rating_range, description, pool, resistance, cost, action, duration, prereq, ... }`. `description` is a one-line summary (median 46 chars) — **must not be modified**.
+- Schema: `server/schemas/purchasable_power.schema.js`. `description` at line 92. Add `rules_text` and `rules_source` near it.
+- Scripts using `../db.js` need `import 'dotenv/config'` as the FIRST import (`.env` lives at `server/.env`).
+- **Hard lesson encoded in this repo (2026-06-16, PR #813):** a find+projection+replaceOne pattern destroyed 13 character docs. This script must use `updateOne` with `$set` on exactly `{ rules_text, rules_source }` and nothing else, and must have an end-to-end integration test that runs its `main()` against a test collection.
+
+## Decisions (locked 2026-07-14, Peter)
+
+- **Option B**: `description` untouched; new `rules_text` (full text) + `rules_source` (provenance, e.g. `"VtR 2e Rulebook"` or `"VtR 2e Rulebook + TM Errata"`).
+- **All categories** in scope.
+- `--apply` against prod is **not run in this story**. Deliverable is the dry-run report for Peter's review; apply is a separate explicitly-authorised step.
+- Cost side-artifact: parsed `**Cost:**` strings are written to a JSON artifact for GDX-6 (#987) reuse; **no cost fields are written to the DB**.
+
+---
+
+## Acceptance Criteria
+
+- [ ] AC1: `rules_text: { type: 'string' }` and `rules_source: { type: 'string' }` added to `server/schemas/purchasable_power.schema.js` (optional fields; not added to `required`).
+- [ ] AC2: New script `server/scripts/uplift-power-rules-text.js` with `main()` export. Default mode is dry-run; writes nothing to the DB. `--apply` flag required for writes.
+- [ ] AC3: Dry-run produces a report file (`server/scripts/reports/992-uplift-report.json` + human-readable `.md` summary) with per-category counts: matched, unmatched-in-db (power in DB, no markdown found), ambiguous (multiple candidate blocks), and per-match `{ key, name, source, before_len, after_len, preview }`.
+- [ ] AC4: Matching is by normalised name (case/punctuation/diacritic-insensitive), sanity-checked against `rank` (dot count in heading, where present). Rank mismatch → ambiguous, not matched.
+- [ ] AC5: Errata precedence — when a power appears in an errata file AND a book, the errata text is used and `rules_source` records both.
+- [ ] AC6: Apply mode: (a) exports a full-collection backup JSON to `server/scripts/backups/` before any write; (b) writes via `updateOne({ _id }, { $set: { rules_text, rules_source } })` only; (c) skips docs whose parsed text is empty; (d) prints written/skipped counts.
+- [ ] AC7: Vitest integration test runs `main()` end-to-end against a seeded test collection (both dry-run and apply paths), asserting: `description` unchanged, `rules_text`/`rules_source` set on matched docs, unmatched docs untouched, backup file created in apply mode.
+- [ ] AC8: Cost side-artifact `server/scripts/reports/992-costs-extract.json`: `[{ key, name, cost_raw }]` for every matched power with a `**Cost:**` line.
+- [ ] AC9: Dry-run executed against the live DB (read-only) and the report committed for review.
+
+---
+
+## Design notes for the dev agent
+
+- Parser pipeline: read book → normalise wrap (join `line\n\nline` fragments into paragraphs; a heading line stays its own unit) → segment into power blocks by heading regex set → for each block capture `{ name, dots, flavour, sections: { cost, dice_pool, action, duration, roll_results, modifiers } }` → serialise `rules_text` as clean markdown (flavour paragraphs + `**Cost:** ...` etc. lines, single-spaced).
+- Keep per-book heading regexes in a declarative table `{ book, file, patterns[] }` so new books are additive.
+- Name normalisation: lowercase, strip diacritics (René), collapse whitespace, strip leading "the ". DB `name` is the join key; report collisions.
+- Do NOT attempt fuzzy matching beyond normalisation in this story — unmatched is a reportable outcome, not a failure.
+- Test DB pattern: follow `server/tests/helpers/db-setup.js` usage as in existing script tests; seed a handful of fake powers + a small fixture markdown string.
+- Only stage/commit files belonging to this story (new script, schema edit, test, reports). The working tree contains unrelated uncommitted specs — leave them alone.
+
+## Test Plan
+
+1. Unit-ish: parser on a fixture markdown covering both heading styles + errata override.
+2. Integration: `main()` dry-run + apply against seeded test collection (AC7).
+3. Live dry-run: run against Atlas read-only, commit the report (AC9).
+
+## Dev Notes
+
+- Do not push, open a PR, or merge — SM handles the git ceremony after verification.
+- Never run `--apply` against the live DB in this story.
+- Run tests: `cd server && npx vitest run tests/issue-992-uplift-rules-text.test.js`.

--- a/specs/stories/994-rules-text-display.story.md
+++ b/specs/stories/994-rules-text-display.story.md
@@ -1,0 +1,71 @@
+---
+issue: 994
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/994
+branch: piatra/issue-994-rules-text-display
+---
+
+# Story 994: Display power `rules_text` in sheet drawers and dice modal
+
+**Story ID:** feat.994
+**Status:** Draft
+**Date:** 2026-07-15
+**Issue:** [#994](https://github.com/angelusvmorningstar/TerraMortis/issues/994)
+**Branch:** `piatra/issue-994-rules-text-display`
+
+---
+
+## User Story
+
+As a player on game day,
+I want to expand a power's full, errata-corrected rules right where the power is shown (sheet drawer, dice modal),
+so that I never have to open a PDF mid-scene.
+
+---
+
+## Background
+
+- #992 (merged, PR #993) added `rules_text` (full rulebook text, markdown-lite) and `rules_source` (provenance, e.g. "VtR 2e Rulebook + TM Errata") to 312 of 619 `purchasable_powers` docs in prod.
+- `/api/rules` (`server/routes/rules.js:27,43`) has **no projection** — full docs already flow to the client and into the `tm_rules_db` localStorage cache via `public/js/data/loader.js`. **No server change needed.** (Payload grows ~600-700KB; acceptable, note in PR.)
+- `rules_text` format: paragraphs separated by blank lines; `**bold**` markers (`**Cost:**`, `**Dice Pool:**`, `**Dramatic Failure:**` etc.); optionally a `---` line followed by `**TM Errata:**` section. No other markdown.
+- Display sites (verified):
+  1. **Suite sheet Powers section** — `public/js/suite/sheet.js` builds `powersHtml` (~:517-739); power rows/drawers show the one-line desc. Find where each discipline power / devotion / rite row renders its expandable body.
+  2. **Editor/legacy sheet drawers** — `public/js/editor/sheet.js`: rules-db map built at `:55` (`db[name] = { desc: r.description, ... }`); drawer bodies render `db.desc` at ~`:783` and ~`:2402`. The `:55` map must also carry `rules_text`/`rules_source`.
+  3. **Dice modal** — `public/js/suite/dice-modal.js` `#dm-pool-info` populated ~`:296-321` (shows pool breakdown + cost line).
+- CSS: tokens in `public/css/theme.css`; reuse existing drawer/expander component classes (`components.css`, `suite.css` — see `.disc-tap-row`/`.disc-drawer` pattern). NO bare hex, NO inline `style=`.
+- British English. No em-dashes in UI copy.
+
+---
+
+## Acceptance Criteria
+
+- [ ] AC1: A shared helper (suggest `public/js/shared/rules-text.js`) exports `renderRulesText(rulesText, rulesSource)` returning safe HTML: escape ALL input first (use existing `esc` helper), then transform exactly three markers — `**...**` → `<strong>`, blank-line paragraph breaks → `<p>`/`<br>`, a line consisting of `---` → `<hr>`-equivalent (tokenised class). Muted provenance line from `rules_source` at the end.
+- [ ] AC2: Suite sheet Powers section — every power row whose rules doc has non-empty `rules_text` gets a collapsed "Full rules" expander inside its drawer; tapping toggles it. Powers without `rules_text` render exactly as today.
+- [ ] AC3: Editor sheet drawers (both `:783`-area and `:2402`-area render paths) — same expander, same helper.
+- [ ] AC4: Dice modal — when the seeded pool has a matching rules doc with `rules_text`, `#dm-pool-info` gains a collapsed "Rules" expander beneath the cost line. Rolling is unaffected.
+- [ ] AC5: XSS-safe — a `rules_text` containing `<script>` or `<img onerror=...>` renders inert (test with a poisoned fixture).
+- [ ] AC6: Usable at 360px — expanded text wraps, scrolls vertically within the drawer if long, never causes horizontal page overflow.
+- [ ] AC7: All styling via theme tokens / existing classes; enforcement grep clean (no bare hex, no inline styles).
+- [ ] AC8: No server/schema changes; no admin-surface changes; edit-mode entry (stripOverlay path) untouched.
+
+## Design notes
+
+- Match key: the rules cache is keyed by name/key depending on site — editor/sheet.js keys `db` by `r.name.toLowerCase()` (`:55`); suite sheet + dice modal resolve powers via `powersForDisc`/`getPool` — pass the rules doc (or its `rules_text`) through the existing lookups rather than re-querying.
+- Lazy render is fine (build expander HTML on first toggle) but not required — 2-4KB strings are cheap.
+- Keep the expander label small-caps muted per existing drawer affordances; reuse an existing chevron/toggle class if one exists rather than inventing one.
+- The `**TM Errata:**` section after the `<hr>` should read as visually distinct via the hr + bold label only — no special colour needed.
+
+## Test Plan
+
+No test framework for client JS — browser smoke (per repo convention) + the AC5 poisoned-fixture check via a temporary console harness:
+1. Boot suite locally (`npx http-server public -p 8080` + `cd server && npm run dev`), pick a character with Animalism (Feral Whispers = book-only) and one with an errata-append power (Raise the Familiar).
+2. Sheet Powers drawer: expander present, toggles, renders bold/paragraphs/hr, provenance line shows.
+3. Power without rules_text (any Auspex power, any devotion): no expander, renders as today.
+4. Dice modal from a discipline row: Rules expander present and collapsed by default.
+5. 360px viewport: no horizontal overflow with the longest matched power.
+6. AC5: temporarily stub a poisoned rules_text in console; verify inert.
+7. Listener-routing check (repo blind spot): verify the toggle works via an actual click in-browser, not just code review — click handlers registered inside `change` listeners silently no-op.
+
+## Dev Notes
+
+- Do not push/PR/merge/commit — SM handles git after verification.
+- Unrelated uncommitted specs exist in the working tree — do not stage or modify them.


### PR DESCRIPTION
## Summary
- #992 / PR #993: `rules_text` + `rules_source` uplift infrastructure (parser, schema fields, tests). Data already applied to prod 2026-07-15, verified non-destructive (312/619 docs, zero changes outside the two new fields).
- #994 / PR #995: expandable 'Full rules' display in sheet drawers (powers, merits, pacts) and dice modal. XSS-safe renderer, token-only CSS, 360px verified, Peter's live smoke passed.

## Deploy notes
Frontend-only behavioural change (Netlify); API change is additive schema fields only (Render). No migration required at deploy time — prod data already in place.