### PR TITLE
fix(#997): collapse status ranking panel into phone drawer

### DIFF
--- a/public/css/suite.css
+++ b/public/css/suite.css
@@ -2246,6 +2246,27 @@ body.desktop-mode.sidebar-collapsed .sb-collapse-btn { width: 100%; justify-cont
 .status-section-title{font-size:15px;}
 .status-col-head{font-size:15px;}
 
+/* ── #997 Phone drawer for the clan/covenant ranking panel ──
+ * The ranking panel is tall and dominates the phone status tab. Collapse it into a
+ * drawer that is hidden by default ≤599px and toggled by tapping the summary pips row
+ * (which gains a chevron affordance). Desktop (≥600px) is unchanged — the slot always
+ * shows and the toggle chrome is hidden. */
+.status-summary--toggle{cursor:pointer;-webkit-tap-highlight-color:transparent;}
+.status-ranking-drawer-toggle{display:none;width:auto;margin:8px 14px 0;padding:6px 0;}
+@media (max-width: 599px){
+  #status-ranking-slot{display:none;}
+  #status-ranking-slot.open{display:block;}
+  .status-summary--toggle{position:relative;}
+  .status-summary--toggle::after{
+    content:'\203A';
+    position:absolute;top:50%;right:14px;transform:translateY(-50%);
+    font-size:16px;line-height:1;color:var(--txt3);
+    transition:transform .15s;pointer-events:none;
+  }
+  .status-summary--toggle.open::after{transform:translateY(-50%) rotate(90deg);}
+  .status-ranking-drawer-toggle{display:flex;}
+}
+
 /* ── #624 Clan/Covenant ranking ballot ── */
 .status-ranking-section {
   margin: 8px 14px;

--- a/public/js/suite/status.js
+++ b/public/js/suite/status.js
@@ -432,6 +432,49 @@ export async function renderSuiteStatusTab(el) {
 
   // #624: clan/covenant ranking (player ballot / ST aggregate) — shared with tabs/status-tab.js
   await appendRankingSection(el.querySelector('#status-ranking-slot'), { chars, activeChar, isST });
+  // #997: on phone the ranking panel is a collapsed drawer toggled by the summary row
+  wireRankingDrawer(el);
   // #691: office actions public log (city status changes this session)
   appendOfficeActionsLog(el.querySelector('#office-log-slot'));
+}
+
+// #997: collapse the (tall) clan/covenant ranking panel into a phone drawer.
+// Collapsed-by-default and toggled by tapping the top status-summary pips row; desktop
+// is unchanged (CSS only hides the slot ≤599px). When no summary row renders (ST with no
+// active character), a fallback toggle header is injected so the drawer is still usable.
+function wireRankingDrawer(el) {
+  const slot = el.querySelector('#status-ranking-slot');
+  if (!slot || !slot.firstElementChild) return; // nothing rendered (no cycle / no char)
+
+  const summary = el.querySelector('.status-summary');
+  let toggleEl = summary;
+  if (summary) {
+    summary.classList.add('status-summary--toggle');
+    summary.setAttribute('role', 'button');
+    summary.setAttribute('tabindex', '0');
+  } else {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'rules-expander-toggle status-ranking-drawer-toggle';
+    btn.innerHTML = '<span class="rules-expander-arr">›</span><span>Clan &amp; Covenant Ranking</span>';
+    slot.parentNode.insertBefore(btn, slot);
+    toggleEl = btn;
+  }
+  toggleEl.setAttribute('aria-controls', 'status-ranking-slot');
+
+  const isOpen = () => slot.classList.contains('open');
+  const setOpen = (open) => {
+    slot.classList.toggle('open', open);
+    toggleEl.classList.toggle('open', open);
+    toggleEl.setAttribute('aria-expanded', String(open));
+  };
+  // Desktop (≥600px) always shows the panel; phone starts collapsed.
+  setOpen(window.matchMedia('(min-width: 600px)').matches);
+
+  toggleEl.addEventListener('click', () => setOpen(!isOpen()));
+  if (summary) {
+    summary.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setOpen(!isOpen()); }
+    });
+  }
 }


### PR DESCRIPTION
## Summary
Fixes #997. On phone (≤599px) the Status tab's Clan & Covenant Ranking panel dominates the screen, pushing the status pips + carousel out of view. This wraps the panel (`#status-ranking-slot`) in a drawer that is **collapsed by default on phone** and toggled by tapping the top status-summary pips row. Desktop/tablet (≥600px) is unchanged.

## Changes
- `public/js/suite/status.js` — new `wireRankingDrawer(el)` helper, called after `appendRankingSection` populates the slot. Adds a real `click` handler (not inside a change listener — repo blind spot) + `keydown` (Enter/Space) on the summary row, sets `role=button` / `tabindex` / `aria-controls` / `aria-expanded`. Fallback: when no summary row renders (ST with no active character), injects a toggle header reusing `.rules-expander-toggle`.
- `public/css/suite.css` — token-only drawer CSS. `#status-ranking-slot` hidden ≤599px unless `.open`; summary row gains a rotating chevron affordance via `::after`; fallback toggle hidden on desktop. No bare hex / inline styles.

## Design decisions
- Desktop unchanged (per issue default recommendation) — CSS media query only, JS opens the drawer at ≥600px so `aria-expanded` stays truthful.
- Shared `public/js/tabs/status-ranking.js` **untouched**, so the legacy `tabs/status-tab.js` (dead `player.html`) path is unaffected. Wiring lives only in the live suite renderer.
- Reused `.rules-expander-toggle` / `.rules-expander-arr` (#994) for the fallback header rather than inventing chrome.

## Test plan / smoke
Playwright smoke against the real CSS at 360px + 1024px, exercising both panel variants (summary-row present and absent). 17/17 assertions pass:
- Phone: slot collapsed by default; chevron affordance present; tap expands; `aria-expanded` flips; ballot **Save** button visible + enabled when expanded; tap again collapses; Enter-key expands.
- Phone no-summary (ST): fallback toggle visible, slot collapsed, click expands, `aria-expanded=true`.
- Desktop: slot visible by default in both variants; fallback toggle hidden.

## Notes
Pure UI, no schema/API surprises encountered. PROCEED-WITH-NOTICE hotfix.
