### PR TITLE
fix(#1001): route game-phase readers through canonical isInGamePhase helper

### DIFF
--- a/public/js/admin/cycle-views.js
+++ b/public/js/admin/cycle-views.js
@@ -235,8 +235,13 @@ async function writePhase(cy, phaseOrNull) {
       throw new Error('Tracker reset failed: ' + err.message);
     }
   }
-  await apiPut('/api/downtime_cycles/' + cy._id, { game_phase: phaseOrNull });
+  // #1001: write the derived legacy `status` alongside game_phase so raw
+  // `status` readers (getActiveCycle, LIVE_STATUSES filters) stay consistent
+  // with the phase while legacy status-based readers still exist.
+  const status = deriveCycleStatus({ ...cy, game_phase: phaseOrNull });
+  await apiPut('/api/downtime_cycles/' + cy._id, { game_phase: phaseOrNull, status });
   cy.game_phase = phaseOrNull;
+  cy.status = status;
   return true;
 }
 

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -8,7 +8,7 @@ import { apiGet, apiPost, apiPut, apiDelete } from '../data/api.js';
 // editor's Add Equipment / Add Asset rows pre-fill acquired_cycle correctly.
 import state from '../data/state.js';
 import { parseDowntimeCSV } from '../downtime/parser.js';
-import { getCycles, getActiveCycle, createCycle, updateCycle, closeCycle, openGamePhase, getSubmissionsForCycle, upsertCycle, updateSubmission, mapRawToResponses, signoffPhase, setManualOpen, DTUX_PHASES } from '../downtime/db.js';
+import { getCycles, getActiveCycle, createCycle, updateCycle, closeCycle, openGamePhase, getSubmissionsForCycle, upsertCycle, updateSubmission, mapRawToResponses, signoffPhase, setManualOpen, isInGamePhase, DTUX_PHASES } from '../downtime/db.js';
 import { TERRITORY_DATA, AMBIENCE_FEEDING_TOLERANCE, AMBIENCE_ENTROPY, AMBIENCE_THRESHOLDS, AMBIENCE_MODS, FEEDING_TERRITORIES, FEED_METHODS as FEED_METHODS_DATA, MAINTENANCE_MERITS, normaliseSorceryTargets } from '../tabs/downtime-data.js';
 import { rollPool, showRollModal, parseDiceString } from '../downtime/roller.js';
 import { getAttrEffective as getAttrVal, getSkillObj, skDots, skTotal, skNineAgain, skSpecs, riteCost, skillAcqPoolStr } from '../data/accessors.js';
@@ -1241,7 +1241,7 @@ async function loadCycleById(cycleId) {
 
   const isPrep   = cycle.status === 'prep';
   const isActive = cycle.status === 'active';
-  const isGame   = cycle.status === 'game';
+  const isGame   = isInGamePhase(cycle); // #1001: game_phase wins over legacy status
   const isOpen   = cycle.status === 'open';
   const isClosed = cycle.status === 'closed';
   const isLive   = isPrep || isActive || isGame || isOpen;

--- a/public/js/downtime/db.js
+++ b/public/js/downtime/db.js
@@ -122,10 +122,21 @@ export async function setManualOpen(cycle, on, userId) {
   return cycle;
 }
 
-/** Get the cycle currently in game phase (status === 'game'). */
+/**
+ * Canonical test: is this cycle in game phase? (#1001)
+ * Resolves through deriveCycleStatus so manual game_phase (#708) wins over the
+ * legacy `status` field. Every "which cycle is live for the game" reader must go
+ * through this — reading raw `status === 'game'` misses game_phase divergence and
+ * broke feeding night (game_phase='game' while status still pointed elsewhere).
+ */
+export function isInGamePhase(cycle) {
+  return deriveCycleStatus(cycle) === 'game';
+}
+
+/** Get the cycle currently in game phase (game_phase wins over legacy status). */
 export async function getGamePhaseCycle() {
   const cycles = await getCycles();
-  return cycles.find(c => c.status === 'game') || null;
+  return cycles.find(isInGamePhase) || null;
 }
 
 // ── Submissions ─────────────────────────────────────────────────────────────

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -30,6 +30,8 @@ import { FAMILIES, kindByCode } from '../data/relationship-kinds.js';
 // other NPC-picker-driven UI under the suppression policy.
 import { charPicker, setCharPickerSources } from '../components/character-picker.js';
 import { isMinimalComplete, missingMinimumPieces } from '../data/dt-completeness.js';
+// #1001: canonical in-game-phase test (game_phase wins over legacy status)
+import { isInGamePhase } from '../downtime/db.js';
 // ECM-4 (#871): catalogue dropdown sources from the shared cache module
 // ECM-5 (#872) introduced. App boot in app.js calls loadCatalogue; we read
 // synchronously here at render time. getCatalogueEntry resolves a
@@ -1715,7 +1717,7 @@ function renderCycleGatePage() {
   }
   const label = esc(currentCycle.label || 'This cycle');
   const isPrep         = currentCycle.status === 'prep';
-  const isGame         = currentCycle.status === 'game';
+  const isGame         = isInGamePhase(currentCycle); // #1001: game_phase wins over legacy status
   const isClosed       = currentCycle.status === 'closed';
   const isDeadlinePast = !!(currentCycle.deadline_at && new Date(currentCycle.deadline_at) < new Date());
   const isPublished    = !!(responseDoc?.published_outcome);

--- a/server/tests/issue-1001-game-phase-canonical.test.js
+++ b/server/tests/issue-1001-game-phase-canonical.test.js
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+
+/**
+ * #1001 regression: getGamePhaseCycle / isInGamePhase must resolve game phase
+ * through deriveCycleStatus (game_phase wins over legacy `status`). The incident:
+ * a cycle carried game_phase='game' while its legacy status still pointed
+ * elsewhere, so the raw `status === 'game'` reader missed it and feeding night
+ * saw "no downtime input" for everyone.
+ *
+ * db.js is browser code (imports ../data/api.js which reads `location`), so we
+ * stub the minimal browser globals and dynamic-import it, then exercise the pure
+ * derivation + the fetch-backed getGamePhaseCycle against a mocked cycles list.
+ */
+
+let deriveCycleStatus, isInGamePhase, getGamePhaseCycle;
+let fetchImpl = async () => ({ status: 200, ok: true, json: async () => [] });
+
+beforeAll(async () => {
+  globalThis.location = { hostname: 'test-host' };
+  globalThis.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+  globalThis.fetch = (...args) => fetchImpl(...args);
+  const mod = await import('../../public/js/downtime/db.js');
+  deriveCycleStatus = mod.deriveCycleStatus;
+  isInGamePhase = mod.isInGamePhase;
+  getGamePhaseCycle = mod.getGamePhaseCycle;
+});
+
+describe('#1001 — deriveCycleStatus / isInGamePhase (dual-field)', () => {
+  it('divergence: game_phase=game + status=active is in-game', () => {
+    const cycle = { game_phase: 'game', status: 'active' };
+    expect(deriveCycleStatus(cycle)).toBe('game');
+    expect(isInGamePhase(cycle)).toBe(true);
+  });
+
+  it('reverse divergence: stale status=game + game_phase=downtime is NOT in-game', () => {
+    const cycle = { game_phase: 'downtime', status: 'game' };
+    expect(deriveCycleStatus(cycle)).toBe('active');
+    expect(isInGamePhase(cycle)).toBe(false);
+  });
+
+  it('game_phase=processing is closed, not in-game', () => {
+    expect(isInGamePhase({ game_phase: 'processing', status: 'game' })).toBe(false);
+  });
+
+  it('legacy cycle (no game_phase) still honours status=game via fallback derivation', () => {
+    // No game_phase, no city sign-off → legacy derivation returns 'game'.
+    expect(isInGamePhase({ phase_signoff: { prep: { at: 'x' } } })).toBe(true);
+  });
+
+  it('plain active cycle is not in-game', () => {
+    expect(isInGamePhase({ status: 'active' })).toBe(false);
+  });
+});
+
+describe('#1001 — getGamePhaseCycle picks by derived phase', () => {
+  it('finds the game_phase=game cycle even when its status=active, ignoring a stale status=game cycle', async () => {
+    const cycles = [
+      { _id: '1', label: 'Game 5', game_phase: 'game', status: 'active' },      // truly in game
+      { _id: '2', label: 'Game 6', game_phase: 'downtime', status: 'game' },    // stale legacy status
+    ];
+    fetchImpl = async () => ({ status: 200, ok: true, json: async () => cycles });
+    const found = await getGamePhaseCycle();
+    expect(found).not.toBeNull();
+    expect(found._id).toBe('1');
+  });
+
+  it('returns null when no cycle is in game phase', async () => {
+    const cycles = [{ _id: '3', game_phase: 'downtime', status: 'active' }];
+    fetchImpl = async () => ({ status: 200, ok: true, json: async () => cycles });
+    expect(await getGamePhaseCycle()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #1001 (tonight's feeding-night incident). `getGamePhaseCycle()` read raw `status === 'game'`, ignoring the #708 `game_phase` field. When the ST flipped Game 5 to `game_phase: 'game'`, the player feeding tab still looked at legacy `status` (pointing at empty Game 6), so every feeding roll saw "no downtime input" and fell back to the Barrens −4 default.

## Root cause
Two views of the same arithmetic in one file: `db.js:72` `deriveCycleStatus` implements the #708 model (game_phase wins over legacy `status`), but `getGamePhaseCycle()` never adopted it and read raw `status`. Admin surfaces (which read `game_phase`) and player surfaces (which read `status`) therefore disagreed about which cycle was live.

## Changes
- `public/js/downtime/db.js` — new exported `isInGamePhase(cycle)` = `deriveCycleStatus(cycle) === 'game'` (game_phase wins, legacy status fallback). `getGamePhaseCycle()` now finds via `isInGamePhase`.
- `public/js/tabs/downtime-form.js:1719` — `isGame` routed through `isInGamePhase`.
- `public/js/admin/downtime-views.js:1244` — `isGame` routed through `isInGamePhase`.
- `public/js/admin/cycle-views.js` `writePhase` — dual-writes the derived legacy `status` alongside `game_phase`, so raw-`status` readers (`getActiveCycle`, `LIVE_STATUSES` filters) stay consistent while legacy readers still exist.

Grep confirms no raw `status === 'game'` readers remain outside the derivation itself.

## Scope decision (notice)
Left `isPrep`/`isActive`/`isClosed`/`isOpen` reading raw `status` rather than routing the whole cluster through `deriveCycleStatus`, because `status: 'open'` is a real live value (dev-fixtures Downtime 3; `app.js:2175`, `downtime-tab.js:33`) that `deriveCycleStatus` does not model — routing them through it would regress `isOpen`. Only the game-phase determination is routed, which is exactly what the incident needed.

## Test plan
New Vitest regression `server/tests/issue-1001-game-phase-canonical.test.js` (7 cases) — stubs the browser globals and dynamic-imports `db.js`:
- divergence `game_phase=game + status=active` → in-game (derive + isInGamePhase)
- reverse divergence stale `status=game + game_phase=downtime` → NOT in-game
- `game_phase=processing` → not in-game
- legacy no-game_phase cycle still honours the fallback derivation
- `getGamePhaseCycle()` picks the `game_phase=game` cycle over a stale `status=game` one; returns null when none.

All green (7 new + `epic.708.1` 20 + `issue-918` 21). No live cycle data touched — SM hand-aligned tonight's Game 5/6 separately.
