### PR TITLE
feat(#1003): guard flip-to-game when target cycle has zero submissions

### DIFF
--- a/public/js/admin/cycle-views.js
+++ b/public/js/admin/cycle-views.js
@@ -1,5 +1,5 @@
 import { apiGet, apiPost, apiDelete, apiPut } from '../data/api.js';
-import { createCycle, updateCycle, deleteCycle, deriveCycleStatus } from '../downtime/db.js';
+import { createCycle, updateCycle, deleteCycle, deriveCycleStatus, getSubmissionsForCycle, zeroSubmissionFlipWarning, zeroSubmissionFlipMessage } from '../downtime/db.js';
 
 const PHASE_LABELS = {
   game:       'Game',
@@ -228,6 +228,11 @@ function buildChaptersPanel(chapters) {
 // Returns false if the ST cancels the Game-phase confirmation.
 async function writePhase(cy, phaseOrNull) {
   if (phaseOrNull === 'game') {
+    // #1003: warn if flipping an empty cycle to game while another live cycle
+    // holds submissions (feeding pulls from the game-phase cycle).
+    const warn = await zeroSubmissionFlipWarning(
+      cy, view.cycles || [], async id => (await getSubmissionsForCycle(id)).length);
+    if (warn && !confirm(zeroSubmissionFlipMessage(warn))) return false;
     if (!confirm('Setting to Game phase will reset the live tracker (all characters reload with default states). Continue?')) return false;
     try {
       await apiDelete('/api/tracker_state');

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -8,7 +8,7 @@ import { apiGet, apiPost, apiPut, apiDelete } from '../data/api.js';
 // editor's Add Equipment / Add Asset rows pre-fill acquired_cycle correctly.
 import state from '../data/state.js';
 import { parseDowntimeCSV } from '../downtime/parser.js';
-import { getCycles, getActiveCycle, createCycle, updateCycle, closeCycle, openGamePhase, getSubmissionsForCycle, upsertCycle, updateSubmission, mapRawToResponses, signoffPhase, setManualOpen, isInGamePhase, DTUX_PHASES } from '../downtime/db.js';
+import { getCycles, getActiveCycle, createCycle, updateCycle, closeCycle, openGamePhase, getSubmissionsForCycle, upsertCycle, updateSubmission, mapRawToResponses, signoffPhase, setManualOpen, isInGamePhase, zeroSubmissionFlipWarning, zeroSubmissionFlipMessage, DTUX_PHASES } from '../downtime/db.js';
 import { TERRITORY_DATA, AMBIENCE_FEEDING_TOLERANCE, AMBIENCE_ENTROPY, AMBIENCE_THRESHOLDS, AMBIENCE_MODS, FEEDING_TERRITORIES, FEED_METHODS as FEED_METHODS_DATA, MAINTENANCE_MERITS, normaliseSorceryTargets } from '../tabs/downtime-data.js';
 import { rollPool, showRollModal, parseDiceString } from '../downtime/roller.js';
 import { getAttrEffective as getAttrVal, getSkillObj, skDots, skTotal, skNineAgain, skSpecs, riteCost, skillAcqPoolStr } from '../data/accessors.js';
@@ -2709,6 +2709,11 @@ async function handleOpenGamePhase() {
   if (!selectedCycleId) return;
   const cycle = allCycles.find(c => c._id === selectedCycleId);
   if (!cycle || cycle.status !== 'closed') return;
+  // #1003: warn if flipping an empty cycle to game while another live cycle
+  // holds submissions (feeding pulls from the game-phase cycle).
+  const warn = await zeroSubmissionFlipWarning(
+    cycle, allCycles, async id => (await getSubmissionsForCycle(id)).length);
+  if (warn && !confirm(zeroSubmissionFlipMessage(warn))) return;
   if (!confirm(`Open game phase for "${cycle.label || 'Unnamed'}"? Players will be able to run their feeding rolls.`)) return;
   await openGamePhase(selectedCycleId);
   const idx = allCycles.findIndex(c => c._id === selectedCycleId);

--- a/public/js/downtime/db.js
+++ b/public/js/downtime/db.js
@@ -139,6 +139,45 @@ export async function getGamePhaseCycle() {
   return cycles.find(isInGamePhase) || null;
 }
 
+/** Human-readable cycle name for dialogs. Label if set, else "Game N". */
+export function cycleDisplayName(cycle) {
+  return cycle?.label || (cycle?.game_number != null ? 'Game ' + cycle.game_number : 'this cycle');
+}
+
+/**
+ * #1003 flip guard: deciding whether flipping `targetCycle` to game phase should
+ * warn the ST. Fires only when the target has zero downtime submissions AND another
+ * non-closed cycle has some — the 2026-07-16 mistake was flipping empty "Game 6"
+ * to game while "Game 5" (27 submissions) sat live, silently defaulting every
+ * feeding roll to Barrens -4. Pure decision (submission counts injected via
+ * `countSubs(cycleId) => Promise<number>`) so it is unit-testable. Returns null
+ * when no warning is warranted, else { target, targetCount, rival, rivalCount }.
+ */
+export async function zeroSubmissionFlipWarning(targetCycle, cycles, countSubs) {
+  if (!targetCycle) return null;
+  const targetCount = await countSubs(targetCycle._id);
+  if (targetCount > 0) return null;
+  // "Closed" via either signal: closeCycle() sets raw status='closed' without
+  // touching phase_signoff, so deriveCycleStatus alone would miss legacy closed
+  // cycles (it derives from game_phase/phase_signoff, not the raw status field).
+  const isClosed = (c) => c.status === 'closed' || deriveCycleStatus(c) === 'closed';
+  for (const c of cycles || []) {
+    if (!c || String(c._id) === String(targetCycle._id)) continue;
+    if (isClosed(c)) continue;
+    const n = await countSubs(c._id);
+    if (n > 0) return { target: targetCycle, targetCount, rival: c, rivalCount: n };
+  }
+  return null;
+}
+
+/** Confirm-dialog copy for the #1003 flip guard. British English, no em-dashes. */
+export function zeroSubmissionFlipMessage(warn) {
+  const t = cycleDisplayName(warn.target);
+  const r = cycleDisplayName(warn.rival);
+  return `${t} has no downtime submissions; ${r} has ${warn.rivalCount}. `
+    + `Players' feeding pulls from the game-phase cycle. Flip ${t} to game phase anyway?`;
+}
+
 // ── Submissions ─────────────────────────────────────────────────────────────
 
 export async function getSubmissionsForCycle(cycleId) {

--- a/server/tests/issue-1003-zero-submission-flip-guard.test.js
+++ b/server/tests/issue-1003-zero-submission-flip-guard.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+
+/**
+ * #1003 guard: flipping a cycle to game phase must warn when the target has zero
+ * downtime submissions while another non-closed cycle has some — the 2026-07-16
+ * incident (empty "Game 6" flipped live while "Game 5" held 27 submissions,
+ * silently defaulting every feeding roll to Barrens -4).
+ *
+ * db.js is browser code (imports ../data/api.js which reads `location`), so we
+ * stub the minimal browser globals and dynamic-import it, then exercise the pure
+ * decision function with injected submission counts.
+ */
+
+let zeroSubmissionFlipWarning, zeroSubmissionFlipMessage, cycleDisplayName;
+
+beforeAll(async () => {
+  globalThis.location = { hostname: 'test-host' };
+  globalThis.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+  globalThis.fetch = async () => ({ status: 200, ok: true, json: async () => [] });
+  const mod = await import('../../public/js/downtime/db.js');
+  zeroSubmissionFlipWarning = mod.zeroSubmissionFlipWarning;
+  zeroSubmissionFlipMessage = mod.zeroSubmissionFlipMessage;
+  cycleDisplayName = mod.cycleDisplayName;
+});
+
+// counts: map of cycleId -> submission count. countSubs closes over it.
+const countsFn = (counts) => async (id) => counts[String(id)] ?? 0;
+
+describe('#1003 — zeroSubmissionFlipWarning', () => {
+  const game6 = { _id: '6', label: 'Game 6', status: 'active' };
+  const game5 = { _id: '5', label: 'Game 5', status: 'active' };
+
+  it('fires on the 0-vs-many condition (target empty, rival has submissions)', async () => {
+    const warn = await zeroSubmissionFlipWarning(game6, [game6, game5], countsFn({ '6': 0, '5': 27 }));
+    expect(warn).not.toBeNull();
+    expect(warn.target._id).toBe('6');
+    expect(warn.targetCount).toBe(0);
+    expect(warn.rival._id).toBe('5');
+    expect(warn.rivalCount).toBe(27);
+  });
+
+  it('does NOT fire when the target has submissions (normal flip)', async () => {
+    const warn = await zeroSubmissionFlipWarning(game5, [game6, game5], countsFn({ '6': 0, '5': 27 }));
+    expect(warn).toBeNull();
+  });
+
+  it('does NOT fire when no other cycle has submissions', async () => {
+    const warn = await zeroSubmissionFlipWarning(game6, [game6, game5], countsFn({ '6': 0, '5': 0 }));
+    expect(warn).toBeNull();
+  });
+
+  it('ignores a rival that is closed even if it has submissions', async () => {
+    const closed = { _id: '4', label: 'Game 4', status: 'closed' };
+    const warn = await zeroSubmissionFlipWarning(game6, [game6, closed], countsFn({ '6': 0, '4': 30 }));
+    expect(warn).toBeNull();
+  });
+
+  it('treats game_phase=processing rival as closed (ignored)', async () => {
+    const processing = { _id: '4', label: 'Game 4', status: 'active', game_phase: 'processing' };
+    const warn = await zeroSubmissionFlipWarning(game6, [game6, processing], countsFn({ '6': 0, '4': 30 }));
+    expect(warn).toBeNull();
+  });
+
+  it('does not count the target as its own rival', async () => {
+    const warn = await zeroSubmissionFlipWarning(game6, [game6], countsFn({ '6': 0 }));
+    expect(warn).toBeNull();
+  });
+
+  it('handles null target gracefully', async () => {
+    expect(await zeroSubmissionFlipWarning(null, [game5], countsFn({ '5': 3 }))).toBeNull();
+  });
+});
+
+describe('#1003 — zeroSubmissionFlipMessage / cycleDisplayName', () => {
+  it('names both cycles with the rival count, no em-dash', () => {
+    const warn = { target: { label: 'Game 6' }, targetCount: 0, rival: { label: 'Game 5' }, rivalCount: 27 };
+    const msg = zeroSubmissionFlipMessage(warn);
+    expect(msg).toContain('Game 6');
+    expect(msg).toContain('Game 5');
+    expect(msg).toContain('27');
+    expect(msg).toContain('no downtime submissions');
+    expect(msg).not.toContain('—'); // no em-dash
+  });
+
+  it('falls back to Game N when label absent', () => {
+    expect(cycleDisplayName({ game_number: 7 })).toBe('Game 7');
+    expect(cycleDisplayName({ label: 'Downtime 7', game_number: 7 })).toBe('Downtime 7');
+    expect(cycleDisplayName(null)).toBe('this cycle');
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #1003. Adds a confirm guard before any flip-to-game phase: if the target cycle has **0 downtime submissions** AND another **non-closed** cycle has some, the ST is warned and names both cycles with counts. This is the 2026-07-16 incident (empty "Game 6" flipped live while "Game 5" held 27, silently defaulting every feeding roll to Barrens −4). Built on #1001's unified in-game-phase model.

## Changes
- `public/js/downtime/db.js`
  - `zeroSubmissionFlipWarning(targetCycle, cycles, countSubs)` — pure decision, submission counts injected (unit-testable). Returns `{ target, targetCount, rival, rivalCount }` or null.
  - `zeroSubmissionFlipMessage(warn)` + `cycleDisplayName(cycle)` — dialog copy (British English, no em-dash).
  - "Closed" is tested via **both** raw `status` and `deriveCycleStatus`, because `closeCycle()` sets `status='closed'` without touching `phase_signoff`, so `deriveCycleStatus` alone would derive `'prep'` and miss legacy closed cycles. (A unit test caught this.)
- `public/js/admin/cycle-views.js` `writePhase` — guard wired before the tracker-reset confirm (game_phase control).
- `public/js/admin/downtime-views.js` `handleOpenGamePhase` — guard wired before the open confirm (legacy status control).

Both flip controls covered per AC. Guard runs first, so cancelling touches nothing (no tracker delete, no write).

## Scope note
Native `confirm()` used, consistent with the existing flip controls (all of `handleCloseCycle`, `handleOpenGamePhase`, and `writePhase`'s tracker-reset already use `confirm()`). No bespoke modal introduced; the guard-decision logic lives in a pure, tested function.

## Test plan
- **Vitest** `server/tests/issue-1003-zero-submission-flip-guard.test.js` (9 cases): fires on 0-vs-many; silent on normal flip / no rival with subs / closed rival / `game_phase=processing` rival / self / null target; message names both cycles + rival count + no em-dash; `cycleDisplayName` fallback.
- **Playwright smoke** over a local http server, driving the real `fetch → getSubmissionsForCycle → zeroSubmissionFlipWarning` chain via a **real click handler** (not inside a change listener) + native `confirm` intercepted with `page.on('dialog')` (9 assertions): guard fires and names Game 6 / Game 5 / 27, no em-dash, accept proceeds, cancel aborts, normal flip fires no dialog.

All green: Vitest 9/9, smoke 9/9.
