### PR TITLE
feat(#1002): cycle labels state their feeds-into span

### DIFF
--- a/public/js/admin/cycle-views.js
+++ b/public/js/admin/cycle-views.js
@@ -1,5 +1,5 @@
 import { apiGet, apiPost, apiDelete, apiPut } from '../data/api.js';
-import { createCycle, updateCycle, deleteCycle, deriveCycleStatus, getSubmissionsForCycle, zeroSubmissionFlipWarning, zeroSubmissionFlipMessage } from '../downtime/db.js';
+import { createCycle, updateCycle, deleteCycle, deriveCycleStatus, getSubmissionsForCycle, zeroSubmissionFlipWarning, zeroSubmissionFlipMessage, cycleSpanLabel, cycleFeedsLabel } from '../downtime/db.js';
 
 const PHASE_LABELS = {
   game:       'Game',
@@ -94,6 +94,7 @@ function renderRibbon() {
     <div class="cy-ribbon-item">
       <span class="cy-ribbon-label">Game Cycle</span>
       <span class="cy-ribbon-val">${esc(cy.label || String(cy._id))}</span>
+      ${cycleSpanLabel(cy) ? `<span class="derived-note">${esc(cycleSpanLabel(cy))}</span>` : ''}
     </div>
     <div class="cy-ribbon-item">
       <span class="cy-ribbon-label">Phase</span>
@@ -233,7 +234,13 @@ async function writePhase(cy, phaseOrNull) {
     const warn = await zeroSubmissionFlipWarning(
       cy, view.cycles || [], async id => (await getSubmissionsForCycle(id)).length);
     if (warn && !confirm(zeroSubmissionFlipMessage(warn))) return false;
-    if (!confirm('Setting to Game phase will reset the live tracker (all characters reload with default states). Continue?')) return false;
+    // #1002: state what the flip means - it opens session play for THIS cycle's
+    // submissions, which feed the following game.
+    const feeds = cycleFeedsLabel(cy);
+    const meaning = feeds
+      ? `This opens session play for the downtimes submitted in this cycle (${feeds}) and resets the live tracker (all characters reload with default states). Continue?`
+      : 'Setting to Game phase will reset the live tracker (all characters reload with default states). Continue?';
+    if (!confirm(meaning)) return false;
     try {
       await apiDelete('/api/tracker_state');
     } catch (err) {
@@ -531,6 +538,15 @@ function buildLabelCell(cy) {
     inner.appendChild(span);
     inner.appendChild(editBtn);
     td.appendChild(inner);
+    // #1002: derived feeds-into span so the cycle name can't be mistaken for the
+    // session it actually feeds.
+    const spanText = cycleSpanLabel(cy);
+    if (spanText) {
+      const note = document.createElement('span');
+      note.className = 'derived-note';
+      note.textContent = spanText;
+      td.appendChild(note);
+    }
   }
 
   function renderEdit() {

--- a/public/js/admin/downtime-views.js
+++ b/public/js/admin/downtime-views.js
@@ -8,7 +8,7 @@ import { apiGet, apiPost, apiPut, apiDelete } from '../data/api.js';
 // editor's Add Equipment / Add Asset rows pre-fill acquired_cycle correctly.
 import state from '../data/state.js';
 import { parseDowntimeCSV } from '../downtime/parser.js';
-import { getCycles, getActiveCycle, createCycle, updateCycle, closeCycle, openGamePhase, getSubmissionsForCycle, upsertCycle, updateSubmission, mapRawToResponses, signoffPhase, setManualOpen, isInGamePhase, zeroSubmissionFlipWarning, zeroSubmissionFlipMessage, DTUX_PHASES } from '../downtime/db.js';
+import { getCycles, getActiveCycle, createCycle, updateCycle, closeCycle, openGamePhase, getSubmissionsForCycle, upsertCycle, updateSubmission, mapRawToResponses, signoffPhase, setManualOpen, isInGamePhase, zeroSubmissionFlipWarning, zeroSubmissionFlipMessage, cycleFeedsLabel, DTUX_PHASES } from '../downtime/db.js';
 import { TERRITORY_DATA, AMBIENCE_FEEDING_TOLERANCE, AMBIENCE_ENTROPY, AMBIENCE_THRESHOLDS, AMBIENCE_MODS, FEEDING_TERRITORIES, FEED_METHODS as FEED_METHODS_DATA, MAINTENANCE_MERITS, normaliseSorceryTargets } from '../tabs/downtime-data.js';
 import { rollPool, showRollModal, parseDiceString } from '../downtime/roller.js';
 import { getAttrEffective as getAttrVal, getSkillObj, skDots, skTotal, skNineAgain, skSpecs, riteCost, skillAcqPoolStr } from '../data/accessors.js';
@@ -1195,7 +1195,10 @@ async function loadAllCycles() {
   const sel = document.getElementById('dt-cycle-sel');
   sel.innerHTML = '<option value="">\u2014 Select cycle \u2014</option>';
   allCycles.forEach(c => {
-    const label = (c.label || 'Unnamed') + (c.status === 'active' ? ' (active)' : '');
+    const feeds = cycleFeedsLabel(c); // #1002: which session this cycle feeds
+    const label = (c.label || 'Unnamed')
+      + (feeds ? ` – ${feeds}` : '')
+      + (c.status === 'active' ? ' (active)' : '');
     sel.innerHTML += `<option value="${c._id}">${esc(label)}</option>`;
   });
 
@@ -2714,7 +2717,11 @@ async function handleOpenGamePhase() {
   const warn = await zeroSubmissionFlipWarning(
     cycle, allCycles, async id => (await getSubmissionsForCycle(id)).length);
   if (warn && !confirm(zeroSubmissionFlipMessage(warn))) return;
-  if (!confirm(`Open game phase for "${cycle.label || 'Unnamed'}"? Players will be able to run their feeding rolls.`)) return;
+  // #1002: state which session these submissions feed so the right cycle is opened.
+  const feeds = cycleFeedsLabel(cycle);
+  const openMsg = `Open game phase for "${cycle.label || 'Unnamed'}"${feeds ? ` (${feeds})` : ''}? `
+    + `Players will run their feeding rolls against the downtimes submitted in this cycle.`;
+  if (!confirm(openMsg)) return;
   await openGamePhase(selectedCycleId);
   const idx = allCycles.findIndex(c => c._id === selectedCycleId);
   if (idx >= 0) allCycles[idx].status = 'game';

--- a/public/js/downtime/db.js
+++ b/public/js/downtime/db.js
@@ -145,6 +145,23 @@ export function cycleDisplayName(cycle) {
 }
 
 /**
+ * #1002: derive a cycle's feeds-into span. Downtimes are collected after game N
+ * and consumed at the following session, so a cycle for game N feeds game N+1.
+ * Derived from game_number - never stored. Empty string when game_number is unknown.
+ *   cycleSpanLabel  → "Downtime after Game 5, feeds Game 6"  (full, for chips/headers)
+ *   cycleFeedsLabel → "feeds Game 6"                          (short, for pickers/copy)
+ */
+export function cycleSpanLabel(cycle) {
+  const n = cycle?.game_number;
+  return n == null ? '' : `Downtime after Game ${n}, feeds Game ${n + 1}`;
+}
+
+export function cycleFeedsLabel(cycle) {
+  const n = cycle?.game_number;
+  return n == null ? '' : `feeds Game ${n + 1}`;
+}
+
+/**
  * #1003 flip guard: deciding whether flipping `targetCycle` to game phase should
  * warn the ST. Fires only when the target has zero downtime submissions AND another
  * non-closed cycle has some — the 2026-07-16 mistake was flipping empty "Game 6"

--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -31,7 +31,8 @@ import { FAMILIES, kindByCode } from '../data/relationship-kinds.js';
 import { charPicker, setCharPickerSources } from '../components/character-picker.js';
 import { isMinimalComplete, missingMinimumPieces } from '../data/dt-completeness.js';
 // #1001: canonical in-game-phase test (game_phase wins over legacy status)
-import { isInGamePhase } from '../downtime/db.js';
+// #1002: cycleSpanLabel - which session this downtime feeds (derived)
+import { isInGamePhase, cycleSpanLabel, cycleFeedsLabel } from '../downtime/db.js';
 // ECM-4 (#871): catalogue dropdown sources from the shared cache module
 // ECM-5 (#872) introduced. App boot in app.js calls loadCatalogue; we read
 // synchronously here at render time. getCatalogueEntry resolves a
@@ -1724,6 +1725,9 @@ function renderCycleGatePage() {
 
   let h = `<div class="reading-pane qf-gate-page">`;
   h += `<h3 class="qf-title">${label}</h3>`;
+  // #1002: which game session this downtime feeds (derived from game_number)
+  const _spanGate = cycleSpanLabel(currentCycle);
+  if (_spanGate) h += `<p class="qf-section-intro">${esc(_spanGate)}</p>`;
 
   if (isPrep) {
     const _openAt = currentCycle.auto_open_at ? new Date(currentCycle.auto_open_at) : null;
@@ -2087,7 +2091,10 @@ function renderForm(container) {
   h += '<div class="qf-header">';
   h += `<h3 class="qf-title">Downtime Submission</h3>`;
   if (currentCycle) {
-    h += `<p class="qf-section-intro">${esc(currentCycle.label || currentCycle.title || 'Current Cycle')}</p>`;
+    // #1002: append the feeds-into span so players see which session this feeds
+    const _feeds = cycleFeedsLabel(currentCycle);
+    const _base = esc(currentCycle.label || currentCycle.title || 'Current Cycle');
+    h += `<p class="qf-section-intro">${_feeds ? `${_base} – ${esc(_feeds)}` : _base}</p>`;
     if (currentCycle.deadline_at) {
       const dl = new Date(currentCycle.deadline_at);
       const past = dl < new Date();

--- a/server/tests/issue-1002-cycle-span-labels.test.js
+++ b/server/tests/issue-1002-cycle-span-labels.test.js
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+
+/**
+ * #1002: cycle labels must state their feeds-into span. Downtimes are collected
+ * after game N and consumed at the following session, so a cycle for game N feeds
+ * game N+1. The 2026-07-16 incident was the cycle NAME ("Game 6") inviting the
+ * ST to flip the wrong cycle. The span is derived from game_number, never stored.
+ *
+ * db.js is browser code (imports ../data/api.js which reads `location`), so we
+ * stub the minimal browser globals and dynamic-import it.
+ */
+
+let cycleSpanLabel, cycleFeedsLabel;
+
+beforeAll(async () => {
+  globalThis.location = { hostname: 'test-host' };
+  globalThis.localStorage = { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+  globalThis.fetch = async () => ({ status: 200, ok: true, json: async () => [] });
+  const mod = await import('../../public/js/downtime/db.js');
+  cycleSpanLabel = mod.cycleSpanLabel;
+  cycleFeedsLabel = mod.cycleFeedsLabel;
+});
+
+describe('#1002 — cycleSpanLabel', () => {
+  it('game N feeds game N+1 (off-by-one is the whole point)', () => {
+    expect(cycleSpanLabel({ game_number: 5 })).toBe('Downtime after Game 5, feeds Game 6');
+    expect(cycleSpanLabel({ game_number: 6 })).toBe('Downtime after Game 6, feeds Game 7');
+  });
+
+  it('empty string when game_number is missing (no fabricated span)', () => {
+    expect(cycleSpanLabel({ label: 'Ad-hoc' })).toBe('');
+    expect(cycleSpanLabel({})).toBe('');
+    expect(cycleSpanLabel(null)).toBe('');
+  });
+
+  it('no em-dash in the copy', () => {
+    expect(cycleSpanLabel({ game_number: 5 })).not.toContain('—');
+  });
+});
+
+describe('#1002 — cycleFeedsLabel', () => {
+  it('short form names the fed session', () => {
+    expect(cycleFeedsLabel({ game_number: 5 })).toBe('feeds Game 6');
+    expect(cycleFeedsLabel({ game_number: 1 })).toBe('feeds Game 2');
+  });
+
+  it('empty string when game_number is missing', () => {
+    expect(cycleFeedsLabel({})).toBe('');
+    expect(cycleFeedsLabel(null)).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #1002. The cycle NAME invites the 2026-07-16 mistake — "Game 6" was flipped to game phase, but tonight's session consumes "Game 5" submissions (downtimes are collected after game N and consumed at session N+1). This makes the feeds-into span explicit everywhere a cycle is shown, derived from `game_number` (never stored).

## Derivation (db.js)
- `cycleSpanLabel(cycle)` → `"Downtime after Game 5, feeds Game 6"` (full — chips/headers)
- `cycleFeedsLabel(cycle)` → `"feeds Game 6"` (short — pickers/copy)
- Both return `''` when `game_number` is absent (no fabricated span).

## Display sites
- **Admin cycle ribbon + label cell** (`cycle-views.js`): full span as a `.derived-note`.
- **Admin cycle picker options** (`downtime-views.js`): appended `feeds Game N+1`.
- **Player DT form**: gate-page header subtitle (full span) + active-form intro (short feeds label).
- **Flip control copy, both controls** (`cycle-views.js` `writePhase` game_phase; `downtime-views.js` `handleOpenGamePhase` legacy status): now state the flip opens session play for **this cycle's** submissions and name the fed session.

## Standards
- British English; **en-dash** separators, no em-dash (verified in smoke).
- Token-only: reuses `.derived-note` (components) and `.qf-section-intro`; no new colours, no inline styles.
- **No schema change** — span is derived from `game_number`.

## Notice (per PROCEED-WITH-NOTICE on copy)
- Copy chosen: full span "Downtime after Game N, feeds Game N+1"; short "feeds Game N+1"; flip copy "This opens session play for the downtimes submitted in this cycle (feeds Game N+1)…". Flag if you want different wording — trivial to adjust in `cycleSpanLabel`/`cycleFeedsLabel`.
- Semantics assumed: `game_number = N` means DT collected after Game N, feeds Game N+1 (matches the incident: the "Game 5" cycle feeds the Game 6 session). If `game_number` instead denotes the fed session, the +1 flips — confirm the convention.

## Test plan
- **Vitest** `server/tests/issue-1002-cycle-span-labels.test.js` (5 cases): N→N+1 off-by-one for both helpers, empty when `game_number` missing, no em-dash.
- **Playwright smoke** over http rendering the real helpers into the picker/header/flip-copy DOM shapes (7 assertions): Game 5→feeds Game 6, Game 6→feeds Game 7, no-game_number cycle shows no span, header full span, flip copy names fed session, no em-dash anywhere.

All green: Vitest 5/5, smoke 7/7; full related set (1001/1002/1003/708/918) 62/62.
