### PR TITLE
Merge dev → main: indomitable rules_text (#1013) + hide Challenge / rename Ordeals→XP (#1015)

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -278,7 +278,7 @@ const NAV_ITEMS = [
   { id: 'whos-who',  label: 'World',     icon: '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>', goTab: 'whos-who' },
   { id: 'feeding',   label: 'Feeding',   icon: '<svg viewBox="0 0 24 24"><path d="M12 2.69l5.66 5.66a8 8 0 1 1-11.31 0z"/></svg>', goTab: 'feeding' },
   { id: 'downtime',  label: 'Downtime',  icon: '<svg viewBox="0 0 24 24"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/><path d="M9 16l2 2 4-4"/></svg>', goTab: 'downtime', seasonal: true },
-  { id: 'ordeals',   label: 'Ordeals',   icon: '<svg viewBox="0 0 24 24"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>', goTab: 'ordeals' },
+  { id: 'ordeals',   label: 'XP',        icon: '<svg viewBox="0 0 24 24"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>', goTab: 'ordeals' },
   { id: 'devlog',    label: 'Devlog',    icon: '<svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>', goTab: 'devlog' },
   { id: 'primer',    label: 'Primer',    icon: '<svg viewBox="0 0 24 24"><path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/><path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/></svg>', goTab: 'primer', guide: true },
   { id: 'game-guide',label: 'Guide',     icon: '<svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>', goTab: 'game-guide', disabled: true, guide: true },
@@ -1523,7 +1523,7 @@ const MORE_APPS = [
   { id: 'ordeals',      label: 'Ordeals',     icon: _svg.ordeals,  section: 'player' },
   { id: 'relationships', label: 'NPCs', icon: '<svg viewBox="0 0 24 24"><circle cx="5" cy="12" r="3"/><circle cx="19" cy="6" r="3"/><circle cx="19" cy="18" r="3"/><line x1="8" y1="12" x2="16" y2="6"/><line x1="8" y1="12" x2="16" y2="18"/></svg>', section: 'st', stOnly: true },
   // Tickets removed — submit form is in Settings
-  { id: 'challenge',    label: 'Challenge',   icon: '<svg viewBox="0 0 24 24"><path d="M14.5 17.5L3 6V3h3l11.5 11.5"/><path d="M13 19l6-6"/><path d="M2 2l20 20"/><path d="M3 14l7-7"/></svg>', section: 'player', playerOnly: true },
+  // Challenge tile hidden (#1015). The click-handler + modal (openChallengeModal) remain wired for future programmatic use.
   // ── Lore section (gated by show_guides setting) ──
   { id: 'primer',       label: 'Primer',      icon: _svg.primer,   section: 'lore', guide: true },
   { id: 'game-guide',   label: 'Game Guide',  icon: _svg.guide,    section: 'lore', guide: true },

--- a/server/scripts/fix-1013-indomitable-rules-text.js
+++ b/server/scripts/fix-1013-indomitable-rules-text.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Fix #1013 — Indomitable merit missing rules_text.
+ *
+ * The #992 uplift script (uplift-power-rules-text.js) skipped Indomitable
+ * with reason `multiple_book_sources` because the merit is defined in both
+ * `Vampire the Requiem 2e Rulebook.md` and `Chronicles of Darkness Rulebook.md`.
+ * The safety default is correct in general; for Indomitable the campaign
+ * preference is unambiguous — the VtR 2e version names "Kindred Dominate"
+ * specifically and is the campaign's canonical book.
+ *
+ * This one-off script writes rules_text and rules_source for the single
+ * Indomitable purchasable_powers document, sourced from the VtR 2e block.
+ * It reuses the uplift script's `loadAllBlocks` + `normalizeName` helpers
+ * so parsing stays a single source of truth.
+ *
+ * Idempotent. Dry-run default; pass --apply to write.
+ */
+
+import 'dotenv/config';
+import { MongoClient } from 'mongodb';
+import { loadAllBlocks, normalizeName } from './uplift-power-rules-text.js';
+
+const APPLY = process.argv.includes('--apply');
+const DRY_RUN = !APPLY;
+const MONGODB_URI = process.env.MONGODB_URI;
+const DB_NAME = process.env.MONGODB_DB || 'tm_suite';
+
+const TARGET_KEY = 'indomitable';
+const PREFERRED_BOOK = 'VtR 2e Rulebook';
+
+export function resolveBlock(blocks, targetName, preferredBook) {
+  const norm = normalizeName(targetName);
+  const candidates = blocks.filter(b => b.normName === norm && !b.isErrata);
+  const preferred = candidates.find(b => b.book === preferredBook);
+  return preferred || null;
+}
+
+async function main() {
+  if (!MONGODB_URI) {
+    console.error('MONGODB_URI is not set. Run from server/ with server/.env in place.');
+    process.exit(1);
+  }
+  console.log(`Mode: ${APPLY ? 'APPLY (will write)' : 'DRY RUN (read only; pass --apply to write)'}`);
+  console.log(`Target DB: ${DB_NAME}`);
+  console.log(`Target power: key=${TARGET_KEY}`);
+  console.log(`Preferred book: ${PREFERRED_BOOK}\n`);
+
+  const { allBlocks } = loadAllBlocks();
+  const block = resolveBlock(allBlocks, 'Indomitable', PREFERRED_BOOK);
+  if (!block) {
+    console.error(`No ${PREFERRED_BOOK} block found for Indomitable. Aborting.`);
+    process.exit(1);
+  }
+  const rulesText = block.rulesText;
+  if (!rulesText || !rulesText.trim()) {
+    console.error(`Resolved block has empty rulesText. Aborting.`);
+    process.exit(1);
+  }
+
+  console.log(`Resolved block: ${block.book} (${block.file})`);
+  console.log(`--- rules_text preview (${rulesText.length} chars) ---`);
+  console.log(rulesText);
+  console.log(`--- end preview ---\n`);
+
+  const client = new MongoClient(MONGODB_URI, { serverSelectionTimeoutMS: 10000, tls: true });
+  try {
+    await client.connect();
+    const col = client.db(DB_NAME).collection('purchasable_powers');
+
+    const doc = await col.findOne(
+      { key: TARGET_KEY },
+      { projection: { key: 1, name: 1, rules_text: 1, rules_source: 1 } }
+    );
+    if (!doc) {
+      console.error(`purchasable_powers.${TARGET_KEY} NOT FOUND — aborting`);
+      process.exit(1);
+    }
+
+    const currentLen = (doc.rules_text || '').length;
+    const currentSource = doc.rules_source || '(none)';
+    console.log(`Current: rules_text=${currentLen} chars, rules_source=${currentSource}`);
+    console.log(`New:     rules_text=${rulesText.length} chars, rules_source=${block.book}`);
+
+    if (doc.rules_text === rulesText && doc.rules_source === block.book) {
+      console.log('\nAlready correct — no write needed. Exiting.');
+      return;
+    }
+
+    if (APPLY) {
+      const res = await col.updateOne(
+        { _id: doc._id },
+        { $set: { rules_text: rulesText, rules_source: block.book } }
+      );
+      console.log(`\nWrote ${res.modifiedCount} doc(s).`);
+    } else {
+      console.log('\n[DRY RUN] Pass --apply to write.');
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+const _invokedDirectly = import.meta.url === `file://${process.argv[1]}`;
+if (_invokedDirectly) {
+  main().catch(err => { console.error(err); process.exit(1); });
+}

--- a/server/tests/issue-1013-indomitable-rules-text.test.js
+++ b/server/tests/issue-1013-indomitable-rules-text.test.js
@@ -1,0 +1,45 @@
+/**
+ * Issue #1013 — resolveBlock() prefers the VtR 2e Rulebook copy of
+ * Indomitable over the Chronicles of Darkness Rulebook copy, and the
+ * composed rules_text names the Kindred-specific phrasing that
+ * distinguishes the two books.
+ *
+ * This is a pure unit test on the resolver — no DB, no filesystem stubbing.
+ * It uses the real markdown corpus via loadAllBlocks() so a future markdown
+ * re-parse regression that shifts Indomitable to a different book (or
+ * removes it from VtR 2e) is caught here rather than at prod-write time.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { loadAllBlocks } from '../scripts/uplift-power-rules-text.js';
+import { resolveBlock } from '../scripts/fix-1013-indomitable-rules-text.js';
+
+describe('fix-1013 — indomitable resolver', () => {
+  const { allBlocks } = loadAllBlocks();
+
+  it('finds Indomitable in both VtR 2e Rulebook and CofD Rulebook', () => {
+    const cands = allBlocks.filter(b => b.normName === 'indomitable' && !b.isErrata);
+    const books = cands.map(b => b.book).sort();
+    expect(books).toEqual(['CofD Rulebook', 'VtR 2e Rulebook']);
+  });
+
+  it('resolveBlock picks the VtR 2e Rulebook copy', () => {
+    const b = resolveBlock(allBlocks, 'Indomitable', 'VtR 2e Rulebook');
+    expect(b).toBeTruthy();
+    expect(b.book).toBe('VtR 2e Rulebook');
+    expect(b.name).toBe('Indomitable');
+  });
+
+  it('resolved rules_text is non-empty and mentions "Kindred Dominate" (VtR-specific phrasing)', () => {
+    const b = resolveBlock(allBlocks, 'Indomitable', 'VtR 2e Rulebook');
+    expect(b.rulesText).toBeTruthy();
+    expect(b.rulesText.length).toBeGreaterThan(200);
+    expect(b.rulesText).toMatch(/Kindred Dominate/);
+    expect(b.rulesText).not.toMatch(/a vampire['’]s mind control/i);
+  });
+
+  it('returns null when the preferred book has no matching block', () => {
+    expect(resolveBlock(allBlocks, 'Indomitable', 'Nonexistent Book')).toBeNull();
+    expect(resolveBlock(allBlocks, 'NotAPower', 'VtR 2e Rulebook')).toBeNull();
+  });
+});

--- a/tests/issue-1015-hide-challenge-rename-ordeals-xp.spec.js
+++ b/tests/issue-1015-hide-challenge-rename-ordeals-xp.spec.js
@@ -1,0 +1,43 @@
+// Smoke for issue #1015 —
+//   1. MORE_APPS no longer contains a challenge entry (drives desktop
+//      sidebar + phone More grid).
+//   2. The phone bottom-nav ordeals entry is labelled 'XP' (id preserved).
+//
+// The player app requires Discord OAuth to render tabs, so these checks
+// go against the delivered `js/app.js` source rather than driving the UI —
+// same shape the parse-check guardrails use.
+
+const { test, expect } = require('@playwright/test');
+
+test('#1015 — MORE_APPS has no challenge entry', async ({ request }) => {
+  const res = await request.get('/js/app.js');
+  const src = await res.text();
+  const start = src.indexOf('const MORE_APPS');
+  expect(start).toBeGreaterThan(0);
+  const end = src.indexOf('];', start);
+  expect(end).toBeGreaterThan(start);
+  const block = src.slice(start, end);
+  expect(block).not.toMatch(/id:\s*['"]challenge['"]/);
+});
+
+test('#1015 — phone bottom-nav ordeals entry is labelled "XP"', async ({ request }) => {
+  const res = await request.get('/js/app.js');
+  const src = await res.text();
+  // The phone bottom-nav array is the first array containing an ordeals
+  // entry with a `goTab: 'ordeals'` field (MORE_APPS uses `section:`, not
+  // `goTab:`). Locate that specific entry line.
+  const re = /\{\s*id:\s*['"]ordeals['"][^}]*goTab:\s*['"]ordeals['"][^}]*\}/;
+  const m = src.match(re);
+  expect(m, 'phone bottom-nav ordeals entry not found').not.toBeNull();
+  expect(m[0]).toMatch(/label:\s*['"]XP['"]/);
+  expect(m[0]).not.toMatch(/label:\s*['"]Ordeals['"]/);
+});
+
+test('#1015 — challenge modal wiring is preserved (only the tile is hidden)', async ({ request }) => {
+  // Guard rail: the click handler and modal function stay wired so future
+  // programmatic uses continue to work. Only the surfaced tile is gone.
+  const res = await request.get('/js/app.js');
+  const src = await res.text();
+  expect(src).toMatch(/openChallengeModal/);
+  expect(src).toMatch(/if\s*\(\s*t\s*===?\s*['"]challenge['"]\s*\)/);
+});


### PR DESCRIPTION
## Summary
Deploy dev → main. Two changes since the last sync:

- **#1013** (`09adb0e8`) — one-off fix script + vitest that lifts `Indomitable` from the #992 `multiple_book_sources` skip and writes rules_text sourced from the VtR 2e Rulebook. Prod DB already carries the write; this PR is repo-hygiene for the script + test.
- **#1015** (`e0b7501e`) — hide the Challenge tile from `MORE_APPS` (removes it from desktop sidebar + phone More grid); rename the phone bottom-nav ordeals tab label 'Ordeals' → 'XP'. Tab id unchanged; Challenge modal + click-handler preserved.

## Deploy footprint
- Netlify (frontend): `public/js/app.js` change is user-visible immediately (Challenge tile gone; phone bottom nav shows 'XP').
- Render (API): no route changes.
- MongoDB: no schema change; `purchasable_powers.indomitable.rules_text` was written directly by the fix script — the doc already has the correct state on prod.

## Test plan
- **Vitest** `server/tests/issue-1013-indomitable-rules-text.test.js` — 4/4 green against real markdown corpus.
- **Playwright** `tests/issue-1015-hide-challenge-rename-ordeals-xp.spec.js` — 3/3 green (source-fetch smokes; the player app is Discord-gated so UI-driven testing needs auth mocking).