### PR TITLE
Merge dev → main: parallel ROLL tab flag (#1018)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -216,6 +216,82 @@
       <!-- Feeding moved to More grid → Feeding app (nav-2-5) -->
     </div>
 
+    <!-- ═══ ROLL TAB (v2 — parallel dev surface, gated by
+             `tm-use-new-dice-roller` flag; issue #1018). Inner IDs are
+             identical to #t-dice on purpose — app.js removes whichever
+             of the two subtrees is inactive at boot so only one set of
+             those IDs exists in the live DOM. ═══ -->
+    <div id="t-roll" class="tab">
+      <div id="lifecycle-cards" style="display:none"></div>
+      <div class="shortcut-row">
+        <button class="sc-btn" id="sc-char" onclick="openPanel('char')">
+          <span class="sc-label" id="sc-char-lbl">Character</span>
+          <span class="sc-val" id="sc-char-val"></span>
+        </button>
+        <button class="sc-btn" id="sc-disc" onclick="openPanel('disc')">
+          <span class="sc-label" id="sc-disc-lbl">Discipline</span>
+          <span class="sc-val" id="sc-disc-val"></span>
+        </button>
+        <button class="sc-btn" id="sc-common" onclick="openPanel('common')">
+          <span class="sc-label">Common</span>
+        </button>
+        <button class="sc-btn sc-btn-auspex" id="sc-auspex" onclick="openPanel('auspex')" style="display:none">
+          <span class="sc-label">Auspex</span>
+        </button>
+      </div>
+      <div id="roll-char-pools" style="display:none"></div>
+      <div>
+        <div class="slabel">Dice pool</div>
+        <div class="crow">
+          <button class="cbtn" onclick="chgPool(-1)">&minus;</button>
+          <div class="cval" id="pval">5</div>
+          <button class="cbtn" onclick="chgPool(1)">+</button>
+        </div>
+        <div class="effline" id="effline">Effective pool: <span>5 dice</span></div>
+      </div>
+      <div id="weapon-ref" style="display:none"></div>
+      <div>
+        <div class="slabel">Bonus / Penalty</div>
+        <div class="crow">
+          <button class="bbtn" onclick="chgMod(-1)">&minus;</button>
+          <div class="bval" id="mval">0</div>
+          <button class="bbtn" onclick="chgMod(1)">+</button>
+        </div>
+      </div>
+      <div id="resist-sec" style="display:none;">
+        <div class="slabel" id="resist-lbl">Resistance</div>
+        <select id="resist-sel" class="resist-sel" onchange="updResist()">
+          <option value="">&#8212; select target &#8212;</option>
+        </select>
+        <div id="resist-line" class="resist-line"></div>
+      </div>
+      <div>
+        <div class="slabel">Again rule</div>
+        <div class="arow">
+          <button class="abtn" id="a8" onclick="setAgain(8)">8-AGAIN</button>
+          <button class="abtn" id="a9" onclick="setAgain(9)">9-AGAIN</button>
+        </div>
+      </div>
+      <div class="mrow">
+        <button class="mchip" id="rote-c" onclick="togMod('rote')">Rote</button>
+        <button class="mchip" id="na-c" onclick="togMod('na')">No Again</button>
+        <button class="mchip wp-chip" id="wp-c" onclick="togMod('wp')">WP (+3)</button>
+      </div>
+      <button id="roll-btn" onclick="doRoll()">Roll the Dice</button>
+      <button id="btn-contested" onclick="openContestedRoll()" style="display:none">Contested Roll</button>
+      <div id="res-area">
+        <div id="res-hdr"></div>
+        <div id="dice-area"><div class="empty-d">No rolls yet</div></div>
+      </div>
+      <div>
+        <div class="hist-hdr">
+          <div class="slabel slabel-inline">History</div>
+          <button class="hist-clr" onclick="clrHist()">Clear</button>
+        </div>
+        <div class="hlist" id="hlist"><div class="hempty">No rolls yet</div></div>
+      </div>
+    </div>
+
     <!-- ═══ TERRITORY TAB ═══ -->
     <div id="t-territory" class="tab">
       <div id="terr-root"></div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -107,7 +107,18 @@ import { applyOverlayToAll } from './data/st-mods.js';
 import { materialiseDerivedDefence } from './data/equipment-derivation.js';
 import { loadGlobalSettings, getGlobalSettings } from './data/app-settings.js';
 import { installStModPopover } from './editor/st-mod-popover.js';
-import { loadPool, chgPool, chgMod, updPool, setAgain, togMod, togSpec, doRoll, clrHist, effPool, togEquipChip, updWeaponRef } from './suite/roll.js';
+// Roll tab: two parallel implementations gated by the localStorage flag
+// `tm-use-new-dice-roller` (issue #1018). Both modules export the same
+// symbols; whichever is active drives BOTH internal callers (below) AND
+// the inline-onclick window globals wired at the bottom of this file.
+// The inactive tab's DOM subtree is removed at boot in `boot()` so
+// getElementById() calls made anywhere (including external touch-points
+// like pickChar, shared/resist.js, contested-roll) target the visible tab.
+import * as rollV1 from './suite/roll.js';
+import * as rollV2 from './suite/roll-v2.js';
+const USE_NEW_ROLLER = localStorage.getItem('tm-use-new-dice-roller') === '1';
+const _roller = USE_NEW_ROLLER ? rollV2 : rollV1;
+const { loadPool, chgPool, chgMod, updPool, setAgain, togMod, togSpec, doRoll, clrHist, effPool, togEquipChip, updWeaponRef } = _roller;
 import { onSheetChar, renderSheet as suiteRenderSheet, repaintSheetTrackers } from './suite/sheet.js';
 import { toggleExp as suiteToggleExp, toggleDisc as suiteToggleDisc } from './suite/sheet-helpers.js';
 import { updResist, showResistSec } from './shared/resist.js';
@@ -270,6 +281,7 @@ const NAV_ALIAS = {
 const NAV_ITEMS = [
   // Sheet split into Stats / Skills / Powers for phone UX
   { id: 'dice',      label: 'Dice',      icon: '<svg viewBox="0 0 24 24"><rect x="2" y="2" width="20" height="20" rx="4"/><circle cx="7" cy="7" r="1.5" fill="currentColor"/><circle cx="17" cy="7" r="1.5" fill="currentColor"/><circle cx="12" cy="12" r="1.5" fill="currentColor"/><circle cx="7" cy="17" r="1.5" fill="currentColor"/><circle cx="17" cy="17" r="1.5" fill="currentColor"/></svg>', goTab: 'dice' },
+  { id: 'roll',      label: 'Roll',      icon: '<svg viewBox="0 0 24 24"><rect x="2" y="2" width="20" height="20" rx="4"/><circle cx="7" cy="7" r="1.5" fill="currentColor"/><circle cx="17" cy="7" r="1.5" fill="currentColor"/><circle cx="12" cy="12" r="1.5" fill="currentColor"/><circle cx="7" cy="17" r="1.5" fill="currentColor"/><circle cx="17" cy="17" r="1.5" fill="currentColor"/></svg>', goTab: 'roll' },
   { id: 'stats',     label: 'Stats',     icon: '<svg viewBox="0 0 24 24"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>', goTab: 'stats' },
   { id: 'skills',    label: 'Skills',    icon: '<svg viewBox="0 0 24 24"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>', goTab: 'skills' },
   { id: 'powers',    label: 'Powers',    icon: '<svg viewBox="0 0 24 24"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>', goTab: 'powers' },
@@ -311,6 +323,9 @@ function renderBottomNav() {
     if (item.coordinatorOnly && !isCoord) continue;
     if (item.condition && !_moreGridCondition(item)) continue;
     if (item.guide && !showGuides) continue;
+    // Roll v2 (#1018): swap 'dice' ↔ 'roll' based on the settings flag.
+    if (item.id === 'dice' && USE_NEW_ROLLER) continue;
+    if (item.id === 'roll' && !USE_NEW_ROLLER) continue;
     if (item.seasonal) {
       // Seasonal items hidden by default, shown by _updateSeasonalNav after lifecycle loads
       h += `<button class="nbtn nbtn-seasonal" id="n-${item.id}" onclick="goTab('${item.goTab}')" style="display:none">${item.icon}<span>${item.label}</span></button>`;
@@ -1262,6 +1277,15 @@ Object.assign(window, {
 // ══════════════════════════════════════════════
 
 async function boot() {
+  // Roll v2 (#1018): remove the inactive DICE/ROLL subtree so the
+  // duplicate inner IDs (`pval`, `mval`, `dice-area`, etc.) don't
+  // collide. getElementById() then resolves to the visible tab across
+  // roll.js/roll-v2.js AND every external touch-point (pickChar,
+  // renderLifecycleCards, applyRoleRestrictions, shared/resist.js,
+  // game/contested-roll.js) without any of them needing to be
+  // flag-aware.
+  document.getElementById(USE_NEW_ROLLER ? 't-dice' : 't-roll')?.remove();
+
   // Suppress iOS PWA edge-swipe creating blank split-view windows.
   // In standalone mode, touches starting within 20px of either edge are
   // consumed so iOS doesn't interpret them as back/forward navigation.
@@ -1671,11 +1695,17 @@ function renderSettingsTab() {
 
   // Show Guides toggle
   const showGuides = localStorage.getItem('tm-show-guides') === '1';
+  const useNewRoller = localStorage.getItem('tm-use-new-dice-roller') === '1';
   h += '<div class="settings-section">';
   h += '<div class="settings-section-label">Navigation</div>';
   h += '<label class="settings-checkbox-row">';
   h += `<input type="checkbox" id="settings-show-guides"${showGuides ? ' checked' : ''}>`;
   h += '<span>Show Primer, Guide &amp; Rules tabs</span>';
+  h += '</label>';
+  // Roll v2 (#1018): experimental new dice roller. Default OFF. Reload on change.
+  h += '<label class="settings-checkbox-row">';
+  h += `<input type="checkbox" id="settings-use-new-dice-roller"${useNewRoller ? ' checked' : ''}>`;
+  h += '<span>Use new dice roller</span>';
   h += '</label>';
   h += '</div>';
 
@@ -1746,6 +1776,13 @@ function renderSettingsTab() {
     localStorage.setItem('tm-show-guides', e.target.checked ? '1' : '0');
     renderBottomNav();
     if (document.body.classList.contains('desktop-mode')) renderDesktopSidebar();
+  });
+
+  // Wire new-dice-roller toggle (#1018). Module + DOM subtree are chosen at
+  // boot, so the swap only takes effect after a reload.
+  el.querySelector('#settings-use-new-dice-roller')?.addEventListener('change', e => {
+    localStorage.setItem('tm-use-new-dice-roller', e.target.checked ? '1' : '0');
+    location.reload();
   });
 
   // Wire ticket submit
@@ -1994,6 +2031,7 @@ function renderDesktopSidebar() {
   // Primary tabs prepended to Game section — Dice/Sheet/Status are first game items
   const primaryTabs = [
     { id: 'dice',   label: 'Dice',   icon: '<svg viewBox="0 0 24 24"><rect x="2" y="2" width="20" height="20" rx="4"/><circle cx="7" cy="7" r="1.5" fill="currentColor"/><circle cx="17" cy="7" r="1.5" fill="currentColor"/><circle cx="12" cy="12" r="1.5" fill="currentColor"/><circle cx="7" cy="17" r="1.5" fill="currentColor"/><circle cx="17" cy="17" r="1.5" fill="currentColor"/></svg>' },
+    { id: 'roll',   label: 'Roll',   icon: '<svg viewBox="0 0 24 24"><rect x="2" y="2" width="20" height="20" rx="4"/><circle cx="7" cy="7" r="1.5" fill="currentColor"/><circle cx="17" cy="7" r="1.5" fill="currentColor"/><circle cx="12" cy="12" r="1.5" fill="currentColor"/><circle cx="7" cy="17" r="1.5" fill="currentColor"/><circle cx="17" cy="17" r="1.5" fill="currentColor"/></svg>' },
     { id: 'chars',  label: 'Sheet',  icon: '<svg viewBox="0 0 24 24"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/></svg>' },
     { id: 'status', label: 'Status', icon: '<svg viewBox="0 0 24 24"><path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>' },
   ];
@@ -2022,6 +2060,9 @@ function renderDesktopSidebar() {
     // Prepend Dice/Sheet/Status to Game section
     if (hasPrimary) {
       for (const { id, label, icon } of primaryTabs) {
+        // Roll v2 (#1018): swap 'dice' ↔ 'roll' based on the settings flag.
+        if (id === 'dice' && USE_NEW_ROLLER) continue;
+        if (id === 'roll' && !USE_NEW_ROLLER) continue;
         const on = isActive(id) ? ' on' : '';
         h += `<button class="sidebar-app-tile${on}" onclick="goTab('${id}')" title="${label}">`;
         h += `<span class="sidebar-app-tile-icon">${icon}</span><span class="sidebar-app-tile-label">${label}</span></button>`;

--- a/public/js/suite/roll-v2.js
+++ b/public/js/suite/roll-v2.js
@@ -1,0 +1,478 @@
+// ══════════════════════════════════════════════
+//  Roll Tab UI (v2 — parallel dev surface, #1018)
+//
+//  Gated by the `tm-use-new-dice-roller` localStorage flag. Started as
+//  a byte-identical copy of ./roll.js so game-day iteration on the
+//  interface doesn't disturb the working DICE tab. Diverges from
+//  roll.js over time.
+// ══════════════════════════════════════════════
+
+import state from './data.js';
+
+import { d10, mkDie, mkChain, rollPool, cntSuc } from '../shared/dice.js';
+import { skSpecs, skNineAgain } from '../data/accessors.js';
+import { hasAoE } from '../data/helpers.js';
+import { getCatalogueEntry } from '../data/equipment-catalogue-cache.js';
+
+// ── Imports from other suite modules (will exist once extracted) ──
+// showResistSec / updResist live in shared/resist.js
+import { showResistSec, updResist } from '../shared/resist.js';
+
+// ── DOM helpers (will be provided by a ui module or inlined) ──
+function closePanel() {
+  const overlay = document.getElementById('panel-overlay');
+  if (overlay) overlay.classList.remove('on');
+}
+
+function toast(msg) {
+  const t = document.getElementById('toast');
+  if (!t) return;
+  t.textContent = msg;
+  t.classList.add('on');
+  clearTimeout(toast._timer);
+  toast._timer = setTimeout(() => t.classList.remove('on'), 2500);
+}
+
+// ── LOAD POOL ──
+
+export function loadPool(total, name, pi) {
+  state.PS = Math.max(0, total);
+  state.MOD = 0;
+  state.specBonuses = {};
+  state.activeEquipBonus = null;
+  state.activeWeaponId = null;
+  state.POOL_INFO = pi || null;
+  // Auto-set 9-Again when the pool source grants it
+  if (pi?.nineAgain) setAgain(9);
+  else setAgain(10);
+  // Reset Rote — player toggles manually (PT dot-5 costs 1 WP)
+  if (state.ROTE) togMod('rote');
+  showResistSec();
+  updPool();
+  const banner = document.getElementById('pool-banner');
+  const cn = state.rollChar ? state.rollChar.name.split(' ')[0] : '';
+  banner.textContent = cn ? cn + ' \u00B7 ' + name + ' \u00B7 ' + total + 'd' : name + ' \u00B7 ' + total + 'd';
+  banner.classList.add('on');
+  document.getElementById('sc-disc-lbl').textContent = '';
+  document.getElementById('sc-disc-val').textContent = name;
+  document.getElementById('sc-disc').classList.add('loaded');
+  closePanel();
+}
+
+// ── EFFECTIVE POOL ──
+
+export function effPool() {
+  const wpBonus = state.WP ? 3 : 0;
+  return state.RESIST_MODE === '-'
+    ? Math.max(0, state.PS + state.MOD + wpBonus - state.RESIST_VAL)
+    : state.PS + state.MOD + wpBonus;
+}
+
+// ── POOL / MOD ADJUSTMENTS ──
+
+export function chgPool(d) {
+  state.PS = Math.max(-5, Math.min(40, state.PS + d));
+  updPool();
+}
+
+export function chgMod(d) {
+  state.MOD = Math.max(-10, Math.min(10, state.MOD + d));
+  updPool();
+}
+
+// ── UPDATE POOL DISPLAY ──
+
+export function updPool() {
+  const eff = effPool();
+  const pv = document.getElementById('pval');
+  pv.textContent = state.PS <= 0 ? 'Chance' : state.PS;
+  pv.className = 'cval' + (state.PS <= 0 ? ' chance' : '');
+
+  const mv = document.getElementById('mval');
+  const mod = state.MOD;
+  mv.textContent = mod === 0 ? '0' : mod > 0 ? '+' + mod : mod;
+  mv.className = 'bval' + (mod > 0 ? ' pos' : mod < 0 ? ' neg' : '');
+
+  const el = document.getElementById('effline');
+  const pi = state.POOL_INFO;
+
+  if (!pi || !pi.attr) {
+    if (eff <= 0) {
+      el.innerHTML = 'Effective pool: <span class="effpool-seg effpool-seg--neg">Chance die</span>';
+    } else {
+      el.innerHTML = 'Effective pool: <span>' + eff + (eff === 1 ? ' die' : ' dice') + '</span>';
+    }
+    return;
+  }
+
+  const segs = [];
+  if (pi.attr) segs.push('<span class="effpool-seg">' + pi.attr + ' <b>' + pi.attrV + '</b></span>');
+  if (pi.skill) segs.push('<span class="effpool-seg">' + pi.skill + ' <b>' + pi.skillV + '</b></span>');
+  if (pi.unskilled) segs.push('<span class="effpool-seg effpool-seg--neg">unskilled <b>' + pi.unskilled + '</b></span>');
+  if (pi.discName && pi.discV) segs.push('<span class="effpool-seg">' + pi.discName + ' <b>' + pi.discV + '</b></span>');
+  if (pi.meritBonus && pi.meritLabel) segs.push('<span class="effpool-seg effpool-seg--merit">' + pi.meritLabel + ' <b>+' + pi.meritBonus + '</b></span>');
+  if (pi.roteEligible && !state.ROTE) segs.push('<span class="effpool-seg effpool-seg--rote" onclick="togMod(\'rote\')" title="PT dot 5: spend 1 WP for Rote quality">Rote \u2713</span>');
+  if (state.WP) segs.push('<span class="effpool-seg effpool-seg--wp">WP <b>+3</b></span>');
+  if (state.RESIST_MODE === '-' && state.RESIST_VAL > 0) {
+    segs.push('<span class="effpool-seg effpool-seg--resist">\u2212Resist <b>' + state.RESIST_VAL + '</b></span>');
+  }
+
+  let html = segs.join('<span class="effpool-sep"> + </span>');
+
+  if (pi.skill && state.rollChar) {
+    const rc = state.rollChar;
+    const specs = skSpecs(rc, pi.skill);
+    const na = skNineAgain(rc, pi.skill);
+    if (specs.length) {
+      html += '<div class="effpool-specs">' + specs.map(s => {
+        const aoe = hasAoE(rc, s);
+        const bonusN = na || aoe ? 2 : 1;
+        const bonusLbl = na ? '2 (9-again)' : aoe ? '2 (AoE)' : '1';
+        const isOn = state.specBonuses[s] !== undefined;
+        const cls = 'effpool-spec' + (isOn ? ' on' : '');
+        const safe = String(s).replace(/"/g, '&quot;');
+        return `<span class="${cls}" data-spec="${safe}" data-bonus="${bonusN}" `
+             + `onclick="togSpec(this)" title="Click to add this specialty's bonus to your modifier">`
+             + `${s} <span class="effpool-spec-bonus">+${bonusLbl}</span></span>`;
+      }).join('') + '</div>';
+    }
+  }
+
+  // Equipment bonus chips (EQ-3): one-active-at-a-time gear bonuses
+  if (pi.skill && state.rollChar) {
+    const rc = state.rollChar;
+    const equip = (rc.equipment || []).filter(item => {
+      const entry = getCatalogueEntry(item.catalogue_id);
+      // #752: 'active' is the strongest in-use state — treat it identically
+      // to carried/worn for chip eligibility (Khepri's option (a) — preserves
+      // 'active' as a semantically-stronger marker an ST may have already used).
+      return entry && entry.bucket === 'equipment' &&
+             entry.bonus_dice > 0 &&
+             entry.skill_domain === pi.skill &&
+             (item.state === 'carried' || item.state === 'worn' || item.state === 'active');
+    });
+    if (equip.length) {
+      html += '<div class="effpool-specs">' + equip.map(item => {
+        const entry = getCatalogueEntry(item.catalogue_id);
+        const isOn = state.activeEquipBonus &&
+                     state.activeEquipBonus.catalogueId === entry.id;
+        const cls = 'effpool-spec' + (isOn ? ' on' : '');
+        const safe = String(entry.id).replace(/"/g, '&quot;');
+        return `<span class="${cls}" data-equip="${safe}" data-bonus="${entry.bonus_dice}" `
+             + `onclick="togEquipChip(this)" title="${entry.name}">`
+             + `${entry.name} <span class="effpool-spec-bonus">+${entry.bonus_dice}</span></span>`;
+      }).join('') + '</div>';
+    }
+  }
+
+  el.innerHTML = html;
+  updWeaponRef();
+}
+
+// ── SPECIALTY TOGGLE ──
+//
+// Click handler for the specialty badges under the effective-pool line.
+// Toggling a badge on adds its dice bonus to MOD; toggling off subtracts
+// the same amount. The per-spec bonus is stored in state.specBonuses so
+// we can reverse the exact amount even if the displayed bonus would be
+// different at toggle-off time (e.g. character data changed mid-roll).
+
+export function togSpec(badge) {
+  if (!badge) return;
+  const name = badge.dataset.spec;
+  const bonus = parseInt(badge.dataset.bonus, 10) || 0;
+  if (!name || !bonus) return;
+  const existing = state.specBonuses[name];
+  if (existing !== undefined) {
+    state.MOD = state.MOD - existing;
+    delete state.specBonuses[name];
+  } else {
+    state.MOD = state.MOD + bonus;
+    state.specBonuses[name] = bonus;
+  }
+  updPool();
+}
+
+// ── EQUIPMENT CHIP TOGGLE (EQ-3) ──
+
+export function togEquipChip(badge) {
+  if (!badge) return;
+  const id = badge.dataset.equip;
+  const bonus = parseInt(badge.dataset.bonus, 10) || 0;
+  if (!id || !bonus) return;
+
+  if (state.activeEquipBonus && state.activeEquipBonus.catalogueId === id) {
+    state.MOD -= state.activeEquipBonus.bonus;
+    state.activeEquipBonus = null;
+  } else {
+    if (state.activeEquipBonus) {
+      state.MOD -= state.activeEquipBonus.bonus;
+    }
+    state.MOD += bonus;
+    state.activeEquipBonus = { catalogueId: id, bonus };
+  }
+  updPool();
+}
+
+// ── WEAPON REFERENCE PANEL (EQ-3) ──
+
+const COMBAT_SKILLS = ['Weaponry', 'Brawl', 'Firearms', 'Archery'];
+
+export function updWeaponRef() {
+  const panel = document.getElementById('weapon-ref');
+  if (!panel) return;
+
+  // Capture live selection before rebuilding innerHTML
+  const liveSel = document.getElementById('weapon-sel');
+  if (liveSel && liveSel.value) state.activeWeaponId = liveSel.value;
+  else if (liveSel && !liveSel.value) state.activeWeaponId = null;
+
+  const pi = state.POOL_INFO;
+  if (!pi || !pi.skill || !COMBAT_SKILLS.includes(pi.skill) || !state.rollChar) {
+    panel.style.display = 'none';
+    return;
+  }
+  const weapons = (state.rollChar.equipment || []).filter(item => {
+    // #752: 'active' is the strongest in-use state — include it in weapon-ref
+    // eligibility (matches the chip predicate above).
+    const entry = getCatalogueEntry(item.catalogue_id);
+    return entry && entry.bucket === 'weapon' &&
+           (item.state === 'carried' || item.state === 'worn' || item.state === 'active');
+  });
+  if (!weapons.length) {
+    panel.style.display = 'none';
+    return;
+  }
+
+  panel.style.display = '';
+  const prevId = state.activeWeaponId;
+
+  const optionsHtml = weapons.map(item => {
+    const e = getCatalogueEntry(item.catalogue_id);
+    const sel = prevId === e.id ? ' selected' : '';
+    return `<option value="${e.id}"${sel}>${e.name}</option>`;
+  }).join('');
+
+  let statsHtml = '';
+  if (prevId) {
+    const e = getCatalogueEntry(prevId);
+    if (e) {
+      const DMGTYPE = { lethal: 'Lethal', bashing: 'Bashing', aggravated: 'Aggravated' };
+      const WPNTYPE = { melee: 'Melee', ranged: 'Ranged', thrown: 'Thrown' };
+      const mod = e.damage_mod > 0 ? '+' + e.damage_mod : String(e.damage_mod);
+      statsHtml = `<div class="trait-qual">`
+               + `${mod} · ${DMGTYPE[e.damage_type] || e.damage_type} · ${WPNTYPE[e.weapon_type] || e.weapon_type}`
+               + `</div>`;
+    }
+  }
+
+  panel.innerHTML = `<div class="slabel">Weapon</div>`
+    + `<select id="weapon-sel" class="resist-sel" onchange="updWeaponRef()">`
+    + `<option value="">-- select --</option>${optionsHtml}</select>${statsHtml}`;
+}
+
+// ── AGAIN / MODIFIER TOGGLES ──
+
+export function setAgain(v) {
+  state.AGAIN = v;
+  [8, 9].forEach(n => {
+    const el = document.getElementById('a' + n);
+    if (el) el.classList.toggle('on', n === v);
+  });
+}
+
+export function togMod(m) {
+  if (m === 'rote') {
+    state.ROTE = !state.ROTE;
+    document.getElementById('rote-c').classList.toggle('on', state.ROTE);
+  } else if (m === 'wp') {
+    state.WP = !state.WP;
+    document.getElementById('wp-c').classList.toggle('on', state.WP);
+    updPool();
+  } else {
+    state.NA = !state.NA;
+    document.getElementById('na-c').classList.toggle('on', state.NA);
+  }
+}
+
+// ── DIE DOM ELEMENTS ──
+
+export function mkDieEl(d, delay, isX) {
+  const el = document.createElement('div');
+  // Exploding re-roll dice use the same success/fail colour as initial dice,
+  // plus an 'ed' marker class for the chain connector styling.
+  let cls = d.s ? 'die sd' : 'die fd';
+  if (isX) cls += ' ed';
+  if (d.x) cls += ' xd';
+  el.className = cls;
+  el.textContent = d.v;
+  el.style.animationDelay = (delay * 40) + 'ms';
+  return el;
+}
+
+export function mkColsEl(cols, base) {
+  const w = document.createElement('div');
+  w.style.cssText = 'display:flex;flex-wrap:wrap;gap:5px;';
+  let delay = base;
+  cols.forEach(col => {
+    const ce = document.createElement('div');
+    ce.className = 'dcol';
+    ce.appendChild(mkDieEl(col.r, delay++, false));
+    col.ch.forEach(child => {
+      const conn = document.createElement('div');
+      conn.className = 'xconn';
+      ce.appendChild(conn);
+      ce.appendChild(mkDieEl(child, delay++, true));
+    });
+    w.appendChild(ce);
+  });
+  return w;
+}
+
+// ── MAIN ROLL ──
+
+export function doRoll() {
+  const eff = effPool();
+  const area = document.getElementById('dice-area');
+  const hdr = document.getElementById('res-hdr');
+  area.innerHTML = '';
+  hdr.classList.remove('on');
+
+  if (eff <= 0) {
+    const v = d10();
+    const suc = v === 10;
+    const dram = v === 1;
+    const cls = dram ? 'd' : suc ? 'e' : 'f';
+    const lbl = dram ? 'Dramatic Failure' : suc ? 'Success (Chance)' : 'Failure (Chance)';
+    const cnt = dram ? '\u2014' : suc ? '1' : '0';
+    hdr.innerHTML = `<div><span class="rcnt ${cls}">${cnt}</span><span class="rlbl ${cls}">${lbl}</span></div><div class="rverd">Chance die</div>`;
+    hdr.classList.add('on');
+    const del = document.createElement('div');
+    del.className = 'die cd';
+    del.textContent = v;
+    area.appendChild(del);
+    addHist('Chance', cls, lbl, cnt, 'Chance die');
+    return;
+  }
+
+  const cA = rollPool(eff);
+  const cB = state.ROTE ? rollPool(eff) : null;
+  const sA = cntSuc(cA);
+  const sB = state.ROTE ? cntSuc(cB) : 0;
+  let wC, wS, lC, lS;
+
+  if (state.ROTE && sB > sA) {
+    wC = cB; wS = sB; lC = cA; lS = sA;
+  } else {
+    wC = cA; wS = sA;
+    if (state.ROTE) { lC = cB; lS = sB; }
+  }
+
+  const mods = [];
+  if (state.WP) mods.push('WP +3');
+  if (state.ROTE) mods.push('rote');
+  if (state.NA) mods.push('no again');
+
+  const pi = state.POOL_INFO;
+  const verdParts = [];
+  if (pi && pi.attr) {
+    if (pi.attr) verdParts.push(pi.attr + ' ' + pi.attrV);
+    if (pi.skill) verdParts.push(pi.skill + ' ' + pi.skillV);
+    if (pi.unskilled) verdParts.push('unskilled ' + pi.unskilled);
+    if (pi.discName && pi.discV) verdParts.push(pi.discName + ' ' + pi.discV);
+  }
+  const poolStr = verdParts.length ? verdParts.join(' + ') : eff + 'd10';
+  const ag = state.AGAIN;
+  const verd = `${poolStr} \u00B7 ${ag}-again${mods.length ? ' \u00B7 ' + mods.join(', ') : ''}`;
+
+  // Contested roll
+  if (state.RESIST_MODE === 'v' && state.RESIST_CHAR && state.RESIST_VAL > 0) {
+    const cR = rollPool(state.RESIST_VAL);
+    const sR = cntSuc(cR);
+    const net = wS - sR;
+    const won = net > 0;
+    const draw = net === 0;
+    const cls = won ? (net >= 5 ? 'e' : 's') : 'f';
+    const outcome = won ? (net >= 5 ? 'Exceptional Success' : 'Success') : draw ? 'Draw (Failure)' : 'Failure';
+    const rcName = state.rollChar ? state.rollChar.name.split(' ')[0] : 'Roll';
+    const resistName = state.RESIST_CHAR.name.split(' ')[0];
+    const resistLabel = pi ? pi.resistance : '';
+
+    hdr.innerHTML = `<div><span class="rcnt ${cls}">${won ? net : wS}</span><span class="rlbl ${cls}">${outcome}</span></div><div class="rverd">${poolStr} vs ${resistName} ${resistLabel} \u00B7 ${wS} vs ${sR}</div>`;
+    hdr.classList.add('on');
+
+    const wb = document.createElement('div');
+    wb.className = 'rote-blk win';
+    wb.innerHTML = `<div class="rote-lbl">${rcName} \u2014 ${wS} success${wS !== 1 ? 'es' : ''}</div>`;
+    wb.appendChild(mkColsEl(wC, 0));
+    area.appendChild(wb);
+
+    const rb = document.createElement('div');
+    rb.className = 'rote-blk' + (won ? '' : ' win');
+    rb.innerHTML = `<div class="rote-lbl">${resistName} (resistance) \u2014 ${sR} success${sR !== 1 ? 'es' : ''}</div>`;
+    rb.appendChild(mkColsEl(cR, wC.length + 2));
+    area.appendChild(rb);
+
+    addHist(eff + 'd10', cls, outcome, won ? net : wS, verd);
+    return;
+  }
+
+  // Standard roll result
+  const exc = wS >= 5;
+  const cls = wS === 0 ? 'f' : exc ? 'e' : 's';
+  const lbl = wS === 0 ? 'Failure' : exc ? 'Exceptional Success' : 'Success';
+  hdr.innerHTML = `<div><span class="rcnt ${cls}">${wS}</span><span class="rlbl ${cls}">${lbl}</span></div><div class="rverd">${verd}</div>`;
+  hdr.classList.add('on');
+
+  if (state.ROTE) {
+    const wb = document.createElement('div');
+    wb.className = 'rote-blk win';
+    wb.innerHTML = `<div class="rote-lbl">Roll 1 \u2014 ${wS} success${wS !== 1 ? 'es' : ''} (selected)</div>`;
+    wb.appendChild(mkColsEl(wC, 0));
+    area.appendChild(wb);
+
+    const lb = document.createElement('div');
+    lb.className = 'rote-blk';
+    lb.innerHTML = `<div class="rote-lbl">Roll 2 \u2014 ${lS} success${lS !== 1 ? 'es' : ''}</div>`;
+    lb.appendChild(mkColsEl(lC, wC.length + 2));
+    area.appendChild(lb);
+  } else {
+    area.appendChild(mkColsEl(wC, 0));
+  }
+
+  addHist(eff + 'd10', cls, lbl, wS, verd);
+
+  // Auto-reset WP after rolling (one-time spend)
+  if (state.WP) {
+    state.WP = false;
+    document.getElementById('wp-c')?.classList.remove('on');
+    updPool();
+  }
+}
+
+// ── ROLL HISTORY ──
+
+export function addHist(pool, cls, lbl, cnt, verd) {
+  const h = state.hist;
+  h.unshift({ pool, lbl, cnt, cls, verd });
+  if (h.length > 20) h.pop();
+  state.hist = h;
+  renderHist();
+}
+
+export function renderHist() {
+  const l = document.getElementById('hlist');
+  const h = state.hist;
+  if (!h.length) {
+    l.innerHTML = '<div class="hempty">No rolls yet</div>';
+    return;
+  }
+  l.innerHTML = h.map(r =>
+    `<div class="hitem"><span class="hmeta">${r.verd}</span><span class="hres ${r.cls}">${r.cnt} ${r.lbl}</span></div>`
+  ).join('');
+}
+
+export function clrHist() {
+  state.hist = [];
+  renderHist();
+}

--- a/tests/issue-1018-parallel-roll-tab-flag.spec.js
+++ b/tests/issue-1018-parallel-roll-tab-flag.spec.js
@@ -1,0 +1,137 @@
+// Smokes for issue #1018 — parallel ROLL tab gated by the
+// `tm-use-new-dice-roller` localStorage flag.
+//
+// The player app is Discord-OAuth-gated, so these are source-fetch smokes
+// (same pattern used for issue-1015). They lock in the wiring contract:
+//
+//   1. `public/js/suite/roll-v2.js` exists as a companion to `roll.js` and
+//      exports the same public surface.
+//   2. `public/index.html` has both `#t-dice` and `#t-roll` blocks with
+//      the same internal id inventory (so external touch-points work
+//      unchanged after the DOM-subtree removal at boot).
+//   3. `public/js/app.js` reads the flag, imports both roll modules,
+//      wires the active one to the internal + window bindings, and
+//      removes the inactive DOM subtree at boot.
+//   4. Nav swap: renderers skip the inactive tab (`dice` vs `roll`).
+//   5. Settings tab has the checkbox with id `settings-use-new-dice-roller`
+//      and its change handler writes the flag + reloads.
+
+const { test, expect } = require('@playwright/test');
+
+const ROLL_EXPORTS = [
+  'loadPool', 'chgPool', 'chgMod', 'updPool',
+  'setAgain', 'togMod', 'togSpec', 'doRoll',
+  'clrHist', 'effPool', 'togEquipChip', 'updWeaponRef',
+];
+
+test('#1018 — roll-v2.js exists and exports the same public surface as roll.js', async ({ request }) => {
+  const [v1Res, v2Res] = await Promise.all([
+    request.get('/js/suite/roll.js'),
+    request.get('/js/suite/roll-v2.js'),
+  ]);
+  expect(v2Res.status()).toBe(200);
+  const v1 = await v1Res.text();
+  const v2 = await v2Res.text();
+  for (const sym of ROLL_EXPORTS) {
+    expect(v1, `roll.js should export ${sym}`).toMatch(new RegExp(`export\\s+function\\s+${sym}\\b`));
+    expect(v2, `roll-v2.js should export ${sym}`).toMatch(new RegExp(`export\\s+function\\s+${sym}\\b`));
+  }
+});
+
+test('#1018 — index.html has both #t-dice and #t-roll tab blocks', async ({ request }) => {
+  const res = await request.get('/index.html');
+  const html = await res.text();
+  expect(html).toMatch(/<div\s+id="t-dice"\s+class="tab">/);
+  expect(html).toMatch(/<div\s+id="t-roll"\s+class="tab">/);
+  // Both must contain the load-bearing inner IDs so the same JS + external
+  // touch-points work against whichever subtree survives boot.
+  for (const id of ['pval', 'mval', 'roll-btn', 'dice-area', 'hlist', 'sc-char-val']) {
+    const matches = html.match(new RegExp(`id="${id}"`, 'g')) || [];
+    expect(matches.length, `id="${id}" should appear in both tab blocks`).toBeGreaterThanOrEqual(2);
+  }
+});
+
+test('#1018 — app.js imports both roll modules and gates by flag', async ({ request }) => {
+  const res = await request.get('/js/app.js');
+  const src = await res.text();
+  expect(src).toMatch(/import\s+\*\s+as\s+rollV1\s+from\s+['"]\.\/suite\/roll\.js['"]/);
+  expect(src).toMatch(/import\s+\*\s+as\s+rollV2\s+from\s+['"]\.\/suite\/roll-v2\.js['"]/);
+  expect(src).toMatch(/tm-use-new-dice-roller/);
+  expect(src).toMatch(/USE_NEW_ROLLER\s*\?\s*rollV2\s*:\s*rollV1/);
+});
+
+test('#1018 — boot() removes the inactive tab subtree', async ({ request }) => {
+  const res = await request.get('/js/app.js');
+  const src = await res.text();
+  // The removal ties the DOM subtree choice to the flag so getElementById
+  // resolves against the visible tab across every touch-point.
+  expect(src).toMatch(/getElementById\(\s*USE_NEW_ROLLER\s*\?\s*['"]t-dice['"]\s*:\s*['"]t-roll['"]\s*\)\??\.remove\(\)/);
+});
+
+test('#1018 — nav renderers gate dice/roll on the flag', async ({ request }) => {
+  const res = await request.get('/js/app.js');
+  const src = await res.text();
+  // Bottom nav + desktop sidebar primaryTabs both skip the inactive item.
+  const gatePattern = /if\s*\(\s*item\.id\s*===\s*['"]dice['"]\s*&&\s*USE_NEW_ROLLER\s*\)\s*continue;/;
+  expect(src.match(gatePattern), 'renderBottomNav should skip dice when flag is on').not.toBeNull();
+  const gatePattern2 = /if\s*\(\s*item\.id\s*===\s*['"]roll['"]\s*&&\s*!USE_NEW_ROLLER\s*\)\s*continue;/;
+  expect(src.match(gatePattern2), 'renderBottomNav should skip roll when flag is off').not.toBeNull();
+  // The desktop primaryTabs loop uses `id` (destructured) rather than `item.id`.
+  expect(src).toMatch(/if\s*\(\s*id\s*===\s*['"]dice['"]\s*&&\s*USE_NEW_ROLLER\s*\)\s*continue;/);
+  expect(src).toMatch(/if\s*\(\s*id\s*===\s*['"]roll['"]\s*&&\s*!USE_NEW_ROLLER\s*\)\s*continue;/);
+});
+
+test('#1018 — settings tab has the "Use new dice roller" checkbox with a reload handler', async ({ request }) => {
+  const res = await request.get('/js/app.js');
+  const src = await res.text();
+  expect(src).toMatch(/id="settings-use-new-dice-roller"/);
+  expect(src).toMatch(/Use new dice roller/);
+  // Change handler writes the flag and reloads.
+  const handlerRe = /#settings-use-new-dice-roller[^]*?localStorage\.setItem\(\s*['"]tm-use-new-dice-roller['"][^]*?location\.reload\(\)/;
+  expect(src.match(handlerRe), 'change handler should persist + reload').not.toBeNull();
+});
+
+// Boot-time smoke: verify no module-level errors and that the correct
+// subtree survives in each flag state. Runs against the login screen —
+// no Discord auth needed because the module-import phase happens before
+// the auth gate.
+
+async function assertSubtreeState(page, flagOn) {
+  await page.goto('/');
+  await page.evaluate((on) => {
+    if (on) localStorage.setItem('tm-use-new-dice-roller', '1');
+    else localStorage.removeItem('tm-use-new-dice-roller');
+  }, flagOn);
+  const errors = [];
+  page.on('pageerror', (e) => errors.push(String(e)));
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') errors.push(msg.text());
+  });
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(400);
+  const state = await page.evaluate(() => ({
+    hasDice: !!document.getElementById('t-dice'),
+    hasRoll: !!document.getElementById('t-roll'),
+    pvalCount: document.querySelectorAll('[id="pval"]').length,
+  }));
+  // Exactly one of the two tab subtrees survives boot.
+  if (flagOn) {
+    expect(state.hasDice, 'flag ON: #t-dice should be removed').toBeFalsy();
+    expect(state.hasRoll, 'flag ON: #t-roll should be present').toBeTruthy();
+  } else {
+    expect(state.hasDice, 'flag OFF: #t-dice should be present').toBeTruthy();
+    expect(state.hasRoll, 'flag OFF: #t-roll should be removed').toBeFalsy();
+  }
+  expect(state.pvalCount, 'exactly one #pval element should remain').toBe(1);
+  // No unrelated module errors.
+  const modErrs = errors.filter((e) => /roll-v2|roll\.js|Failed to resolve module|USE_NEW_ROLLER/i.test(e));
+  expect(modErrs, `module errors: ${modErrs.join('\n')}`).toEqual([]);
+}
+
+test('#1018 — boot with flag OFF: #t-dice survives, #t-roll removed', async ({ page }) => {
+  await assertSubtreeState(page, false);
+});
+
+test('#1018 — boot with flag ON: #t-roll survives, #t-dice removed', async ({ page }) => {
+  await assertSubtreeState(page, true);
+});


### PR DESCRIPTION
## Summary
Deploy dev → main.

- **#1018** (`04afad98`) — parallel ROLL tab as a byte-identical clone of DICE, gated by the `tm-use-new-dice-roller` localStorage flag (default OFF). Setting persists; changing it reloads to swap the module + DOM subtree cleanly. Zero refactor of external DICE-tab touch-points.

## Deploy footprint
- Netlify (frontend): `public/index.html`, `public/js/app.js`, new `public/js/suite/roll-v2.js`. Behaviour is unchanged for every user until they toggle the setting.
- Render (API): no route changes.
- MongoDB: no schema change.

## Test plan
- Playwright `tests/issue-1018-parallel-roll-tab-flag.spec.js` — 8/8 green (6 source-contract + 2 runtime reload tests confirming the correct subtree survives in each flag state).