### PR TITLE
Merge dev → main: Failed Breakpoint merit (#1021)

### DIFF
--- a/server/scripts/add-1021-failed-breakpoint-merit.js
+++ b/server/scripts/add-1021-failed-breakpoint-merit.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * Issue #1021 — insert 'Failed Breakpoint' merit into purchasable_powers.
+ *
+ * Narrative-consequence merit at 2 dots (2 XP total under VtR 2e's flat
+ * 1 XP/dot merit rule). No mechanical prereqs; description is the exact
+ * text supplied on the ticket.
+ *
+ * Idempotent. Dry-run default; pass --apply to write. If the doc already
+ * exists it's a no-op — this script never overwrites.
+ */
+
+import 'dotenv/config';
+import { MongoClient } from 'mongodb';
+
+const APPLY = process.argv.includes('--apply');
+const DRY_RUN = !APPLY;
+const MONGODB_URI = process.env.MONGODB_URI;
+const DB_NAME = process.env.MONGODB_DB || 'tm_suite';
+
+export const FAILED_BREAKPOINT_DOC = {
+  key: 'failed-breakpoint',
+  name: 'Failed Breakpoint',
+  category: 'merit',
+  sub_category: 'general',
+  parent: null,
+  rank: null,
+  rating_range: [2, 2],
+  description: 'You have failed a break point that has reduced your humanity',
+  pool: null,
+  resistance: null,
+  cost: null,
+  action: null,
+  duration: null,
+  prereq: null,
+  exclusive: null,
+  xp_fixed: null,
+  bloodline: null,
+  offering: null,
+  cult: null,
+  implemented: false,
+};
+
+async function main() {
+  if (!MONGODB_URI) {
+    console.error('MONGODB_URI is not set. Run from server/ with server/.env in place.');
+    process.exit(1);
+  }
+  console.log(`Mode: ${APPLY ? 'APPLY (will write)' : 'DRY RUN (read only; pass --apply to write)'}`);
+  console.log(`Target DB: ${DB_NAME}`);
+  console.log(`Target key: ${FAILED_BREAKPOINT_DOC.key}\n`);
+
+  console.log('--- Document to insert ---');
+  console.log(JSON.stringify(FAILED_BREAKPOINT_DOC, null, 2));
+  console.log('--- end document ---\n');
+
+  const client = new MongoClient(MONGODB_URI, { serverSelectionTimeoutMS: 10000, tls: true });
+  try {
+    await client.connect();
+    const col = client.db(DB_NAME).collection('purchasable_powers');
+
+    const existing = await col.findOne(
+      { key: FAILED_BREAKPOINT_DOC.key },
+      { projection: { _id: 1, name: 1 } }
+    );
+    if (existing) {
+      console.log(`Already present (_id=${existing._id}). No-op.`);
+      return;
+    }
+
+    if (APPLY) {
+      const res = await col.insertOne({ ...FAILED_BREAKPOINT_DOC });
+      console.log(`Inserted 1 doc (_id=${res.insertedId}).`);
+    } else {
+      console.log('[DRY RUN] Pass --apply to write.');
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+const _invokedDirectly = import.meta.url === `file://${process.argv[1]}`;
+if (_invokedDirectly) {
+  main().catch(err => { console.error(err); process.exit(1); });
+}

--- a/server/tests/issue-1021-failed-breakpoint-merit.test.js
+++ b/server/tests/issue-1021-failed-breakpoint-merit.test.js
@@ -1,0 +1,34 @@
+/**
+ * Issue #1021 — validate the Failed Breakpoint merit doc shape and
+ * confirm it passes the purchasable_power JSON Schema.
+ *
+ * Pure unit — no DB, no filesystem. Catches doc-shape drift from
+ * the schema before any prod write.
+ */
+
+import { describe, it, expect } from 'vitest';
+import Ajv from 'ajv';
+import { purchasablePowerSchema } from '../schemas/purchasable_power.schema.js';
+import { FAILED_BREAKPOINT_DOC } from '../scripts/add-1021-failed-breakpoint-merit.js';
+
+describe('#1021 — Failed Breakpoint merit', () => {
+  const ajv = new Ajv({ allErrors: true });
+  const validate = ajv.compile(purchasablePowerSchema);
+
+  it('passes the purchasable_power JSON Schema', () => {
+    const ok = validate(FAILED_BREAKPOINT_DOC);
+    expect(ok, `schema errors: ${JSON.stringify(validate.errors, null, 2)}`).toBe(true);
+  });
+
+  it('matches the requested shape verbatim', () => {
+    expect(FAILED_BREAKPOINT_DOC.key).toBe('failed-breakpoint');
+    expect(FAILED_BREAKPOINT_DOC.name).toBe('Failed Breakpoint');
+    expect(FAILED_BREAKPOINT_DOC.category).toBe('merit');
+    expect(FAILED_BREAKPOINT_DOC.sub_category).toBe('general');
+    expect(FAILED_BREAKPOINT_DOC.description).toBe(
+      'You have failed a break point that has reduced your humanity'
+    );
+    expect(FAILED_BREAKPOINT_DOC.rating_range).toEqual([2, 2]);
+    expect(FAILED_BREAKPOINT_DOC.prereq).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
Deploy dev → main. Ships:

- **#1021** (`8ed84a30`) — repo hygiene for the `Failed Breakpoint` merit insert script + vitest. Prod DB already carries the new doc (applied 2026-07-18 at `_id=6a5b146be52a00ec6f2d8ba8`).

## Deploy footprint
- Netlify (frontend): no code change.
- Render (API): no route change.
- MongoDB: `purchasable_powers.failed-breakpoint` doc is already present on prod — this PR is repo-hygiene for the tooling.

## Test plan
- Vitest `server/tests/issue-1021-failed-breakpoint-merit.test.js` — 2/2 green (ajv schema validate + shape-verbatim check).
- Re-run of the insert script against prod reports "Already present. No-op." — write took, idempotency confirmed.