### PR TITLE
Merge dev → main: ROLL v2 slice A+D (#1024)

### DIFF
--- a/public/css/suite.css
+++ b/public/css/suite.css
@@ -2639,3 +2639,196 @@ body.desktop-mode.sidebar-collapsed .sb-collapse-btn { width: 100%; justify-cont
 .office-log-target { color: var(--txt); flex: 1; min-width: 80px; }
 .office-log-status { color: var(--txt2); font-size: 12px; white-space: nowrap; }
 .office-log-time   { color: var(--txt2); font-size: 11px; opacity: .7; white-space: nowrap; }
+
+/* ══════════════════════════════════════════════════════════════
+   Roll v2 — anchor layout + segmented Again rule (issue #1024)
+   ══════════════════════════════════════════════════════════════ */
+
+.rv2-anchor {
+  padding: 20px 16px 8px;
+  text-align: center;
+}
+.rv2-eff-wrap {
+  display: flex;
+  align-items: baseline;
+  justify-content: center;
+  gap: 8px;
+}
+.rv2-eff {
+  font-family: var(--fh);
+  font-size: 64px;
+  font-weight: 700;
+  color: var(--gold2);
+  line-height: 1;
+  letter-spacing: -0.02em;
+}
+.rv2-eff.chance {
+  color: var(--err);
+  font-size: 40px;
+}
+.rv2-eff-unit {
+  font-family: var(--fl);
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--txt3);
+}
+.rv2-sub {
+  margin-top: 8px;
+  font-family: var(--fl);
+  font-size: 12px;
+  color: var(--txt2);
+  line-height: 1.4;
+}
+
+.rv2-steppers {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  padding: 8px 16px 12px;
+  max-width: 420px;
+  margin: 0 auto;
+}
+.rv2-stepper-lbl {
+  font-family: var(--fl);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--txt3);
+  text-align: center;
+  margin-bottom: 4px;
+}
+.rv2-stepper-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: var(--surf2);
+  border: 1px solid var(--bdr);
+  border-radius: 8px;
+  padding: 3px;
+}
+.rv2-adj {
+  width: 36px;
+  height: 36px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--gold2);
+  font-family: var(--fh);
+  font-size: 20px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+.rv2-adj:active { background: var(--surf3); }
+.rv2-stepper-val {
+  flex: 1;
+  text-align: center;
+  font-family: var(--ft);
+  font-size: 18px;
+  font-weight: 700;
+  color: var(--txt);
+}
+.rv2-stepper-val.chance { color: var(--err); font-size: 14px; }
+.rv2-stepper-val.pos { color: var(--gold2); }
+.rv2-stepper-val.neg { color: var(--err); }
+
+.rv2-again-wrap {
+  padding: 8px 16px;
+}
+.rv2-again-lbl {
+  font-family: var(--fl);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--txt3);
+  margin-bottom: 6px;
+}
+.rv2-again-seg {
+  display: flex;
+  background: var(--surf2);
+  border: 1px solid var(--bdr);
+  border-radius: 8px;
+  padding: 3px;
+  gap: 3px;
+}
+.rv2-again-seg button {
+  flex: 1;
+  padding: 8px 4px;
+  border: none;
+  background: transparent;
+  border-radius: 6px;
+  color: var(--txt2);
+  font-family: var(--fl);
+  font-size: 12px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+}
+.rv2-again-seg button:hover:not(.on) {
+  background: var(--surf3);
+}
+.rv2-again-seg button.on {
+  background: var(--gold2-a25);
+  color: var(--gold2);
+}
+
+.rv2-chip-row {
+  display: flex;
+  gap: 8px;
+  padding: 4px 16px 8px;
+  justify-content: center;
+}
+
+.rv2-breakdown {
+  padding: 4px 16px 8px;
+}
+.rv2-breakdown summary {
+  font-family: var(--fl);
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--txt3);
+  cursor: pointer;
+  padding: 6px 0;
+  list-style: none;
+}
+.rv2-breakdown summary::-webkit-details-marker { display: none; }
+.rv2-breakdown summary::before {
+  content: '▸ ';
+  display: inline-block;
+  transition: transform 0.15s;
+}
+.rv2-breakdown[open] summary::before {
+  transform: rotate(90deg);
+}
+.rv2-breakdown[open] summary { color: var(--txt2); }
+
+.rv2-roll-btn {
+  position: sticky;
+  bottom: 8px;
+  z-index: 10;
+  display: block;
+  width: calc(100% - 32px);
+  margin: 12px 16px 16px;
+  padding: 16px;
+  border: none;
+  border-radius: 10px;
+  background: var(--crim);
+  color: var(--txt-on-dark);
+  font-family: var(--fh);
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  cursor: pointer;
+  box-shadow: 0 -4px 16px var(--overlay);
+  transition: filter 0.12s;
+}
+.rv2-roll-btn:active { filter: brightness(1.15); }

--- a/public/index.html
+++ b/public/index.html
@@ -217,10 +217,18 @@
     </div>
 
     <!-- ═══ ROLL TAB (v2 — parallel dev surface, gated by
-             `tm-use-new-dice-roller` flag; issue #1018). Inner IDs are
-             identical to #t-dice on purpose — app.js removes whichever
-             of the two subtrees is inactive at boot so only one set of
-             those IDs exists in the live DOM. ═══ -->
+             `tm-use-new-dice-roller` flag; issues #1018, #1024).
+
+             Slice A+D layout: effective-pool as the visual anchor;
+             segmented Again rule. The load-bearing "shared surface"
+             IDs (sc-*, roll-char-pools, weapon-ref, resist-*,
+             lifecycle-cards, btn-contested, effline, res-hdr,
+             dice-area, hlist, rote-c, wp-c, pval, mval, roll-btn) are
+             preserved so external touch-points (pickChar,
+             applyRoleRestrictions, renderLifecycleCards,
+             shared/resist.js, game/contested-roll.js) continue to
+             work unchanged. New rv2-* IDs drive the anchor + seg
+             control and are painted by roll-v2.js. ═══ -->
     <div id="t-roll" class="tab">
       <div id="lifecycle-cards" style="display:none"></div>
       <div class="shortcut-row">
@@ -240,24 +248,38 @@
         </button>
       </div>
       <div id="roll-char-pools" style="display:none"></div>
-      <div>
-        <div class="slabel">Dice pool</div>
-        <div class="crow">
-          <button class="cbtn" onclick="chgPool(-1)">&minus;</button>
-          <div class="cval" id="pval">5</div>
-          <button class="cbtn" onclick="chgPool(1)">+</button>
+
+      <!-- Anchor: huge effective pool + always-visible sub-line -->
+      <div class="rv2-anchor">
+        <div class="rv2-eff-wrap">
+          <span id="rv2-eff" class="rv2-eff">5</span>
+          <span id="rv2-eff-unit" class="rv2-eff-unit">dice</span>
         </div>
-        <div class="effline" id="effline">Effective pool: <span>5 dice</span></div>
+        <div id="rv2-sub" class="rv2-sub">base 5 &middot; 10-again</div>
       </div>
+
+      <!-- Base + Mod compact steppers -->
+      <div class="rv2-steppers">
+        <div class="rv2-stepper">
+          <div class="rv2-stepper-lbl">Base</div>
+          <div class="rv2-stepper-row">
+            <button class="rv2-adj" onclick="chgPool(-1)">&minus;</button>
+            <span id="pval" class="rv2-stepper-val">5</span>
+            <button class="rv2-adj" onclick="chgPool(1)">+</button>
+          </div>
+        </div>
+        <div class="rv2-stepper">
+          <div class="rv2-stepper-lbl">Mod</div>
+          <div class="rv2-stepper-row">
+            <button class="rv2-adj" onclick="chgMod(-1)">&minus;</button>
+            <span id="mval" class="rv2-stepper-val">0</span>
+            <button class="rv2-adj" onclick="chgMod(1)">+</button>
+          </div>
+        </div>
+      </div>
+
       <div id="weapon-ref" style="display:none"></div>
-      <div>
-        <div class="slabel">Bonus / Penalty</div>
-        <div class="crow">
-          <button class="bbtn" onclick="chgMod(-1)">&minus;</button>
-          <div class="bval" id="mval">0</div>
-          <button class="bbtn" onclick="chgMod(1)">+</button>
-        </div>
-      </div>
+
       <div id="resist-sec" style="display:none;">
         <div class="slabel" id="resist-lbl">Resistance</div>
         <select id="resist-sel" class="resist-sel" onchange="updResist()">
@@ -265,20 +287,35 @@
         </select>
         <div id="resist-line" class="resist-line"></div>
       </div>
-      <div>
-        <div class="slabel">Again rule</div>
-        <div class="arow">
-          <button class="abtn" id="a8" onclick="setAgain(8)">8-AGAIN</button>
-          <button class="abtn" id="a9" onclick="setAgain(9)">9-AGAIN</button>
+
+      <!-- Segmented Again rule — replaces a8/a9 buttons + na-c chip -->
+      <div class="rv2-again-wrap">
+        <div class="rv2-again-lbl">Again rule</div>
+        <div id="rv2-again-seg" class="rv2-again-seg">
+          <button type="button" data-again="10"   onclick="setAgainSeg('10')">10</button>
+          <button type="button" data-again="9"    onclick="setAgainSeg('9')">9</button>
+          <button type="button" data-again="8"    onclick="setAgainSeg('8')">8</button>
+          <button type="button" data-again="none" onclick="setAgainSeg('none')">None</button>
         </div>
       </div>
-      <div class="mrow">
+
+      <!-- Rote + WP still compose with the Again rule -->
+      <div class="rv2-chip-row">
         <button class="mchip" id="rote-c" onclick="togMod('rote')">Rote</button>
-        <button class="mchip" id="na-c" onclick="togMod('na')">No Again</button>
         <button class="mchip wp-chip" id="wp-c" onclick="togMod('wp')">WP (+3)</button>
       </div>
-      <button id="roll-btn" onclick="doRoll()">Roll the Dice</button>
+
+      <!-- Full breakdown lives inside a disclosure so it's available but
+           not competing with the anchor for visual weight. -->
+      <details class="rv2-breakdown">
+        <summary>Pool breakdown</summary>
+        <div id="effline" class="effline">Effective pool: <span>5 dice</span></div>
+      </details>
+
+      <!-- Sticky bottom Roll button; label updates on every state change. -->
+      <button id="roll-btn" class="rv2-roll-btn" onclick="doRoll()">&#10022; ROLL 5 DICE</button>
       <button id="btn-contested" onclick="openContestedRoll()" style="display:none">Contested Roll</button>
+
       <div id="res-area">
         <div id="res-hdr"></div>
         <div id="dice-area"><div class="empty-d">No rolls yet</div></div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -119,6 +119,9 @@ import * as rollV2 from './suite/roll-v2.js';
 const USE_NEW_ROLLER = localStorage.getItem('tm-use-new-dice-roller') === '1';
 const _roller = USE_NEW_ROLLER ? rollV2 : rollV1;
 const { loadPool, chgPool, chgMod, updPool, setAgain, togMod, togSpec, doRoll, clrHist, effPool, togEquipChip, updWeaponRef } = _roller;
+// setAgainSeg exists on rollV2 (slice A+D, #1024). Guarded so the tab
+// works when the flag is off and only rollV1 is active.
+const setAgainSeg = _roller.setAgainSeg || setAgain;
 import { onSheetChar, renderSheet as suiteRenderSheet, repaintSheetTrackers } from './suite/sheet.js';
 import { toggleExp as suiteToggleExp, toggleDisc as suiteToggleDisc } from './suite/sheet-helpers.js';
 import { updResist, showResistSec } from './shared/resist.js';
@@ -1213,6 +1216,7 @@ Object.assign(window, {
   chgMod,
   updPool,
   setAgain,
+  setAgainSeg,
   togMod,
   togSpec,
   doRoll,

--- a/public/js/suite/roll-v2.js
+++ b/public/js/suite/roll-v2.js
@@ -2,9 +2,22 @@
 //  Roll Tab UI (v2 — parallel dev surface, #1018)
 //
 //  Gated by the `tm-use-new-dice-roller` localStorage flag. Started as
-//  a byte-identical copy of ./roll.js so game-day iteration on the
-//  interface doesn't disturb the working DICE tab. Diverges from
-//  roll.js over time.
+//  a byte-identical copy of ./roll.js.
+//
+//  Slice A+D (#1024) — divergence from roll.js:
+//    A. Anchor number = `effPool()` (the count you'll ACTUALLY roll),
+//       painted into `#rv2-eff` / `#rv2-eff-unit`, with a
+//       always-visible sub-line at `#rv2-sub`
+//       ("base 8 · +2 mod · 9-again"). The full skill-breakdown is
+//       still written into `#effline` — moved inside a
+//       `<details>` disclosure in the markup.
+//    D. `setAgainSeg(v)` drives one exclusive segmented Again pill
+//       ("10" / "9" / "8" / "None") that maps to `state.AGAIN` +
+//       `state.NA`; replaces the old `#a8` / `#a9` / `#na-c` trio.
+//       `setAgain()` is kept as an export (loadPool calls it) and
+//       delegates to `setAgainSeg`.
+//
+//  Rote / WP chips are unchanged (they compose with Again).
 // ══════════════════════════════════════════════
 
 import state from './data.js';
@@ -82,16 +95,74 @@ export function chgMod(d) {
 
 // ── UPDATE POOL DISPLAY ──
 
+// Human-readable "again" phrase for the anchor sub-line (slice A).
+function _againPhrase() {
+  if (state.NA) return 'no again';
+  return String(state.AGAIN) + '-again';
+}
+
+// Paint the segmented Again pill so its `on` class tracks state.AGAIN + NA
+// (slice D). Safe to call when the container isn't in the DOM (v1 tab).
+function _paintAgainSeg() {
+  const seg = document.getElementById('rv2-again-seg');
+  if (!seg) return;
+  const buttons = seg.querySelectorAll('button[data-again]');
+  buttons.forEach(b => {
+    const val = b.dataset.again;
+    const on = val === 'none'
+      ? state.NA
+      : (!state.NA && String(state.AGAIN) === val);
+    b.classList.toggle('on', on);
+  });
+}
+
 export function updPool() {
   const eff = effPool();
-  const pv = document.getElementById('pval');
-  pv.textContent = state.PS <= 0 ? 'Chance' : state.PS;
-  pv.className = 'cval' + (state.PS <= 0 ? ' chance' : '');
 
+  // v2 stepper values (small).
+  const pv = document.getElementById('pval');
+  if (pv) {
+    pv.textContent = state.PS <= 0 ? 'Chance' : state.PS;
+    pv.className = 'rv2-stepper-val' + (state.PS <= 0 ? ' chance' : '');
+  }
   const mv = document.getElementById('mval');
-  const mod = state.MOD;
-  mv.textContent = mod === 0 ? '0' : mod > 0 ? '+' + mod : mod;
-  mv.className = 'bval' + (mod > 0 ? ' pos' : mod < 0 ? ' neg' : '');
+  if (mv) {
+    const mod = state.MOD;
+    mv.textContent = mod === 0 ? '0' : mod > 0 ? '+' + mod : mod;
+    mv.className = 'rv2-stepper-val' + (mod > 0 ? ' pos' : mod < 0 ? ' neg' : '');
+  }
+
+  // v2 anchor: huge effective count + sub-line (slice A).
+  const effEl = document.getElementById('rv2-eff');
+  const unitEl = document.getElementById('rv2-eff-unit');
+  const subEl = document.getElementById('rv2-sub');
+  const rollBtn = document.getElementById('roll-btn');
+  const isChance = eff <= 0;
+  if (effEl) {
+    effEl.textContent = isChance ? 'CHANCE' : String(eff);
+    effEl.classList.toggle('chance', isChance);
+  }
+  if (unitEl) {
+    unitEl.textContent = isChance ? 'die' : (eff === 1 ? 'die' : 'dice');
+  }
+  if (subEl) {
+    const parts = [
+      'base ' + (state.PS <= 0 ? 'chance' : state.PS),
+    ];
+    if (state.MOD !== 0) parts.push((state.MOD > 0 ? '+' : '') + state.MOD + ' mod');
+    parts.push(_againPhrase());
+    if (state.WP) parts.push('WP +3');
+    if (state.ROTE) parts.push('rote');
+    if (state.RESIST_MODE === '-' && state.RESIST_VAL > 0) parts.push('−' + state.RESIST_VAL + ' resist');
+    // U+00B7 middle-dot separator (matches sub-line separators elsewhere).
+    subEl.textContent = parts.join(' · ');
+  }
+  if (rollBtn) {
+    // ✦ = decorative four-point star.
+    rollBtn.textContent = isChance ? '✦ ROLL CHANCE DIE' : ('✦ ROLL ' + eff + ' DICE');
+  }
+
+  _paintAgainSeg();
 
   const el = document.getElementById('effline');
   const pi = state.POOL_INFO;
@@ -273,25 +344,45 @@ export function updWeaponRef() {
 
 // ── AGAIN / MODIFIER TOGGLES ──
 
+// Segmented Again pill entry point (slice D). `v` is one of
+// '10' | '9' | '8' | 'none' (or the numeric variants). 'none' disables
+// die explosion via state.NA; the other values set state.AGAIN and clear
+// NA. Repaints the pill and the sub-line via updPool().
+export function setAgainSeg(v) {
+  if (v === 'none' || v === 'None') {
+    state.NA = true;
+  } else {
+    state.NA = false;
+    state.AGAIN = Number(v);
+  }
+  // updPool paints the seg AND the anchor sub-line so both stay in sync.
+  updPool();
+}
+
+// Kept as an export because loadPool() calls it. Delegates to the new
+// segmented entry point so the pill + sub-line stay in sync when a pool
+// with a `nineAgain` flag is loaded.
 export function setAgain(v) {
-  state.AGAIN = v;
-  [8, 9].forEach(n => {
-    const el = document.getElementById('a' + n);
-    if (el) el.classList.toggle('on', n === v);
-  });
+  setAgainSeg(v);
 }
 
 export function togMod(m) {
   if (m === 'rote') {
     state.ROTE = !state.ROTE;
-    document.getElementById('rote-c').classList.toggle('on', state.ROTE);
+    const el = document.getElementById('rote-c');
+    if (el) el.classList.toggle('on', state.ROTE);
+    updPool();
   } else if (m === 'wp') {
     state.WP = !state.WP;
-    document.getElementById('wp-c').classList.toggle('on', state.WP);
+    const el = document.getElementById('wp-c');
+    if (el) el.classList.toggle('on', state.WP);
     updPool();
   } else {
+    // 'na' — no dedicated button in v2 markup; routed through the
+    // segmented pill instead. Kept for any external caller still on the
+    // old chip contract.
     state.NA = !state.NA;
-    document.getElementById('na-c').classList.toggle('on', state.NA);
+    updPool();
   }
 }
 

--- a/tests/issue-1024-roll-v2-anchor-and-again-seg.spec.js
+++ b/tests/issue-1024-roll-v2-anchor-and-again-seg.spec.js
@@ -1,0 +1,208 @@
+// Smokes for issue #1024 — ROLL v2 slice A (anchor) + D (segmented Again).
+//
+// Source-fetch smokes plus a live boot smoke that confirms the new
+// anchor + seg control are present and functional in the `flag ON`
+// state without needing Discord OAuth. DICE (#t-dice) markup is
+// asserted unchanged (safety-net for the flag-off path).
+
+const { test, expect } = require('@playwright/test');
+
+test('#1024 — #t-roll has the new anchor + segmented Again elements', async ({ request }) => {
+  const res = await request.get('/index.html');
+  const html = await res.text();
+
+  // Slice A: anchor (huge effective count) + always-visible sub-line.
+  expect(html).toMatch(/id="rv2-eff"/);
+  expect(html).toMatch(/id="rv2-eff-unit"/);
+  expect(html).toMatch(/id="rv2-sub"/);
+
+  // Slice D: exactly one segmented Again pill with the four options.
+  expect(html).toMatch(/id="rv2-again-seg"/);
+  for (const v of ['10', '9', '8', 'none']) {
+    expect(html).toMatch(new RegExp(`data-again="${v}"`));
+  }
+
+  // Compact steppers reuse #pval / #mval for state (roll-v2 writes them).
+  expect(html).toMatch(/class="rv2-stepper-row"/);
+
+  // Sticky roll button carries the new class.
+  expect(html).toMatch(/id="roll-btn"[^>]*class="rv2-roll-btn"/);
+});
+
+test('#1024 — #t-roll no longer has the old a8/a9/na-c chips', async ({ request }) => {
+  const res = await request.get('/index.html');
+  const html = await res.text();
+
+  // Locate just the #t-roll block so we don't accidentally hit #t-dice.
+  const start = html.indexOf('<div id="t-roll"');
+  expect(start).toBeGreaterThan(0);
+  const end = html.indexOf('</div>\n\n    <!-- ═══ TERRITORY', start);
+  expect(end).toBeGreaterThan(start);
+  const rollBlock = html.slice(start, end);
+
+  expect(rollBlock).not.toMatch(/id="a8"/);
+  expect(rollBlock).not.toMatch(/id="a9"/);
+  expect(rollBlock).not.toMatch(/id="na-c"/);
+});
+
+test('#1024 — #t-dice block is untouched (safety net for flag-off path)', async ({ request }) => {
+  const res = await request.get('/index.html');
+  const html = await res.text();
+
+  const start = html.indexOf('<div id="t-dice"');
+  const end = html.indexOf('<!-- ═══ ROLL TAB', start);
+  expect(start).toBeGreaterThan(0);
+  expect(end).toBeGreaterThan(start);
+  const diceBlock = html.slice(start, end);
+
+  // DICE keeps the legacy controls exactly.
+  expect(diceBlock).toMatch(/id="a8"/);
+  expect(diceBlock).toMatch(/id="a9"/);
+  expect(diceBlock).toMatch(/id="na-c"/);
+  expect(diceBlock).toMatch(/id="pval"/);
+  expect(diceBlock).toMatch(/id="mval"/);
+  // And has none of the v2 anchor bits.
+  expect(diceBlock).not.toMatch(/id="rv2-eff"/);
+  expect(diceBlock).not.toMatch(/id="rv2-again-seg"/);
+});
+
+test('#1024 — roll-v2.js exports setAgainSeg', async ({ request }) => {
+  const res = await request.get('/js/suite/roll-v2.js');
+  const src = await res.text();
+  expect(src).toMatch(/export\s+function\s+setAgainSeg\b/);
+  // setAgain still exported so loadPool() keeps working.
+  expect(src).toMatch(/export\s+function\s+setAgain\b/);
+});
+
+test('#1024 — suite.css contains the .rv2-* styles', async ({ request }) => {
+  const res = await request.get('/css/suite.css');
+  const css = await res.text();
+  for (const cls of [
+    '.rv2-anchor',
+    '.rv2-eff',
+    '.rv2-sub',
+    '.rv2-stepper-row',
+    '.rv2-again-seg',
+    '.rv2-roll-btn',
+    '.rv2-breakdown',
+  ]) {
+    expect(css.includes(cls), `${cls} missing from suite.css`).toBe(true);
+  }
+  // Tokens only — the new block introduces no bare hex color values or
+  // theme-blind rgba() (project standard). Anchor via the block header
+  // comment so we don't accidentally match unrelated CSS.
+  const rvIdx = css.indexOf('Roll v2 — anchor layout + segmented Again rule');
+  expect(rvIdx).toBeGreaterThan(0);
+  const rvBlock = css.slice(rvIdx);
+  // Color-value context: `: #abc123;` etc. (skips issue refs in comments).
+  expect(rvBlock).not.toMatch(/:\s*#[0-9a-fA-F]{3,8}\b/);
+  expect(rvBlock).not.toMatch(/rgba\(\s*255\s*,/);
+});
+
+// ── Live boot smokes: reload the app with the flag set, confirm the
+//    ROLL tab's anchor + seg pill actually render and behave.
+//    No OAuth needed — the tab markup + rv2 painters run pre-login.
+
+async function bootWithFlag(page, on) {
+  await page.goto('/');
+  await page.evaluate((flag) => {
+    if (flag) localStorage.setItem('tm-use-new-dice-roller', '1');
+    else localStorage.removeItem('tm-use-new-dice-roller');
+  }, on);
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.waitForTimeout(400);
+}
+
+test('#1024 — flag ON: anchor + seg pill are in the live DOM', async ({ page }) => {
+  const errors = [];
+  page.on('pageerror', (e) => errors.push(String(e)));
+  await bootWithFlag(page, true);
+
+  const state = await page.evaluate(() => ({
+    hasEff: !!document.getElementById('rv2-eff'),
+    hasSub: !!document.getElementById('rv2-sub'),
+    hasSeg: !!document.getElementById('rv2-again-seg'),
+    segButtons: Array.from(
+      document.querySelectorAll('#rv2-again-seg [data-again]')
+    ).map((b) => b.dataset.again),
+    dice: !!document.getElementById('t-dice'),
+    roll: !!document.getElementById('t-roll'),
+  }));
+
+  expect(state.hasEff, 'rv2-eff should be present').toBeTruthy();
+  expect(state.hasSub, 'rv2-sub should be present').toBeTruthy();
+  expect(state.hasSeg, 'rv2-again-seg should be present').toBeTruthy();
+  expect(state.segButtons).toEqual(['10', '9', '8', 'none']);
+  expect(state.dice, '#t-dice should be removed at boot').toBeFalsy();
+  expect(state.roll, '#t-roll should survive at boot').toBeTruthy();
+
+  // No module errors from the rewired painter.
+  const relevant = errors.filter((e) =>
+    /roll-v2|setAgainSeg|updPool|rv2/i.test(e)
+  );
+  expect(relevant).toEqual([]);
+});
+
+test('#1024 — flag OFF: v1 DICE tab remains, no v2 elements leak', async ({ page }) => {
+  await bootWithFlag(page, false);
+  const state = await page.evaluate(() => ({
+    hasEff: !!document.getElementById('rv2-eff'),
+    hasSeg: !!document.getElementById('rv2-again-seg'),
+    hasA8: !!document.getElementById('a8'),
+    dice: !!document.getElementById('t-dice'),
+    roll: !!document.getElementById('t-roll'),
+  }));
+  expect(state.hasEff, 'rv2-eff should NOT exist when flag off').toBeFalsy();
+  expect(state.hasSeg, 'rv2-again-seg should NOT exist when flag off').toBeFalsy();
+  expect(state.hasA8, '#a8 (v1 chip) should exist when flag off').toBeTruthy();
+  expect(state.dice, '#t-dice should survive at boot').toBeTruthy();
+  expect(state.roll, '#t-roll should be removed at boot').toBeFalsy();
+});
+
+test('#1024 — flag ON: clicking a seg button flips the .on class exclusively', async ({ page }) => {
+  await bootWithFlag(page, true);
+  // Directly invoke the exposed global — bypasses the login gate.
+  await page.evaluate(() => window.setAgainSeg('8'));
+  const state = await page.evaluate(() => {
+    const btns = Array.from(
+      document.querySelectorAll('#rv2-again-seg [data-again]')
+    );
+    return btns.map((b) => ({ v: b.dataset.again, on: b.classList.contains('on') }));
+  });
+  expect(state.find((s) => s.v === '8').on).toBe(true);
+  expect(state.filter((s) => s.v !== '8').every((s) => !s.on)).toBe(true);
+
+  // Now flip to "none".
+  await page.evaluate(() => window.setAgainSeg('none'));
+  const state2 = await page.evaluate(() => {
+    const btns = Array.from(
+      document.querySelectorAll('#rv2-again-seg [data-again]')
+    );
+    return btns.map((b) => ({ v: b.dataset.again, on: b.classList.contains('on') }));
+  });
+  expect(state2.find((s) => s.v === 'none').on).toBe(true);
+  expect(state2.filter((s) => s.v !== 'none').every((s) => !s.on)).toBe(true);
+});
+
+test('#1024 — flag ON: sticky Roll button label reflects effective count', async ({ page }) => {
+  await bootWithFlag(page, true);
+  // Set base pool to 7 via chgPool. Fresh state has PS=5 (roll-v2 default).
+  await page.evaluate(() => {
+    window.chgPool(2);
+    window.updPool();
+  });
+  const label = await page.evaluate(
+    () => document.getElementById('roll-btn').textContent
+  );
+  expect(label).toMatch(/ROLL 7 DICE/);
+
+  // Drop to chance.
+  await page.evaluate(() => {
+    window.chgPool(-10);
+    window.updPool();
+  });
+  const label2 = await page.evaluate(
+    () => document.getElementById('roll-btn').textContent
+  );
+  expect(label2).toMatch(/ROLL CHANCE DIE/);
+});


### PR DESCRIPTION
## Summary
Deploy dev → main.

- **#1024** (`42f6b1a7`) — ROLL v2 slice A (effective-pool anchor + sub-line + sticky Roll button label) and slice D (segmented Again pill replacing the three legacy chips). Behind the `tm-use-new-dice-roller` flag; default OFF, so every user still sees the DICE tab today unless they opt in.

## Deploy footprint
- Netlify (frontend): `public/index.html`, `public/css/suite.css`, `public/js/app.js`, `public/js/suite/roll-v2.js`. No behaviour change for anyone until they flip the setting.
- Render (API): no route change.
- MongoDB: no schema change.

## Test plan
- Playwright `tests/issue-1024-roll-v2-anchor-and-again-seg.spec.js` — 9/9 green (source contract + runtime seg toggle + sticky roll button label).
- Parse-check clean on both `app.js` and `roll-v2.js`.