### PR TITLE
fix(#1027): DT Connected Characters dropdown — remove 10-cap, match name/fullName/player

### DIFF
--- a/public/js/tabs/downtime-form.js
+++ b/public/js/tabs/downtime-form.js
@@ -6001,11 +6001,14 @@ function initConnectedCharsTypeaheads(container) {
       const selected = getSelectedIds();
       const q = query.trim().toLowerCase();
       const matches = others.filter(c =>
-        !selected.has(String(c.id)) && (!q || String(c.name).toLowerCase().includes(q))
+        !selected.has(String(c.id)) && (!q ||
+          String(c.name).toLowerCase().includes(q) ||
+          String(c.fullName).toLowerCase().includes(q) ||
+          String(c.player).toLowerCase().includes(q))
       );
       if (!matches.length) { dropdown.style.display = 'none'; return; }
       dropdown.innerHTML = '';
-      for (const c of matches.slice(0, 10)) {
+      for (const c of matches) {
         const item = document.createElement('div');
         item.className = 'dt-conn-dd-item';
         item.dataset.connId = String(c.id);

--- a/specs/stories/1027.dt-connected-chars-dropdown-cap.story.md
+++ b/specs/stories/1027.dt-connected-chars-dropdown-cap.story.md
@@ -1,0 +1,131 @@
+---
+issue: 1027
+issue_url: https://github.com/angelusvmorningstar/TerraMortis/issues/1027
+branch: piatra/issue-1027-connected-chars-dropdown-cap
+epic: none (standalone bug)
+---
+
+# Story 1027: DT form Connected Characters typeahead — remove 10-item cap and broaden match fields
+
+## Status
+
+Review
+
+## Story
+
+**As a** player filling in the downtime form,
+**I want** the "Connected Characters" control on an action (e.g. Personal Maintenance) to surface every eligible character and to find them whether I type their legal name, moniker, or player name,
+**so that** I can link any PC to my action instead of only the first ten alphabetically.
+
+## Acceptance Criteria
+
+1. Given a roster of more than 10 non-retired characters, when the player focuses the Connected Characters control on a Personal Maintenance action with an empty query, then more than 10 options are reachable — all matches render, scrolled within the existing `.dt-conn-dropdown` container. No fixed 10-item cap.
+2. Given a character whose `moniker` differs from their legal `name`, when the player types the legal `name`, then that character appears in the dropdown.
+3. Given a player name typed as the query, when it matches a character's `player` field, then that character appears in the dropdown.
+4. Already-chipped characters and the current character remain excluded — no regression to the existing exclusions (`downtime-form.js:1529` self-exclusion; `:6004` already-chipped exclusion).
+5. Styling uses design-system tokens and reuses existing component classes — no inline `style=`, no bare hex/`rgba()`.
+
+## Tasks / Subtasks
+
+- [x] Remove the hard 10-item cap in `showDropdown()` (AC: 1)
+  - [x] In `public/js/tabs/downtime-form.js`, function `showDropdown(query)` (around line 6000-6016), change `for (const c of matches.slice(0, 10))` to iterate all `matches`. The `.dt-conn-dropdown` scroll container (`public/css/components.css:6092`, `max-height: 180px; overflow-y: auto`) already handles overflow, so no CSS change is required.
+  - [x] Optional soft cap: not applied — no cap required to pass ACs; iterating all `matches` is sufficient given the existing scroll container.
+- [x] Broaden the substring match to include `fullName` and `player` (AC: 2, 3)
+  - [x] In the same `showDropdown()` filter (`:6003-6005`), extend the match predicate so the query matches against `c.name` (already present), `c.fullName`, and `c.player`. All three fields are already populated on `allCharacters` entries at `:1530-1535` (`name = moniker || name`, `fullName = name`, `player = player`). Guard each field with `String(...)` before `.toLowerCase().includes(q)` to avoid throwing on undefined.
+- [x] Verify exclusions unchanged (AC: 4)
+  - [x] Confirm the `!selected.has(String(c.id))` check at `:6004` and the self-exclusion at `:1529` still hold after the predicate change.
+- [x] Manual in-browser verification (see Testing) — deferred to reviewer/QA; code inspected against all 5 ACs, `node --check` parse-clean.
+
+## Dev Notes
+
+### Root cause (from issue #1027 investigation)
+
+Two defects in the **same function** — `showDropdown(query)` inside `initConnectedCharsTypeaheads`, `public/js/tabs/downtime-form.js` ~line 6000:
+
+```js
+function showDropdown(query) {
+  const selected = getSelectedIds();
+  const q = query.trim().toLowerCase();
+  const matches = others.filter(c =>
+    !selected.has(String(c.id)) && (!q || String(c.name).toLowerCase().includes(q))   // :6004 — matches c.name ONLY
+  );
+  if (!matches.length) { dropdown.style.display = 'none'; return; }
+  dropdown.innerHTML = '';
+  for (const c of matches.slice(0, 10)) {                                             // :6008 — HARD 10-item cap
+    ...
+  }
+}
+```
+
+1. **10-item cap** at `:6008` — `matches.slice(0, 10)`. On empty query this renders only the first 10 characters alphabetically. This is the primary "list is truncated" symptom.
+2. **Name-only match** at `:6004` — searches `c.name`, which is `moniker || name` (set at `:1532`). For any character with a moniker, typing their legal name matches nothing; combined with the cap, moniker'd characters become effectively unreachable. `c.fullName` (legal name) and `c.player` are fetched at `:1533-1534` but neither is searched.
+
+### Data source — no upstream limit
+
+`allCharacters` is loaded once per `renderDowntimeTab()` mount from `GET /api/characters/names` (`downtime-form.js:1526-1540`). The endpoint (`server/routes/characters.js:382-390`) returns **every** non-retired character (`retired: { $ne: true }`), no `limit`, no pagination, and an **identical payload for player and ST** (no `requireRole` branch — only router-level `requireAuth`). So the fix is entirely client-side in `showDropdown()`; do not touch the endpoint.
+
+Each `allCharacters` entry shape (`:1530-1535`):
+```js
+{ id: c._id, name: c.moniker || c.name, fullName: c.name, player: c.player || '' }
+```
+
+### Scope guardrails
+
+- **Personal Maintenance specifics**: on a `maintenance` action the Target zone renders merit chips, not a character picker (`downtime-form.js:5919-5923` → `renderMaintenanceChips`). The Connected Characters typeahead (`renderConnectedCharsZone`, unconditional for all actions at `:3830`) is the only character-linking control on that action — it is the correct and only surface to fix.
+- **Do not** refactor this typeahead to use the shared `charPicker` component (`public/js/components/character-picker.js`). That component has no slice and already shows all matches, but swapping it in is out of scope and higher-risk. In scope is only: remove the cap, broaden the match.
+- **Do not** change `/api/characters/names` or retired-character handling.
+
+### CSS / design-system
+
+No new styling needed. The dropdown items reuse `.dt-conn-dd-item` and the container `.dt-conn-dropdown` (`public/css/components.css`, ~:6092) which already has `max-height` + `overflow-y: auto`. If any markup is added, reuse existing component classes and `public/css/theme.css` tokens — no inline `style=`, no bare hex. Reference: `specs/architecture/coding-standards.md` → CSS Standards; `specs/project-context.md`.
+
+### Relevant source tree
+
+- `public/js/tabs/downtime-form.js`
+  - `:1526-1546` — `allCharacters` load + shape + `setCharPickerSources`
+  - `:5940` — `renderConnectedCharsZone(n, saved, chars)` markup
+  - `:6000-6016` — `showDropdown(query)` ← **the fix site**
+  - `:6034-6041` — `saveToResponseDoc()` (unchanged; confirms chip persistence into `responseDoc.responses`)
+- `public/css/components.css:6092` — `.dt-conn-dropdown` scroll container (unchanged)
+- `server/routes/characters.js:382-390` — `GET /api/characters/names` (unchanged; confirms no upstream cap)
+
+### Testing
+
+- **No automated test framework in this repo** (per CLAUDE.md). Verify manually in-browser.
+- Local frontend: `npx http-server public -p 8080`. Local API: `cd server && npm run dev`.
+- Manual test plan:
+  1. Open the player downtime form with a roster of >10 non-retired characters. Add a Personal Maintenance action. Focus the Connected Characters input with no text typed → confirm more than 10 characters are listed and the list scrolls (AC 1).
+  2. Pick a character who has a moniker distinct from their legal name. Type part of their **legal name** → confirm they appear (AC 2).
+  3. Type part of a **player's name** → confirm their character(s) appear (AC 3).
+  4. Add a character as a chip, reopen the dropdown → confirm the chipped character and the current character are absent (AC 4).
+  5. Confirm no console errors on characters with a null/undefined `player` or `fullName` (the `String(...)` guard).
+
+## Change Log
+
+| Date       | Version | Description                        | Author       |
+|------------|---------|------------------------------------|--------------|
+| 2026-07-23 | 0.1     | Initial draft from issue #1027     | Khepri (SM)  |
+
+## Dev Agent Record
+
+### Agent Model Used
+
+Claude Sonnet 5 (BMAD dev agent)
+
+### Debug Log References
+
+`node --check public/js/tabs/downtime-form.js` — parse OK, no errors.
+
+### Completion Notes List
+
+- Removed the hard `matches.slice(0, 10)` cap in `showDropdown()`; now iterates all `matches`. The existing `.dt-conn-dropdown` CSS scroll container (`max-height: 180px; overflow-y: auto`) handles overflow — no CSS change made.
+- Broadened the filter predicate to match `q` against `c.name`, `c.fullName`, and `c.player`, each guarded with `String(...)` before `.toLowerCase().includes(q)` to avoid throwing on undefined/null fields.
+- No changes to the `!selected.has(String(c.id))` exclusion or the self-exclusion at `:1529` — both preserved as-is.
+- No changes to `/api/characters/names`, CSS, or the shared `charPicker` component, per scope guardrails.
+
+### File List
+
+- `public/js/tabs/downtime-form.js` (modified — `showDropdown()` in `initConnectedCharsTypeaheads`)
+- `specs/stories/1027.dt-connected-chars-dropdown-cap.story.md` (modified — Dev Agent Record, task checkboxes, status)
+
+## QA Results


### PR DESCRIPTION
## Summary

- The player downtime "Connected Characters" typeahead (e.g. on Personal Maintenance actions) rendered only the first 10 matches alphabetically due to a hardcoded `matches.slice(0, 10)`; the rest were unreachable without typing a substring.
- The same filter searched `c.name` only (which is `moniker || name`), so typing a character's legal name or their player's name matched nothing. Characters with a moniker were effectively unfindable.
- Fix is client-side only in `showDropdown()`: remove the cap (the existing `.dt-conn-dropdown` scroll container handles overflow) and broaden the match to `name`, `fullName`, and `player`, each `String()`-guarded.

## Closes

- Closes #1027

## Story

- `specs/stories/1027.dt-connected-chars-dropdown-cap.story.md`

## Test plan

- [ ] `node --check public/js/tabs/downtime-form.js` — parse-clean (verified locally)
- [ ] Manual: open the downtime form with a roster of >10 non-retired characters; add a Personal Maintenance action; focus the Connected Characters input with no text — confirm more than 10 options are listed and the container scrolls.
- [ ] Manual: type a moniker'd character's **legal name** — they appear (AC2).
- [ ] Manual: type a **player's name** — their character(s) appear (AC3).
- [ ] Manual: chip a character, reopen the dropdown — chipped char and current char remain excluded (AC4).
- [ ] Manual: no console errors on characters with null/undefined `player` or `fullName`.

## Branch flow

- From: \`piatra/issue-1027-connected-chars-dropdown-cap\`
- Into: \`dev\`

_No automated test framework in this repo (per CLAUDE.md) — verification is code inspection + `node --check` + the manual smoke test above._